### PR TITLE
Restore getUIImplementation() stub for backwards compatibility

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4358,6 +4358,7 @@ public class com/facebook/react/uimanager/UIManagerModule : com/facebook/react/b
 	public fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
 	public fun getName ()Ljava/lang/String;
 	public fun getPerformanceCounters ()Ljava/util/Map;
+	public fun getUIImplementation ()Lcom/facebook/react/uimanager/UIImplementation;
 	public fun getViewManagerRegistry_DO_NOT_USE ()Lcom/facebook/react/uimanager/ViewManagerRegistry;
 	public fun initialize ()V
 	public fun invalidate ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -205,6 +205,16 @@ public class UIManagerModule extends ReactContextBaseJavaModule
     return mViewManagerRegistry;
   }
 
+  /**
+   * @deprecated This method is a stub retained for backward compatibility with third-party
+   *     libraries. It always returns null. UIImplementation is part of the Legacy Architecture and
+   *     will be removed in a future release.
+   */
+  @Deprecated
+  public @Nullable UIImplementation getUIImplementation() {
+    return null;
+  }
+
   private static Map<String, Object> createConstants(ViewManagerResolver viewManagerResolver) {
     ReactMarker.logMarker(CREATE_UI_MANAGER_MODULE_CONSTANTS_START);
     SystraceMessage.beginSection(Systrace.TRACE_TAG_REACT, "CreateUIManagerConstants")


### PR DESCRIPTION
Summary:
D93806249 removed `getUIImplementation()` from `UIManagerModule` as part of the
Legacy Architecture cleanup. However, third-party libraries like
`react-native-safe-area-context` still reference this method, causing build
failures in the e2e template app tests (https://github.com/facebook/react-native/actions/runs/22461280936/job/65112346970)

This restores the method as a deprecated stub that returns `null`, maintaining
backwards compatibility while keeping the Legacy Architecture cleanup intact.
Libraries that depend on this method will need to handle the `null` return value
or update to newer versions that don't use this deprecated API.

Changelog: [Android][Fixed] - Restore getUIImplementation() stub for backwards compatibility with third-party libraries

Reviewed By: cipolleschi

Differential Revision: D94654682


