### PR TITLE
Guard WindowManager access in DisplayMetricsHolder for non-visual contexts

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.uimanager
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.util.DisplayMetrics
@@ -61,19 +62,21 @@ public object DisplayMetricsHolder {
   }
 
   @JvmStatic
-  @Suppress("DEPRECATION")
+  @SuppressLint("DeprecatedMethod") // for Andriod Lint
+  @Suppress("DEPRECATION") // for Kotlin compiler
   public fun initDisplayMetrics(context: Context) {
     val displayMetrics = context.resources.displayMetrics
     windowDisplayMetrics = displayMetrics
     val screenDisplayMetrics = DisplayMetrics()
     screenDisplayMetrics.setTo(displayMetrics)
-    val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-    // Get the real display metrics if we are using API level 17 or higher.
-    // The real metrics include system decor elements (e.g. soft menu bar).
-    //
-    // See:
-    // http://developer.android.com/reference/android/view/Display.html#getRealMetrics(android.util.DisplayMetrics)
-    wm.defaultDisplay.getRealMetrics(screenDisplayMetrics)
+    try {
+      val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+      // getRealMetrics includes system decor (e.g. nav bar) excluded from resource metrics.
+      wm.defaultDisplay.getRealMetrics(screenDisplayMetrics)
+    } catch (_: Exception) {
+      // Non-visual contexts (e.g. Application) may throw on API 30+.
+      // Falls back to resource display metrics copied via setTo() above.
+    }
     // Preserve fontScale from the configuration because getRealMetrics() returns
     // physical display metrics without the system font scale setting.
     // This is needed for proper text scaling when fontScale < 1.0


### PR DESCRIPTION
Summary:
`DisplayMetricsHolder.initDisplayMetrics()` calls `context.getSystemService(WINDOW_SERVICE)` which throws `IllegalAccessException` on Android 11+ (API 30+) when called from a non-visual context (e.g. Application context). Multiple callers pass non-Activity contexts (ReactHostImpl, UIManagerModule, DeviceInfoModule, ReactInstance, ReactInstanceManager).

This adds a try-catch around the WindowManager access as defense-in-depth. When it fails, `screenDisplayMetrics` retains the values already copied from resource display metrics via `setTo()`, which is a graceful degradation (only missing system decor dimensions like nav bar height).

Changelog: [Internal] - Guard WindowManager access in DisplayMetricsHolder against non-visual contexts on API 30+

Reviewed By: javache, mdvacca

Differential Revision: D94283765


