### PR TITLE
Use std::ranges::reverse_view and enable clang-tidy reverse ranges

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1227,9 +1227,9 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     if (!_boxShadowLayers) {
       _boxShadowLayers = [NSMutableArray new];
     }
-    for (auto it = _props->boxShadow.rbegin(); it != _props->boxShadow.rend(); ++it) {
+    for (const auto &shadow : std::ranges::reverse_view(_props->boxShadow)) {
       CALayer *shadowLayer = RCTGetBoxShadowLayer(
-          *it,
+          shadow,
           RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
           RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths),
           self.layer.bounds.size);

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
@@ -10,6 +10,7 @@
 #include "ProfileTreeNode.h"
 #include "TraceEventSerializer.h"
 
+#include <ranges>
 #include <string_view>
 #include <unordered_map>
 
@@ -192,8 +193,7 @@ void processCallStack(
   }
 
   ProfileTreeNode* previousNode = &rootNode;
-  for (auto it = callStack.rbegin(); it != callStack.rend(); ++it) {
-    const RuntimeSamplingProfile::SampleCallStackFrame& callFrame = *it;
+  for (const auto& callFrame : std::ranges::reverse_view(callStack)) {
     bool isGarbageCollectorFrame = callFrame.kind ==
         RuntimeSamplingProfile::SampleCallStackFrame::Kind::GarbageCollector;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -7,6 +7,8 @@
 
 #include "LayoutableShadowNode.h"
 
+#include <ranges>
+
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/core/LayoutMetrics.h>
@@ -106,8 +108,8 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
   // root because we measure it from an outside tree perspective.
   shadowNodeList.push_back(descendantNode);
 
-  for (auto it = ancestors.rbegin(); it != ancestors.rend(); it++) {
-    auto& shadowNode = it->first.get();
+  for (auto& ancestor : std::ranges::reverse_view(ancestors)) {
+    auto& shadowNode = ancestor.first.get();
 
     shadowNodeList.push_back(&shadowNode);
 
@@ -334,8 +336,8 @@ std::shared_ptr<const ShadowNode> LayoutableShadowNode::findNodeAtPoint(
         return lhs->getOrderIndex() < rhs->getOrderIndex();
       });
 
-  for (auto it = sortedChildren.rbegin(); it != sortedChildren.rend(); it++) {
-    const auto& childShadowNode = *it;
+  for (const auto& childShadowNode :
+       std::ranges::reverse_view(sortedChildren)) {
     auto hitView = findNodeAtPoint(childShadowNode, newPoint);
     if (hitView) {
       return hitView;

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -14,6 +14,7 @@
 #include <react/renderer/core/ShadowNodeFragment.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
+#include <ranges>
 
 #include <utility>
 
@@ -391,9 +392,8 @@ std::shared_ptr<ShadowNode> ShadowNode::cloneTree(
 
   auto childNode = newShadowNode;
 
-  for (auto it = ancestors.rbegin(); it != ancestors.rend(); ++it) {
-    auto& parentNode = it->first.get();
-    auto childIndex = it->second;
+  for (auto& [ancestorRef, childIndex] : std::ranges::reverse_view(ancestors)) {
+    auto& parentNode = ancestorRef.get();
 
     auto children = parentNode.getChildren();
     react_native_assert(

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
@@ -12,6 +12,7 @@
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/State.h>
+#include <ranges>
 
 #include <utility>
 
@@ -116,8 +117,7 @@ AncestorList ShadowNodeFamily::getAncestors(
 
   auto ancestors = AncestorList{};
   auto parentNode = &ancestorShadowNode;
-  for (auto it = families.rbegin(); it != families.rend(); it++) {
-    auto childFamily = *it;
+  for (auto childFamily : std::ranges::reverse_view(families)) {
     auto found = false;
     auto childIndex = 0;
     for (const auto& childNode : *parentNode->children_) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
@@ -9,6 +9,7 @@
 
 #include <glog/logging.h>
 #include <react/renderer/bridging/bridging.h>
+#include <ranges>
 
 namespace facebook::react {
 
@@ -79,8 +80,9 @@ static bool isAnyViewInPathToRootListeningToEvents(
   auto ancestors = nodeFamily.getAncestors(*owningRootShadowNode);
 
   // Check for listeners from the target's parent to the root
-  for (auto it = ancestors.rbegin(); it != ancestors.rend(); it++) {
-    auto& currentNode = it->first.get();
+  for (auto& [ancestorNode, childIndex] :
+       std::ranges::reverse_view(ancestors)) {
+    auto& currentNode = ancestorNode.get();
     if (isViewListeningToEvents(currentNode, eventTypes)) {
       return true;
     }
@@ -488,11 +490,9 @@ void PointerEventsProcessor::handleIncomingPointerEventOnNode(
   }
 
   // Actually emit the leave events (in order from target to root)
-  for (auto it = targetsToEmitLeaveTo.rbegin();
-       it != targetsToEmitLeaveTo.rend();
-       it++) {
+  for (auto& target : std::ranges::reverse_view(targetsToEmitLeaveTo)) {
     eventDispatcher(
-        *it, "topPointerLeave", ReactEventPriority::Discrete, event);
+        target, "topPointerLeave", ReactEventPriority::Discrete, event);
   }
 
   // Over

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
@@ -7,6 +7,7 @@
 
 #include "PointerHoverTracker.h"
 
+#include <ranges>
 #include <utility>
 
 namespace facebook::react {
@@ -139,8 +140,8 @@ EventPath PointerHoverTracker::getEventPathTargets() const {
   auto ancestors = target_->getFamily().getAncestors(*root_);
 
   result.emplace_back(*target_);
-  for (auto it = ancestors.rbegin(); it != ancestors.rend(); it++) {
-    result.push_back(it->first);
+  for (auto& [ancestor, index] : std::ranges::reverse_view(ancestors)) {
+    result.push_back(ancestor);
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerUpdateShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerUpdateShadowTree.cpp
@@ -14,6 +14,7 @@
 #include <deque>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <vector>
 
 namespace facebook::react {
@@ -52,8 +53,8 @@ void addAncestorsToUpdateList(
 
   int ancestorDepth = static_cast<int>(ancestors.size() - 1);
   // iterate from current ShadowNode's parent to root ShadowNode
-  for (auto iter = ancestors.rbegin(); iter != ancestors.rend(); ++iter) {
-    auto& ancestorShadowNode = iter->first.get();
+  for (auto& [ancestorRef, childIdx] : std::ranges::reverse_view(ancestors)) {
+    auto& ancestorShadowNode = ancestorRef.get();
     auto ancestorTag = ancestorShadowNode.getTag();
     auto ancestorAddedToUpdateList = std::find_if(
         shadowNodesToUpdate.begin(),
@@ -67,10 +68,10 @@ void addAncestorsToUpdateList(
           .tag = ancestorShadowNode.getTag(),
           .depth = ancestorDepth,
           .node = ancestorShadowNodesShared[ancestorDepth],
-          .updatedChildrenIndices = {iter->second},
+          .updatedChildrenIndices = {childIdx},
       });
     } else {
-      ancestorAddedToUpdateList->updatedChildrenIndices.push_back(iter->second);
+      ancestorAddedToUpdateList->updatedChildrenIndices.push_back(childIdx);
     }
     ancestorDepth--;
   }


### PR DESCRIPTION
Summary:
Previously, the RN build in fbcode was using an old platform version with poor support for std::ranges, so we had disabled clang-tidy's `modernize-loop-convert.UseCxx20ReverseRanges` check. This is no longer the case, so we can remove the suppression and replace instances of reverse iteration using rbegin/rend iterators with `std::ranges::reverse_view`.

Changelog: [Internal]

Differential Revision: D75834622


