### PR TITLE
Fix visibility of DevSupportHttpClient by extracting DevSupportRequestHeaders

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2184,6 +2184,13 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun onResume ()V
 }
 
+public final class com/facebook/react/devsupport/interfaces/DevSupportRequestHeaders {
+	public static final field INSTANCE Lcom/facebook/react/devsupport/interfaces/DevSupportRequestHeaders;
+	public static final fun addRequestHeader (Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun allHeaders ()Ljava/util/Map;
+	public static final fun removeRequestHeader (Ljava/lang/String;)V
+}
+
 public abstract interface class com/facebook/react/devsupport/interfaces/ErrorCustomizer {
 	public abstract fun customizeErrorInfo (Landroid/util/Pair;)Landroid/util/Pair;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportRequestHeaders.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportRequestHeaders.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.interfaces
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Thread-safe singleton for registering custom HTTP headers that will be applied to all React
+ * Native dev-support network traffic (bundle fetches, packager status checks, inspector
+ * connections, HMR WebSocket upgrades).
+ *
+ * Headers are stored globally and survive across React Host re-creations, so they can be set before
+ * the first app load.
+ */
+public object DevSupportRequestHeaders {
+
+  private val headers = ConcurrentHashMap<String, String>()
+
+  /** Adds (or replaces) a custom request header. */
+  @JvmStatic
+  public fun addRequestHeader(name: String, value: String) {
+    headers[name] = value
+  }
+
+  /** Removes a previously added custom request header. */
+  @JvmStatic
+  public fun removeRequestHeader(name: String) {
+    headers.remove(name)
+  }
+
+  /** Returns a snapshot of all currently registered headers. */
+  @JvmStatic public fun allHeaders(): Map<String, String> = HashMap(headers)
+}


### PR DESCRIPTION
Summary:
Extract header management from the `internal` `DevSupportHttpClient` into a new
public `DevSupportRequestHeaders` singleton in `devsupport.interfaces`. This
allows external consumers (e.g. Expo Dev Launcher) to register custom HTTP
headers that will be applied to all React Native dev-support network traffic
without depending on internal APIs.

`DevSupportHttpClient` now delegates to `DevSupportRequestHeaders.allHeaders()`
instead of maintaining its own `ConcurrentHashMap`.

A separate `request_headers` Buck target is introduced to avoid a dependency
cycle (`bridge` → `inspector` → `interfaces` → `bridge`).

Changelog: [Android][Added] - Public DevSupportRequestHeaders API for registering custom dev-support HTTP headers

Differential Revision: D94354168


