### PR TITLE
Allow HermesJSRuntime/HermesRuntimeTargetDelegate to take both jsi::Runtime and HermesRuntime arguments in ctor

### DIFF
--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -265,7 +265,7 @@ HermesExecutor::getRuntimeTargetDelegate() {
   if (!targetDelegate_) {
     targetDelegate_ =
         std::make_unique<jsinspector_modern::HermesRuntimeTargetDelegate>(
-            hermesRuntime_);
+            hermesRuntime_, *hermesRuntime_);
   }
   return *targetDelegate_;
 }

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -29,7 +29,7 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
   /**
    * Creates a HermesRuntimeTargetDelegate for the given runtime.
    */
-  explicit HermesRuntimeTargetDelegate(std::shared_ptr<hermes::HermesRuntime> hermesRuntime);
+  explicit HermesRuntimeTargetDelegate(std::shared_ptr<jsi::Runtime> runtime, hermes::HermesRuntime &hermesRuntime);
 
   ~HermesRuntimeTargetDelegate() override;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
@@ -17,7 +17,7 @@ JsiIntegrationTestHermesEngineAdapter::JsiIntegrationTestHermesEngineAdapter(
                   ::hermes::vm::CompilationMode::ForceLazyCompilation)
               .build())},
       jsExecutor_{jsExecutor},
-      runtimeTargetDelegate_{runtime_} {
+      runtimeTargetDelegate_{runtime_, *runtime_} {
   // NOTE: In React Native, registerForProfiling is called by
   // HermesInstance::unstable_initializeOnJsThread, called from
   // ReactInstance::initializeRuntime. Ideally, we should figure out how to


### PR DESCRIPTION
Summary:
Ideally we only need to pass jsi::Runtime, from which we can cast to
IHermes for Hermes specific interface methods. But in some scenarios
like instrumenting the runtime or tracing JSI calls, the passed runtime
would be a decorator of the actual HermesRuntime, we can't do casting
on the decoration type since it doesn't implement IHermes. So this diff
changes it to pass both a shared_ptr of jsi::Runtime and HermesRuntime
reference. It has no behavioral change.

Changelog: [Internal]

Differential Revision: D94258352


