### PR TITLE
loadBundleFromServer test: remove legacy Jest timers, increased coverage and improved assertions

### DIFF
--- a/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
+++ b/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
@@ -10,6 +10,12 @@
 
 'use strict';
 
+import {
+  LoadBundleFromServerError,
+  LoadBundleFromServerRequestError,
+} from '../loadBundleFromServer';
+import invariant from 'invariant';
+
 jest.mock('../../../Utilities/HMRClient');
 
 jest.mock('../../../Core/Devtools/getDevServer', () => ({
@@ -55,11 +61,11 @@ const sendRequest = jest.fn(
 const removeListener = jest.fn();
 const addListener = jest.fn((name, fn) => {
   if (name === 'didReceiveNetworkData') {
-    Promise.resolve().then(() => fn([REQUEST_ID, mockDataResponse]));
+    void Promise.resolve().then(() => fn([REQUEST_ID, mockDataResponse]));
   } else if (name === 'didCompleteNetworkResponse') {
-    Promise.resolve().then(() => fn([REQUEST_ID, mockRequestError]));
+    void Promise.resolve().then(() => fn([REQUEST_ID, mockRequestError]));
   } else if (name === 'didReceiveNetworkResponse') {
-    Promise.resolve().then(() => fn([REQUEST_ID, null, mockHeaders]));
+    void Promise.resolve().then(() => fn([REQUEST_ID, null, mockHeaders]));
   }
   return {remove: removeListener};
 });
@@ -73,10 +79,6 @@ jest.mock('../../../Network/RCTNetworking', () => ({
 }));
 
 let loadBundleFromServer: (bundlePathAndQuery: string) => Promise<void>;
-const {
-  LoadBundleFromServerError,
-  LoadBundleFromServerRequestError,
-} = require('../loadBundleFromServer');
 
 let mockHeaders: {'Content-Type': string};
 let mockDataResponse;
@@ -93,11 +95,14 @@ test('loadBundleFromServer will throw for JSON responses', async () => {
   mockDataResponse = JSON.stringify({message: 'Error thrown from Metro'});
   mockRequestError = null;
 
-  const error = await loadBundleFromServer('/Fail.bundle?platform=ios').catch(
-    e => e,
-  );
+  const error: mixed = await loadBundleFromServer(
+    '/Fail.bundle?platform=ios',
+  ).catch(e => e);
 
-  expect(error).toBeInstanceOf(LoadBundleFromServerError);
+  invariant(
+    error instanceof LoadBundleFromServerError,
+    'Expected a LoadBundleFromServerError',
+  );
   expect(error.message).toBe('Could not load bundle');
   expect(error.cause).toBe('Error thrown from Metro');
 });
@@ -107,11 +112,14 @@ test('loadBundleFromServer will throw LoadBundleFromServerError for request erro
   mockDataResponse = '';
   mockRequestError = 'Some error';
 
-  const error = await loadBundleFromServer('/Fail.bundle?platform=ios').catch(
-    e => e,
-  );
+  const error: mixed = await loadBundleFromServer(
+    '/Fail.bundle?platform=ios',
+  ).catch(e => e);
 
-  expect(error).toBeInstanceOf(LoadBundleFromServerRequestError);
+  invariant(
+    error instanceof LoadBundleFromServerRequestError,
+    'Expected a LoadBundleFromServerRequestError',
+  );
   expect(error.message).toBe('Could not load bundle');
   expect(error.cause).toBe('Some error');
 });


### PR DESCRIPTION
## Summary:

This PR removes the dependency on Jest legacy fake timers from the `loadBundleFromServer` test suite.

Together with #55757, this should remove the last usages of `jest.useFakeTimers({legacyFakeTimers: true});` in the codebase.

In this PR in particular, instead of migrating to modern  timers, I refactored the `addListener` mock to use a Promise based approach. By leveraging microtask scheduling, the tests simulate asynchronous functions flushed after the execution of the `sendRequest` without relying on timers.

In addition, I also improved the tests in other areas:

* improved readability by extracting a constant for the request id, used in both `sendRequest` and `addListener` mocks
* improved errors assertions to explicitly verify the errors are thrown (before the refactoring these tests could still be green if no error was thrown, because the expectations were only in the catch clause that could be skipped)
* improved the tests that verify the successful bundle load:
  * spit long test in ad hoc isolated ones
  * added listeners registration and cleanup verification to improve the coverage
  * added more fine-grained check for the `sendRequest` parameters 

I tried to separate all the changes above in specific commit so that the review can check the incremental improvements I applied with the refactoring steps.

## Changelog:

[GENERAL] [CHANGED] - loadBundleFromServer test: remove legacy Jest timers, increased coverage and improved assertions

## Test Plan:

* Ran loadBundleFromServer-test and verified all tests cases passed
* Ran the React Native test suite to ensure all tests pass
* Verified test correctness by intentionally breaking production code after fixing the tests (eg. remove observer/change listener code)