### PR TITLE
Handle constexpr functions

### DIFF
--- a/scripts/cxx-api/parser/main.py
+++ b/scripts/cxx-api/parser/main.py
@@ -316,6 +316,7 @@ def get_function_member(
     function_arg_string = function_def.get_argsstring()
     is_pure_virtual = function_def.get_virt() == "pure-virtual"
     function_virtual = function_def.get_virt() == "virtual" or is_pure_virtual
+    is_constexpr = function_def.constexpr == "yes"
 
     # Doxygen incorrectly merges "=0" into the return type for pure-virtual
     # functions using trailing return types (e.g. "auto f() -> T = 0").
@@ -333,6 +334,7 @@ def get_function_member(
         is_pure_virtual,
         is_static,
         doxygen_params,
+        is_constexpr,
     )
 
     function.add_template(get_template_params(function_def))

--- a/scripts/cxx-api/parser/member.py
+++ b/scripts/cxx-api/parser/member.py
@@ -206,11 +206,13 @@ class FunctionMember(Member):
         is_pure_virtual: bool,
         is_static: bool,
         doxygen_params: list[Argument] | None = None,
+        is_constexpr: bool = False,
     ) -> None:
         super().__init__(name, visibility)
         self.type: str = type
         self.is_virtual: bool = is_virtual
         self.is_static: bool = is_static
+        self.is_constexpr: bool = is_constexpr
         parsed_arguments, self.modifiers = parse_arg_string(arg_string)
         self.arguments = (
             doxygen_params if doxygen_params is not None else parsed_arguments
@@ -257,6 +259,9 @@ class FunctionMember(Member):
 
         if self.is_static:
             result += "static "
+
+        if self.is_constexpr:
+            result += "constexpr "
 
         if self.type:
             result += f"{self.type} "

--- a/scripts/cxx-api/tests/snapshots/should_handle_constexpr_free_function/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_constexpr_free_function/snapshot.api
@@ -1,0 +1,1 @@
+constexpr int test::makeValue();

--- a/scripts/cxx-api/tests/snapshots/should_handle_constexpr_free_function/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_constexpr_free_function/test.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+constexpr int makeValue();
+
+} // namespace test

--- a/scripts/cxx-api/tests/snapshots/should_handle_constexpr_method/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_constexpr_method/snapshot.api
@@ -1,0 +1,4 @@
+class test::Clss {
+  public constexpr int getValue() const;
+  public static constexpr int getDefault();
+}

--- a/scripts/cxx-api/tests/snapshots/should_handle_constexpr_method/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_constexpr_method/test.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+class Clss {
+ public:
+  constexpr int getValue() const;
+  static constexpr int getDefault();
+};
+
+} // namespace test


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Handle `constexpr` functions in the C++ API snapshot

Differential Revision: D94658128


