### PR TITLE
Add back receiveTouches on RCTEventEmitter with default implementation

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4794,6 +4794,11 @@ public final class com/facebook/react/uimanager/events/NativeGestureUtil {
 
 public abstract interface class com/facebook/react/uimanager/events/RCTEventEmitter : com/facebook/react/bridge/JavaScriptModule {
 	public abstract fun receiveEvent (ILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
+	public abstract fun receiveTouches (Ljava/lang/String;Lcom/facebook/react/bridge/WritableArray;Lcom/facebook/react/bridge/WritableArray;)V
+}
+
+public final class com/facebook/react/uimanager/events/RCTEventEmitter$DefaultImpls {
+	public static fun receiveTouches (Lcom/facebook/react/uimanager/events/RCTEventEmitter;Ljava/lang/String;Lcom/facebook/react/bridge/WritableArray;Lcom/facebook/react/bridge/WritableArray;)V
 }
 
 public abstract interface class com/facebook/react/uimanager/events/RCTModernEventEmitter : com/facebook/react/uimanager/events/RCTEventEmitter {
@@ -4805,6 +4810,7 @@ public abstract interface class com/facebook/react/uimanager/events/RCTModernEve
 public final class com/facebook/react/uimanager/events/RCTModernEventEmitter$DefaultImpls {
 	public static fun receiveEvent (Lcom/facebook/react/uimanager/events/RCTModernEventEmitter;IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public static fun receiveEvent (Lcom/facebook/react/uimanager/events/RCTModernEventEmitter;ILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
+	public static fun receiveTouches (Lcom/facebook/react/uimanager/events/RCTModernEventEmitter;Ljava/lang/String;Lcom/facebook/react/bridge/WritableArray;Lcom/facebook/react/bridge/WritableArray;)V
 }
 
 public final class com/facebook/react/uimanager/events/TouchEvent : com/facebook/react/uimanager/events/Event {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTEventEmitter.kt
@@ -9,6 +9,7 @@ package com.facebook.react.uimanager.events
 
 import com.facebook.proguard.annotations.DoNotStripAny
 import com.facebook.react.bridge.JavaScriptModule
+import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.annotations.internal.InteropLegacyArchitecture
 
@@ -28,4 +29,11 @@ public interface RCTEventEmitter : JavaScriptModule {
    */
   @Deprecated("Use [RCTModernEventEmitter.receiveEvent] instead")
   public fun receiveEvent(targetTag: Int, eventName: String, params: WritableMap?)
+
+  @Deprecated("Use [EventDispatcher] to dispatch touch events instead")
+  public fun receiveTouches(
+      eventName: String,
+      touches: WritableArray,
+      changedIndices: WritableArray,
+  ): Unit = Unit
 }


### PR DESCRIPTION
Summary:
D91320248 removed `receiveTouches` from the `RCTEventEmitter` interface entirely.
This was too big of a breaking change — ecosystem libraries that implement
`RCTEventEmitter` or `RCTModernEventEmitter` and override `receiveTouches` would
fail to compile.

This brings back `receiveTouches` on `RCTEventEmitter` but with a default no-op
implementation, so existing implementers that override it continue to compile, and
new implementers don't need to provide one.

Changelog: [Android][Changed] Re-added `receiveTouches` to `RCTEventEmitter` with a default no-op implementation to avoid breaking ecosystem libraries

Differential Revision: D94903267


