### PR TITLE
Babel transformer: Use `envName` to hint default value of `dev`, don't mutate `process.env.BABEL_ENV`

### DIFF
--- a/packages/react-native-babel-transformer/src/index.js
+++ b/packages/react-native-babel-transformer/src/index.js
@@ -141,6 +141,9 @@ function buildBabelConfig(
         : true,
     code: false,
     cwd: options.projectRoot,
+    envName: options.dev
+      ? 'development'
+      : process.env.BABEL_ENV || 'production',
     filename,
     highlightCode: true,
   };
@@ -183,67 +186,49 @@ const transform /*: BabelTransformer['transform'] */ = ({
   src,
   plugins,
 }) => {
-  const OLD_BABEL_ENV = process.env.BABEL_ENV;
-  process.env.BABEL_ENV = options.dev
-    ? 'development'
-    : process.env.BABEL_ENV || 'production';
+  const babelConfig /*: BabelCoreOptions */ = {
+    // ES modules require sourceType='module' but OSS may not always want that
+    sourceType: 'unambiguous',
+    ...buildBabelConfig(filename, options, plugins),
+    caller: {
+      // Varies Babel's config cache - presets will be re-initialized
+      // if they use caller information.
+      name: 'metro',
+      bundler: 'metro',
+      platform: options.platform,
+      unstable_transformProfile: options.unstable_transformProfile,
+    },
+    ast: true,
 
-  try {
-    const babelConfig /*: BabelCoreOptions */ = {
-      // ES modules require sourceType='module' but OSS may not always want that
-      sourceType: 'unambiguous',
-      ...buildBabelConfig(filename, options, plugins),
-      caller: {
-        // Varies Babel's config cache - presets will be re-initialized
-        // if they use caller information.
-        name: 'metro',
-        bundler: 'metro',
-        platform: options.platform,
-        unstable_transformProfile: options.unstable_transformProfile,
-      },
-      ast: true,
+    // NOTE(EvanBacon): We split the parse/transform steps up to accommodate
+    // Hermes parsing, but this defaults to cloning the AST which increases
+    // the transformation time by a fair amount.
+    // You get this behavior by default when using Babel's `transform` method directly.
+    cloneInputAst: false,
+  };
+  const sourceAst /*: BabelNodeFile */ =
+    isTypeScriptSource(filename) ||
+    isTSXSource(filename) ||
+    !options.hermesParser
+      ? parseSync(src, babelConfig)
+      : // $FlowFixMe[incompatible-exact]
+        require('hermes-parser').parse(src, {
+          babel: true,
+          reactRuntimeTarget: '19',
+          sourceType: babelConfig.sourceType,
+        });
 
-      // NOTE(EvanBacon): We split the parse/transform steps up to accommodate
-      // Hermes parsing, but this defaults to cloning the AST which increases
-      // the transformation time by a fair amount.
-      // You get this behavior by default when using Babel's `transform` method directly.
-      cloneInputAst: false,
-    };
-    const sourceAst /*: BabelNodeFile */ =
-      isTypeScriptSource(filename) ||
-      isTSXSource(filename) ||
-      !options.hermesParser
-        ? parseSync(src, babelConfig)
-        : // $FlowFixMe[incompatible-exact]
-          require('hermes-parser').parse(src, {
-            babel: true,
-            reactRuntimeTarget: '19',
-            sourceType: babelConfig.sourceType,
-          });
+  const result /*: TransformResult<MetroBabelFileMetadata> */ =
+    transformFromAstSync(sourceAst, src, babelConfig);
 
-    const result /*: TransformResult<MetroBabelFileMetadata> */ =
-      transformFromAstSync(sourceAst, src, babelConfig);
-
-    // The result from `transformFromAstSync` can be null (if the file is ignored)
-    if (!result) {
-      /* $FlowFixMe[incompatible-type] BabelTransformer specifies that the `ast` can never be null but
-       * the function returns here. Discovered when typing `BabelNode`. */
-      return {ast: null};
-    }
-
-    return {ast: nullthrows(result.ast), metadata: result.metadata};
-  } finally {
-    // Restore the old process.env.BABEL_ENV
-    if (OLD_BABEL_ENV == null) {
-      // We have to treat this as a special case because writing undefined to
-      // an environment variable coerces it to the string 'undefined'. To
-      // unset it, we must delete it.
-      // See https://github.com/facebook/metro/pull/446
-      delete process.env.BABEL_ENV;
-    } else {
-      process.env.BABEL_ENV = OLD_BABEL_ENV;
-    }
+  // The result from `transformFromAstSync` can be null (if the file is ignored)
+  if (!result) {
+    /* $FlowFixMe[incompatible-type] BabelTransformer specifies that the `ast` can never be null but
+     * the function returns here. Discovered when typing `BabelNode`. */
+    return {ast: null};
   }
+
+  return {ast: nullthrows(result.ast), metadata: result.metadata};
 };
 
 function getCacheKey() {


### PR DESCRIPTION
Summary:
After https://github.com/facebook/react-native/pull/55805, the RN Babel preset no longer reads `process.env.BABEL_ENV` directly, instead using Babel's `env()` API, which is both cache-aware and properly respects explicit `envName` config.

See:
 - https://babeljs.io/docs/config-files#apienv
 - https://babeljs.io/docs/options#envname

Now, instead of mutating `process.env.BABEL_ENV` to force the environment for a transform, we can specify `envName` instead.

Changelog: [Internal]

Differential Revision: D94662935


