### PR TITLE
Use DevSupportHttpClient for WebSocket and HTTP connections

### DIFF
--- a/packages/react-native/Libraries/Core/setUpReactDevTools.js
+++ b/packages/react-native/Libraries/Core/setUpReactDevTools.js
@@ -146,17 +146,36 @@ if (__DEV__) {
         ? guessHostFromDevServerUrl(devServer.url)
         : 'localhost';
 
-      // Read the optional global variable for backward compatibility.
-      // It was added in https://github.com/facebook/react-native/commit/bf2b435322e89d0aeee8792b1c6e04656c2719a0.
-      const port =
+      // Derive scheme and port from the dev server URL when possible,
+      // falling back to ws://host:8097 for local development.
+      let wsScheme = 'ws';
+      let port = 8097;
+
+      if (
         // $FlowFixMe[prop-missing]
         // $FlowFixMe[incompatible-use]
         window.__REACT_DEVTOOLS_PORT__ != null
-          ? window.__REACT_DEVTOOLS_PORT__
-          : 8097;
+      ) {
+        // $FlowFixMe[prop-missing]
+        port = window.__REACT_DEVTOOLS_PORT__;
+      } else if (devServer.bundleLoadedFromServer) {
+        try {
+          const devUrl = new URL(devServer.url);
+          if (devUrl.protocol === 'https:') {
+            wsScheme = 'wss';
+          }
+          if (devUrl.port) {
+            port = parseInt(devUrl.port, 10);
+          } else if (devUrl.protocol === 'https:') {
+            port = 443;
+          } else {
+            port = 80;
+          }
+        } catch (e) {}
+      }
 
       const WebSocket = require('../WebSocket/WebSocket').default;
-      ws = new WebSocket('ws://' + host + ':' + port);
+      ws = new WebSocket(wsScheme + '://' + host + ':' + port);
       ws.addEventListener('close', event => {
         isWebSocketOpen = false;
       });

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.modules.network
 
 import android.content.Context
+import com.facebook.react.devsupport.inspector.DevSupportHttpClient
 import java.io.File
 import java.util.concurrent.TimeUnit
 import okhttp3.Cache
@@ -47,8 +48,10 @@ public object OkHttpClientProvider {
   @JvmStatic
   public fun createClientBuilder(): OkHttpClient.Builder {
     // No timeouts by default
+    // Use DevSupportHttpClient as base to inherit custom header interceptor
     val client: OkHttpClient.Builder =
-        OkHttpClient.Builder()
+        DevSupportHttpClient.httpClient
+            .newBuilder()
             .connectTimeout(0, TimeUnit.MILLISECONDS)
             .readTimeout(0, TimeUnit.MILLISECONDS)
             .writeTimeout(0, TimeUnit.MILLISECONDS)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableMap
 import com.facebook.react.common.ReactConstants
+import com.facebook.react.devsupport.inspector.DevSupportHttpClient
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.modules.network.CustomClientBuilder
 import com.facebook.react.modules.network.ForwardingCookieHandler
@@ -80,7 +81,8 @@ public class WebSocketModule(context: ReactApplicationContext) :
   ) {
     val id = socketID.toInt()
     val okHttpBuilder =
-        OkHttpClient.Builder()
+        DevSupportHttpClient.httpClient
+            .newBuilder()
             .connectTimeout(10, TimeUnit.SECONDS)
             .writeTimeout(10, TimeUnit.SECONDS)
             .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
@@ -199,8 +201,9 @@ public class WebSocketModule(context: ReactApplicationContext) :
         },
     )
 
-    // Trigger shutdown of the dispatcher's executor so this process can exit cleanly
-    client.dispatcher().executorService().shutdown()
+    // Note: Do NOT call client.dispatcher().executorService().shutdown() here.
+    // When building from a shared OkHttpClient (DevSupportHttpClient), the dispatcher
+    // is shared across all clients. Shutting it down would kill all connections.
   }
 
   override fun close(code: Double, reason: String?, socketID: Double) {


### PR DESCRIPTION
Summary:
## Summary:

Use `DevSupportHttpClient` as base for `OkHttpClientProvider` and `WebSocketModule`
so that custom headers (e.g. auth tokens) are automatically injected into all
networking requests. Also derive the WebSocket scheme (ws/wss) and port from the
dev server URL in `setUpReactDevTools.js` so React DevTools connections work over
HTTPS.

## Changelog:

[GENERAL][CHANGED] - Derive WebSocket scheme and port from dev server URL for React DevTools connections, supporting HTTPS dev servers
[ANDROID][CHANGED] - Use shared DevSupportHttpClient for OkHttpClientProvider and WebSocketModule to propagate custom headers

## Test Plan:

Validated that the changes compile and the custom header interceptor from
DevSupportHttpClient is correctly inherited by the OkHttpClient instances
used in OkHttpClientProvider and WebSocketModule.

## Facebook:
Applied from nest/mobile/apps/atod-sample/patches/react-native+0.83.1+004+atod-websocket.patch

Differential Revision: D95037793


