### PR TITLE
Fix crash in RCTWebSocketModule when delegate callbacks fire after module invalidation

### DIFF
--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
@@ -140,6 +140,9 @@ RCT_EXPORT_METHOD(close : (double)code reason : (NSString *)reason socketID : (d
   NSString *type;
 
   NSNumber *socketID = [webSocket reactTag];
+  if (!socketID) {
+    return;
+  }
   id contentHandler = _contentHandlers[socketID];
   if (contentHandler) {
     message = [contentHandler processWebsocketMessage:message forSocketID:socketID withType:&type];
@@ -152,18 +155,25 @@ RCT_EXPORT_METHOD(close : (double)code reason : (NSString *)reason socketID : (d
     }
   }
 
-  [self sendEventWithName:@"websocketMessage" body:@{@"data" : message, @"type" : type, @"id" : webSocket.reactTag}];
+  [self sendEventWithName:@"websocketMessage" body:@{@"data" : message, @"type" : type, @"id" : socketID}];
 }
 
 - (void)webSocketDidOpen:(SRWebSocket *)webSocket
 {
+  NSNumber *socketID = [webSocket reactTag];
+  if (!socketID) {
+    return;
+  }
   [self sendEventWithName:@"websocketOpen"
-                     body:@{@"id" : webSocket.reactTag, @"protocol" : webSocket.protocol ? webSocket.protocol : @""}];
+                     body:@{@"id" : socketID, @"protocol" : webSocket.protocol ? webSocket.protocol : @""}];
 }
 
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error
 {
   NSNumber *socketID = [webSocket reactTag];
+  if (!socketID) {
+    return;
+  }
   _contentHandlers[socketID] = nil;
   _sockets[socketID] = nil;
   NSDictionary *body =
@@ -177,6 +187,9 @@ RCT_EXPORT_METHOD(close : (double)code reason : (NSString *)reason socketID : (d
             wasClean:(BOOL)wasClean
 {
   NSNumber *socketID = [webSocket reactTag];
+  if (!socketID) {
+    return;
+  }
   _contentHandlers[socketID] = nil;
   _sockets[socketID] = nil;
   [self sendEventWithName:@"websocketClosed"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Guard against nil socketID in all SRWebSocketDelegate callbacks in RCTWebSocketModule.

When the module is invalidated during teardown, invalidate nils the delegate and closes each socket. However, SocketRocket's network thread may have already dispatched a delegate callback to the main queue via setDelegateDispatchQueue:. By the time the block executes, the SRWebSocket has been deallocated and reactTag (an associated object) returns nil, causing either an objc_retain crash on a dangling pointer or an NSInvalidArgumentException when inserting nil into an NSDictionary literal.

The didFailWithError: callback already had a partial nil guard (socketID ?: @(-1)), but didCloseWithCode:, webSocketDidOpen:, and didReceiveMessage: did not. This adds consistent early-return nil checks to all four callbacks.
Previously reported in #28278, #29525, and #31048 — all closed by the stale bot without a fix being merged.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Fix crash in RCTWebSocketModule when delegate callbacks fire after module invalidation

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This is a race condition during module teardown that is difficult to reproduce deterministically — it surfaces in production Crashlytics reports (< 0.1% of sessions). The fix is a nil guard matching the defensive pattern already present in didFailWithError:.