### PR TITLE
Default operator== definitions in react-native-github

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
@@ -25,11 +25,7 @@ class ScrollViewMaintainVisibleContentPosition final {
   int minIndexForVisible{0};
   std::optional<int> autoscrollToTopThreshold{};
 
-  bool operator==(const ScrollViewMaintainVisibleContentPosition &rhs) const
-  {
-    return std::tie(this->minIndexForVisible, this->autoscrollToTopThreshold) ==
-        std::tie(rhs.minIndexForVisible, rhs.autoscrollToTopThreshold);
-  }
+  bool operator==(const ScrollViewMaintainVisibleContentPosition &rhs) const = default;
 
   bool operator!=(const ScrollViewMaintainVisibleContentPosition &rhs) const
   {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -183,35 +183,7 @@ struct CascadedRectangleEdges {
     };
   }
 
-  bool operator==(const CascadedRectangleEdges<T> &rhs) const
-  {
-    return std::tie(
-               this->left,
-               this->top,
-               this->right,
-               this->bottom,
-               this->start,
-               this->end,
-               this->horizontal,
-               this->vertical,
-               this->all,
-               this->block,
-               this->blockStart,
-               this->blockEnd) ==
-        std::tie(
-               rhs.left,
-               rhs.top,
-               rhs.right,
-               rhs.bottom,
-               rhs.start,
-               rhs.end,
-               rhs.horizontal,
-               rhs.vertical,
-               rhs.all,
-               rhs.block,
-               rhs.blockStart,
-               rhs.blockEnd);
-  }
+  bool operator==(const CascadedRectangleEdges<T> &rhs) const = default;
 
   bool operator!=(const CascadedRectangleEdges<T> &rhs) const
   {
@@ -261,37 +233,7 @@ struct CascadedRectangleCorners {
     };
   }
 
-  bool operator==(const CascadedRectangleCorners<T> &rhs) const
-  {
-    return std::tie(
-               this->topLeft,
-               this->topRight,
-               this->bottomLeft,
-               this->bottomRight,
-               this->topStart,
-               this->topEnd,
-               this->bottomStart,
-               this->bottomEnd,
-               this->all,
-               this->endEnd,
-               this->endStart,
-               this->startEnd,
-               this->startStart) ==
-        std::tie(
-               rhs.topLeft,
-               rhs.topRight,
-               rhs.bottomLeft,
-               rhs.bottomRight,
-               rhs.topStart,
-               rhs.topEnd,
-               rhs.bottomStart,
-               rhs.bottomEnd,
-               rhs.all,
-               rhs.endEnd,
-               rhs.endStart,
-               rhs.startEnd,
-               rhs.startStart);
-  }
+  bool operator==(const CascadedRectangleCorners<T> &rhs) const = default;
 
   bool operator!=(const CascadedRectangleCorners<T> &rhs) const
   {
@@ -318,12 +260,7 @@ struct BorderMetrics {
   BorderCurves borderCurves{};
   BorderStyles borderStyles{};
 
-  bool operator==(const BorderMetrics &rhs) const
-  {
-    return std::tie(
-               this->borderColors, this->borderWidths, this->borderRadii, this->borderCurves, this->borderStyles) ==
-        std::tie(rhs.borderColors, rhs.borderWidths, rhs.borderRadii, rhs.borderCurves, rhs.borderStyles);
-  }
+  bool operator==(const BorderMetrics &rhs) const = default;
 
   bool operator!=(const BorderMetrics &rhs) const
   {

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
@@ -169,10 +169,7 @@ static_assert(CSSDataType<CSSLinearGradientDirection>);
 struct CSSColorHint {
   std::variant<CSSLength, CSSPercentage> position{}; // Support both lengths and percentages
 
-  bool operator==(const CSSColorHint &rhs) const
-  {
-    return position == rhs.position;
-  }
+  bool operator==(const CSSColorHint &rhs) const = default;
 };
 
 template <>
@@ -423,10 +420,7 @@ struct CSSRadialGradientPosition {
   std::optional<std::variant<CSSLength, CSSPercentage>> left{};
   std::optional<std::variant<CSSLength, CSSPercentage>> right{};
 
-  bool operator==(const CSSRadialGradientPosition &rhs) const
-  {
-    return top == rhs.top && bottom == rhs.bottom && left == rhs.left && right == rhs.right;
-  }
+  bool operator==(const CSSRadialGradientPosition &rhs) const = default;
 };
 
 struct CSSRadialGradientFunction {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
@@ -31,10 +31,7 @@ struct GradientDirection {
   GradientDirectionType type;
   std::variant<Float, GradientKeyword> value;
 
-  bool operator==(const GradientDirection &other) const
-  {
-    return type == other.type && value == other.value;
-  }
+  bool operator==(const GradientDirection &other) const = default;
 
 #ifdef RN_SERIALIZABLE_STATE
   folly::dynamic toDynamic() const;
@@ -45,10 +42,7 @@ struct LinearGradient {
   GradientDirection direction;
   std::vector<ColorStop> colorStops;
 
-  bool operator==(const LinearGradient &other) const
-  {
-    return direction == other.direction && colorStops == other.colorStops;
-  }
+  bool operator==(const LinearGradient &other) const = default;
 
 #ifdef RN_SERIALIZABLE_STATE
   folly::dynamic toDynamic() const;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RadialGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RadialGradient.h
@@ -31,10 +31,7 @@ struct RadialGradientSize {
     ValueUnit x;
     ValueUnit y;
 
-    bool operator==(const Dimensions &other) const
-    {
-      return x == other.x && y == other.y;
-    }
+    bool operator==(const Dimensions &other) const = default;
 
     bool operator!=(const Dimensions &other) const
     {
@@ -48,10 +45,7 @@ struct RadialGradientSize {
 
   std::variant<SizeKeyword, Dimensions> value;
 
-  bool operator==(const RadialGradientSize &other) const
-  {
-    return value == other.value;
-  }
+  bool operator==(const RadialGradientSize &other) const = default;
 
   bool operator!=(const RadialGradientSize &other) const
   {
@@ -69,10 +63,7 @@ struct RadialGradientPosition {
   std::optional<ValueUnit> right;
   std::optional<ValueUnit> bottom;
 
-  bool operator==(const RadialGradientPosition &other) const
-  {
-    return top == other.top && left == other.left && right == other.right && bottom == other.bottom;
-  }
+  bool operator==(const RadialGradientPosition &other) const = default;
 
   bool operator!=(const RadialGradientPosition &other) const
   {
@@ -90,10 +81,7 @@ struct RadialGradient {
   RadialGradientPosition position;
   std::vector<ColorStop> colorStops;
 
-  bool operator==(const RadialGradient &other) const
-  {
-    return shape == other.shape && size == other.size && position == other.position && colorStops == other.colorStops;
-  }
+  bool operator==(const RadialGradient &other) const = default;
   bool operator!=(const RadialGradient &other) const
   {
     return !(*this == other);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
@@ -24,10 +24,7 @@ struct Rect {
   Point origin{.x = 0, .y = 0};
   Size size{.width = 0, .height = 0};
 
-  bool operator==(const Rect &rhs) const noexcept
-  {
-    return std::tie(this->origin, this->size) == std::tie(rhs.origin, rhs.size);
-  }
+  bool operator==(const Rect &rhs) const noexcept = default;
 
   bool operator!=(const Rect &rhs) const noexcept
   {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
@@ -25,11 +25,7 @@ struct RectangleCorners {
   T bottomLeft{};
   T bottomRight{};
 
-  bool operator==(const RectangleCorners<T> &rhs) const noexcept
-  {
-    return std::tie(this->topLeft, this->topRight, this->bottomLeft, this->bottomRight) ==
-        std::tie(rhs.topLeft, rhs.topRight, rhs.bottomLeft, rhs.bottomRight);
-  }
+  bool operator==(const RectangleCorners<T> &rhs) const noexcept = default;
 
   bool operator!=(const RectangleCorners<T> &rhs) const noexcept
   {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
@@ -26,11 +26,7 @@ struct RectangleEdges {
   T right{};
   T bottom{};
 
-  bool operator==(const RectangleEdges<T> &rhs) const noexcept
-  {
-    return std::tie(this->left, this->top, this->right, this->bottom) ==
-        std::tie(rhs.left, rhs.top, rhs.right, rhs.bottom);
-  }
+  bool operator==(const RectangleEdges<T> &rhs) const noexcept = default;
 
   bool operator!=(const RectangleEdges<T> &rhs) const noexcept
   {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -49,10 +49,7 @@ struct TransformOrigin {
   std::array<ValueUnit, 2> xy = {ValueUnit(0.0f, UnitType::Undefined), ValueUnit(0.0f, UnitType::Undefined)};
   float z = 0.0f;
 
-  bool operator==(const TransformOrigin &other) const
-  {
-    return xy[0] == other.xy[0] && xy[1] == other.xy[1] && z == other.z;
-  }
+  bool operator==(const TransformOrigin &other) const = default;
   bool operator!=(const TransformOrigin &other) const
   {
     return !(*this == other);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
@@ -29,10 +29,7 @@ struct ValueUnit {
   constexpr ValueUnit() = default;
   constexpr ValueUnit(float v, UnitType u) : value(v), unit(u) {}
 
-  constexpr bool operator==(const ValueUnit &other) const
-  {
-    return value == other.value && unit == other.unit;
-  }
+  constexpr bool operator==(const ValueUnit &other) const = default;
 
   constexpr bool operator!=(const ValueUnit &other) const
   {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
@@ -62,37 +62,7 @@ class ImageRequestParams {
   std::string analyticTag{};
   Size size{};
 
-  bool operator==(const ImageRequestParams &rhs) const
-  {
-    return std::tie(
-               this->blurRadius,
-               this->defaultSource,
-               this->resizeMode,
-               this->resizeMethod,
-               this->resizeMultiplier,
-               this->shouldNotifyLoadEvents,
-               this->overlayColor,
-               this->tintColor,
-               this->fadeDuration,
-               this->progressiveRenderingEnabled,
-               this->loadingIndicatorSource,
-               this->analyticTag,
-               this->size) ==
-        std::tie(
-               rhs.blurRadius,
-               rhs.defaultSource,
-               rhs.resizeMode,
-               rhs.resizeMethod,
-               rhs.resizeMultiplier,
-               rhs.shouldNotifyLoadEvents,
-               rhs.overlayColor,
-               rhs.tintColor,
-               rhs.fadeDuration,
-               rhs.progressiveRenderingEnabled,
-               rhs.loadingIndicatorSource,
-               rhs.analyticTag,
-               rhs.size);
-  }
+  bool operator==(const ImageRequestParams &rhs) const = default;
 
   bool operator!=(const ImageRequestParams &rhs) const
   {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequestParams.h
@@ -18,10 +18,7 @@ class ImageRequestParams {
 
   Float blurRadius{};
 
-  bool operator==(const ImageRequestParams &rhs) const
-  {
-    return this->blurRadius == rhs.blurRadius;
-  }
+  bool operator==(const ImageRequestParams &rhs) const = default;
 
   bool operator!=(const ImageRequestParams &rhs) const
   {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequestParams.h
@@ -18,10 +18,7 @@ class ImageRequestParams {
 
   Float blurRadius{};
 
-  bool operator==(const ImageRequestParams &rhs) const
-  {
-    return this->blurRadius == rhs.blurRadius;
-  }
+  bool operator==(const ImageRequestParams &rhs) const = default;
 
   bool operator!=(const ImageRequestParams &rhs) const
   {


### PR DESCRIPTION
Summary:
Replace explicit `operator==` implementations with `= default` where the
operator performs simple memberwise comparison of all data members. The
compiler-generated defaulted operator is equivalent but less error-prone
and easier to maintain as members are added or removed.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D94371201


