### PR TITLE
Use stable Hermes for dry-run builds on stable branches

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -54,7 +54,12 @@ runs:
         if [[ "${{ inputs.release-type }}" == "dry-run" ]]; then
           # dry-run: we only build ARM64 to save time/resources. For release/nightlies the default is to build all archs.
           export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a,x86" # x86 is required for E2E testing
-          export HERMES_PREBUILT_FLAG="ORG_GRADLE_PROJECT_react.internal.useHermesNightly=true"
+          # Use stable Hermes on stable branches, nightly Hermes on main
+          if [[ "${{ github.ref_name }}" == *"-stable" ]] || [[ "${{ github.base_ref }}" == *"-stable" ]]; then
+            export HERMES_PREBUILT_FLAG="ORG_GRADLE_PROJECT_react.internal.useHermesStable=true"
+          else
+            export HERMES_PREBUILT_FLAG="ORG_GRADLE_PROJECT_react.internal.useHermesNightly=true"
+          fi
           TASKS="publishAllToMavenTempLocal build"
         elif [[ "${{ inputs.release-type }}" == "nightly" ]]; then
           # nightly: we set isSnapshot to true so artifacts are sent to the right repository on Maven Central.


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The build_android workflow was incorrectly using for dry-run
builds on stable branches (e.g., 0.85-stable), causing it to append  suffix
to the Hermes version. This resulted in trying to fetch non-existent SNAPSHOT artifacts
like in https://github.com/facebook/react-native/actions/runs/22592250332/job/65471130298.

This fix adds a check to detect stable branches (via github.ref_name or github.base_ref)
and uses  instead, which fetches the stable Hermes release from
Maven Central without the -SNAPSHOT suffix.

We check both github.ref_name and github.base_ref to cover two scenarios:
* ref_name: Direct pushes to stable branches (e.g. pushing to 0.85-stable)
* base_ref: Pull requests targeting stable branches (e.g. cherry-pick PRs where the source branch isn't named -stable but the target is)

Reviewed By: cipolleschi

Differential Revision: D95022571


