### PR TITLE
Fix DynamicFromArray thread-safety by using ThreadLocal pool

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromArray.kt
@@ -17,7 +17,7 @@ internal class DynamicFromArray private constructor() : Dynamic {
   override fun recycle() {
     array = null
     index = -1
-    pool.release(this)
+    pool.get()?.release(this)
   }
 
   override val type: ReadableType
@@ -48,11 +48,16 @@ internal class DynamicFromArray private constructor() : Dynamic {
       array?.getString(index) ?: throw IllegalStateException("This dynamic value has been recycled")
 
   companion object {
-    private val pool = Pools.SimplePool<DynamicFromArray>(10)
+    private val pool: ThreadLocal<Pools.SimplePool<DynamicFromArray>> =
+        object : ThreadLocal<Pools.SimplePool<DynamicFromArray>>() {
+          override fun initialValue(): Pools.SimplePool<DynamicFromArray> {
+            return Pools.SimplePool(10)
+          }
+        }
 
     @JvmStatic
     fun create(array: ReadableArray, index: Int): DynamicFromArray {
-      val dynamic = pool.acquire() ?: DynamicFromArray()
+      val dynamic = pool.get()?.acquire() ?: DynamicFromArray()
       dynamic.array = array
       dynamic.index = index
       return dynamic


### PR DESCRIPTION
## Summary

`DynamicFromArray` uses a plain `Pools.SimplePool` shared across all threads. When two threads concurrently access the same pooled `DynamicFromArray` instance — one calling `recycle()` while the other reads from it — the reader sees `array == null` and throws `IllegalStateException("This dynamic value has been recycled")`.

The sibling class `DynamicFromMap` was fixed for this exact issue in #17842 (2018) by switching to `ThreadLocal<SimplePool>`, giving each thread its own isolated pool. A reviewer on that PR [noted](https://github.com/facebook/react-native/pull/17842#issuecomment-426784854) the same fix should be applied to `DynamicFromArray`, but it never was.

This PR applies the identical `ThreadLocal` pattern from `DynamicFromMap` to `DynamicFromArray`.

## Changelog:

[ANDROID] [FIXED] - Fix thread-safety crash in `DynamicFromArray` by using `ThreadLocal<SimplePool>` instead of a shared `SimplePool`, matching the existing fix in `DynamicFromMap`

## Test Plan

The change mirrors the existing pattern in `DynamicFromMap.kt` in the same directory — the only difference is the type parameter. The crash is a race condition that is not reliably reproducible in a unit test, but can be confirmed by:

1. Verify `DynamicFromArray.kt` now uses `ThreadLocal<Pools.SimplePool<DynamicFromArray>>` for its pool, `pool.get()?.acquire()` in `create()`, and `pool.get()?.release(this)` in `recycle()`
2. Verify this matches the pattern in `DynamicFromMap.kt` line-for-line
3. Build and run the Android app — no behavioral change expected since the pooling logic is identical, just thread-isolated