### PR TITLE
Add template normalizing

### DIFF
--- a/scripts/cxx-api/parser/utils/text_resolution.py
+++ b/scripts/cxx-api/parser/utils/text_resolution.py
@@ -104,12 +104,12 @@ def resolve_ref_text_name(type_def: compound.refTextType) -> str:
                     name += part.value.valueOf_
                 else:
                     name += str(part.value)
-        return name
+        return normalize_angle_brackets(name)
 
     if type_def.ref:
-        return type_def.ref[0].get_valueOf_()
+        return normalize_angle_brackets(type_def.ref[0].get_valueOf_())
 
-    return type_def.get_valueOf_()
+    return normalize_angle_brackets(type_def.get_valueOf_())
 
 
 class InitializerType(Enum):


### PR DESCRIPTION
Summary:
Doxygen adds spaces inside angle brackets in its XML output:
- Outputs: `std::vector< PropNameID >`
- Expected: `std::vector<PropNameID>`

Applying `normalize_angle_brackets()` in `resolve_ref_text_name()` to normalize spacing consistently.

Changelog:
[Internal]

Reviewed By: cipolleschi

Differential Revision: D94232505
