### PR TITLE
Unify CSSCompoundDataType with its variant

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.cpp
@@ -477,7 +477,7 @@ void fromCSSColorStop(
 }
 
 std::optional<BackgroundImage> fromCSSBackgroundImage(
-    const CSSBackgroundImageVariant& cssBackgroundImage) {
+    const CSSBackgroundImage& cssBackgroundImage) {
   if (std::holds_alternative<CSSLinearGradientFunction>(cssBackgroundImage)) {
     const auto& gradient =
         std::get<CSSLinearGradientFunction>(cssBackgroundImage);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
@@ -108,7 +108,7 @@ parseProcessedFilter(const PropsParserContext &context, const RawValue &value, s
   result = filter;
 }
 
-inline FilterType filterTypeFromVariant(const CSSFilterFunctionVariant &filter)
+inline FilterType filterTypeFromVariant(const CSSFilterFunction &filter)
 {
   return std::visit(
       [](auto &&filter) -> FilterType {
@@ -148,7 +148,7 @@ inline FilterType filterTypeFromVariant(const CSSFilterFunctionVariant &filter)
       filter);
 }
 
-inline std::optional<FilterFunction> fromCSSFilter(const CSSFilterFunctionVariant &cssFilter)
+inline std::optional<FilterFunction> fromCSSFilter(const CSSFilterFunction &cssFilter)
 {
   return std::visit(
       [&](auto &&filter) -> std::optional<FilterFunction> {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -550,7 +550,7 @@ inline ValueUnit cssLengthPercentageToValueUnit(const std::variant<CSSLength, CS
   }
 }
 
-inline std::optional<TransformOperation> fromCSSTransformFunction(const CSSTransformFunctionVariant &cssTransform)
+inline std::optional<TransformOperation> fromCSSTransformFunction(const CSSTransformFunction &cssTransform)
 {
   constexpr auto Zero = ValueUnit(0, UnitType::Point);
   constexpr auto One = ValueUnit(1, UnitType::Point);

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
@@ -846,11 +846,6 @@ static_assert(CSSDataType<CSSLinearGradientFunction>);
 using CSSBackgroundImage = CSSCompoundDataType<CSSLinearGradientFunction, CSSRadialGradientFunction>;
 
 /**
- * Variant of possible CSS background image types
- */
-using CSSBackgroundImageVariant = CSSVariantWithTypes<CSSBackgroundImage>;
-
-/**
  * Representation of <background-image-list>
  */
 using CSSBackgroundImageList = CSSCommaSeparatedList<CSSBackgroundImage>;

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
@@ -308,11 +308,6 @@ using CSSFilterFunction = CSSCompoundDataType<
     CSSSepiaFilter>;
 
 /**
- * Variant of possible CSS filter function types
- */
-using CSSFilterFunctionVariant = CSSVariantWithTypes<CSSFilterFunction>;
-
-/**
  * Representation of <filter-value-list>
  * https://www.w3.org/TR/filter-effects-1/#typedef-filter-value-list
  */

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
@@ -24,7 +24,7 @@ template <CSSDataType AllowedTypeT, CSSDelimiter Delim>
 struct CSSList<AllowedTypeT, Delim> : public std::vector<AllowedTypeT> {};
 
 template <CSSValidCompoundDataType AllowedTypesT, CSSDelimiter Delim>
-struct CSSList<AllowedTypesT, Delim> : public std::vector<CSSVariantWithTypes<AllowedTypesT>> {};
+struct CSSList<AllowedTypesT, Delim> : public std::vector<AllowedTypesT> {};
 
 template <CSSMaybeCompoundDataType AllowedTypeT, CSSDelimiter Delim>
 struct CSSDataTypeParser<CSSList<AllowedTypeT, Delim>> {

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
@@ -453,11 +453,6 @@ using CSSTransformFunction = CSSCompoundDataType<
     CSSPerspective>;
 
 /**
- * Variant of possible CSS transform function types
- */
-using CSSTransformFunctionVariant = CSSVariantWithTypes<CSSTransformFunction>;
-
-/**
  * Represents the <transform-list> type.
  * https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
  */

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -33,7 +33,7 @@ class CSSValueParser {
   template <CSSDataType... AllowedTypesT>
   constexpr std::variant<std::monostate, AllowedTypesT...> consumeValue(
       CSSDelimiter delimeter,
-      CSSCompoundDataType<AllowedTypesT...> /*unused*/)
+      std::variant<AllowedTypesT...> /*unused*/)
   {
     using ReturnT = std::variant<std::monostate, AllowedTypesT...>;
 


### PR DESCRIPTION
Summary:
Previously, CSS compound data types used two separate types:
`CSSCompoundDataType<T1, T2, ...>` as an empty marker struct for template
parameter deduction, and `CSSVariantWithTypes<CSSCompoundDataType<T1, T2, ...>>`
which resolved to `std::variant<T1, T2, ...>` for actual storage. This resulted
in redundant type aliases like `CSSTransformFunctionVariant`.

This change makes `CSSCompoundDataType<T1, T2, ...>` a `using` alias for
`std::variant<T1, T2, ...>` directly, so one type serves both roles: template
parameter deduction for parsing AND storage.

- Change `CSSCompoundDataType` from a marker struct to a `using` alias for
  `std::variant`
- Replace `CSSValidCompoundDataType` concept with `is_variant_of_data_types`
  trait that pattern-matches `std::variant` where all types satisfy `CSSDataType`
- Update `merge_data_types` and `merge_variant` specializations to use
  `std::variant` directly
- Store `AllowedTypesT` directly in `CSSList` compound type specialization
  (since it IS now the variant)
- Remove redundant `CSSTransformFunctionVariant`, `CSSFilterFunctionVariant`,
  and `CSSBackgroundImageVariant` aliases
- Update all downstream references in conversions

Changelog: [Internal]

Differential Revision: D94347088


