### PR TITLE
Add c++ AnimatedModule to DefaultTurboModules

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -424,6 +424,7 @@ let reactFabric = RNTarget(
   name: .reactFabric,
   path: "ReactCommon/react/renderer",
   excludedPaths: [
+    "animated/tests",
     "animations/tests",
     "attributedstring/tests",
     "core/tests",
@@ -456,7 +457,7 @@ let reactFabric = RNTarget(
     "components/root/tests",
   ],
   dependencies: [.reactNativeDependencies, .reactJsiExecutor, .rctTypesafety, .reactTurboModuleCore, .jsi, .logger, .reactDebug, .reactFeatureFlags, .reactUtils, .reactRuntimeScheduler, .reactCxxReact, .reactRendererDebug, .reactGraphics, .yoga],
-  sources: ["animationbackend", "animations", "attributedstring", "core", "componentregistry", "componentregistry/native", "components/root", "components/view", "components/view/platform/cxx", "components/scrollview", "components/scrollview/platform/cxx", "components/scrollview/platform/ios", "components/legacyviewmanagerinterop", "components/legacyviewmanagerinterop/platform/ios", "dom", "scheduler", "mounting", "observers/events", "observers/intersection", "telemetry", "consistency", "leakchecker", "uimanager", "uimanager/consistency", "viewtransition"]
+  sources: ["animated", "animationbackend", "animations", "attributedstring", "core", "componentregistry", "componentregistry/native", "components/root", "components/view", "components/view/platform/cxx", "components/scrollview", "components/scrollview/platform/cxx", "components/scrollview/platform/ios", "components/legacyviewmanagerinterop", "components/legacyviewmanagerinterop/platform/ios", "dom", "scheduler", "mounting", "observers/events", "observers/intersection", "telemetry", "consistency", "leakchecker", "uimanager", "uimanager/consistency", "viewtransition"]
 )
 
 let reactFabricInputAccessory = RNTarget(

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -82,6 +82,7 @@ add_react_common_subdir(react/debug)
 add_react_common_subdir(react/featureflags)
 add_react_common_subdir(react/performance/cdpmetrics)
 add_react_common_subdir(react/performance/timeline)
+add_react_common_subdir(react/renderer/animated)
 add_react_common_subdir(react/renderer/animationbackend)
 add_react_common_subdir(react/renderer/animations)
 add_react_common_subdir(react/renderer/attributedstring)
@@ -202,6 +203,7 @@ add_library(reactnative
           $<TARGET_OBJECTS:react_newarchdefaults>
           $<TARGET_OBJECTS:react_performance_cdpmetrics>
           $<TARGET_OBJECTS:react_performance_timeline>
+          $<TARGET_OBJECTS:react_renderer_animated>
           $<TARGET_OBJECTS:react_renderer_animationbackend>
           $<TARGET_OBJECTS:react_renderer_animations>
           $<TARGET_OBJECTS:react_renderer_attributedstring>
@@ -297,6 +299,7 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:react_newarchdefaults,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_performance_cdpmetrics,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_performance_timeline,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_animated,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_animationbackend,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_animations,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_attributedstring,INTERFACE_INCLUDE_DIRECTORIES>

--- a/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.mm
+++ b/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.mm
@@ -70,7 +70,10 @@
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {
-  if (facebook::react::ReactNativeFeatureFlags::cxxNativeAnimatedEnabled()) {
+  if (facebook::react::ReactNativeFeatureFlags::cxxNativeAnimatedEnabled() &&
+      // initialization is moved to DefaultTurboModules when using shared animated backend
+      // TODO: T257053961 deprecate RCTAnimatedModuleProvider.
+      !facebook::react::ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
     if (name == facebook::react::AnimatedModule::kModuleName) {
       __weak RCTAnimatedModuleProvider *weakSelf = self;
       auto provider = std::make_shared<facebook::react::NativeAnimatedNodesManagerProvider>(

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(react_nativemodule_defaults
         react_nativemodule_idlecallbacks
         react_nativemodule_intersectionobserver
         react_nativemodule_webperformance
+        react_renderer_animated
 )
 target_compile_reactnative_options(react_nativemodule_defaults PRIVATE)
 target_compile_options(react_nativemodule_defaults PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.cpp
@@ -13,6 +13,7 @@
 #include <react/nativemodule/intersectionobserver/NativeIntersectionObserver.h>
 #include <react/nativemodule/microtasks/NativeMicrotasks.h>
 #include <react/nativemodule/webperformance/NativePerformance.h>
+#include <react/renderer/animated/AnimatedModule.h>
 
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY
 #include <react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h>
@@ -47,6 +48,13 @@ namespace facebook::react {
     if (name == NativeIntersectionObserver::kModuleName) {
       return std::make_shared<NativeIntersectionObserver>(jsInvoker);
     }
+  }
+
+  if (ReactNativeFeatureFlags::cxxNativeAnimatedEnabled() &&
+      ReactNativeFeatureFlags::useSharedAnimatedBackend() &&
+      name == AnimatedModule::kModuleName) {
+    return std::make_shared<AnimatedModule>(
+        jsInvoker, std::make_shared<NativeAnimatedNodesManagerProvider>());
   }
 
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -54,6 +54,7 @@ Pod::Spec.new do |s|
   s.dependency "React-idlecallbacksnativemodule"
   s.dependency "React-intersectionobservernativemodule"
   s.dependency "React-webperformancenativemodule"
+  s.dependency "React-Fabric/animated"
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-featureflags")
   add_dependency(s, "React-featureflagsnativemodule")

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -45,8 +45,16 @@ std::shared_ptr<NativeAnimatedNodesManager>
 NativeAnimatedNodesManagerProvider::getOrCreate(
     jsi::Runtime& runtime,
     std::shared_ptr<CallInvoker> jsInvoker) {
-  if (nativeAnimatedNodesManager_ == nullptr) {
-    auto* uiManager = &UIManagerBinding::getBinding(runtime)->getUIManager();
+  if (nativeAnimatedNodesManager_ != nullptr) {
+    return nativeAnimatedNodesManager_;
+  }
+
+  auto* uiManager = &UIManagerBinding::getBinding(runtime)->getUIManager();
+
+  if (!ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+    // === PATH 1: Legacy Backend (useSharedAnimatedBackend = false) ===
+    // Uses the architecture with MergedValueDispatcher and
+    // AnimatedMountingOverrideDelegate
 
     mergedValueDispatcher_ = std::make_unique<MergedValueDispatcher>(
         [jsInvoker](std::function<void()>&& func) {
@@ -84,78 +92,78 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
       }
     };
 
-    if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-      auto animationBackend = uiManager->unstable_getAnimationBackend().lock();
-      react_native_assert(
-          animationBackend != nullptr && "animationBackend is nullptr");
-      animationBackend->registerJSInvoker(jsInvoker);
+    nativeAnimatedNodesManager_ = std::make_shared<NativeAnimatedNodesManager>(
+        std::move(directManipulationCallback),
+        std::move(fabricCommitCallback),
+        std::move(resolvePlatformColor),
+        std::move(startOnRenderCallback_),
+        std::move(stopOnRenderCallback_),
+        std::move(frameRateListenerCallback_));
 
-      nativeAnimatedNodesManager_ =
-          std::make_shared<NativeAnimatedNodesManager>(animationBackend);
-    } else {
-      nativeAnimatedNodesManager_ =
-          std::make_shared<NativeAnimatedNodesManager>(
-              std::move(directManipulationCallback),
-              std::move(fabricCommitCallback),
-              std::move(resolvePlatformColor),
-              std::move(startOnRenderCallback_),
-              std::move(stopOnRenderCallback_),
-              std::move(frameRateListenerCallback_));
+    nativeAnimatedDelegate_ =
+        std::make_shared<UIManagerNativeAnimatedDelegateImpl>(
+            nativeAnimatedNodesManager_);
 
-      nativeAnimatedDelegate_ =
-          std::make_shared<UIManagerNativeAnimatedDelegateImpl>(
-              nativeAnimatedNodesManager_);
-    }
+    animatedMountingOverrideDelegate_ =
+        std::make_shared<AnimatedMountingOverrideDelegate>(
+            *nativeAnimatedNodesManager_, *scheduler);
 
-    addEventEmitterListener(
-        nativeAnimatedNodesManager_->getEventEmitterListener());
+    // Register on existing surfaces
+    uiManager->getShadowTreeRegistry().enumerate(
+        [animatedMountingOverrideDelegate =
+             std::weak_ptr<const AnimatedMountingOverrideDelegate>(
+                 animatedMountingOverrideDelegate_)](
+            const ShadowTree& shadowTree, bool& /*stop*/) {
+          shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(
+              animatedMountingOverrideDelegate);
+        });
 
-    uiManager->addEventListener(
-        std::make_shared<EventListener>(
-            [eventEmitterListenerContainerWeak =
-                 std::weak_ptr<EventEmitterListenerContainer>(
-                     eventEmitterListenerContainer_)](
-                const RawEvent& rawEvent) {
-              const auto& eventTarget = rawEvent.eventTarget;
-              const auto& eventPayload = rawEvent.eventPayload;
-              if (eventTarget && eventPayload) {
-                if (auto eventEmitterListenerContainer =
-                        eventEmitterListenerContainerWeak.lock();
-                    eventEmitterListenerContainer != nullptr) {
-                  return eventEmitterListenerContainer->willDispatchEvent(
-                      eventTarget->getTag(), rawEvent.type, *eventPayload);
-                }
-              }
-              return false;
-            }));
+    // Register on surfaces started in the future
+    uiManager->setOnSurfaceStartCallback(
+        [animatedMountingOverrideDelegate =
+             std::weak_ptr<const AnimatedMountingOverrideDelegate>(
+                 animatedMountingOverrideDelegate_)](
+            const ShadowTree& shadowTree) {
+          shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(
+              animatedMountingOverrideDelegate);
+        });
 
     uiManager->setNativeAnimatedDelegate(nativeAnimatedDelegate_);
+  } else {
+    // === PATH 2: Shared AnimationBackend (useSharedAnimatedBackend = true) ===
+    // Uses the shared AnimationBackend from UIManager. The backend handles all
+    // animation commits and platform integration internally.
 
-    if (!ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-      animatedMountingOverrideDelegate_ =
-          std::make_shared<AnimatedMountingOverrideDelegate>(
-              *nativeAnimatedNodesManager_, *scheduler);
+    auto animationBackend = uiManager->unstable_getAnimationBackend().lock();
+    react_native_assert(
+        animationBackend != nullptr && "animationBackend is nullptr");
+    animationBackend->registerJSInvoker(jsInvoker);
 
-      // Register on existing surfaces
-      uiManager->getShadowTreeRegistry().enumerate(
-          [animatedMountingOverrideDelegate =
-               std::weak_ptr<const AnimatedMountingOverrideDelegate>(
-                   animatedMountingOverrideDelegate_)](
-              const ShadowTree& shadowTree, bool& /*stop*/) {
-            shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(
-                animatedMountingOverrideDelegate);
-          });
-      // Register on surfaces started in the future
-      uiManager->setOnSurfaceStartCallback(
-          [animatedMountingOverrideDelegate =
-               std::weak_ptr<const AnimatedMountingOverrideDelegate>(
-                   animatedMountingOverrideDelegate_)](
-              const ShadowTree& shadowTree) {
-            shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(
-                animatedMountingOverrideDelegate);
-          });
-    }
+    nativeAnimatedNodesManager_ =
+        std::make_shared<NativeAnimatedNodesManager>(animationBackend);
   }
+
+  addEventEmitterListener(
+      nativeAnimatedNodesManager_->getEventEmitterListener());
+
+  uiManager->addEventListener(
+      std::make_shared<EventListener>(
+          [eventEmitterListenerContainerWeak =
+               std::weak_ptr<EventEmitterListenerContainer>(
+                   eventEmitterListenerContainer_)](const RawEvent& rawEvent) {
+            const auto& eventTarget = rawEvent.eventTarget;
+            const auto& eventPayload = rawEvent.eventPayload;
+            if (eventTarget && eventPayload) {
+              if (auto eventEmitterListenerContainer =
+                      eventEmitterListenerContainerWeak.lock();
+                  eventEmitterListenerContainer != nullptr) {
+                return eventEmitterListenerContainer->willDispatchEvent(
+                    eventTarget->getTag(), rawEvent.type, *eventPayload);
+              }
+            }
+            return false;
+          }));
+
   return nativeAnimatedNodesManager_;
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/runtime/TurboModuleManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/TurboModuleManager.cpp
@@ -62,15 +62,19 @@ std::shared_ptr<TurboModule> TurboModuleManager::operator()(
     }
   }
 
+  if (animatedNodesManagerProvider_ != nullptr &&
+      name == AnimatedModule::kModuleName) {
+    // when animatedNodesManagerProvider_ is null, defer to default
+    return std::make_shared<AnimatedModule>(
+        jsInvoker_, animatedNodesManagerProvider_);
+  }
+
   if (auto turboModule =
           DefaultTurboModules::getTurboModule(name, jsInvoker_)) {
     return turboModule;
   }
 
-  if (name == AnimatedModule::kModuleName) {
-    return std::make_shared<AnimatedModule>(
-        jsInvoker_, animatedNodesManagerProvider_);
-  } else if (name == AppStateModule::kModuleName) {
+  if (name == AppStateModule::kModuleName) {
     return std::make_shared<AppStateModule>(jsInvoker_);
   } else if (name == DeviceInfoModule::kModuleName) {
     return std::make_shared<DeviceInfoModule>(jsInvoker_);

--- a/private/react-native-fantom/tester/src/TesterAppDelegate.cpp
+++ b/private/react-native-fantom/tester/src/TesterAppDelegate.cpp
@@ -112,9 +112,7 @@ TesterAppDelegate::TesterAppDelegate(
 
   std::shared_ptr<NativeAnimatedNodesManagerProvider> provider;
 
-  if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-    provider = std::make_shared<NativeAnimatedNodesManagerProvider>();
-  } else {
+  if (!ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
     provider = std::make_shared<NativeAnimatedNodesManagerProvider>(
         [this](std::function<void()>&& onRender, bool /*isAsync*/) {
           onAnimationRender_ = std::move(onRender);


### PR DESCRIPTION
Summary:
This is added so that one can easily enables c++ AnimatedModule in open source.

If an app doesn't use `RCTAnimatedModuleProvider`(ios) or `AnimatedCxxReactPackage`(android), it can fallback to this default AnimatedModule when it has both c++animated and shared backend enabled
- shared backend removes the need to pass down start/stop callbacks to NativeAnimatedNodesManagerProvider, so we can cleanly initialize it as static default
  -  RCTAnimatedModuleProvider uses the version of AnimatedModule that still relies on a dedicated CADisplayLink for start/stop
  - AnimatedCxxReactPackage also bundles internal ViewEventModule (for NativeViewEvents) that shares `NativeAnimatedNodesManagerProvider` with AnimatedModule, but NativeViewEvents is not needed for open source
    - Alternatively we could also expose `NativeAnimatedNodesManagerProvider` via UIManager so other turbomodules can also use it. However I don't think it makes sense to double down on another animation API on UIManager given we have shared backend.
- This assumes DefaultTurboModules is always the fallback module provider. So it'll not override when app already uses RCTAnimatedModuleProvider or AnimatedCxxReactPackage

## Changelog:

[General] [Added] - Add c++ AnimatedModule to DefaultTurboModules

Differential Revision: D94244698


