### PR TITLE
Replace CSSSyntaxParser with CSSValueParser in data type sinks

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.cpp
@@ -477,7 +477,7 @@ void fromCSSColorStop(
 }
 
 std::optional<BackgroundImage> fromCSSBackgroundImage(
-    const CSSBackgroundImageVariant& cssBackgroundImage) {
+    const CSSBackgroundImage& cssBackgroundImage) {
   if (std::holds_alternative<CSSLinearGradientFunction>(cssBackgroundImage)) {
     const auto& gradient =
         std::get<CSSLinearGradientFunction>(cssBackgroundImage);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
@@ -108,7 +108,7 @@ parseProcessedFilter(const PropsParserContext &context, const RawValue &value, s
   result = filter;
 }
 
-inline FilterType filterTypeFromVariant(const CSSFilterFunctionVariant &filter)
+inline FilterType filterTypeFromVariant(const CSSFilterFunction &filter)
 {
   return std::visit(
       [](auto &&filter) -> FilterType {
@@ -148,7 +148,7 @@ inline FilterType filterTypeFromVariant(const CSSFilterFunctionVariant &filter)
       filter);
 }
 
-inline std::optional<FilterFunction> fromCSSFilter(const CSSFilterFunctionVariant &cssFilter)
+inline std::optional<FilterFunction> fromCSSFilter(const CSSFilterFunction &cssFilter)
 {
   return std::visit(
       [&](auto &&filter) -> std::optional<FilterFunction> {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -550,7 +550,7 @@ inline ValueUnit cssLengthPercentageToValueUnit(const std::variant<CSSLength, CS
   }
 }
 
-inline std::optional<TransformOperation> fromCSSTransformFunction(const CSSTransformFunctionVariant &cssTransform)
+inline std::optional<TransformOperation> fromCSSTransformFunction(const CSSTransformFunction &cssTransform)
 {
   constexpr auto Zero = ValueUnit(0, UnitType::Point);
   constexpr auto One = ValueUnit(1, UnitType::Point);

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
@@ -846,11 +846,6 @@ static_assert(CSSDataType<CSSLinearGradientFunction>);
 using CSSBackgroundImage = CSSCompoundDataType<CSSLinearGradientFunction, CSSRadialGradientFunction>;
 
 /**
- * Variant of possible CSS background image types
- */
-using CSSBackgroundImageVariant = CSSVariantWithTypes<CSSBackgroundImage>;
-
-/**
  * Representation of <background-image-list>
  */
 using CSSBackgroundImageList = CSSCommaSeparatedList<CSSBackgroundImage>;

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSColor.h
@@ -47,7 +47,7 @@ struct CSSDataTypeParser<CSSColor> {
     return {};
   }
 
-  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSSyntaxParser &parser)
+  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSValueParser &parser)
       -> std::optional<CSSColor>
   {
     return parseCSSColorFunction<CSSColor>(func.name, parser);

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSDataType.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSDataType.h
@@ -16,6 +16,8 @@
 
 namespace facebook::react {
 
+class CSSValueParser;
+
 /**
  * May be specialized to instruct the CSS value parser how to parse a given data
  * type, according to CSSValidDataTypeParser.
@@ -24,26 +26,28 @@ template <typename CSSDataTypeT>
 struct CSSDataTypeParser {};
 
 /**
- * Accepts a CSS function block and may parse it (and future syntax) into a
- * concrete representation.
+ * Accepts a CSS function block and may parse it into a concrete representation.
+ * The CSSValueParser provides methods for parsing sub-values within the
+ * function block scope.
  */
 template <typename T, typename ReturnT = std::any>
-concept CSSFunctionBlockSink = requires(const CSSFunctionBlock &func, CSSSyntaxParser &parser) {
+concept CSSFunctionBlockSink = requires(const CSSFunctionBlock &func, CSSValueParser &parser) {
   { T::consumeFunctionBlock(func, parser) } -> std::convertible_to<ReturnT>;
 };
 
 /**
- * Accepts a CSS simple block and may parse it (and future syntax) into a
- * concrete representation.
+ * Accepts a CSS simple block and may parse it into a concrete representation.
+ * The CSSValueParser provides methods for parsing sub-values within the
+ * block scope.
  */
 template <typename T, typename ReturnT = std::any>
-concept CSSSimpleBlockSink = requires(const CSSSimpleBlock &block, CSSSyntaxParser &parser) {
+concept CSSSimpleBlockSink = requires(const CSSSimpleBlock &block, CSSValueParser &parser) {
   { T::consumeSimpleBlock(block, parser) } -> std::convertible_to<ReturnT>;
 };
 
 /**
- * Accepts a CSS preserved token and may parse it (and future syntax) into a
- * concrete representation.
+ * Accepts a CSS preserved token and may parse it into a concrete
+ * representation.
  */
 template <typename T, typename ReturnT = std::any>
 concept CSSPreservedTokenSink = requires(const CSSPreservedToken &token) {
@@ -51,10 +55,11 @@ concept CSSPreservedTokenSink = requires(const CSSPreservedToken &token) {
 };
 
 /**
- * Accepts a raw syntax parser, to be able to parse compounded values
+ * Accepts a CSSValueParser to be able to parse compounded values spanning
+ * multiple component values.
  */
 template <typename T, typename ReturnT = std::any>
-concept CSSParserSink = requires(CSSSyntaxParser &parser) {
+concept CSSParserSink = requires(CSSValueParser &parser) {
   { T::consume(parser) } -> std::convertible_to<ReturnT>;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
@@ -308,11 +308,6 @@ using CSSFilterFunction = CSSCompoundDataType<
     CSSSepiaFilter>;
 
 /**
- * Variant of possible CSS filter function types
- */
-using CSSFilterFunctionVariant = CSSVariantWithTypes<CSSFilterFunction>;
-
-/**
  * Representation of <filter-value-list>
  * https://www.w3.org/TR/filter-effects-1/#typedef-filter-value-list
  */

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
@@ -28,14 +28,14 @@ namespace detail {
 template <typename DataT, TemplateStringLiteral Name>
   requires(std::is_same_v<decltype(DataT::amount), float>)
 struct CSSFilterSimpleAmountParser {
-  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSSyntaxParser &parser)
+  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSValueParser &parser)
       -> std::optional<DataT>
   {
     if (!iequals(func.name, Name)) {
       return {};
     }
 
-    auto amount = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+    auto amount = parser.parseNextValue<CSSNumber, CSSPercentage>();
     if (std::holds_alternative<CSSNumber>(amount)) {
       if (std::get<CSSNumber>(amount).value < 0.0f) {
         return {};
@@ -65,14 +65,14 @@ struct CSSBlurFilter {
 
 template <>
 struct CSSDataTypeParser<CSSBlurFilter> {
-  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSSyntaxParser &parser)
+  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSValueParser &parser)
       -> std::optional<CSSBlurFilter>
   {
     if (!iequals(func.name, "blur")) {
       return {};
     }
 
-    auto len = parseNextCSSValue<CSSLength>(parser);
+    auto len = parser.parseNextValue<CSSLength>();
     return CSSBlurFilter{std::holds_alternative<CSSLength>(len) ? std::get<CSSLength>(len) : CSSLength{}};
   }
 };
@@ -123,7 +123,7 @@ struct CSSDropShadowFilter {
 
 template <>
 struct CSSDataTypeParser<CSSDropShadowFilter> {
-  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSSyntaxParser &parser)
+  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSValueParser &parser)
       -> std::optional<CSSDropShadowFilter>
   {
     if (!iequals(func.name, "drop-shadow")) {
@@ -133,7 +133,7 @@ struct CSSDataTypeParser<CSSDropShadowFilter> {
     std::optional<CSSColor> color{};
     std::optional<std::array<CSSLength, 3>> lengths{};
 
-    auto firstVal = parseNextCSSValue<CSSColor, CSSLength>(parser);
+    auto firstVal = parser.parseNextValue<CSSColor, CSSLength>();
     if (std::holds_alternative<std::monostate>(firstVal)) {
       return {};
     }
@@ -147,7 +147,7 @@ struct CSSDataTypeParser<CSSDropShadowFilter> {
       }
     }
 
-    auto secondVal = parseNextCSSValue<CSSColor, CSSLength>(parser, CSSDelimiter::Whitespace);
+    auto secondVal = parser.parseNextValue<CSSColor, CSSLength>(CSSDelimiter::Whitespace);
     if (std::holds_alternative<CSSColor>(secondVal)) {
       if (color.has_value()) {
         return {};
@@ -173,14 +173,14 @@ struct CSSDataTypeParser<CSSDropShadowFilter> {
   }
 
  private:
-  static constexpr std::optional<std::array<CSSLength, 3>> parseLengths(CSSLength offsetX, CSSSyntaxParser &parser)
+  static constexpr std::optional<std::array<CSSLength, 3>> parseLengths(CSSLength offsetX, CSSValueParser &parser)
   {
-    auto offsetY = parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    auto offsetY = parser.parseNextValue<CSSLength>(CSSDelimiter::Whitespace);
     if (!std::holds_alternative<CSSLength>(offsetY)) {
       return {};
     }
 
-    auto standardDeviation = parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    auto standardDeviation = parser.parseNextValue<CSSLength>(CSSDelimiter::Whitespace);
     if (std::holds_alternative<CSSLength>(standardDeviation) && std::get<CSSLength>(standardDeviation).value < 0.0f) {
       return {};
     }
@@ -220,14 +220,14 @@ struct CSSHueRotateFilter {
 
 template <>
 struct CSSDataTypeParser<CSSHueRotateFilter> {
-  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSSyntaxParser &parser)
+  static constexpr auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSValueParser &parser)
       -> std::optional<CSSHueRotateFilter>
   {
     if (!iequals(func.name, "hue-rotate")) {
       return {};
     }
 
-    auto angle = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    auto angle = parser.parseNextValue<CSSAngle, CSSZero>();
     return CSSHueRotateFilter{std::holds_alternative<CSSAngle>(angle) ? std::get<CSSAngle>(angle).degrees : 0.0f};
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSKeyword.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSKeyword.h
@@ -23,6 +23,7 @@ namespace facebook::react {
  */
 enum class CSSKeyword : uint8_t {
   Absolute,
+  At,
   Auto,
   Baseline,
   Block,
@@ -110,6 +111,7 @@ enum class CSSKeyword : uint8_t {
   TabularNums,
   Thick,
   Thin,
+  To,
   Top,
   Unset,
   Visible,
@@ -143,6 +145,7 @@ enum class CSSWideKeyword : std::underlying_type_t<CSSKeyword> {
   }
 
 CSS_DEFINE_KEYWORD(Absolute, "absolute")
+CSS_DEFINE_KEYWORD(At, "at")
 CSS_DEFINE_KEYWORD(Auto, "auto")
 CSS_DEFINE_KEYWORD(Baseline, "baseline")
 CSS_DEFINE_KEYWORD(Block, "block")
@@ -230,6 +233,7 @@ CSS_DEFINE_KEYWORD(StylisticTwo, "stylistic-two")
 CSS_DEFINE_KEYWORD(TabularNums, "tabular-nums")
 CSS_DEFINE_KEYWORD(Thick, "thick")
 CSS_DEFINE_KEYWORD(Thin, "thin")
+CSS_DEFINE_KEYWORD(To, "to")
 CSS_DEFINE_KEYWORD(Top, "top")
 CSS_DEFINE_KEYWORD(Unset, "unset")
 CSS_DEFINE_KEYWORD(Visible, "visible")
@@ -254,6 +258,7 @@ constexpr std::optional<KeywordT> parseCSSKeyword(std::string_view ident)
 {
   switch (fnv1aLowercase(ident)) {
     CSS_HANDLE_KEYWORD(Absolute)
+    CSS_HANDLE_KEYWORD(At)
     CSS_HANDLE_KEYWORD(Auto)
     CSS_HANDLE_KEYWORD(Baseline)
     CSS_HANDLE_KEYWORD(Block)
@@ -341,6 +346,7 @@ constexpr std::optional<KeywordT> parseCSSKeyword(std::string_view ident)
     CSS_HANDLE_KEYWORD(TabularNums)
     CSS_HANDLE_KEYWORD(Thick)
     CSS_HANDLE_KEYWORD(Thin)
+    CSS_HANDLE_KEYWORD(To)
     CSS_HANDLE_KEYWORD(Top)
     CSS_HANDLE_KEYWORD(Unset)
     CSS_HANDLE_KEYWORD(Visible)

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
@@ -28,11 +28,11 @@ struct CSSList<AllowedTypesT, Delim> : public std::vector<AllowedTypesT> {};
 
 template <CSSMaybeCompoundDataType AllowedTypeT, CSSDelimiter Delim>
 struct CSSDataTypeParser<CSSList<AllowedTypeT, Delim>> {
-  static inline auto consume(CSSSyntaxParser &parser) -> std::optional<CSSList<AllowedTypeT, Delim>>
+  static inline auto consume(CSSValueParser &parser) -> std::optional<CSSList<AllowedTypeT, Delim>>
   {
     CSSList<AllowedTypeT, Delim> result;
-    for (auto nextValue = parseNextCSSValue<AllowedTypeT>(parser); !std::holds_alternative<std::monostate>(nextValue);
-         nextValue = parseNextCSSValue<AllowedTypeT>(parser, Delim)) {
+    for (auto nextValue = parser.parseNextValue<AllowedTypeT>(); !std::holds_alternative<std::monostate>(nextValue);
+         nextValue = parser.parseNextValue<AllowedTypeT>(Delim)) {
       // Copy from the variant of possible values to the element (either the
       // concrete type, or a variant of compound types which exlcudes the
       // possibility of std::monostate for parse error)

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
@@ -24,7 +24,7 @@ template <CSSDataType AllowedTypeT, CSSDelimiter Delim>
 struct CSSList<AllowedTypeT, Delim> : public std::vector<AllowedTypeT> {};
 
 template <CSSValidCompoundDataType AllowedTypesT, CSSDelimiter Delim>
-struct CSSList<AllowedTypesT, Delim> : public std::vector<CSSVariantWithTypes<AllowedTypesT>> {};
+struct CSSList<AllowedTypesT, Delim> : public std::vector<AllowedTypesT> {};
 
 template <CSSMaybeCompoundDataType AllowedTypeT, CSSDelimiter Delim>
 struct CSSDataTypeParser<CSSList<AllowedTypeT, Delim>> {

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -38,20 +38,20 @@ struct CSSRatio {
 
 template <>
 struct CSSDataTypeParser<CSSRatio> {
-  static constexpr auto consume(CSSSyntaxParser &parser) -> std::optional<CSSRatio>
+  static constexpr auto consume(CSSValueParser &parser) -> std::optional<CSSRatio>
   {
     // <ratio> = <number [0,∞]> [ / <number [0,∞]> ]?
     // https://www.w3.org/TR/css-values-4/#ratio
-    auto numerator = parseNextCSSValue<CSSNumber>(parser);
+    auto numerator = parser.parseNextValue<CSSNumber>();
     if (!std::holds_alternative<CSSNumber>(numerator)) {
       return {};
     }
 
     auto numeratorValue = std::get<CSSNumber>(numerator).value;
     if (numeratorValue >= 0) {
-      auto denominator = peekNextCSSValue<CSSNumber>(parser, CSSDelimiter::Solidus);
+      auto denominator = parser.peekNextValue<CSSNumber>(CSSDelimiter::Solidus);
       if (std::holds_alternative<CSSNumber>(denominator) && std::get<CSSNumber>(denominator).value >= 0) {
-        parseNextCSSValue<CSSNumber>(parser, CSSDelimiter::Solidus);
+        parser.parseNextValue<CSSNumber>(CSSDelimiter::Solidus);
         return CSSRatio{.numerator = numeratorValue, .denominator = std::get<CSSNumber>(denominator).value};
       }
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSShadow.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSShadow.h
@@ -46,15 +46,15 @@ static_assert(CSSDataType<CSSInsetShadowKeyword>);
 
 template <>
 struct CSSDataTypeParser<CSSShadow> {
-  static constexpr auto consume(CSSSyntaxParser &parser) -> std::optional<CSSShadow>
+  static constexpr auto consume(CSSValueParser &parser) -> std::optional<CSSShadow>
   {
     std::optional<CSSColor> color{};
     bool inset{false};
     std::optional<std::tuple<CSSLength, CSSLength, CSSLength, CSSLength>> lengths{};
 
-    for (auto nextValue = parseNextCSSValue<CSSLength, CSSColor, CSSInsetShadowKeyword>(parser);
+    for (auto nextValue = parser.parseNextValue<CSSLength, CSSColor, CSSInsetShadowKeyword>();
          !std::holds_alternative<std::monostate>(nextValue);
-         nextValue = parseNextCSSValue<CSSLength, CSSColor, CSSInsetShadowKeyword>(parser, CSSDelimiter::Whitespace)) {
+         nextValue = parser.parseNextValue<CSSLength, CSSColor, CSSInsetShadowKeyword>(CSSDelimiter::Whitespace)) {
       if (std::holds_alternative<CSSLength>(nextValue)) {
         if (lengths.has_value()) {
           return {};
@@ -98,15 +98,15 @@ struct CSSDataTypeParser<CSSShadow> {
   }
 
  private:
-  static constexpr auto parseRestLengths(CSSLength offsetX, CSSSyntaxParser &parser)
+  static constexpr auto parseRestLengths(CSSLength offsetX, CSSValueParser &parser)
       -> std::optional<std::tuple<CSSLength, CSSLength, CSSLength, CSSLength>>
   {
-    auto offsetY = parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    auto offsetY = parser.parseNextValue<CSSLength>(CSSDelimiter::Whitespace);
     if (std::holds_alternative<std::monostate>(offsetY)) {
       return {};
     }
 
-    auto blurRadius = parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    auto blurRadius = parser.parseNextValue<CSSLength>(CSSDelimiter::Whitespace);
     if (std::holds_alternative<std::monostate>(blurRadius)) {
       return std::make_tuple(offsetX, std::get<CSSLength>(offsetY), CSSLength{}, CSSLength{});
     }
@@ -114,7 +114,7 @@ struct CSSDataTypeParser<CSSShadow> {
       return {};
     }
 
-    auto spreadDistance = parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    auto spreadDistance = parser.parseNextValue<CSSLength>(CSSDelimiter::Whitespace);
     if (std::holds_alternative<std::monostate>(spreadDistance)) {
       return std::make_tuple(offsetX, std::get<CSSLength>(offsetY), std::get<CSSLength>(blurRadius), CSSLength{});
     }

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -113,6 +113,7 @@ enum class CSSDelimiter {
 class CSSSyntaxParser {
   template <CSSSyntaxVisitorReturn ReturnT, CSSComponentValueVisitor<ReturnT>... VisitorsT>
   friend struct CSSComponentValueVisitorDispatcher;
+  friend class CSSValueParser;
 
  public:
   /**
@@ -231,15 +232,18 @@ class CSSSyntaxParser {
     }
   }
 
+  /**
+   * Returns the current token without consuming it.
+   */
+  constexpr const CSSToken &peek() const
+  {
+    return currentToken_;
+  }
+
  private:
   constexpr CSSSyntaxParser(CSSSyntaxParser &parser, CSSTokenType terminator)
       : tokenizer_{parser.tokenizer_}, currentToken_{parser.currentToken_}, terminator_{terminator}
   {
-  }
-
-  constexpr const CSSToken &peek() const
-  {
-    return currentToken_;
   }
 
   constexpr CSSToken consumeToken()

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
@@ -453,11 +453,6 @@ using CSSTransformFunction = CSSCompoundDataType<
     CSSPerspective>;
 
 /**
- * Variant of possible CSS transform function types
- */
-using CSSTransformFunctionVariant = CSSVariantWithTypes<CSSTransformFunction>;
-
-/**
  * Represents the <transform-list> type.
  * https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
  */

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTransformOrigin.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTransformOrigin.h
@@ -45,7 +45,7 @@ struct CSSTransformOrigin {
 
 template <>
 struct CSSDataTypeParser<CSSTransformOrigin> {
-  static constexpr auto consume(CSSSyntaxParser &parser) -> std::optional<CSSTransformOrigin>
+  static constexpr auto consume(CSSValueParser &parser) -> std::optional<CSSTransformOrigin>
   {
     //  [ left | center | right | top | bottom | <length-percentage> ]
     // |
@@ -54,19 +54,18 @@ struct CSSDataTypeParser<CSSTransformOrigin> {
     // |
     //   [ [ center | left | right ] && [ center | top | bottom ] ] <length>?
 
-    auto firstValue = parseNextCSSValue<CSSLengthPercentage, CSSTransformOriginKeyword>(parser);
+    auto firstValue = parser.parseNextValue<CSSLengthPercentage, CSSTransformOriginKeyword>();
     if (std::holds_alternative<std::monostate>(firstValue)) {
       return {};
     }
 
-    auto secondValue =
-        parseNextCSSValue<CSSLengthPercentage, CSSTransformOriginKeyword>(parser, CSSDelimiter::Whitespace);
+    auto secondValue = parser.parseNextValue<CSSLengthPercentage, CSSTransformOriginKeyword>(CSSDelimiter::Whitespace);
 
     if (std::holds_alternative<std::monostate>(secondValue)) {
       return singleValue(firstValue);
     }
 
-    auto thirdValue = parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    auto thirdValue = parser.parseNextValue<CSSLength>(CSSDelimiter::Whitespace);
 
     if (std::holds_alternative<CSSLength>(firstValue) || std::holds_alternative<CSSPercentage>(firstValue) ||
         std::holds_alternative<CSSLength>(secondValue) || std::holds_alternative<CSSPercentage>(secondValue)) {

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -33,7 +33,7 @@ class CSSValueParser {
   template <CSSDataType... AllowedTypesT>
   constexpr std::variant<std::monostate, AllowedTypesT...> consumeValue(
       CSSDelimiter delimeter,
-      CSSCompoundDataType<AllowedTypesT...> /*unused*/)
+      std::variant<AllowedTypesT...> /*unused*/)
   {
     using ReturnT = std::variant<std::monostate, AllowedTypesT...>;
 

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSValueParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSValueParserTest.cpp
@@ -21,8 +21,8 @@ struct ConsumeDataType {
 template <>
 struct CSSDataTypeParser<ConsumeDataType> {
   constexpr static std::optional<ConsumeDataType> consume(
-      CSSSyntaxParser& parser) {
-    auto val = parseNextCSSValue<CSSNumber>(parser);
+      CSSValueParser& parser) {
+    auto val = parser.parseNextValue<CSSNumber>();
     if (std::holds_alternative<CSSNumber>(val)) {
       return ConsumeDataType{std::get<CSSNumber>(val).value};
     }
@@ -34,32 +34,33 @@ struct CSSDataTypeParser<ConsumeDataType> {
 static_assert(CSSDataType<ConsumeDataType>);
 
 TEST(CSSValueParser, consume_multiple_with_delimeter) {
-  CSSSyntaxParser parser{"1 2, 3, 4 / 5"};
+  CSSSyntaxParser syntaxParser{"1 2, 3, 4 / 5"};
+  CSSValueParser parser{syntaxParser};
 
-  auto next = parseNextCSSValue<ConsumeDataType>(parser);
+  auto next = parser.parseNextValue<ConsumeDataType>();
   EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
   EXPECT_EQ(std::get<ConsumeDataType>(next).number, 1);
 
-  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::None);
+  next = parser.parseNextValue<ConsumeDataType>(CSSDelimiter::None);
   EXPECT_FALSE(std::holds_alternative<ConsumeDataType>(next));
 
-  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::Whitespace);
+  next = parser.parseNextValue<ConsumeDataType>(CSSDelimiter::Whitespace);
   EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
   EXPECT_EQ(std::get<ConsumeDataType>(next).number, 2);
 
-  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::Comma);
+  next = parser.parseNextValue<ConsumeDataType>(CSSDelimiter::Comma);
   EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
   EXPECT_EQ(std::get<ConsumeDataType>(next).number, 3);
 
-  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::Comma);
+  next = parser.parseNextValue<ConsumeDataType>(CSSDelimiter::Comma);
   EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
   EXPECT_EQ(std::get<ConsumeDataType>(next).number, 4);
 
-  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::Solidus);
+  next = parser.parseNextValue<ConsumeDataType>(CSSDelimiter::Solidus);
   EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
   EXPECT_EQ(std::get<ConsumeDataType>(next).number, 5);
 
-  next = parseNextCSSValue<ConsumeDataType>(parser);
+  next = parser.parseNextValue<ConsumeDataType>();
   EXPECT_FALSE(std::holds_alternative<ConsumeDataType>(next));
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.cpp
@@ -32,6 +32,7 @@ std::vector<MarginValue> parseNormalizedRootMargin(
 
   std::vector<MarginValue> values;
   CSSSyntaxParser syntaxParser(marginStr);
+  CSSValueParser valueParser(syntaxParser);
 
   // Parse exactly 4 space-separated values
   while (!syntaxParser.isFinished() && values.size() < 4) {
@@ -40,7 +41,7 @@ std::vector<MarginValue> parseNormalizedRootMargin(
       break;
     }
 
-    auto parsed = parseNextCSSValue<CSSLength, CSSPercentage>(syntaxParser);
+    auto parsed = valueParser.parseNextValue<CSSLength, CSSPercentage>();
 
     if (std::holds_alternative<CSSLength>(parsed)) {
       auto length = std::get<CSSLength>(parsed);


### PR DESCRIPTION
Summary:
Previously, CSSDataTypeParser sinks received a raw CSSSyntaxParser& reference,
which exposed low-level tokenization APIs (consumeComponentValue with lambdas,
consumeToken, etc.) that data type parsers should not use directly. This made
it unclear what operations are appropriate when implementing a new CSS data
type.

This change promotes detail::CSSValueParser to a public CSSValueParser class
that wraps CSSSyntaxParser and exposes only value-level parsing operations:
parseNextValue, peekNextValue, consumeWhitespace, consumeDelimiter, isFinished,
peekNextTokenIs, and saveState/restoreState for lookahead patterns.

All CSSDataTypeParser sink methods now receive CSSValueParser& instead of
CSSSyntaxParser&, and use parser.parseNextValue<T>() instead of the free
function parseNextCSSValue<T>(parser). Direct consumeComponentValue calls in
gradient parsers (CSSBackgroundImage.h) are replaced with keyword set parsing
via parseNextValue<KeywordEnum>, with new To/At keywords added to CSSKeyword.

The free functions parseCSSProperty, parseNextCSSValue, and peekNextCSSValue
remain as convenience wrappers for backward compatibility.

Changelog: [Internal]

Reviewed By: jorge-cab

Differential Revision: D94357104
