### PR TITLE
Deprecate getEventDispatcher variants

### DIFF
--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
@@ -34,7 +34,7 @@ public class ReactPopupMenuContainer(context: Context) : FrameLayout(context) {
     }
     popupMenu.setOnMenuItemClickListener { menuItem ->
       val reactContext = context as ReactContext
-      val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+      val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
       if (eventDispatcher != null) {
         val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
         eventDispatcher.dispatchEvent(PopupMenuSelectionEvent(surfaceId, id, menuItem.order))
@@ -43,7 +43,7 @@ public class ReactPopupMenuContainer(context: Context) : FrameLayout(context) {
     }
     popupMenu.setOnDismissListener {
       val reactContext = context as ReactContext
-      val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+      val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
       if (eventDispatcher != null) {
         val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
         eventDispatcher.dispatchEvent(PopupMenuDismissEvent(surfaceId, id))

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4324,6 +4324,7 @@ public final class com/facebook/react/uimanager/UIManagerHelper {
 	public static final field PADDING_START_INDEX I
 	public static final field PADDING_TOP_INDEX I
 	public static final fun getDefaultTextInputPadding (Landroid/content/Context;)[F
+	public static final fun getEventDispatcher (Lcom/facebook/react/bridge/ReactContext;)Lcom/facebook/react/uimanager/events/EventDispatcher;
 	public static final fun getEventDispatcher (Lcom/facebook/react/bridge/ReactContext;I)Lcom/facebook/react/uimanager/events/EventDispatcher;
 	public static final fun getEventDispatcherForReactTag (Lcom/facebook/react/bridge/ReactContext;I)Lcom/facebook/react/uimanager/events/EventDispatcher;
 	public static final fun getReactContext (Landroid/view/View;)Lcom/facebook/react/bridge/ReactContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -213,8 +213,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       return;
     }
 
-    EventDispatcher eventDispatcher =
-        UIManagerHelper.getEventDispatcher(reactContext, getUIManagerType());
+    EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext);
     if (eventDispatcher != null) {
       mJSTouchDispatcher.onChildStartedNativeGesture(ev, eventDispatcher, reactContext);
       if (childView != null && mJSPointerDispatcher != null) {
@@ -229,8 +228,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       return;
     }
 
-    EventDispatcher eventDispatcher =
-        UIManagerHelper.getEventDispatcher(getCurrentReactContext(), getUIManagerType());
+    EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcher(getCurrentReactContext());
     if (eventDispatcher != null) {
       mJSTouchDispatcher.onChildEndedNativeGesture(ev, eventDispatcher);
       if (mJSPointerDispatcher != null) {
@@ -411,8 +409,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       return;
     }
 
-    EventDispatcher eventDispatcher =
-        UIManagerHelper.getEventDispatcher(getCurrentReactContext(), getUIManagerType());
+    EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcher(getCurrentReactContext());
     if (eventDispatcher != null) {
       mJSPointerDispatcher.handleMotionEvent(event, eventDispatcher, isCapture);
     }
@@ -428,8 +425,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       return;
     }
 
-    EventDispatcher eventDispatcher =
-        UIManagerHelper.getEventDispatcher(getCurrentReactContext(), getUIManagerType());
+    EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcher(getCurrentReactContext());
     if (eventDispatcher != null) {
       mJSTouchDispatcher.handleTouchEvent(event, eventDispatcher, getCurrentReactContext());
     }
@@ -451,8 +447,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     }
     ReactContext context = getCurrentReactContext();
     if (context != null) {
-      EventDispatcher eventDispatcher =
-          UIManagerHelper.getEventDispatcher(context, getUIManagerType());
+      EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcher(context);
       int surfaceId = UIManagerHelper.getSurfaceId(context);
       if (eventDispatcher != null) {
         mJSKeyDispatcher.handleKeyEvent(ev, eventDispatcher, surfaceId);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
@@ -134,7 +134,7 @@ internal class BridgelessReactContext(context: Context, private val reactHost: R
         logSoftException(
             TAG,
             IllegalArgumentException(
-                "getJSModule(RCTEventEmitter) is not recommended in the new architecture and will stop working with interop disabled. Please use UIManagerHelper.getEventDispatcher or UIManagerHelper.getEventDispatcherForReactTag instead"
+                "getJSModule(RCTEventEmitter) is not recommended in the new architecture and will stop working with interop disabled. Please use UIManagerHelper.getEventDispatcher instead"
             ),
         )
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -1039,8 +1039,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       if (view.getContext() instanceof ThemedReactContext) {
         ThemedReactContext themedReactContext = (ThemedReactContext) view.getContext();
         @Nullable
-        EventDispatcher eventDispatcher =
-            UIManagerHelper.getEventDispatcherForReactTag(themedReactContext, view.getId());
+        EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcher(themedReactContext);
         if (eventDispatcher != null) {
           if (hasFocus) {
             eventDispatcher.dispatchEvent(new FocusEvent(surfaceId, view.getId()));

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.kt
@@ -112,56 +112,32 @@ public object UIManagerHelper {
     }
   }
 
+  /** @return the [EventDispatcher] that handles events for the given [ReactContext]. */
+  @JvmStatic
+  public fun getEventDispatcher(context: ReactContext): EventDispatcher? {
+    var localContext = context
+    if (localContext is ThemedReactContext) {
+      localContext = localContext.reactApplicationContext
+    }
+    return (localContext as EventDispatcherProvider).getEventDispatcher()
+  }
+
   /** @return the [EventDispatcher] that handles events for the reactTag received as a parameter. */
   @JvmStatic
-  public fun getEventDispatcherForReactTag(context: ReactContext, reactTag: Int): EventDispatcher? {
-    val eventDispatcher = getEventDispatcher(context, getUIManagerType(reactTag))
-    if (eventDispatcher == null) {
-      ReactSoftExceptionLogger.logSoftException(
-          TAG,
-          IllegalStateException("Cannot get EventDispatcher for reactTag $reactTag"),
-      )
-    }
-    return eventDispatcher
-  }
+  @Deprecated("reactTag is no longer needed", ReplaceWith("getEventDispatcher(context)"))
+  public fun getEventDispatcherForReactTag(context: ReactContext, reactTag: Int): EventDispatcher? =
+      getEventDispatcher(context)
 
   /**
    * @return the [EventDispatcher] that handles events for the [UIManagerType] received as a
    *   parameter.
    */
   @JvmStatic
+  @Deprecated("UIManagerType is no longer needed", ReplaceWith("getEventDispatcher(context)"))
   public fun getEventDispatcher(
       context: ReactContext,
       @UIManagerType uiManagerType: Int,
-  ): EventDispatcher? {
-    // TODO T67518514 Clean this up once we migrate everything over to bridgeless mode
-    var localContext = context
-    if (localContext.isBridgeless()) {
-      if (localContext is ThemedReactContext) {
-        localContext = localContext.reactApplicationContext
-      }
-      return (localContext as EventDispatcherProvider).getEventDispatcher()
-    }
-    val uiManager = getUIManager(localContext, uiManagerType, false)
-    if (uiManager == null) {
-      ReactSoftExceptionLogger.logSoftException(
-          TAG,
-          ReactNoCrashSoftException("Unable to find UIManager for UIManagerType $uiManagerType"),
-      )
-      return null
-    }
-    val eventDispatcher = uiManager.eventDispatcher
-    // Linter shows "Condition is always 'false'."
-    // Keeping it for now as it was in the original Java code.
-    @Suppress("SENSELESS_COMPARISON")
-    if (eventDispatcher == null) {
-      ReactSoftExceptionLogger.logSoftException(
-          TAG,
-          IllegalStateException("Cannot get EventDispatcher for UIManagerType $uiManagerType"),
-      )
-    }
-    return eventDispatcher
-  }
+  ): EventDispatcher? = getEventDispatcher(context)
 
   /**
    * @return The [ReactContext] associated to the [View] received as a parameter.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
@@ -46,8 +46,7 @@ public class ReactDrawerLayoutManager :
       reactContext: ThemedReactContext,
       view: ReactDrawerLayout,
   ) {
-    val eventDispatcher =
-        UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id) ?: return
+    val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext) ?: return
     view.addDrawerListener(DrawerEventEmitter(view, eventDispatcher))
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -129,9 +129,7 @@ public class ReactImageView(
     if (!shouldNotify) {
       downloadListener = null
     } else {
-      val eventDispatcher =
-          UIManagerHelper.getEventDispatcherForReactTag((context as ReactContext), id)
-
+      val eventDispatcher = UIManagerHelper.getEventDispatcher((context as ReactContext))
       downloadListener =
           object : ReactImageDownloadListener<ImageInfo>() {
             override fun onProgressChange(loaded: Int, total: Int) {
@@ -378,8 +376,7 @@ public class ReactImageView(
       } catch (e: RuntimeException) {
         // Only provide updates if downloadListener is set (shouldNotify is true)
         if (downloadListener != null) {
-          val eventDispatcher =
-              UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
+          val eventDispatcher = UIManagerHelper.getEventDispatcher(context as ReactContext)
           eventDispatcher?.dispatchEvent(
               createErrorEvent(UIManagerHelper.getSurfaceId(this), id, e)
           )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -91,7 +91,7 @@ internal class ReactModalHostManager :
   }
 
   override fun addEventEmitters(reactContext: ThemedReactContext, view: ReactModalHostView) {
-    val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id)
+    val dispatcher = UIManagerHelper.getEventDispatcher(reactContext)
     if (dispatcher != null) {
       view.onRequestCloseListener = OnRequestCloseListener {
         dispatcher.dispatchEvent(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -133,7 +133,7 @@ public object ReactScrollViewHelper {
     // if there's a crash initiated from JS and we tap on a ScrollView
     // around teardown of RN, this will cause a NPE. We can safely ignore
     // this since the crash is usually a red herring.
-    val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, scrollView.id)
+    val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
     if (eventDispatcher != null) {
       eventDispatcher.dispatchEvent(
           ScrollEvent.obtain(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
@@ -112,7 +112,7 @@ internal open class SwipeRefreshLayoutManager :
 
   override fun addEventEmitters(reactContext: ThemedReactContext, view: ReactSwipeRefreshLayout) {
     view.setOnRefreshListener {
-      val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id)
+      val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
       eventDispatcher?.dispatchEvent(RefreshEvent(UIManagerHelper.getSurfaceId(view), view.id))
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
@@ -139,7 +139,7 @@ internal class ReactSwitchManager :
         CompoundButton.OnCheckedChangeListener { buttonView, isChecked ->
           val reactContext = buttonView.context as ReactContext
           val reactTag = buttonView.id
-          UIManagerHelper.getEventDispatcherForReactTag(reactContext, reactTag)
+          UIManagerHelper.getEventDispatcher(reactContext)
               ?.dispatchEvent(
                   ReactSwitchEvent(UIManagerHelper.getSurfaceId(reactContext), reactTag, isChecked)
               )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactClickableSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactClickableSpan.kt
@@ -42,7 +42,7 @@ internal class ReactClickableSpan(val reactTag: Int) : ClickableSpan(), ReactSpa
 
   override fun onClick(view: View) {
     val context = view.context as ReactContext
-    val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, reactTag)
+    val eventDispatcher = UIManagerHelper.getEventDispatcher(context)
     eventDispatcher?.dispatchEvent(
         ViewGroupClickEvent(UIManagerHelper.getSurfaceId(context), reactTag)
     )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactLinkSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactLinkSpan.kt
@@ -42,7 +42,7 @@ internal class ReactLinkSpan(val fragmentIndex: Int) : ClickableSpan(), ReactSpa
           else -> null
         } ?: return
     val reactTag = preparedLayout.reactTags[fragmentIndex]
-    val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, reactTag)
+    val eventDispatcher = UIManagerHelper.getEventDispatcher(context)
     eventDispatcher?.dispatchEvent(
         ViewGroupClickEvent(UIManagerHelper.getSurfaceId(context), reactTag)
     )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextContentSizeWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextContentSizeWatcher.kt
@@ -20,7 +20,7 @@ internal class ReactTextContentSizeWatcher(private val editText: ReactEditText) 
 
   init {
     val reactContext = UIManagerHelper.getReactContext(editText)
-    eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, editText.id)
+    eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
     surfaceId = UIManagerHelper.getSurfaceId(reactContext)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -1151,6 +1151,6 @@ public open class ReactTextInputManager public constructor() :
     private fun getEventDispatcher(
         reactContext: ReactContext,
         editText: ReactEditText,
-    ): EventDispatcher? = UIManagerHelper.getEventDispatcherForReactTag(reactContext, editText.id)
+    ): EventDispatcher? = UIManagerHelper.getEventDispatcher(reactContext)
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputTextWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputTextWatcher.kt
@@ -19,8 +19,7 @@ internal class ReactTextInputTextWatcher(
     reactContext: ReactContext,
     private val editText: ReactEditText,
 ) : TextWatcher {
-  private val eventDispatcher: EventDispatcher? =
-      UIManagerHelper.getEventDispatcherForReactTag(reactContext, editText.id)
+  private val eventDispatcher: EventDispatcher? = UIManagerHelper.getEventDispatcher(reactContext)
   private val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
   private var previousText: String? = null
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextScrollWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextScrollWatcher.kt
@@ -20,7 +20,7 @@ internal class ReactTextScrollWatcher(private val editText: ReactEditText) : Scr
 
   init {
     val reactContext = UIManagerHelper.getReactContext(editText)
-    eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, editText.id)
+    eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
     surfaceId = UIManagerHelper.getSurfaceId(reactContext)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextSelectionWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextSelectionWatcher.kt
@@ -20,7 +20,7 @@ internal class ReactTextSelectionWatcher(private val editText: ReactEditText) : 
 
   init {
     val reactContext = UIManagerHelper.getReactContext(editText)
-    eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, editText.id)
+    eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
     surfaceId = UIManagerHelper.getSurfaceId(reactContext)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -402,8 +402,7 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
   public open fun setFocusable(view: ReactViewGroup, focusable: Boolean) {
     if (focusable) {
       view.setOnClickListener {
-        val eventDispatcher =
-            UIManagerHelper.getEventDispatcherForReactTag((view.context as ReactContext), view.id)
+        val eventDispatcher = UIManagerHelper.getEventDispatcher(view.context as ReactContext)
         eventDispatcher?.dispatchEvent(
             ViewGroupClickEvent(UIManagerHelper.getSurfaceId(view.context), view.id)
         )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualViewManager.kt
@@ -61,7 +61,7 @@ public class ReactVirtualViewManager :
       reactContext: ThemedReactContext,
       view: ReactVirtualView,
   ) {
-    val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id) ?: return
+    val dispatcher = UIManagerHelper.getEventDispatcher(reactContext) ?: return
     view.modeChangeEmitter =
         VirtualViewEventEmitter(view.id, UIManagerHelper.getSurfaceId(reactContext), dispatcher)
   }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeView.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeView.kt
@@ -118,7 +118,7 @@ internal class MyNativeView(context: ThemedReactContext) : View(context) {
 
     val reactContext = context as ReactContext
     val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
-    val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+    val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
     val event = OnIntArrayChangedEvent(surfaceId, id, payload)
 
     eventDispatcher?.dispatchEvent(event)
@@ -127,7 +127,7 @@ internal class MyNativeView(context: ThemedReactContext) : View(context) {
   fun emitLegacyStyleEvent() {
     val reactContext = context as ReactContext
     val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
-    val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+    val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext)
     val payload = Arguments.createMap().apply { putString("string", "Legacy Style Event Fired.") }
     val event = OnLegacyStyleEvent(surfaceId, id, payload)
     eventDispatcher?.dispatchEvent(event)


### PR DESCRIPTION
Summary:
Cleanup this UIManagerHelper helper - now that we're fully on the new arch this can be simplified.

Changelog: [Android][Breaking] Deprecated UIManagerHelper.getEventDispatcherForReactTag and UIManagerHelper.getEventDispatcher(ReactContext, UIManagerType Int), use getEventDispatcher

Differential Revision: D94514934
