### PR TITLE
Remove const_cast from appendChild by fixing API signature

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -740,7 +740,7 @@ void FabricUIManagerBinding::schedulerDidRequestPreliminaryViewAllocation(
   // to be destroyed if the ShadowNode is destroyed but it was never mounted
   // on the screen.
   if (shadowNode.getTraits().check(ShadowNodeTraits::Trait::FormsView)) {
-    shadowNode.getFamily().onUnmountedFamilyDestroyed(
+    shadowNode.getFamilyShared()->onUnmountedFamilyDestroyed(
         [weakMountingManager =
              std::weak_ptr(mountingManager)](const ShadowNodeFamily& family) {
           if (auto mountingManager = weakMountingManager.lock()) {

--- a/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
@@ -89,7 +89,7 @@ class AnimatedModule : public NativeAnimatedModuleCxxSpec<AnimatedModule>, publi
 
   struct ConnectAnimatedNodeToShadowNodeFamilyOp {
     Tag nodeTag{};
-    std::shared_ptr<const ShadowNodeFamily> shadowNodeFamily{};
+    std::shared_ptr<ShadowNodeFamily> shadowNodeFamily{};
   };
 
   struct DisconnectAnimatedNodeFromViewOp {

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -236,7 +236,7 @@ void NativeAnimatedNodesManager::connectAnimatedNodeToView(
 
 void NativeAnimatedNodesManager::connectAnimatedNodeToShadowNodeFamily(
     Tag propsNodeTag,
-    std::shared_ptr<const ShadowNodeFamily> family) noexcept {
+    std::shared_ptr<ShadowNodeFamily> family) noexcept {
   react_native_assert(propsNodeTag);
   auto node = getAnimatedNode<PropsAnimatedNode>(propsNodeTag);
   if (node != nullptr && family != nullptr) {

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -101,7 +101,7 @@ class NativeAnimatedNodesManager {
 
   void connectAnimatedNodeToView(Tag propsNodeTag, Tag viewTag) noexcept;
 
-  void connectAnimatedNodeToShadowNodeFamily(Tag propsNodeTag, std::shared_ptr<const ShadowNodeFamily> family) noexcept;
+  void connectAnimatedNodeToShadowNodeFamily(Tag propsNodeTag, std::shared_ptr<ShadowNodeFamily> family) noexcept;
 
   void disconnectAnimatedNodes(Tag parentTag, Tag childTag) noexcept;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
@@ -59,7 +59,7 @@ RootShadowNode::Unshared RootShadowNode::clone(
 
 void RootShadowNode::setInstanceHandle(
     InstanceHandle::Shared instanceHandle) const {
-  getFamily().setInstanceHandle(instanceHandle);
+  getFamilyShared()->setInstanceHandle(instanceHandle);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -91,7 +91,7 @@ class ComponentDescriptor {
    * Appends (by mutating) a given `childShadowNode` to `parentShadowNode`.
    */
   virtual void appendChild(
-      const std::shared_ptr<const ShadowNode> &parentShadowNode,
+      const std::shared_ptr<ShadowNode> &parentShadowNode,
       const std::shared_ptr<const ShadowNode> &childShadowNode) const = 0;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -89,11 +89,11 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   }
 
   void appendChild(
-      const std::shared_ptr<const ShadowNode> &parentShadowNode,
+      const std::shared_ptr<ShadowNode> &parentShadowNode,
       const std::shared_ptr<const ShadowNode> &childShadowNode) const override
   {
-    auto &concreteParentShadowNode = static_cast<const ShadowNodeT &>(*parentShadowNode);
-    const_cast<ShadowNodeT &>(concreteParentShadowNode).appendChild(childShadowNode);
+    auto &concreteParentShadowNode = static_cast<ShadowNodeT &>(*parentShadowNode);
+    concreteParentShadowNode.appendChild(childShadowNode);
   }
 
   virtual Props::Shared cloneProps(const PropsParserContext &context, const Props::Shared &props, RawProps rawProps)

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
@@ -33,7 +33,7 @@ ShadowNodeFamily::ShadowNodeFamily(
       componentHandle_(componentDescriptor.getComponentHandle()),
       componentName_(componentDescriptor.getComponentName()) {}
 
-void ShadowNodeFamily::setParent(const ShadowNodeFamily::Shared& parent) const {
+void ShadowNodeFamily::setParent(const ShadowNodeFamily::Shared& parent) {
   react_native_assert(parent_.lock() == nullptr || parent_.lock() == parent);
   if (hasParent_) {
     return;
@@ -59,7 +59,7 @@ ComponentName ShadowNodeFamily::getComponentName() const {
   return componentName_;
 }
 
-void ShadowNodeFamily::setMounted() const {
+void ShadowNodeFamily::setMounted() {
   hasBeenMounted_ = true;
 }
 
@@ -68,7 +68,7 @@ const ComponentDescriptor& ShadowNodeFamily::getComponentDescriptor() const {
 }
 
 void ShadowNodeFamily::onUnmountedFamilyDestroyed(
-    std::function<void(const ShadowNodeFamily& family)> callback) const {
+    std::function<void(const ShadowNodeFamily& family)> callback) {
   onUnmountedFamilyDestroyedCallback_ = std::move(callback);
 }
 
@@ -89,7 +89,7 @@ InstanceHandle::Shared ShadowNodeFamily::getInstanceHandle() const {
 }
 
 void ShadowNodeFamily::setInstanceHandle(
-    InstanceHandle::Shared& instanceHandle) const {
+    InstanceHandle::Shared& instanceHandle) {
   instanceHandle_ = instanceHandle;
 }
 
@@ -144,7 +144,7 @@ State::Shared ShadowNodeFamily::getMostRecentState() const {
   return mostRecentState_;
 }
 
-void ShadowNodeFamily::setMostRecentState(const State::Shared& state) const {
+void ShadowNodeFamily::setMostRecentState(const State::Shared& state) {
   std::unique_lock lock(mutex_);
 
   /*
@@ -175,7 +175,7 @@ std::shared_ptr<const State> ShadowNodeFamily::getMostRecentStateIfObsolete(
 
 void ShadowNodeFamily::dispatchRawState(
     StateUpdate&& stateUpdate,
-    EventQueue::UpdateMode updateMode) const {
+    EventQueue::UpdateMode updateMode) {
   auto eventDispatcher = eventDispatcher_.lock();
   if (!eventDispatcher) {
     return;

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -41,8 +41,8 @@ struct ShadowNodeFamilyFragment {
  */
 class ShadowNodeFamily final : public jsi::NativeState {
  public:
-  using Shared = std::shared_ptr<const ShadowNodeFamily>;
-  using Weak = std::weak_ptr<const ShadowNodeFamily>;
+  using Shared = std::shared_ptr<ShadowNodeFamily>;
+  using Weak = std::weak_ptr<ShadowNodeFamily>;
 
   using AncestorList =
       std::vector<std::pair<std::reference_wrapper<const ShadowNode> /* parentNode */, int /* childIndex */>>;
@@ -58,7 +58,7 @@ class ShadowNodeFamily final : public jsi::NativeState {
    * This is not technically thread-safe, but practically it mutates the object
    * only once (and the model enforces that this first call is not concurrent).
    */
-  void setParent(const ShadowNodeFamily::Shared &parent) const;
+  void setParent(const ShadowNodeFamily::Shared &parent);
 
   /*
    * Returns a handle (or name) associated with the component.
@@ -90,23 +90,23 @@ class ShadowNodeFamily final : public jsi::NativeState {
    * @param callback will be executed when an unmounted instance of
    * ShadowNodeFamily is destroyed.
    */
-  void onUnmountedFamilyDestroyed(std::function<void(const ShadowNodeFamily &family)> callback) const;
+  void onUnmountedFamilyDestroyed(std::function<void(const ShadowNodeFamily &family)> callback);
 
   /*
    * Sets and gets the most recent state.
    */
   std::shared_ptr<const State> getMostRecentState() const;
-  void setMostRecentState(const std::shared_ptr<const State> &state) const;
+  void setMostRecentState(const std::shared_ptr<const State> &state);
 
   /**
    * Mark this ShadowNodeFamily as mounted.
    */
-  void setMounted() const;
+  void setMounted();
 
   /*
    * Dispatches a state update with given priority.
    */
-  void dispatchRawState(StateUpdate &&stateUpdate, EventQueue::UpdateMode updateMode) const;
+  void dispatchRawState(StateUpdate &&stateUpdate, EventQueue::UpdateMode updateMode);
 
   /*
    * Holds currently applied native props. `nullptr` if setNativeProps API is
@@ -122,7 +122,7 @@ class ShadowNodeFamily final : public jsi::NativeState {
 
   jsi::Value getInstanceHandle(jsi::Runtime &runtime) const;
   InstanceHandle::Shared getInstanceHandle() const;
-  void setInstanceHandle(InstanceHandle::Shared &instanceHandle) const;
+  void setInstanceHandle(InstanceHandle::Shared &instanceHandle);
 
   /**
    * Override destructor to call onUnmountedFamilyDestroyedCallback() for
@@ -142,10 +142,10 @@ class ShadowNodeFamily final : public jsi::NativeState {
   std::shared_ptr<const State> getMostRecentStateIfObsolete(const State &state) const;
 
   EventDispatcher::Weak eventDispatcher_;
-  mutable std::shared_ptr<const State> mostRecentState_;
+  std::shared_ptr<const State> mostRecentState_;
   mutable std::shared_mutex mutex_;
 
-  mutable std::function<void(ShadowNodeFamily &family)> onUnmountedFamilyDestroyedCallback_ = nullptr;
+  std::function<void(ShadowNodeFamily &family)> onUnmountedFamilyDestroyedCallback_ = nullptr;
 
   /*
    * Deprecated.
@@ -160,7 +160,7 @@ class ShadowNodeFamily final : public jsi::NativeState {
   /*
    * Weak reference to the React instance handle
    */
-  mutable InstanceHandle::Shared instanceHandle_;
+  InstanceHandle::Shared instanceHandle_;
 
   /*
    * `EventEmitter` associated with all nodes of the family.
@@ -184,18 +184,18 @@ class ShadowNodeFamily final : public jsi::NativeState {
   /*
    * Points to a family of all parent nodes of all nodes of the family.
    */
-  mutable ShadowNodeFamily::Weak parent_{};
+  ShadowNodeFamily::Weak parent_{};
 
   /*
    * Represents a case where `parent_` is `nullptr`.
    * For optimization purposes only.
    */
-  mutable bool hasParent_{false};
+  bool hasParent_{false};
 
   /*
    * Determines if the ShadowNodeFamily was ever mounted on the screen.
    */
-  mutable bool hasBeenMounted_{false};
+  bool hasBeenMounted_{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
@@ -111,7 +111,7 @@ TEST(ComponentDescriptorTest, appendChild) {
           /* .surfaceId = */ .surfaceId = 1,
           /* .instanceHandle = */ .instanceHandle = nullptr,
       });
-  std::shared_ptr<const ShadowNode> node1 = descriptor->createShadowNode(
+  std::shared_ptr<ShadowNode> node1 = descriptor->createShadowNode(
       ShadowNodeFragment{
           /* .props = */ .props = props,
       },

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -175,7 +175,7 @@ std::shared_ptr<ShadowNode> UIManager::cloneNode(
 }
 
 void UIManager::appendChild(
-    const std::shared_ptr<const ShadowNode>& parentShadowNode,
+    const std::shared_ptr<ShadowNode>& parentShadowNode,
     const std::shared_ptr<const ShadowNode>& childShadowNode) const {
   TraceSection s("UIManager::appendChild");
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -152,7 +152,7 @@ class UIManager final : public ShadowTreeDelegate {
       RawProps rawProps) const;
 
   void appendChild(
-      const std::shared_ptr<const ShadowNode> &parentShadowNode,
+      const std::shared_ptr<ShadowNode> &parentShadowNode,
       const std::shared_ptr<const ShadowNode> &childShadowNode) const;
 
   void completeSurface(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -395,8 +395,12 @@ jsi::Value UIManagerBinding::get(
           validateArgumentCount(runtime, methodName, paramCount, count);
 
           uiManager->appendChild(
-              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
-                  runtime, arguments[0]),
+              // const_pointer_cast is safe here because appendChild is called
+              // on an unsealed shadow node during tree construction, before it
+              // is sealed and becomes truly immutable.
+              std::const_pointer_cast<ShadowNode>(
+                  Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                      runtime, arguments[0])),
               Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
                   runtime, arguments[1]));
           return jsi::Value::undefined();


### PR DESCRIPTION
Summary:
Change appendChild to take non-const parent ShadowNode pointer since the
method mutates the parent by appending a child to it. This removes the
const_cast in ConcreteComponentDescriptor::appendChild which was a code
smell.

The parent node is always unsealed during tree construction when
appendChild is called, so passing a non-const pointer accurately
reflects the mutation that occurs.

Changelog:
[Internal] [Changed] - Remove const_cast from appendChild in Fabric renderer

Reviewed By: javache

Differential Revision: D90763774


