### PR TITLE
Move Linkification for dataDetectorType into TextLayoutManager (fixes dataDetectorType with Facsimile)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6056,6 +6056,7 @@ public final class com/facebook/react/views/text/DefaultStyleValuesUtil {
 	public static final fun getDefaultTextColor (Landroid/content/Context;)Landroid/content/res/ColorStateList;
 	public static final fun getDefaultTextColorHighlight (Landroid/content/Context;)I
 	public static final fun getDefaultTextColorHint (Landroid/content/Context;)Landroid/content/res/ColorStateList;
+	public static final fun getDefaultTextColorLink (Landroid/content/Context;)I
 	public static final fun getTextColorSecondary (Landroid/content/Context;)Landroid/content/res/ColorStateList;
 }
 
@@ -6100,7 +6101,6 @@ public class com/facebook/react/views/text/ReactTextView : androidx/appcompat/wi
 	public fun setHyphenationFrequency (I)V
 	public fun setIncludeFontPadding (Z)V
 	public fun setLetterSpacing (F)V
-	public fun setLinkifyMask (I)V
 	public fun setMinimumFontSize (F)V
 	public fun setNumberOfLines (I)V
 	public fun setOverflow (Ljava/lang/String;)V
@@ -6135,7 +6135,6 @@ public final class com/facebook/react/views/text/ReactTextViewManager : com/face
 	public final fun setBorderRadius (Lcom/facebook/react/views/text/ReactTextView;IF)V
 	public final fun setBorderStyle (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
 	public final fun setBorderWidth (Lcom/facebook/react/views/text/ReactTextView;IF)V
-	public final fun setDataDetectorType (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
 	public final fun setDisabled (Lcom/facebook/react/views/text/ReactTextView;Z)V
 	public final fun setEllipsizeMode (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
 	public final fun setFontSize (Lcom/facebook/react/views/text/ReactTextView;F)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/DefaultStyleValuesUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/DefaultStyleValuesUtil.kt
@@ -56,6 +56,17 @@ public object DefaultStyleValuesUtil {
       getDefaultTextAttribute(context, android.R.attr.textColorHighlight)?.defaultColor
           ?: 0 // if the highlight color is not defined in the theme, return black
 
+  /**
+   * Utility method that returns the default text link color as defined by the theme
+   *
+   * @param context The Context
+   * @return The default color int for links as defined in the style
+   */
+  @JvmStatic
+  public fun getDefaultTextColorLink(context: Context): Int =
+      getDefaultTextAttribute(context, android.R.attr.textColorLink)?.defaultColor
+          ?: 0xFF0000EE.toInt() // fallback to a standard blue if not defined by the theme
+
   private fun getDefaultTextAttribute(context: Context, attribute: Int): ColorStateList? {
     context.theme.obtainStyledAttributes(intArrayOf(attribute)).use { typedArray ->
       return typedArray.getColorStateList(0)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -13,11 +13,10 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.text.Layout;
 import android.text.Spannable;
-import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
-import android.text.util.Linkify;
+import android.text.style.URLSpan;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -71,7 +70,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private float mFontSize;
   private float mMinimumFontSize;
   private float mLetterSpacing;
-  private int mLinkifyMaskType;
   private boolean mTextIsSelectable;
   private boolean mShouldAdjustSpannableFontSize;
   private Overflow mOverflow = Overflow.VISIBLE;
@@ -91,7 +89,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private void initView() {
     mNumberOfLines = ViewDefaults.NUMBER_OF_LINES;
     mAdjustsFontSizeToFit = false;
-    mLinkifyMaskType = 0;
     mTextIsSelectable = false;
     mShouldAdjustSpannableFontSize = false;
     mEllipsizeLocation = TextUtils.TruncateAt.END;
@@ -131,16 +128,12 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     setGravity(DEFAULT_GRAVITY);
     setNumberOfLines(mNumberOfLines);
     setAdjustFontSizeToFit(mAdjustsFontSizeToFit);
-    setLinkifyMask(mLinkifyMaskType);
     setTextIsSelectable(mTextIsSelectable);
 
     // Default true:
     // https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/widget/TextView.java#L9347
     setIncludeFontPadding(true);
     setEnabled(true);
-
-    // reset data detectors
-    setLinkifyMask(0);
 
     setEllipsizeLocation(mEllipsizeLocation);
 
@@ -386,14 +379,14 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
         setLayoutParams(EMPTY_LAYOUT_PARAMS);
       }
       Spanned spanned = update.getText();
-      if (mLinkifyMaskType > 0) {
-        if (!(spanned instanceof Spannable)) {
-          spanned = new SpannableString(spanned);
-        }
-        Linkify.addLinks((Spannable) spanned, mLinkifyMaskType);
-        setMovementMethod(LinkMovementMethod.getInstance());
-      }
       setText(spanned);
+
+      URLSpan[] urlSpans = spanned.getSpans(0, spanned.length(), URLSpan.class);
+      if (urlSpans != null && urlSpans.length > 0) {
+        setMovementMethod(LinkMovementMethod.getInstance());
+      } else if (getMovementMethod() instanceof LinkMovementMethod) {
+        setMovementMethod(null);
+      }
 
       int nextTextAlign = update.getTextAlign();
       if (nextTextAlign != getGravityHorizontal()) {
@@ -625,10 +618,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   public @Nullable Spannable getSpanned() {
     return mSpanned;
-  }
-
-  public void setLinkifyMask(int mask) {
-    mLinkifyMaskType = mask;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
@@ -14,7 +14,6 @@ import android.text.Layout
 import android.text.Spannable
 import android.text.Spanned
 import android.text.TextUtils
-import android.text.util.Linkify
 import android.view.Gravity
 import com.facebook.common.logging.FLog
 import com.facebook.react.R
@@ -152,8 +151,10 @@ public constructor(
         TextLayoutManager.getOrCreateSpannableForText(
             view.context,
             attributedString,
+            paragraphAttributes,
             reactTextViewManagerCallback,
         )
+
     view.setSpanned(spanned)
 
     val minimumFontSize: Float =
@@ -343,31 +344,6 @@ public constructor(
   @ReactProp(name = "disabled", defaultBoolean = false)
   public fun setDisabled(view: ReactTextView, disabled: Boolean) {
     view.isEnabled = !disabled
-  }
-
-  @ReactProp(name = "dataDetectorType")
-  public fun setDataDetectorType(view: ReactTextView, type: String?) {
-    when (type) {
-      "phoneNumber" -> {
-        view.setLinkifyMask(Linkify.PHONE_NUMBERS)
-        return
-      }
-      "link" -> {
-        view.setLinkifyMask(Linkify.WEB_URLS)
-        return
-      }
-      "email" -> {
-        view.setLinkifyMask(Linkify.EMAIL_ADDRESSES)
-        return
-      }
-      "all" -> {
-        @Suppress("DEPRECATION") view.setLinkifyMask(Linkify.ALL)
-        return
-      }
-    }
-
-    // "none" case, default, and null type are equivalent.
-    view.setLinkifyMask(0)
   }
 
   public companion object {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -21,6 +21,7 @@ import android.text.StaticLayout
 import android.text.TextDirectionHeuristics
 import android.text.TextPaint
 import android.text.TextUtils
+import android.text.util.Linkify
 import android.util.LayoutDirection
 import android.view.Gravity
 import android.view.View
@@ -88,6 +89,7 @@ internal object TextLayoutManager {
   const val PA_KEY_MINIMUM_FONT_SIZE: Int = 6
   const val PA_KEY_MAXIMUM_FONT_SIZE: Int = 7
   const val PA_KEY_TEXT_ALIGN_VERTICAL: Int = 8
+  const val PA_KEY_DATA_DETECTOR_TYPE: Int = 9
 
   private val TAG: String = TextLayoutManager::class.java.simpleName
 
@@ -530,6 +532,7 @@ internal object TextLayoutManager {
   fun getOrCreateSpannableForText(
       context: Context,
       attributedString: MapBuffer,
+      paragraphAttributes: MapBuffer,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
   ): Spannable {
     var text: Spannable?
@@ -541,6 +544,7 @@ internal object TextLayoutManager {
           createSpannableFromAttributedString(
               context,
               attributedString.getMapBuffer(AS_KEY_FRAGMENTS),
+              paragraphAttributes,
               reactTextViewManagerCallback,
               null,
           )
@@ -552,37 +556,47 @@ internal object TextLayoutManager {
   private fun createSpannableFromAttributedString(
       context: Context,
       fragments: MapBuffer,
+      paragraphAttributes: MapBuffer,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
       outputReactTags: IntArray?,
   ): Spannable {
-    if (ReactNativeFeatureFlags.enableAndroidTextMeasurementOptimizations()) {
-      val spannable = buildSpannableFromFragmentsOptimized(context, fragments, outputReactTags)
+    val spannable =
+        if (ReactNativeFeatureFlags.enableAndroidTextMeasurementOptimizations()) {
+          val s = buildSpannableFromFragmentsOptimized(context, fragments, outputReactTags)
+          reactTextViewManagerCallback?.onPostProcessSpannable(s)
+          s
+        } else {
+          val sb = SpannableStringBuilder()
 
-      reactTextViewManagerCallback?.onPostProcessSpannable(spannable)
-      return spannable
-    } else {
-      val sb = SpannableStringBuilder()
+          // The [SpannableStringBuilder] implementation require setSpan operation to be called
+          // up-to-bottom, otherwise all the spannables that are within the region for which one may
+          // set
+          // a new spannable will be wiped out
+          val ops: MutableList<SetSpanOperation> = ArrayList()
 
-      // The [SpannableStringBuilder] implementation require setSpan operation to be called
-      // up-to-bottom, otherwise all the spannables that are within the region for which one may set
-      // a new spannable will be wiped out
-      val ops: MutableList<SetSpanOperation> = ArrayList()
+          buildSpannableFromFragments(context, fragments, sb, ops, outputReactTags)
 
-      buildSpannableFromFragments(context, fragments, sb, ops, outputReactTags)
+          // TODO T31905686: add support for inline Images
+          // While setting the Spans on the final text, we also check whether any of them are
+          // images.
+          for (priorityIndex in ops.indices) {
+            val op = ops[ops.size - priorityIndex - 1]
 
-      // TODO T31905686: add support for inline Images
-      // While setting the Spans on the final text, we also check whether any of them are images.
-      for (priorityIndex in ops.indices) {
-        val op = ops[ops.size - priorityIndex - 1]
+            // Actual order of calling {@code execute} does NOT matter,
+            // but the {@code priorityIndex} DOES matter.
+            op.execute(sb, priorityIndex)
+          }
 
-        // Actual order of calling {@code execute} does NOT matter,
-        // but the {@code priorityIndex} DOES matter.
-        op.execute(sb, priorityIndex)
-      }
+          reactTextViewManagerCallback?.onPostProcessSpannable(sb)
+          sb
+        }
 
-      reactTextViewManagerCallback?.onPostProcessSpannable(sb)
-      return sb
+    val linkifyMask = getLinkifyMask(paragraphAttributes)
+    if (linkifyMask > 0) {
+      Linkify.addLinks(spannable, linkifyMask)
     }
+
+    return spannable
   }
 
   private fun createLayout(
@@ -742,6 +756,8 @@ internal object TextLayoutManager {
       baseTextAttributes: TextAttributeProps,
       context: Context,
   ) {
+    paint.linkColor = DefaultStyleValuesUtil.getDefaultTextColorLink(context)
+
     if (baseTextAttributes.fontSize != ReactConstants.UNSET) {
       paint.textSize = baseTextAttributes.fontSize.toFloat()
     }
@@ -809,7 +825,13 @@ internal object TextLayoutManager {
       heightYogaMeasureMode: YogaMeasureMode,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
   ): Layout {
-    val text = getOrCreateSpannableForText(context, attributedString, reactTextViewManagerCallback)
+    val text =
+        getOrCreateSpannableForText(
+            context,
+            attributedString,
+            paragraphAttributes,
+            reactTextViewManagerCallback,
+        )
 
     val paint: TextPaint
     if (attributedString.contains(AS_KEY_CACHE_ID)) {
@@ -915,6 +937,19 @@ internal object TextLayoutManager {
     )
   }
 
+  private fun getLinkifyMask(paragraphAttributes: MapBuffer): Int {
+    if (!paragraphAttributes.contains(PA_KEY_DATA_DETECTOR_TYPE)) {
+      return 0
+    }
+    return when (paragraphAttributes.getString(PA_KEY_DATA_DETECTOR_TYPE)) {
+      "phoneNumber" -> Linkify.PHONE_NUMBERS
+      "link" -> Linkify.WEB_URLS
+      "email" -> Linkify.EMAIL_ADDRESSES
+      "all" -> @Suppress("DEPRECATION") Linkify.ALL
+      else -> 0
+    }
+  }
+
   @JvmStatic
   fun createPreparedLayout(
       context: Context,
@@ -932,9 +967,11 @@ internal object TextLayoutManager {
         createSpannableFromAttributedString(
             context,
             fragments,
+            paragraphAttributes,
             reactTextViewManagerCallback,
             reactTags,
         )
+
     val baseTextAttributes =
         TextAttributeProps.fromMapBuffer(attributedString.getMapBuffer(AS_KEY_BASE_ATTRIBUTES))
     val layout =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -1014,6 +1014,7 @@ public open class ReactTextInputManager public constructor() :
         TextLayoutManager.getOrCreateSpannableForText(
             view.context,
             attributedString,
+            paragraphAttributes,
             reactTextViewManagerCallback,
         )
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
@@ -22,7 +22,8 @@ bool ParagraphAttributes::operator==(const ParagraphAttributes& rhs) const {
              adjustsFontSizeToFit,
              includeFontPadding,
              android_hyphenationFrequency,
-             textAlignVertical) ==
+             textAlignVertical,
+             dataDetectorType) ==
       std::tie(
              rhs.maximumNumberOfLines,
              rhs.ellipsizeMode,
@@ -30,7 +31,8 @@ bool ParagraphAttributes::operator==(const ParagraphAttributes& rhs) const {
              rhs.adjustsFontSizeToFit,
              rhs.includeFontPadding,
              rhs.android_hyphenationFrequency,
-             rhs.textAlignVertical) &&
+             rhs.textAlignVertical,
+             rhs.dataDetectorType) &&
       floatEquality(minimumFontSize, rhs.minimumFontSize) &&
       floatEquality(maximumFontSize, rhs.maximumFontSize) &&
       floatEquality(minimumFontScale, rhs.minimumFontScale);
@@ -75,7 +77,11 @@ SharedDebugStringConvertibleList ParagraphAttributes::getDebugProps() const {
       debugStringConvertibleItem(
           "textAlignVertical",
           textAlignVertical,
-          paragraphAttributes.textAlignVertical)};
+          paragraphAttributes.textAlignVertical),
+      debugStringConvertibleItem(
+          "dataDetectorType",
+          dataDetectorType,
+          paragraphAttributes.dataDetectorType)};
 }
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -82,6 +82,12 @@ class ParagraphAttributes : public DebugStringConvertible {
    */
   std::optional<TextAlignmentVertical> textAlignVertical{};
 
+  /*
+   * (Android only) Defines the type of data to be detected and converted to
+   * clickable URLs in the text.
+   */
+  std::optional<DataDetectorType> dataDetectorType{};
+
   bool operator==(const ParagraphAttributes &rhs) const;
 
 #pragma mark - DebugStringConvertible
@@ -109,7 +115,8 @@ struct hash<facebook::react::ParagraphAttributes> {
         attributes.includeFontPadding,
         attributes.android_hyphenationFrequency,
         attributes.minimumFontScale,
-        attributes.textAlignVertical);
+        attributes.textAlignVertical,
+        attributes.dataDetectorType);
   }
 };
 } // namespace std

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -889,6 +889,54 @@ inline void fromRawValue(const PropsParserContext &context, const RawValue &valu
   result = HyphenationFrequency::None;
 }
 
+inline std::string toString(const DataDetectorType &value)
+{
+  switch (value) {
+    case DataDetectorType::All:
+      return "all";
+    case DataDetectorType::Email:
+      return "email";
+    case DataDetectorType::Link:
+      return "link";
+    case DataDetectorType::None:
+      return "none";
+    case DataDetectorType::PhoneNumber:
+      return "phoneNumber";
+  }
+
+  LOG(ERROR) << "Unsupported DataDetectorType value";
+  react_native_expect(false);
+  return "none";
+}
+
+inline void fromRawValue(const PropsParserContext & /*context*/, const RawValue &value, DataDetectorType &result)
+{
+  react_native_expect(value.hasType<std::string>());
+  if (value.hasType<std::string>()) {
+    auto string = (std::string)value;
+    if (string == "all") {
+      result = DataDetectorType::All;
+    } else if (string == "email") {
+      result = DataDetectorType::Email;
+    } else if (string == "link") {
+      result = DataDetectorType::Link;
+    } else if (string == "none") {
+      result = DataDetectorType::None;
+    } else if (string == "phoneNumber") {
+      result = DataDetectorType::PhoneNumber;
+    } else {
+      LOG(ERROR) << "Unsupported DataDetectorType value: " << string;
+      react_native_expect(false);
+      result = DataDetectorType::None;
+    }
+    return;
+  }
+
+  LOG(ERROR) << "Unsupported DataDetectorType type";
+  react_native_expect(false);
+  result = DataDetectorType::None;
+}
+
 inline ParagraphAttributes convertRawProp(
     const PropsParserContext &context,
     const RawProps &rawProps,
@@ -957,6 +1005,12 @@ inline ParagraphAttributes convertRawProp(
       "textAlignVertical",
       sourceParagraphAttributes.textAlignVertical,
       defaultParagraphAttributes.textAlignVertical);
+  paragraphAttributes.dataDetectorType = convertRawProp(
+      context,
+      rawProps,
+      "dataDetectorType",
+      sourceParagraphAttributes.dataDetectorType,
+      defaultParagraphAttributes.dataDetectorType);
 
   return paragraphAttributes;
 }
@@ -1038,6 +1092,7 @@ constexpr static MapBuffer::Key PA_KEY_HYPHENATION_FREQUENCY = 5;
 constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SIZE = 6;
 constexpr static MapBuffer::Key PA_KEY_MAXIMUM_FONT_SIZE = 7;
 constexpr static MapBuffer::Key PA_KEY_TEXT_ALIGN_VERTICAL = 8;
+constexpr static MapBuffer::Key PA_KEY_DATA_DETECTOR_TYPE = 9;
 
 inline MapBuffer toMapBuffer(const ParagraphAttributes &paragraphAttributes)
 {
@@ -1050,6 +1105,9 @@ inline MapBuffer toMapBuffer(const ParagraphAttributes &paragraphAttributes)
   builder.putString(PA_KEY_HYPHENATION_FREQUENCY, toString(paragraphAttributes.android_hyphenationFrequency));
   if (paragraphAttributes.textAlignVertical.has_value()) {
     builder.putString(PA_KEY_TEXT_ALIGN_VERTICAL, toString(*paragraphAttributes.textAlignVertical));
+  }
+  if (paragraphAttributes.dataDetectorType.has_value()) {
+    builder.putString(PA_KEY_DATA_DETECTOR_TYPE, toString(*paragraphAttributes.dataDetectorType));
   }
   builder.putDouble(PA_KEY_MINIMUM_FONT_SIZE, paragraphAttributes.minimumFontSize);
   builder.putDouble(PA_KEY_MAXIMUM_FONT_SIZE, paragraphAttributes.maximumFontSize);

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/primitives.h
@@ -150,4 +150,12 @@ enum class HyphenationFrequency {
   Full // Standard amount of hyphenation.
 };
 
+enum class DataDetectorType {
+  All,
+  Email,
+  Link,
+  None,
+  PhoneNumber,
+};
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.cpp
@@ -132,6 +132,12 @@ void BaseParagraphProps::setProp(
         paragraphAttributes,
         textAlignVertical,
         "textAlignVertical");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        dataDetectorType,
+        "dataDetectorType");
   }
 
   switch (hash) {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/conversions.h
@@ -7,45 +7,4 @@
 
 #pragma once
 
-#include <react/renderer/components/text/primitives.h>
-#include <react/renderer/core/PropsParserContext.h>
-#include <react/renderer/core/RawValue.h>
-#include <string>
-
-namespace facebook::react {
-
-inline void fromRawValue(const PropsParserContext & /*context*/, const RawValue &value, DataDetectorType &result)
-{
-  auto string = static_cast<std::string>(value);
-  if (string == "all") {
-    result = DataDetectorType::All;
-  } else if (string == "email") {
-    result = DataDetectorType::Email;
-  } else if (string == "link") {
-    result = DataDetectorType::Link;
-  } else if (string == "none") {
-    result = DataDetectorType::None;
-  } else if (string == "phoneNumber") {
-    result = DataDetectorType::PhoneNumber;
-  } else {
-    abort();
-  }
-}
-
-inline std::string toString(const DataDetectorType &value)
-{
-  switch (value) {
-    case DataDetectorType::All:
-      return "all";
-    case DataDetectorType::Email:
-      return "email";
-    case DataDetectorType::Link:
-      return "link";
-    case DataDetectorType::None:
-      return "none";
-    case DataDetectorType::PhoneNumber:
-      return "phoneNumber";
-  }
-}
-
-} // namespace facebook::react
+#include <react/renderer/attributedstring/conversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/primitives.h
@@ -7,14 +7,4 @@
 
 #pragma once
 
-namespace facebook::react {
-
-enum class DataDetectorType {
-  All,
-  Email,
-  Link,
-  None,
-  PhoneNumber,
-};
-
-} // namespace facebook::react
+#include <react/renderer/attributedstring/primitives.h>


### PR DESCRIPTION
Summary:
Move `dataDetectorType` Linkify handling from `ReactTextView` (view-level
`Linkify` on the `TextView`) to `TextLayoutManager.kt` (`Linkify` on the
`Spannable`), so it works for both `ReactTextView` and `PreparedLayoutTextView`.

Previously, `dataDetectorType` was handled as a `ReactProp` on
`ReactTextViewManager`, which called `Linkify.addLinks()` inside
`ReactTextView.setText()`. This meant the feature only worked for the legacy
`ReactTextView` path, not for the new `PreparedLayoutTextView`.

This diff:
- Moves the `DataDetectorType` C++ enum from `components/text/platform/android/`
  to `attributedstring/primitives.h` (where all other paragraph-related enums
  live), replacing the original with a forwarding include.
- Moves the `DataDetectorType` conversion functions to
  `attributedstring/conversions.h`, replacing the originals with a forwarding
  include.
- Adds `dataDetectorType` as a field on `ParagraphAttributes` (with hash,
  equality, and debug support).
- Serializes `dataDetectorType` via MapBuffer (key=9) so it flows from C++
  to Java.
- Adds `REBUILD_FIELD_SWITCH_CASE` for `dataDetectorType` in
  `BaseParagraphProps.cpp`.
- In `TextLayoutManager.kt`, reads `PA_KEY_DATA_DETECTOR_TYPE` from the
  paragraph attributes MapBuffer and calls `Linkify.addLinks()` on the
  `Spannable` before layout creation.
- Removes the `ReactProp` handler and `setLinkifyMask`/`mLinkifyMaskType`
  from `ReactTextViewManager.kt` and `ReactTextView.java`.
- Adds URLSpan-based `LinkMovementMethod` detection in `ReactTextView.setText()`
  so that links added by `TextLayoutManager` remain clickable.

`HostPlatformParagraphProps` is intentionally left unchanged—`dataDetectorType`
is parsed into both `BaseParagraphProps::paragraphAttributes` (for MapBuffer)
and `HostPlatformParagraphProps` (for getDiffProps).

Changelog: [Internal]

Differential Revision: D94017172
