### PR TITLE
Return null from resolveView for stopped surfaces

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1059,7 +1059,10 @@ public class FabricUIManager
     UiThreadUtil.assertOnUiThread();
 
     SurfaceMountingManager surfaceManager = mMountingManager.getSurfaceManagerForView(reactTag);
-    return surfaceManager == null ? null : surfaceManager.getView(reactTag);
+    if (surfaceManager == null || surfaceManager.isStopped()) {
+      return null;
+    }
+    return surfaceManager.getView(reactTag);
   }
 
   @Override


### PR DESCRIPTION
Summary:
`FabricUIManager.resolveView` can throw `IllegalViewOperationException` when called with a tag belonging to a stopped surface. This happens because `getSurfaceManagerForView` returns a stopped `SurfaceMountingManager` (via `tagSetForStoppedSurface`), but `getView` then throws since `tagToViewState` was cleared during `stopSurface()`.

Add an `isStopped()` check before calling `getView`, returning `null` instead. This follows the same pattern already used by `measure()` and `measureText()` in the same file.

Changelog: [Internal]

Fixes T257147576.

Differential Revision: D94347789


