### PR TITLE
Skip observer notifications during performance tracing

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -130,6 +130,9 @@ function handleUpdate(): void {
   if (updateTimeout == null) {
     updateTimeout = setImmediate(() => {
       updateTimeout = null;
+      if (TracingStateObserver.isTracing()) {
+        return;
+      }
       const nextState = getNextState();
       observers.forEach(({observer}) => observer(nextState));
     });
@@ -212,6 +215,8 @@ export function addLog(log: LogData): void {
       isTracing => {
         if (isTracing) {
           clear();
+        } else {
+          handleUpdate();
         }
       },
     );

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -853,5 +853,73 @@ describe('LogBoxData', () => {
       LogBoxDataWithMock.observe(observerAfter).unsubscribe();
       expect(Array.from(observerAfter.mock.calls[0][0].logs).length).toBe(0);
     });
+
+    it('does not notify observers while tracing is active', () => {
+      const LogBoxDataWithMock = require('../LogBoxData');
+
+      LogBoxDataWithMock.addLog({
+        level: 'warn',
+        message: {content: 'Log 1', substitutions: []},
+        category: 'log-1',
+        componentStack: [],
+      });
+      jest.runOnlyPendingTimers();
+
+      const observer = jest.fn();
+      const subscription = LogBoxDataWithMock.observe(observer);
+
+      // observe() calls the observer once synchronously on subscribe
+      expect(observer).toHaveBeenCalledTimes(1);
+
+      // Start tracing
+      mockIsTracing = jest.fn(() => true);
+      if (mockSubscribeCallback) {
+        mockSubscribeCallback(true);
+      }
+      jest.runOnlyPendingTimers();
+
+      // Observer should NOT have been called again during tracing
+      expect(observer).toHaveBeenCalledTimes(1);
+
+      subscription.unsubscribe();
+    });
+
+    it('notifies observers when tracing ends to sync state', () => {
+      const LogBoxDataWithMock = require('../LogBoxData');
+
+      LogBoxDataWithMock.addLog({
+        level: 'warn',
+        message: {content: 'Log 1', substitutions: []},
+        category: 'log-1',
+        componentStack: [],
+      });
+      jest.runOnlyPendingTimers();
+
+      const observer = jest.fn();
+      const subscription = LogBoxDataWithMock.observe(observer);
+
+      // observe() calls once on subscribe
+      expect(observer).toHaveBeenCalledTimes(1);
+      expect(Array.from(observer.mock.calls[0][0].logs).length).toBe(1);
+
+      // Start tracing — clears logs but does not notify
+      mockIsTracing = jest.fn(() => true);
+      if (mockSubscribeCallback) {
+        mockSubscribeCallback(true);
+      }
+      jest.runOnlyPendingTimers();
+      expect(observer).toHaveBeenCalledTimes(1);
+
+      // End tracing — should notify observer with cleared state
+      mockIsTracing = jest.fn(() => false);
+      if (mockSubscribeCallback) {
+        mockSubscribeCallback(false);
+      }
+      jest.runOnlyPendingTimers();
+      expect(observer).toHaveBeenCalledTimes(2);
+      expect(Array.from(observer.mock.calls[1][0].logs).length).toBe(0);
+
+      subscription.unsubscribe();
+    });
   });
 });


### PR DESCRIPTION
Summary:
During performance tracing, LogBoxStateSubscription was causing an unnecessary re-render even though LogBox messages are already dropped. This happened because async work (e.g. symbolication completing) could trigger `handleUpdate()` during a trace, notifying observers and causing `LogBoxStateSubscription` to `setState` and re-render.

The fix adds an `isTracing()` guard inside `handleUpdate()`'s `setImmediate` callback so observer notifications are skipped for the entire duration of a trace. When tracing ends, a new `handleUpdate()` call syncs observers with the current (cleared) state.

This eliminates a spurious update visible in Marketplace sell items page performance traces.

Differential Revision: D94075642


