### PR TITLE
Babel preset: don't override `dev` based on omission of redundant `withDevTools`, infer from `env()` instead.

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -51,6 +51,8 @@ const getPreset = (src, options, babel) => {
   const transformProfile =
     options?.unstable_transformProfile ?? babel?.caller(getTransformProfile);
 
+  const dev = options?.dev ?? babel.env('development');
+
   // Hermes V1 (aka Static Hermes) uses more optimised profiles.
   // There is currently no difference between stable and canary, but canary
   // may in future be used to test features in pre-prod Hermes versions.
@@ -66,7 +68,7 @@ const getPreset = (src, options, babel) => {
   // Use native generators in release mode because it has already yielded perf
   // wins. The next release of Hermes will close this gap, so this won't
   // be permanent.
-  const enableRegenerator = isHermesV1 && options.dev;
+  const enableRegenerator = isHermesV1 && dev;
 
   // Preserve class syntax and related if we're using Hermes V1.
   const preserveClasses = isHermesV1;
@@ -155,11 +157,11 @@ const getPreset = (src, options, babel) => {
     ]);
   }
 
-  if (options && options.dev && !options.disableDeepImportWarnings) {
+  if (options && dev && !options.disableDeepImportWarnings) {
     firstPartyPlugins.push([require('../plugin-warn-on-deep-imports.js')]);
   }
 
-  if (options && options.dev && !options.useTransformReactJSXExperimental) {
+  if (options && dev && !options.useTransformReactJSXExperimental) {
     extraPlugins.push([require('@babel/plugin-transform-react-jsx-source')]);
     extraPlugins.push([require('@babel/plugin-transform-react-jsx-self')]);
   }
@@ -262,12 +264,6 @@ const getPreset = (src, options, babel) => {
 };
 
 module.exports = (options, babel) => {
-  if (options.withDevTools == null) {
-    const env = process.env.BABEL_ENV || process.env.NODE_ENV;
-    if (!env || env === 'development') {
-      return getPreset(null, {...options, dev: true}, babel);
-    }
-  }
   return getPreset(null, options, babel);
 };
 


### PR DESCRIPTION
Summary:
Currently the RN Babel preset has this surprising bit of behaviour:

```js
module.exports = (options, babel) => {
  if (options.withDevTools == null) {
    const env = process.env.BABEL_ENV || process.env.NODE_ENV;
    if (!env || env === 'development') {
      return getPreset(null, {...options, dev: true}, babel);
    }
  }
  return getPreset(null, options, babel);
};
```

If the (undocumented, otherwise unused) `withDevTools` option is set (to anything), we will override any given value of `dev` to `true` if `BABEL_ENV` || `NODE_ENV || 'development' === 'development'`.

To put that another way, with `NODE_ENV=development` and `BABEL_ENV` unset, we would always produce a dev bundle even if `{ dev: false }`

Expo sets `withDevTools: false` to stop this happening, and always set `dev` (so this diff means **no observable change under Expo**):

https://github.com/expo/expo/blob/4a46dbff7a5a77d9fe06d30a70d7fab38cfc7f9a/packages/babel-preset-expo/build/index.js#L235-L236

This odd-looking override was introduced in 2017 in https://github.com/facebook/react-native/commit/bc22a4da7ea74d17cd701717268c8e50f001d614 / D5237158 as a way to gate `babel/plugin-transform-react-jsx-source`, *before the preset accepted any other options* - it was never intended to override `dev`. Now, we gate that same plugin under `options.dev`.

## Inferring `dev` when unspecified

The one potentially load-bearing piece of this is that, when a consumer specifies neither `withDevTools` nor `dev` (or maybe no options at all), this code serves to infer it from `process.env.BABEL_ENV || process.env.NODE_ENV`, which is reasonable and actually closer to the way typical plugins/presets work, but a better mechanism is to use the `env()` API (which defaults to `process.env.BABEL_ENV || process.env.NODE_ENV`).

https://babeljs.io/docs/config-files#apienv

## This change
 - Removes the obsolete use of `withDevToolss`, and never overrides the explicitly-passed `dev`
 - Where `dev` is not specified, falls back to the Babel environment.

Changelog:
[General][Fixed] Babel-preset: Don't override explicitly-passed `dev` config if obsolete `withDevTools` is missing

Differential Revision: D94660480


