### PR TITLE
Fix typos: "boostrap" -> "bootstrap" and "informations" -> "information"

### DIFF
--- a/packages/core-cli-utils/src/private/apple.js
+++ b/packages/core-cli-utils/src/private/apple.js
@@ -64,7 +64,7 @@ function checkPodfileInSyncWithManifest(
       );
     }
   } catch (e) {
-    throw new Error('Please run: yarn run boostrap ios: ' + e.message);
+    throw new Error('Please run: yarn run bootstrap ios: ' + e.message);
   }
 }
 
@@ -166,7 +166,7 @@ export const tasks = {
             fs.constants.F_OK | fs.constants.R_OK,
           );
         } catch (e) {
-          throw new Error('Please run: yarn run boostrap ios: ' + e.message);
+          throw new Error('Please run: yarn run bootstrap ios: ' + e.message);
         }
       }
       checkPodfileInSyncWithManifest(

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -72,7 +72,7 @@ function getCppArrayTypeForAnnotation(
         case 'object':
           if (!structParts) {
             throw new Error(
-              `Trying to generate the event emitter for an Array of ${typeElement.type} without informations to generate the generic type`,
+              `Trying to generate the event emitter for an Array of ${typeElement.type} without information to generate the generic type`,
             );
           }
           return `std::vector<${generateEventStructName(structParts)}>`;
@@ -84,7 +84,7 @@ function getCppArrayTypeForAnnotation(
           ) {
             if (!structParts) {
               throw new Error(
-                `Trying to generate the event emitter for an Array of ${typeElement.type} without informations to generate the generic type`,
+                `Trying to generate the event emitter for an Array of ${typeElement.type} without information to generate the generic type`,
               );
             }
             return `std::vector<${generateEventStructName(structParts)}>`;


### PR DESCRIPTION
## Summary

This PR fixes simple typos found in error messages:

- **apple.js**: Fixed "boostrap" -> "bootstrap" in error messages (lines 67, 169)
- **CppHelpers.js**: Fixed "informations" -> "information" in error messages (lines 75, 87, 101)

Note: "information" is an uncountable noun in English and should not be pluralized.

## Changelog

[Internal] - 

## Test plan

These are typo fixes in error message strings. No code behavior changes.