### PR TITLE
Use HTTPS/WSS for dev-support traffic when port is 443

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2106,7 +2106,9 @@ public final class com/facebook/react/devsupport/inspector/DevSupportHttpClient 
 	public static final fun addRequestHeader (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getHttpClient ()Lokhttp3/OkHttpClient;
 	public final fun getWebsocketClient ()Lokhttp3/OkHttpClient;
+	public static final fun httpScheme (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun removeRequestHeader (Ljava/lang/String;)V
+	public static final fun wsScheme (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract interface class com/facebook/react/devsupport/interfaces/BundleLoadCallback {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
@@ -79,7 +79,8 @@ public open class DevServerHelper(
   }
 
   public val websocketProxyURL: String
-    get() = "ws://${packagerConnectionSettings.debugServerHost}/debugger-proxy?role=client"
+    get() =
+        "${DevSupportHttpClient.wsScheme(packagerConnectionSettings.debugServerHost)}://${packagerConnectionSettings.debugServerHost}/debugger-proxy?role=client"
 
   private enum class BundleType(val typeID: String) {
     BUNDLE("bundle"),
@@ -124,7 +125,8 @@ public open class DevServerHelper(
     get() =
         String.format(
             Locale.US,
-            "http://%s/inspector/device?name=%s&app=%s&device=%s&profiling=%b",
+            "%s://%s/inspector/device?name=%s&app=%s&device=%s&profiling=%b",
+            DevSupportHttpClient.httpScheme(packagerConnectionSettings.debugServerHost),
             packagerConnectionSettings.debugServerHost,
             Uri.encode(getFriendlyDeviceName()),
             Uri.encode(packageName),
@@ -287,7 +289,8 @@ public open class DevServerHelper(
     }
     return (String.format(
         Locale.US,
-        "http://%s/%s.%s?platform=android&dev=%s&lazy=%s&minify=%s&app=%s&modulesOnly=%s&runModule=%s",
+        "%s://%s/%s.%s?platform=android&dev=%s&lazy=%s&minify=%s&app=%s&modulesOnly=%s&runModule=%s",
+        DevSupportHttpClient.httpScheme(host),
         host,
         mainModuleID,
         type.typeID,
@@ -362,7 +365,8 @@ public open class DevServerHelper(
     requestUrlBuilder.append(
         String.format(
             Locale.US,
-            "http://%s/open-debugger?device=%s",
+            "%s://%s/open-debugger?device=%s",
+            DevSupportHttpClient.httpScheme(packagerConnectionSettings.debugServerHost),
             packagerConnectionSettings.debugServerHost,
             Uri.encode(inspectorDeviceId),
         )
@@ -440,7 +444,13 @@ public open class DevServerHelper(
         FLog.w(ReactConstants.TAG, "Resource path should not begin with `/`, removing it.")
         resourcePath = resourcePath.substring(1)
       }
-      return String.format(Locale.US, "http://%s/%s", host, resourcePath)
+      return String.format(
+          Locale.US,
+          "%s://%s/%s",
+          DevSupportHttpClient.httpScheme(host),
+          host,
+          resourcePath,
+      )
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
@@ -79,9 +79,14 @@ internal class PackagerStatusCheck(private val client: OkHttpClient) {
 
   private companion object {
     private const val PACKAGER_OK_STATUS = "packager-status:running"
-    private const val PACKAGER_STATUS_URL_TEMPLATE = "http://%s/status"
+    private const val PACKAGER_STATUS_URL_TEMPLATE = "%s://%s/status"
 
     private fun createPackagerStatusURL(host: String): String =
-        String.format(Locale.US, PACKAGER_STATUS_URL_TEMPLATE, host)
+        String.format(
+            Locale.US,
+            PACKAGER_STATUS_URL_TEMPLATE,
+            DevSupportHttpClient.httpScheme(host),
+            host,
+        )
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/DevSupportHttpClient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/DevSupportHttpClient.kt
@@ -58,4 +58,17 @@ public object DevSupportHttpClient {
   public fun removeRequestHeader(name: String) {
     customHeaders.remove(name)
   }
+
+  /**
+   * Returns the appropriate HTTP scheme ("http" or "https") for the given host. Uses "https" when
+   * the host specifies port 443 explicitly (e.g. "example.com:443").
+   */
+  @JvmStatic
+  public fun httpScheme(host: String): String = if (host.endsWith(":443")) "https" else "http"
+
+  /**
+   * Returns the appropriate WebSocket scheme ("ws" or "wss") for the given host. Uses "wss" when
+   * the host specifies port 443 explicitly (e.g. "example.com:443").
+   */
+  @JvmStatic public fun wsScheme(host: String): String = if (host.endsWith(":443")) "wss" else "ws"
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/JSPackagerClient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/JSPackagerClient.kt
@@ -9,6 +9,7 @@ package com.facebook.react.packagerconnection
 
 import android.net.Uri
 import com.facebook.common.logging.FLog
+import com.facebook.react.devsupport.inspector.DevSupportHttpClient
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers.getFriendlyDeviceName
 import com.facebook.react.packagerconnection.ReconnectingWebSocket.MessageCallback
 import okio.ByteString
@@ -28,7 +29,7 @@ public constructor(
   init {
     val url =
         Uri.Builder()
-            .scheme("ws")
+            .scheme(DevSupportHttpClient.wsScheme(settings.debugServerHost))
             .encodedAuthority(settings.debugServerHost)
             .appendPath("message")
             .appendQueryParameter("device", getFriendlyDeviceName())


### PR DESCRIPTION
Summary:
React Native hardcodes http:// and ws:// schemes for all dev-support
URLs (inspector, message, status, bundle, debugger). When routing
through the atod proxy on port 443, this causes plain HTTP connections
to an HTTPS port, which fail.

Add httpScheme()/wsScheme() helpers to DevSupportHttpClient that
return https/wss when the host ends with :443, and update all URL
construction sites: DevServerHelper, JSPackagerClient, and
PackagerStatusCheck.

Changelog: [Internal]

Differential Revision: D94529835


