### PR TITLE
Fix UIManagerModule.getUIImplementation() to return a non-null UIImplementation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -204,8 +204,8 @@ public class UIManagerModule extends ReactContextBaseJavaModule
    *     will be removed in a future release.
    */
   @Deprecated
-  public @Nullable UIImplementation getUIImplementation() {
-    return null;
+  public UIImplementation getUIImplementation() {
+    return new UIImplementation(null, null, null, 0);
   }
 
   private static Map<String, Object> createConstants(ViewManagerResolver viewManagerResolver) {


### PR DESCRIPTION
Summary:
This unblocks the Android CI on master

The deprecated getUIImplementation() method was returning null, which could
cause NullPointerExceptions for callers that still depend on it. Return a
new UIImplementation instance instead.

Changelog: [Internal] - Fix `UIManagerModule.getUIImplementation()` to return a non-null `UIImplementation` instead of null

Reviewed By: alanleedev

Differential Revision: D94743629


