### PR TITLE
Move base64Encode into react/utils

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -8,10 +8,10 @@
 #include "NetworkIOAgent.h"
 #include "InspectorFlags.h"
 
-#include "Base64.h"
 #include "Utf8.h"
 
 #include <jsinspector-modern/network/NetworkHandler.h>
+#include <react/utils/Base64.h>
 
 #include <sstream>
 #include <tuple>

--- a/packages/react-native/ReactCommon/react/utils/Base64.h
+++ b/packages/react-native/ReactCommon/react/utils/Base64.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <string_view>
 
-namespace facebook::react::jsinspector_modern {
+namespace facebook::react {
 
 namespace {
 // Vendored from Folly
@@ -96,4 +96,4 @@ inline std::string base64Encode(const std::string_view s)
   return res;
 }
 
-} // namespace facebook::react::jsinspector_modern
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Move `base64Encode` implementation (originally vendored in D58323859) into `ReactCommon/react/utils/` for reuse in other C++ packages.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D95041544
