### PR TITLE
Add headers validation check to prevent crash

### DIFF
--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
@@ -94,8 +94,23 @@ RCT_EXPORT_METHOD(
   // Load supplied headers
   if ([options.headers() isKindOfClass:NSDictionary.class]) {
     NSDictionary *headers = (NSDictionary *)options.headers();
-    [headers enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
-      [request addValue:[RCTConvert NSString:value] forHTTPHeaderField:key];
+    [headers enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+      NSString *headerKey = [RCTConvert NSString:key];
+      NSString *headerValue = [RCTConvert NSString:value];
+
+      if (headerKey == nil || headerValue == nil) {
+        RCTLogError(
+            @"RCTWebSocketModule: Invalid header key and/or value types. "
+             "Expected NSString for both, got key of type %@ and value of type %@.",
+            NSStringFromClass([key class]),
+            NSStringFromClass([value class]));
+      }
+
+      if (headerKey == nil) {
+        return;
+      }
+
+      [request addValue:headerValue == nil ? @"" : headerValue forHTTPHeaderField:headerKey];
     }];
   }
 


### PR DESCRIPTION
Summary:
Add defensive checks when processing custom headers to ensure:
1. Header keys are valid NSString instances before using them
2. Header values are successfully converted before adding to the request

This prevents potential crashes when invalid header data (non-string keys or values that fail conversion) is passed from JavaScript to the WebSocket module.

Changelog: [Internal]

Differential Revision: D94375533


