### PR TITLE
Back out "Use stable Hermes for dry-run builds on stable branches"

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -54,12 +54,7 @@ runs:
         if [[ "${{ inputs.release-type }}" == "dry-run" ]]; then
           # dry-run: we only build ARM64 to save time/resources. For release/nightlies the default is to build all archs.
           export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a,x86" # x86 is required for E2E testing
-          # Use stable Hermes on stable branches, nightly Hermes on main
-          if [[ "${{ github.ref_name }}" == *"-stable" ]] || [[ "${{ github.base_ref }}" == *"-stable" ]]; then
-            export HERMES_PREBUILT_FLAG="ORG_GRADLE_PROJECT_react.internal.useHermesStable=true"
-          else
-            export HERMES_PREBUILT_FLAG="ORG_GRADLE_PROJECT_react.internal.useHermesNightly=true"
-          fi
+          export HERMES_PREBUILT_FLAG="ORG_GRADLE_PROJECT_react.internal.useHermesNightly=true"
           TASKS="publishAllToMavenTempLocal build"
         elif [[ "${{ inputs.release-type }}" == "nightly" ]]; then
           # nightly: we set isSnapshot to true so artifacts are sent to the right repository on Maven Central.


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Original commit changeset: d5888a00b29c

Original Phabricator Diff: D95022571

It turns out, this didn't fix the issue.

Reviewed By: cipolleschi

Differential Revision: D95051094


