### PR TITLE
Add getDefinedEventHandlers API

### DIFF
--- a/packages/react-native/Libraries/Components/View/__tests__/FantomEventHandlers-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/FantomEventHandlers-itest.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import * as Fantom from '@react-native/fantom';
+import * as React from 'react';
+import {createRef} from 'react';
+import {ScrollView, View} from 'react-native';
+
+describe('Fantom.getDefinedEventHandlers', () => {
+  it('returns event handler names registered on a view', () => {
+    const root = Fantom.createRoot();
+    const ref = createRef<React.ElementRef<typeof View>>();
+
+    Fantom.runTask(() => {
+      root.render(
+        <View ref={ref} onLayout={() => {}} onTouchStart={() => {}} />,
+      );
+    });
+
+    const handlers = Fantom.getDefinedEventHandlers(ref);
+    expect(handlers).toContain('onLayout');
+    expect(handlers).toContain('onTouchStart');
+  });
+
+  it('returns an empty array when no event handlers are registered', () => {
+    const root = Fantom.createRoot();
+    const ref = createRef<React.ElementRef<typeof View>>();
+
+    Fantom.runTask(() => {
+      root.render(<View ref={ref} />);
+    });
+
+    expect(Fantom.getDefinedEventHandlers(ref)).toEqual([]);
+  });
+
+  it('returns multiple event handler names when multiple are registered', () => {
+    const root = Fantom.createRoot();
+    const ref = createRef<React.ElementRef<typeof View>>();
+
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={ref}
+          onLayout={() => {}}
+          onTouchStart={() => {}}
+          onTouchEnd={() => {}}
+          onTouchCancel={() => {}}
+          onClick={() => {}}
+        />,
+      );
+    });
+
+    const handlers = Fantom.getDefinedEventHandlers(ref);
+    expect(handlers).toContain('onLayout');
+    expect(handlers).toContain('onTouchStart');
+    expect(handlers).toContain('onTouchEnd');
+    expect(handlers).toContain('onTouchCancel');
+    expect(handlers).toContain('onClick');
+  });
+
+  it('detects onScroll on a ScrollView', () => {
+    const root = Fantom.createRoot();
+    const ref = createRef<React.ElementRef<typeof ScrollView>>();
+
+    Fantom.runTask(() => {
+      root.render(<ScrollView ref={ref} onScroll={() => {}} />);
+    });
+
+    expect(Fantom.getDefinedEventHandlers(ref)).toContain('onScroll');
+  });
+});

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -23,7 +23,10 @@ import {LogBox} from 'react-native';
 import NativeFantom, {
   NativeEventCategory,
 } from 'react-native/src/private/testing/fantom/specs/NativeFantom';
-import {getNativeNodeReference} from 'react-native/src/private/webapis/dom/nodes/internals/NodeInternals';
+import {
+  getInstanceHandle,
+  getNativeNodeReference,
+} from 'react-native/src/private/webapis/dom/nodes/internals/NodeInternals';
 import ReadOnlyNode from 'react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
 
 const nativeRuntimeScheduler = global.nativeRuntimeScheduler;
@@ -235,6 +238,32 @@ export function unstable_getFabricUpdateProps(nodeOrRef: NodeOrRef): Readonly<{
   const node = getNode(nodeOrRef);
   const shadowNode = getNativeNodeReference(node);
   return NativeFantom.getFabricUpdateProps(shadowNode);
+}
+
+/**
+ * Returns the names of event handlers registered on a component's shadow node.
+ *
+ * @param nodeOrRef - The node or ref for which to retrieve event handlers.
+ * @returns Array of event handler prop names (e.g. `['onLayout', 'onTouchStart']`)
+ */
+export function getDefinedEventHandlers(
+  nodeOrRef: NodeOrRef,
+): ReadonlyArray<string> {
+  const node = getNode(nodeOrRef);
+  const instanceHandle = getInstanceHandle(node);
+  if (typeof instanceHandle !== 'object' || instanceHandle == null) {
+    return [];
+  }
+  // WARNING: This uses React private API (fiber internals).
+  // $FlowExpectedError[incompatible-type]
+  const memoizedProps = (instanceHandle as {memoizedProps?: {[string]: mixed}})
+    .memoizedProps;
+  if (memoizedProps == null) {
+    return [];
+  }
+  return Object.keys(memoizedProps).filter(
+    key => key.startsWith('on') && typeof memoizedProps[key] === 'function',
+  );
 }
 
 /**

--- a/private/react-native-fantom/tester/src/NativeFantom.cpp
+++ b/private/react-native-fantom/tester/src/NativeFantom.cpp
@@ -86,7 +86,8 @@ std::string NativeFantom::getRenderedOutput(
     SurfaceId surfaceId,
     NativeFantomGetRenderedOutputRenderFormatOptions options) {
   RenderFormatOptions formatOptions{
-      options.includeRoot, options.includeLayoutMetrics};
+      .includeRoot = options.includeRoot,
+      .includeLayoutMetrics = options.includeLayoutMetrics};
 
   auto viewTree = appDelegate_.mountingManager_->getViewTree(surfaceId);
   return appDelegate_.mountingManager_->renderer()->render(
@@ -124,10 +125,10 @@ void NativeFantom::enqueueNativeEvent(
     std::optional<bool> isUnique) {
   if (isUnique.value_or(false)) {
     shadowNode->getEventEmitter()->dispatchUniqueEvent(
-        std::move(type), payload.value_or(folly::dynamic::object()));
+        type, payload.value_or(folly::dynamic::object()));
   } else {
     shadowNode->getEventEmitter()->dispatchEvent(
-        std::move(type),
+        type,
         payload.value_or(folly::dynamic::object()),
         category.value_or(RawEvent::Category::Unspecified));
   }


### PR DESCRIPTION
Summary:
Add Fantom.getDefinedEventHandlers(element) which returns the names of
event handlers registered on a component's shadow node.

Changelog: [Internal]

Differential Revision: D94936370


