### PR TITLE
Simplify LinearGradient angle

### DIFF
--- a/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
@@ -24,18 +24,13 @@ using namespace facebook::react;
   CGPoint startPoint;
   CGPoint endPoint;
 
-  if (direction.type == GradientDirectionType::Angle) {
-    CGFloat angle = std::get<Float>(direction.value);
-    std::tie(startPoint, endPoint) = getPointsFromAngle(angle, size);
-  } else if (direction.type == GradientDirectionType::Keyword) {
-    auto keyword = std::get<GradientKeyword>(direction.value);
-    CGFloat angle = getAngleForKeyword(keyword, size);
+  if (std::holds_alternative<Float>(direction)) {
+    CGFloat angle = std::get<Float>(direction);
     std::tie(startPoint, endPoint) = getPointsFromAngle(angle, size);
   } else {
-    // Default to top-to-bottom gradient
-    CGFloat centerX = size.width / 2;
-    startPoint = CGPointMake(centerX, 0.0);
-    endPoint = CGPointMake(centerX, size.height);
+    auto keyword = std::get<GradientKeyword>(direction);
+    CGFloat angle = getAngleForKeyword(keyword, size);
+    std::tie(startPoint, endPoint) = getPointsFromAngle(angle, size);
   }
 
   CGFloat dx = endPoint.x - startPoint.x;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.cpp
@@ -119,14 +119,12 @@ void parseProcessedBackgroundImage(
           std::string directionType = (std::string)(directionTypeIt->second);
 
           if (directionType == "angle") {
-            linearGradient.direction.type = GradientDirectionType::Angle;
             if (valueIt->second.hasType<Float>()) {
-              linearGradient.direction.value = (Float)(valueIt->second);
+              linearGradient.direction = (Float)(valueIt->second);
             }
           } else if (directionType == "keyword") {
-            linearGradient.direction.type = GradientDirectionType::Keyword;
             if (valueIt->second.hasType<std::string>()) {
-              linearGradient.direction.value =
+              linearGradient.direction =
                   parseGradientKeyword((std::string)(valueIt->second));
             }
           }
@@ -309,30 +307,26 @@ void parseUnprocessedBackgroundImageList(
                 std::get<CSSLinearGradientDirection>(cssDirection);
 
             if (std::holds_alternative<CSSAngle>(direction.value)) {
-              linearGradient.direction.type = GradientDirectionType::Angle;
-              linearGradient.direction.value =
+              linearGradient.direction =
                   std::get<CSSAngle>(direction.value).degrees;
             } else if (std::holds_alternative<
                            CSSLinearGradientDirectionKeyword>(
                            direction.value)) {
-              linearGradient.direction.type = GradientDirectionType::Keyword;
               auto keyword =
                   std::get<CSSLinearGradientDirectionKeyword>(direction.value);
 
               switch (keyword) {
                 case CSSLinearGradientDirectionKeyword::ToTopLeft:
-                  linearGradient.direction.value = GradientKeyword::ToTopLeft;
+                  linearGradient.direction = GradientKeyword::ToTopLeft;
                   break;
                 case CSSLinearGradientDirectionKeyword::ToTopRight:
-                  linearGradient.direction.value = GradientKeyword::ToTopRight;
+                  linearGradient.direction = GradientKeyword::ToTopRight;
                   break;
                 case CSSLinearGradientDirectionKeyword::ToBottomLeft:
-                  linearGradient.direction.value =
-                      GradientKeyword::ToBottomLeft;
+                  linearGradient.direction = GradientKeyword::ToBottomLeft;
                   break;
                 case CSSLinearGradientDirectionKeyword::ToBottomRight:
-                  linearGradient.direction.value =
-                      GradientKeyword::ToBottomRight;
+                  linearGradient.direction = GradientKeyword::ToBottomRight;
                   break;
               }
             }
@@ -486,26 +480,23 @@ std::optional<BackgroundImage> fromCSSBackgroundImage(
     if (gradient.direction.has_value()) {
       if (std::holds_alternative<CSSAngle>(gradient.direction->value)) {
         const auto& angle = std::get<CSSAngle>(gradient.direction->value);
-        linearGradient.direction.type = GradientDirectionType::Angle;
-        linearGradient.direction.value = angle.degrees;
+        linearGradient.direction = angle.degrees;
       } else if (std::holds_alternative<CSSLinearGradientDirectionKeyword>(
                      gradient.direction->value)) {
         const auto& dirKeyword = std::get<CSSLinearGradientDirectionKeyword>(
             gradient.direction->value);
-        linearGradient.direction.type = GradientDirectionType::Keyword;
-
         switch (dirKeyword) {
           case CSSLinearGradientDirectionKeyword::ToTopLeft:
-            linearGradient.direction.value = GradientKeyword::ToTopLeft;
+            linearGradient.direction = GradientKeyword::ToTopLeft;
             break;
           case CSSLinearGradientDirectionKeyword::ToTopRight:
-            linearGradient.direction.value = GradientKeyword::ToTopRight;
+            linearGradient.direction = GradientKeyword::ToTopRight;
             break;
           case CSSLinearGradientDirectionKeyword::ToBottomLeft:
-            linearGradient.direction.value = GradientKeyword::ToBottomLeft;
+            linearGradient.direction = GradientKeyword::ToBottomLeft;
             break;
           case CSSLinearGradientDirectionKeyword::ToBottomRight:
-            linearGradient.direction.value = GradientKeyword::ToBottomRight;
+            linearGradient.direction = GradientKeyword::ToBottomRight;
             break;
         }
       }
@@ -606,14 +597,14 @@ void parseUnprocessedBackgroundImageString(
   for (const auto& cssBackgroundImage :
        std::get<CSSBackgroundImageList>(backgroundImageList)) {
     if (auto backgroundImage = fromCSSBackgroundImage(cssBackgroundImage)) {
-      backgroundImages.push_back(*backgroundImage);
+      backgroundImages.push_back(std::move(*backgroundImage));
     } else {
       result = {};
       return;
     }
   }
 
-  result = backgroundImages;
+  result = std::move(backgroundImages);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.cpp
@@ -10,21 +10,14 @@
 namespace facebook::react {
 
 #ifdef RN_SERIALIZABLE_STATE
-folly::dynamic GradientDirection::toDynamic() const {
+namespace {
+folly::dynamic directionToDynamic(const GradientDirection& value) {
   folly::dynamic result = folly::dynamic::object();
-  result["type"] = [&]() {
-    switch (type) {
-      case GradientDirectionType::Angle:
-        return "angle";
-      case GradientDirectionType::Keyword:
-        return "keyword";
-    }
-    return "";
-  }();
-
   if (std::holds_alternative<Float>(value)) {
+    result["type"] = "angle";
     result["value"] = std::get<Float>(value);
   } else if (std::holds_alternative<GradientKeyword>(value)) {
+    result["type"] = "keyword";
     result["value"] = [&]() {
       switch (std::get<GradientKeyword>(value)) {
         case GradientKeyword::ToTopRight:
@@ -41,11 +34,12 @@ folly::dynamic GradientDirection::toDynamic() const {
   }
   return result;
 }
+} // namespace
 
 folly::dynamic LinearGradient::toDynamic() const {
   folly::dynamic result = folly::dynamic::object();
   result["type"] = "linear-gradient";
-  result["direction"] = direction.toDynamic();
+  result["direction"] = directionToDynamic(direction);
 
   folly::dynamic colorStopsArray = folly::dynamic::array();
   for (const auto& colorStop : colorStops) {
@@ -60,10 +54,10 @@ folly::dynamic LinearGradient::toDynamic() const {
 void LinearGradient::toString(std::stringstream& ss) const {
   ss << "linear-gradient(";
 
-  if (direction.type == GradientDirectionType::Angle) {
-    ss << std::get<Float>(direction.value) << "deg";
+  if (std::holds_alternative<Float>(direction)) {
+    ss << std::get<Float>(direction) << "deg";
   } else {
-    auto keyword = std::get<GradientKeyword>(direction.value);
+    auto keyword = std::get<GradientKeyword>(direction);
     switch (keyword) {
       case GradientKeyword::ToTopRight:
         ss << "to top right";

--- a/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
@@ -18,25 +18,19 @@
 
 namespace facebook::react {
 
-enum class GradientDirectionType { Angle, Keyword };
+enum class [[deprecated("Use std::holds_alternative")]] GradientDirectionType {
+  Angle,
+  Keyword,
+};
 
-enum class GradientKeyword {
+enum class GradientKeyword : uint8_t {
   ToTopRight,
   ToBottomRight,
   ToTopLeft,
   ToBottomLeft,
 };
 
-struct GradientDirection {
-  GradientDirectionType type;
-  std::variant<Float, GradientKeyword> value;
-
-  bool operator==(const GradientDirection &other) const = default;
-
-#ifdef RN_SERIALIZABLE_STATE
-  folly::dynamic toDynamic() const;
-#endif
-};
+using GradientDirection = std::variant<Float, GradientKeyword>;
 
 struct LinearGradient {
   GradientDirection direction;


### PR DESCRIPTION
Summary:
No need for a separate enum here when we can just use the std::variant itself.

Changelog: [Internal] Changed layout of GradientDirection

Reviewed By: sammy-SC

Differential Revision: D94522238


