### PR TITLE
Add UIManagerViewTransitionDelegate interface and View Transition APIs

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -488,6 +488,10 @@ void UIManager::sendAccessibilityEvent(
   }
 }
 
+UIManagerViewTransitionDelegate* UIManager::getViewTransitionDelegate() const {
+  return viewTransitionDelegate_;
+}
+
 void UIManager::configureNextLayoutAnimation(
     jsi::Runtime& runtime,
     const RawValue& config,
@@ -706,6 +710,13 @@ void UIManager::stopSurfaceForAnimationDelegate(SurfaceId surfaceId) const {
 void UIManager::setNativeAnimatedDelegate(
     std::weak_ptr<UIManagerNativeAnimatedDelegate> delegate) {
   nativeAnimatedDelegate_ = delegate;
+}
+
+void UIManager::setViewTransitionDelegate(
+    UIManagerViewTransitionDelegate* delegate) {
+  if (ReactNativeFeatureFlags::viewTransitionEnabled()) {
+    viewTransitionDelegate_ = delegate;
+  }
 }
 
 void UIManager::unstable_setAnimationBackend(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -27,6 +27,7 @@
 #include <react/renderer/uimanager/UIManagerAnimationDelegate.h>
 #include <react/renderer/uimanager/UIManagerDelegate.h>
 #include <react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h>
+#include <react/renderer/uimanager/UIManagerViewTransitionDelegate.h>
 #include <react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/uimanager/consistency/ShadowTreeRevisionProvider.h>
 #include <react/renderer/uimanager/primitives.h>
@@ -73,6 +74,12 @@ class UIManager final : public ShadowTreeDelegate {
   void stopSurfaceForAnimationDelegate(SurfaceId surfaceId) const;
 
   void setNativeAnimatedDelegate(std::weak_ptr<UIManagerNativeAnimatedDelegate> delegate);
+
+  /**
+   * Sets and gets UIManager's ViewTransition API delegate.
+   */
+  void setViewTransitionDelegate(UIManagerViewTransitionDelegate *delegate);
+  UIManagerViewTransitionDelegate *getViewTransitionDelegate() const;
 
   void animationTick() const;
 
@@ -242,6 +249,7 @@ class UIManager final : public ShadowTreeDelegate {
   UIManagerDelegate *delegate_{};
   UIManagerAnimationDelegate *animationDelegate_{nullptr};
   std::weak_ptr<UIManagerNativeAnimatedDelegate> nativeAnimatedDelegate_;
+  UIManagerViewTransitionDelegate *viewTransitionDelegate_{nullptr};
 
   const RuntimeExecutor runtimeExecutor_{};
   ShadowTreeRegistry shadowTreeRegistry_{};

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -876,6 +876,265 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
+  if (methodName == "measureInstance") {
+    auto paramCount = 1;
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        paramCount,
+        [uiManager, methodName, paramCount](
+            jsi::Runtime& runtime,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* arguments,
+            size_t count) -> jsi::Value {
+          validateArgumentCount(runtime, methodName, paramCount, count);
+
+          if (!arguments[0].isObject()) {
+            auto result = jsi::Object(runtime);
+            result.setProperty(runtime, "x", 0);
+            result.setProperty(runtime, "y", 0);
+            result.setProperty(runtime, "width", 0);
+            result.setProperty(runtime, "height", 0);
+            return result;
+          }
+
+          auto shadowNode = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[0]);
+
+          auto currentRevision =
+              uiManager->getShadowTreeRevisionProvider()->getCurrentRevision(
+                  shadowNode->getSurfaceId());
+
+          if (currentRevision == nullptr) {
+            auto result = jsi::Object(runtime);
+            result.setProperty(runtime, "x", 0);
+            result.setProperty(runtime, "y", 0);
+            result.setProperty(runtime, "width", 0);
+            result.setProperty(runtime, "height", 0);
+            return result;
+          }
+
+          auto domRect = dom::getBoundingClientRect(
+              currentRevision, *shadowNode, true /* includeTransform */);
+
+          auto result = jsi::Object(runtime);
+          result.setProperty(runtime, "x", domRect.x);
+          result.setProperty(runtime, "y", domRect.y);
+          result.setProperty(runtime, "width", domRect.width);
+          result.setProperty(runtime, "height", domRect.height);
+
+          auto* viewTransitionDelegate = uiManager->getViewTransitionDelegate();
+          if (viewTransitionDelegate != nullptr) {
+            viewTransitionDelegate->captureLayoutMetricsFromRoot(shadowNode);
+          }
+
+          return result;
+        });
+  }
+
+  if (methodName == "applyViewTransitionName") {
+    auto paramCount = 3;
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        paramCount,
+        [uiManager, methodName, paramCount](
+            jsi::Runtime& runtime,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* arguments,
+            size_t count) -> jsi::Value {
+          validateArgumentCount(runtime, methodName, paramCount, count);
+
+          if (arguments[0].isObject()) {
+            auto shadowNode =
+                Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                    runtime, arguments[0]);
+            auto transitionName = arguments[1].isString()
+                ? stringFromValue(runtime, arguments[1])
+                : "";
+            auto className = arguments[2].isString()
+                ? stringFromValue(runtime, arguments[2])
+                : "";
+            if (!transitionName.empty()) {
+              auto* viewTransitionDelegate =
+                  uiManager->getViewTransitionDelegate();
+              if (viewTransitionDelegate != nullptr) {
+                viewTransitionDelegate->applyViewTransitionName(
+                    shadowNode, transitionName, className);
+              }
+            }
+          }
+
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (methodName == "cancelViewTransitionName") {
+    auto paramCount = 2;
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        paramCount,
+        [uiManager, methodName, paramCount](
+            jsi::Runtime& runtime,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* arguments,
+            size_t count) -> jsi::Value {
+          validateArgumentCount(runtime, methodName, paramCount, count);
+
+          if (arguments[0].isObject()) {
+            auto shadowNode =
+                Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                    runtime, arguments[0]);
+            auto transitionName = arguments[1].isString()
+                ? stringFromValue(runtime, arguments[1])
+                : "";
+            if (!transitionName.empty()) {
+              auto* viewTransitionDelegate =
+                  uiManager->getViewTransitionDelegate();
+              if (viewTransitionDelegate != nullptr) {
+                viewTransitionDelegate->cancelViewTransitionName(
+                    shadowNode, transitionName);
+              }
+            }
+          }
+
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (methodName == "restoreViewTransitionName") {
+    auto paramCount = 1;
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        paramCount,
+        [uiManager, methodName, paramCount](
+            jsi::Runtime& runtime,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* arguments,
+            size_t count) -> jsi::Value {
+          validateArgumentCount(runtime, methodName, paramCount, count);
+
+          if (arguments[0].isObject()) {
+            auto shadowNode =
+                Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                    runtime, arguments[0]);
+            auto* viewTransitionDelegate =
+                uiManager->getViewTransitionDelegate();
+            if (viewTransitionDelegate != nullptr) {
+              viewTransitionDelegate->restoreViewTransitionName(shadowNode);
+            }
+          }
+
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (methodName == "startViewTransition") {
+    auto paramCount = 1;
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        paramCount,
+        [uiManager, methodName, paramCount](
+            jsi::Runtime& runtime,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* arguments,
+            size_t count) -> jsi::Value {
+          validateArgumentCount(runtime, methodName, paramCount, count);
+
+          auto* viewTransitionDelegate = uiManager->getViewTransitionDelegate();
+          if (viewTransitionDelegate == nullptr) {
+            return jsi::Value::undefined();
+          }
+
+          auto promiseConstructor =
+              runtime.global().getPropertyAsFunction(runtime, "Promise");
+
+          auto readyResolveFunc =
+              std::make_shared<std::shared_ptr<jsi::Function>>();
+          auto finishedResolveFunc =
+              std::make_shared<std::shared_ptr<jsi::Function>>();
+
+          auto mutationFunc = std::make_shared<jsi::Function>(
+              arguments[0].asObject(runtime).asFunction(runtime));
+
+          auto readyPromise = promiseConstructor.callAsConstructor(
+              runtime,
+              jsi::Function::createFromHostFunction(
+                  runtime,
+                  jsi::PropNameID::forAscii(runtime, "readyExecutor"),
+                  2,
+                  [readyResolveFunc](
+                      jsi::Runtime& runtime,
+                      const jsi::Value& /*thisValue*/,
+                      const jsi::Value* args,
+                      size_t /*count*/) -> jsi::Value {
+                    auto onReadyFunc = std::make_shared<jsi::Function>(
+                        args[0].asObject(runtime).asFunction(runtime));
+                    *readyResolveFunc = onReadyFunc;
+                    return jsi::Value::undefined();
+                  }));
+
+          auto finishedPromise = promiseConstructor.callAsConstructor(
+              runtime,
+              jsi::Function::createFromHostFunction(
+                  runtime,
+                  jsi::PropNameID::forAscii(runtime, "finishedExecutor"),
+                  2,
+                  [finishedResolveFunc, viewTransitionDelegate](
+                      jsi::Runtime& rt,
+                      const jsi::Value& /*thisValue*/,
+                      const jsi::Value* args,
+                      size_t /*count*/) -> jsi::Value {
+                    auto onCompleteFunc = std::make_shared<jsi::Function>(
+                        args[0].asObject(rt).asFunction(rt));
+                    *finishedResolveFunc = std::make_shared<jsi::Function>(
+                        jsi::Function::createFromHostFunction(
+                            rt,
+                            jsi::PropNameID::forAscii(rt, "finishedResolve"),
+                            0,
+                            [onCompleteFunc, viewTransitionDelegate](
+                                jsi::Runtime& runtime,
+                                const jsi::Value& /*thisValue*/,
+                                const jsi::Value* /*args*/,
+                                size_t /*count*/) -> jsi::Value {
+                              onCompleteFunc->call(runtime);
+                              viewTransitionDelegate->startViewTransitionEnd();
+                              return jsi::Value::undefined();
+                            }));
+                    return jsi::Value::undefined();
+                  }));
+
+          auto result = jsi::Object(runtime);
+          result.setProperty(runtime, "ready", std::move(readyPromise));
+          result.setProperty(runtime, "finished", std::move(finishedPromise));
+
+          viewTransitionDelegate->startViewTransition(
+              [&runtime, mutationFunc = std::move(mutationFunc)]() {
+                mutationFunc->call(runtime);
+              },
+              [readyResolveFunc = std::move(readyResolveFunc), &runtime]() {
+                if (*readyResolveFunc) {
+                  (*readyResolveFunc)->call(runtime);
+                }
+              },
+              [finishedResolveFunc = std::move(finishedResolveFunc),
+               uiManager]() {
+                uiManager->runtimeExecutor_(
+                    [finishedResolveFunc = std::move(finishedResolveFunc)](
+                        jsi::Runtime& rt) mutable {
+                      if (*finishedResolveFunc) {
+                        (*finishedResolveFunc)->call(rt);
+                      }
+                    });
+              });
+
+          return jsi::Value(runtime, result);
+        });
+  }
+
   return jsi::Value::undefined();
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerViewTransitionDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerViewTransitionDelegate.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/core/ShadowNode.h>
+#include <functional>
+
+namespace facebook::react {
+
+class UIManagerViewTransitionDelegate {
+ public:
+  virtual ~UIManagerViewTransitionDelegate() = default;
+
+  virtual void applyViewTransitionName(
+      const std::shared_ptr<const ShadowNode> &shadowNode,
+      const std::string &name,
+      const std::string &className)
+  {
+  }
+
+  virtual void cancelViewTransitionName(const std::shared_ptr<const ShadowNode> &shadowNode, const std::string &name) {}
+
+  virtual void restoreViewTransitionName(const std::shared_ptr<const ShadowNode> &shadowNode) {}
+
+  virtual void captureLayoutMetricsFromRoot(const std::shared_ptr<const ShadowNode> &shadowNode) {}
+
+  virtual void startViewTransition(
+      std::function<void()> mutationCallback,
+      std::function<void()> onReadyCallback,
+      std::function<void()> onCompleteCallback)
+  {
+  }
+
+  virtual void startViewTransitionEnd() {}
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog:
[General] [Added] - Add UIManagerViewTransitionDelegate interface and View Transition APIs

Adds `UIManagerViewTransitionDelegate` interface and View Transition APIs to UIManager, enabling integration with React reconciler's `<ViewTransition/>` component. 

Exposes JSI bindings in UIManagerBinding, which will be consumed by react fabric renderer (https://github.com/facebook/react/pull/35764)
- `measureInstance` - returns layout metrics and calls `captureLayoutMetricsFromRoot` to capture snapshot
- `applyViewTransitionName` / `cancelViewTransitionName` / `restoreViewTransitionName` - manage transition name registration
- `startViewTransition` - orchestrates transition lifecycle with mutation/ready/complete callbacks

The delegate methods are gated by the `viewTransitionEnabled` feature flag.

Reviewed By: sammy-SC

Differential Revision: D92537193


