### PR TITLE
Fix asan/tsan env options handling

### DIFF
--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -70,7 +70,7 @@ export function getBuckModesForPlatform(
       });
     }
   } else {
-    if (EnvironmentOptions.enableASAN) {
+    if (EnvironmentOptions.enableASAN && EnvironmentOptions.enableTSAN) {
       printConsoleLog({
         type: 'console-log',
         level: 'warn',


### PR DESCRIPTION
Summary:
The warning "ASAN and TSAN modes cannot be used together" was incorrectly displayed when only ASAN was enabled. This happened because the condition checked only `enableASAN` instead of `enableASAN && enableTSAN`. Updated the conditional logic to properly check that both flags are enabled before showing the conflict warning.

Changelog: [Internal]

Differential Revision: D94393117


