### PR TITLE
Fix race causing NPE in AccessibilityInfoModule event emission

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -211,22 +211,16 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
   private fun updateAndSendTouchExplorationChangeEvent(enabled: Boolean) {
     if (touchExplorationEnabled != enabled) {
       touchExplorationEnabled = enabled
-      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
-      if (reactApplicationContext != null) {
-        getReactApplicationContext()
-            .emitDeviceEvent(TOUCH_EXPLORATION_EVENT_NAME, touchExplorationEnabled)
-      }
+      getReactApplicationContextIfActiveOrWarn()
+          ?.emitDeviceEvent(TOUCH_EXPLORATION_EVENT_NAME, touchExplorationEnabled)
     }
   }
 
   private fun updateAndSendAccessibilityServiceChangeEvent(enabled: Boolean) {
     if (accessibilityServiceEnabled != enabled) {
       accessibilityServiceEnabled = enabled
-      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
-      if (reactApplicationContext != null) {
-        getReactApplicationContext()
-            .emitDeviceEvent(ACCESSIBILITY_SERVICE_EVENT_NAME, accessibilityServiceEnabled)
-      }
+      getReactApplicationContextIfActiveOrWarn()
+          ?.emitDeviceEvent(ACCESSIBILITY_SERVICE_EVENT_NAME, accessibilityServiceEnabled)
     }
   }
 


### PR DESCRIPTION
Summary:
Fixing this reported crash:
```
android:java.lang.NullPointerException:com.facebook.react.modules.accessibilityinfo.AccessibilityInfoModule.updateAndSendTouchExplorationChangeEvent:unknown
```

Prevent `NullPointerException` crashes by removing a TOCTOU (Time-Of-Check to Time-Of-Use) race when emitting accessibility state change events.
The React context can become invalid between check and use; using a safe call on `getReactApplicationContextIfActiveOrWarn` ensures events are only sent when the context is active.

Changelog: [Internal]

---

Differential Revision: D94558522


