### PR TITLE
Add cookie URL validation check to prevent crash

### DIFF
--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
@@ -84,8 +84,12 @@ RCT_EXPORT_METHOD(
   }
 
   // Load and set the cookie header.
-  NSArray<NSHTTPCookie *> *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:components.URL];
-  request.allHTTPHeaderFields = [NSHTTPCookie requestHeaderFieldsWithCookies:cookies];
+  if (components != nil && components.URL != nil) {
+    NSArray<NSHTTPCookie *> *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:components.URL];
+    request.allHTTPHeaderFields = [NSHTTPCookie requestHeaderFieldsWithCookies:cookies];
+  } else {
+    RCTLogError(@"RCTWebSocketModule: Invalid URL components - components or components.URL is nil");
+  }
 
   // Load supplied headers
   if ([options.headers() isKindOfClass:NSDictionary.class]) {


### PR DESCRIPTION
Summary:
Add defensive check to validate components.URL before using it to load cookies.
If NSURLComponents fails to parse the URL or returns nil for components.URL, this prevents passing nil to cookiesForURL which could cause issues in the network stack.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D94375528


