### PR TITLE
[0.83] Fix rncore tarball extraction for EdenFS compatibility

### DIFF
--- a/packages/react-native/scripts/replace-rncore-version.js
+++ b/packages/react-native/scripts/replace-rncore-version.js
@@ -75,23 +75,21 @@ function replaceRNCoreConfiguration(
 
   try {
     console.log('Extracting the tarball to temp dir', tarballURLPath);
-    const result = spawnSync('tar', ['-xf', tarballURLPath, '-C', tmpExtractDir], {
-      stdio: 'inherit',
-    });
+    const result = spawnSync(
+      'tar',
+      ['-xf', tarballURLPath, '-C', tmpExtractDir],
+      {
+        stdio: 'inherit',
+      },
+    );
 
     if (result.status !== 0) {
-      throw new Error(
-        `tar extraction failed with exit code ${result.status}`,
-      );
+      throw new Error(`tar extraction failed with exit code ${result.status}`);
     }
 
     // Verify extraction produced the expected xcframework structure
     const xcfwPath = path.join(tmpExtractDir, 'React.xcframework');
-    const modulemapPath = path.join(
-      xcfwPath,
-      'Modules',
-      'module.modulemap',
-    );
+    const modulemapPath = path.join(xcfwPath, 'Modules', 'module.modulemap');
     if (!fs.existsSync(modulemapPath)) {
       throw new Error(
         `Extraction verification failed: ${modulemapPath} not found`,
@@ -119,9 +117,7 @@ function replaceRNCoreConfiguration(
         {stdio: 'inherit'},
       );
       if (cpResult.status !== 0) {
-        throw new Error(
-          `cp fallback failed with exit code ${cpResult.status}`,
-        );
+        throw new Error(`cp fallback failed with exit code ${cpResult.status}`);
       }
     }
   } finally {


### PR DESCRIPTION
## Summary
- Extract the rncore tarball to a temporary directory on a regular filesystem first, then move it to the final location
- This avoids issues with partial tar extraction on EdenFS where extracting directly can silently produce incomplete results
- Adds extraction verification (checks for expected xcframework structure) and mv/cp fallback logic

## Changelog:
[Internal] - Fix rncore tarball extraction on EdenFS by extracting to a temp dir first and moving to final location

## Test plan
- Build an iOS app on EdenFS and verify that React-Core-prebuilt is correctly extracted
- Verify the script still works on non-EdenFS filesystems