### PR TITLE
LogBoxData test migrated to Jest modern timers

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -10,9 +10,6 @@
 
 'use strict';
 
-// TODO(legacy-fake-timers): Fix these tests to work with modern timers.
-jest.useFakeTimers({legacyFakeTimers: true});
-
 jest.mock('../../../Core/Devtools/parseErrorStack', () => {
   return {__esModule: true, default: jest.fn(() => [])};
 });
@@ -144,16 +141,17 @@ const addSyntaxError = (options: $FlowFixMe) => {
   );
 };
 
-beforeEach(() => {
-  jest.resetModules();
-});
-
 const flushToObservers = () => {
   // Observer updates are debounced and need to advance timers to flush.
   jest.runOnlyPendingTimers();
 };
 
 describe('LogBoxData', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+  });
+
   it('adds and dismisses logs', () => {
     addLogs(['A']);
     addSoftErrors(['B']);
@@ -590,9 +588,13 @@ describe('LogBoxData', () => {
     expect(observer.mock.calls.length).toBe(1);
 
     addLogs(['A']);
+    flushToObservers();
     addSoftErrors(['B']);
+    flushToObservers();
     addFatalErrors(['C']);
+    flushToObservers();
     addSyntaxError();
+    flushToObservers();
     expect(observer.mock.calls.length).toBe(5);
 
     LogBoxData.clearWarnings();
@@ -610,9 +612,13 @@ describe('LogBoxData', () => {
     expect(observer.mock.calls.length).toBe(1);
 
     addLogs(['A']);
+    flushToObservers();
     addSoftErrors(['B']);
+    flushToObservers();
     addFatalErrors(['C']);
+    flushToObservers();
     addSyntaxError();
+    flushToObservers();
     expect(observer.mock.calls.length).toBe(5);
 
     LogBoxData.clearErrors();
@@ -853,5 +859,9 @@ describe('LogBoxData', () => {
       LogBoxDataWithMock.observe(observerAfter).unsubscribe();
       expect(Array.from(observerAfter.mock.calls[0][0].logs).length).toBe(0);
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary:

This PR migrates the LogBoxData tests so that it uses Jest modern timers.
I removed the `legacyFakeTimers` property from  `useFakeTimers` (like I did in the previous PR for Pressability tests #55410), and moved it to a `beforeEach`. This in combination with restoring real timers in `afterEach` improves tests reliability and isolation.
Then I modified some tests that started to fail by adding explicit  `flushToObservers()`.
The extra flushToObservers() calls are necessary because addLog/addException schedule processing using `setImmediate`, and inside that callback `handleUpdate()` schedules observer notifications using another `setImmediate` (so we need to flush twice to simulate the correct behaviour like it was already done in some other tests in the test suite). 

## Changelog:

[GENERAL] [CHANGED] - Migrated LogBoxData tests to Jest modern timers

## Test Plan:

- Ran LogBoxData-test and verify all tests cases passed
- Ran the React Native test suite to ensure all tests pass
- Verified test correctness by intentionally breaking production code after fixing the tests (eg. removing the `handleUpdate` call in `addException`,  that changes the call to the `observer`)