### PR TITLE
Fix parsing of Objective-C interface generic inheritance

### DIFF
--- a/scripts/cxx-api/parser/builders.py
+++ b/scripts/cxx-api/parser/builders.py
@@ -465,7 +465,24 @@ def create_interface_scope(
 
     interface_scope = snapshot.create_interface(interface_name)
     base_classes = get_base_classes(scope_def, base_class=InterfaceScopeKind.Base)
-    interface_scope.kind.add_base(base_classes)
+
+    # Doxygen incorrectly splits "Foo <Protocol1, Protocol2>" into separate base classes:
+    # "Foo", "<Protocol1>", "<Protocol2>". Combine them back into "Foo <Protocol1, Protocol2>".
+    combined_bases = []
+    for base in base_classes:
+        if base.name.startswith("<") and base.name.endswith(">") and combined_bases:
+            prev_name = combined_bases[-1].name
+            protocol = base.name[1:-1]  # Strip < and >
+            if "<" in prev_name and prev_name.endswith(">"):
+                # Previous base already has protocols, merge inside the brackets
+                combined_bases[-1].name = f"{prev_name[:-1]}, {protocol}>"
+            else:
+                # First protocol for this base class
+                combined_bases[-1].name = f"{prev_name} <{protocol}>"
+        else:
+            combined_bases.append(base)
+
+    interface_scope.kind.add_base(combined_bases)
     interface_scope.location = scope_def.location.file
 
     _process_objc_sections(

--- a/scripts/cxx-api/tests/snapshots/should_handle_class_with_generic_inheritance/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_class_with_generic_inheritance/snapshot.api
@@ -1,0 +1,3 @@
+interface RCTAppearance : public RCTEventEmitter <RCTBridgeModule> {
+  public virtual instancetype init();
+}

--- a/scripts/cxx-api/tests/snapshots/should_handle_class_with_generic_inheritance/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_class_with_generic_inheritance/test.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+@interface RCTAppearance : RCTEventEmitter <RCTBridgeModule>
+- (instancetype)init;
+@end
+
+} // namespace test

--- a/scripts/cxx-api/tests/snapshots/should_handle_class_with_multiple_protocol_conformances/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_class_with_multiple_protocol_conformances/snapshot.api
@@ -1,0 +1,2 @@
+interface RCTAlertManager : public NSObject <RCTBridgeModule, RCTInvalidating> {
+}

--- a/scripts/cxx-api/tests/snapshots/should_handle_class_with_multiple_protocol_conformances/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_class_with_multiple_protocol_conformances/test.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+@interface RCTAlertManager : NSObject <RCTBridgeModule, RCTInvalidating>
+
+@end
+
+} // namespace test


### PR DESCRIPTION
Summary:
Doxygen incorrectly parses Objective-C interface declarations with protocol conformance. For example:

```objc
interface RCTAppearance : RCTEventEmitter <RCTBridgeModule>
```

Doxygen splits this into **two separate base classes** in the XML:
```xml
<basecompoundref>RCTEventEmitter</basecompoundref>
<basecompoundref>&lt;RCTBridgeModule&gt;</basecompoundref>
```

This caused the parser to output:
```
interface RCTAppearance : public RCTEventEmitter, public <RCTBridgeModule> {
```

Instead of the expected:
```
interface RCTAppearance : public RCTEventEmitter <RCTBridgeModule> {
```

The fix detects when a "base class" name starts and ends with `<...>` (indicating it's a protocol conformance) and combines it with the preceding actual base class name.

Also for multiple generics like:
```
interface RCTAlertManager : NSObject <RCTBridgeModule, RCTInvalidating>

end
```

The output should be
```
interface RCTAlertManager : public NSObject <RCTBridgeModule, RCTInvalidating>
end
```

Changelog:
[Internal]

Reviewed By: cipolleschi

Differential Revision: D94351731
