### PR TITLE
fix(iOS): correct RTL ScrollView offset on recycle in Fabric

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -684,6 +684,9 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   _scrollView.contentOffset = RCTCGPointFromPoint(props.contentOffset);
   // Reset zoom scale to default
   _scrollView.zoomScale = 1.0;
+  // Invalidate cached content size so that updateState: recalculates the
+  // container frame after zoomScale reset (which may have mutated it in RTL).
+  _contentSize = CGSizeZero;
   // Reset contentInset to prevent stale insets leaking into recycled scroll views.
   _scrollView.contentInset = UIEdgeInsetsZero;
   // We set the default behavior to "never" so that iOS


### PR DESCRIPTION
## Summary:

Fixes #55768

When a `ScrollView` is recycled in RTL mode, resetting `_scrollView.zoomScale = 1.0` inside `prepareForRecycle` causes UIKit to mutate `_containerView.frame`, pushing the content off-screen.
Because the old `_contentSize` still matches the new `contentSize`, `updateState:` hits an early return optimization and fails to correct the mutated frame.

This PR invalidates the cached `_contentSize` by setting it to `CGSizeZero` immediately after the `zoomScale` reset. This bypasses the early return and forces a correct recalculation of the frame.

*Credit: Full credit to @kligarski for debugging and pinpointing the exact mechanism in the original issue.*

## Changelog:

[IOS] [FIXED] - Fixed RTL ScrollView offset bug upon recycling in Fabric

## Test Plan:

1. Ran the reproducer app provided in issue #55768.
2. Verified that navigating (Push/Pop) multiple times with a `ScrollView` in an RTL layout no longer causes the content to offset to the left of the window. The ScrollView remains correctly positioned.