### PR TITLE
Formalize event timestamps and propagate from host platform to JS

### DIFF
--- a/packages/react-native/React/Fabric/RCTConversions.h
+++ b/packages/react-native/React/Fabric/RCTConversions.h
@@ -13,8 +13,27 @@
 #import <react/renderer/graphics/Color.h>
 #import <react/renderer/graphics/RCTPlatformColorUtils.h>
 #import <react/renderer/graphics/Transform.h>
+#import <react/timing/primitives.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+/*
+ * Converts an iOS timestamp (seconds since boot, NOT including sleep time, from
+ * NSProcessInfo.processInfo.systemUptime or UITouch.timestamp) to a HighResTimeStamp.
+ *
+ * iOS timestamps use mach_absolute_time() which doesn't account for sleep time,
+ * while std::chrono::steady_clock uses mach_continuous_time() which does.
+ * To handle this correctly, we compute the relative offset from the current time
+ * and apply it to HighResTimeStamp::now().
+ */
+inline facebook::react::HighResTimeStamp RCTHighResTimeStampFromSeconds(NSTimeInterval seconds)
+{
+  NSTimeInterval nowSystemUptime = NSProcessInfo.processInfo.systemUptime;
+  NSTimeInterval delta = nowSystemUptime - seconds;
+  auto deltaDuration =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<double>(delta));
+  return facebook::react::HighResTimeStamp::now() - facebook::react::HighResDuration::fromChrono(deltaDuration);
+}
 
 inline NSString *RCTNSStringFromString(
     const std::string &string,

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -285,6 +285,7 @@ static PointerEvent CreatePointerEventFromActivePointer(
   PointerEvent event = {};
   event.pointerId = activePointer.identifier;
   event.pointerType = PointerTypeCStringFromUITouchType(activePointer.touchType);
+  event.timeStamp = RCTHighResTimeStampFromSeconds(activePointer.timestamp);
 
   if (eventType == RCTPointerEventTypeCancel) {
     event.clientPoint = RCTPointFromCGPoint(CGPointZero);
@@ -345,7 +346,8 @@ static PointerEvent CreatePointerEventFromIncompleteHoverData(
     CGPoint clientLocation,
     CGPoint screenLocation,
     CGPoint offsetLocation,
-    UIKeyModifierFlags modifierFlags)
+    UIKeyModifierFlags modifierFlags,
+    HighResTimeStamp timeStamp)
 {
   PointerEvent event = {};
   event.pointerId = pointerId;
@@ -365,6 +367,7 @@ static PointerEvent CreatePointerEventFromIncompleteHoverData(
   event.tangentialPressure = 0.0;
   event.twist = 0;
   event.isPrimary = true;
+  event.timeStamp = timeStamp;
 
   return event;
 }
@@ -760,8 +763,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 
   modifierFlags = recognizer.modifierFlags;
 
+  // For hover events, use the current time as we don't have a precise timestamp
+  HighResTimeStamp eventTimestamp = HighResTimeStamp::now();
+
   PointerEvent event = CreatePointerEventFromIncompleteHoverData(
-      pointerId, pointerType, clientLocation, screenLocation, offsetLocation, modifierFlags);
+      pointerId, pointerType, clientLocation, screenLocation, offsetLocation, modifierFlags, eventTimestamp);
 
   SharedTouchEventEmitter eventEmitter = GetTouchEmitterFromView(targetView, offsetLocation);
   if (eventEmitter != nil) {

--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -67,6 +67,7 @@ static void UpdateActiveTouchWithUITouch(
   activeTouch.touch.pagePoint = RCTPointFromCGPoint(pagePoint);
 
   activeTouch.touch.timestamp = uiTouch.timestamp;
+  activeTouch.touch.timeStamp = RCTHighResTimeStampFromSeconds(uiTouch.timestamp);
 
   if (RCTForceTouchAvailable()) {
     activeTouch.touch.force = RCTZeroIfNaN(uiTouch.force / uiTouch.maximumPossibleForce);

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2261,6 +2261,7 @@ public class com/facebook/react/fabric/FabricUIManager : com/facebook/react/brid
 	public fun receiveEvent (IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public fun receiveEvent (IILjava/lang/String;ZLcom/facebook/react/bridge/WritableMap;I)V
 	public fun receiveEvent (IILjava/lang/String;ZLcom/facebook/react/bridge/WritableMap;IZ)V
+	public fun receiveEvent (IILjava/lang/String;ZLcom/facebook/react/bridge/WritableMap;IZJ)V
 	public fun receiveEvent (ILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public fun removeUIManagerEventListener (Lcom/facebook/react/bridge/UIManagerListener;)V
 	public fun resolveCustomDirectEventName (Ljava/lang/String;)Ljava/lang/String;
@@ -2287,6 +2288,7 @@ public final class com/facebook/react/fabric/mounting/SurfaceMountingManager {
 	public final fun attachRootView (Landroid/view/View;Lcom/facebook/react/uimanager/ThemedReactContext;)V
 	public final fun deleteView (I)V
 	public final fun enqueuePendingEvent (ILjava/lang/String;ZLcom/facebook/react/bridge/WritableMap;I)V
+	public final fun enqueuePendingEvent (ILjava/lang/String;ZLcom/facebook/react/bridge/WritableMap;IJ)V
 	public final fun getContext ()Lcom/facebook/react/uimanager/ThemedReactContext;
 	public final fun getSurfaceId ()I
 	public final fun getView (I)Landroid/view/View;
@@ -4804,11 +4806,13 @@ public final class com/facebook/react/uimanager/events/RCTEventEmitter$DefaultIm
 public abstract interface class com/facebook/react/uimanager/events/RCTModernEventEmitter : com/facebook/react/uimanager/events/RCTEventEmitter {
 	public abstract fun receiveEvent (IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public abstract fun receiveEvent (IILjava/lang/String;ZILcom/facebook/react/bridge/WritableMap;I)V
+	public abstract fun receiveEvent (IILjava/lang/String;ZILcom/facebook/react/bridge/WritableMap;IJ)V
 	public abstract fun receiveEvent (ILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 }
 
 public final class com/facebook/react/uimanager/events/RCTModernEventEmitter$DefaultImpls {
 	public static fun receiveEvent (Lcom/facebook/react/uimanager/events/RCTModernEventEmitter;IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
+	public static fun receiveEvent (Lcom/facebook/react/uimanager/events/RCTModernEventEmitter;IILjava/lang/String;ZILcom/facebook/react/bridge/WritableMap;IJ)V
 	public static fun receiveEvent (Lcom/facebook/react/uimanager/events/RCTModernEventEmitter;ILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public static fun receiveTouches (Lcom/facebook/react/uimanager/events/RCTModernEventEmitter;Ljava/lang/String;Lcom/facebook/react/bridge/WritableArray;Lcom/facebook/react/bridge/WritableArray;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/EventAnimationDriver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/EventAnimationDriver.kt
@@ -22,6 +22,7 @@ internal class EventAnimationDriver(
     private val eventPath: List<String>,
     @JvmField internal var valueNode: ValueAnimatedNode,
 ) : RCTModernEventEmitter {
+  @Deprecated("Use the overload with eventTimestamp parameter instead.")
   override fun receiveEvent(
       surfaceId: Int,
       targetTag: Int,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1067,11 +1067,13 @@ public class FabricUIManager
     return surfaceManager.getView(reactTag);
   }
 
+  @Deprecated
   @Override
   public void receiveEvent(int reactTag, String eventName, @Nullable WritableMap params) {
     receiveEvent(View.NO_ID, reactTag, eventName, false, params, EventCategoryDef.UNSPECIFIED);
   }
 
+  @Deprecated
   @Override
   public void receiveEvent(
       int surfaceId, int reactTag, String eventName, @Nullable WritableMap params) {
@@ -1091,7 +1093,9 @@ public class FabricUIManager
    * @param canCoalesceEvent
    * @param params
    * @param eventCategory
+   * @deprecated Use the overload with eventTimestamp parameter instead.
    */
+  @Deprecated
   public void receiveEvent(
       int surfaceId,
       int reactTag,
@@ -1099,9 +1103,34 @@ public class FabricUIManager
       boolean canCoalesceEvent,
       @Nullable WritableMap params,
       @EventCategoryDef int eventCategory) {
-    receiveEvent(surfaceId, reactTag, eventName, canCoalesceEvent, params, eventCategory, false);
+    receiveEvent(
+        surfaceId,
+        reactTag,
+        eventName,
+        canCoalesceEvent,
+        params,
+        eventCategory,
+        false,
+        SystemClock.uptimeMillis());
   }
 
+  /**
+   * receiveEvent API that emits an event to C++. If {@code canCoalesceEvent} is true, that signals
+   * that C++ may coalesce the event optionally. Otherwise, coalescing can happen in Java before
+   * emitting.
+   *
+   * <p>{@code customCoalesceKey} is currently unused.
+   *
+   * @param surfaceId
+   * @param reactTag
+   * @param eventName
+   * @param canCoalesceEvent
+   * @param params
+   * @param eventCategory
+   * @param experimentalIsSynchronous
+   * @deprecated Use the overload with eventTimestamp parameter instead.
+   */
+  @Deprecated
   @Override
   public void receiveEvent(
       int surfaceId,
@@ -1111,6 +1140,43 @@ public class FabricUIManager
       @Nullable WritableMap params,
       @EventCategoryDef int eventCategory,
       boolean experimentalIsSynchronous) {
+    receiveEvent(
+        surfaceId,
+        reactTag,
+        eventName,
+        canCoalesceEvent,
+        params,
+        eventCategory,
+        experimentalIsSynchronous,
+        SystemClock.uptimeMillis());
+  }
+
+  /**
+   * receiveEvent API that emits an event to C++. If {@code canCoalesceEvent} is true, that signals
+   * that C++ may coalesce the event optionally. Otherwise, coalescing can happen in Java before
+   * emitting.
+   *
+   * <p>{@code customCoalesceKey} is currently unused.
+   *
+   * @param surfaceId
+   * @param reactTag
+   * @param eventName
+   * @param canCoalesceEvent
+   * @param params
+   * @param eventCategory
+   * @param experimentalIsSynchronous
+   * @param eventTimestamp
+   */
+  @Override
+  public void receiveEvent(
+      int surfaceId,
+      int reactTag,
+      String eventName,
+      boolean canCoalesceEvent,
+      @Nullable WritableMap params,
+      @EventCategoryDef int eventCategory,
+      boolean experimentalIsSynchronous,
+      long eventTimestamp) {
 
     if (ReactBuildConfig.DEBUG && surfaceId == View.NO_ID) {
       FLog.d(TAG, "Emitted event without surfaceId: [%d] %s", reactTag, eventName);
@@ -1128,7 +1194,13 @@ public class FabricUIManager
         // access to the event emitter later when the view is mounted. For now just save the event
         // in the view state and trigger it later.
         mMountingManager.enqueuePendingEvent(
-            surfaceId, reactTag, eventName, canCoalesceEvent, params, eventCategory);
+            surfaceId,
+            reactTag,
+            eventName,
+            canCoalesceEvent,
+            params,
+            eventCategory,
+            eventTimestamp);
       } else {
         // This can happen if the view has disappeared from the screen (because of async events)
         FLog.i(TAG, "Unable to invoke event: " + eventName + " for reactTag: " + reactTag);
@@ -1142,13 +1214,13 @@ public class FabricUIManager
       boolean firstEventForFrame =
           mSynchronousEvents.add(new SynchronousEvent(surfaceId, reactTag, eventName));
       if (firstEventForFrame) {
-        eventEmitter.dispatchEventSynchronously(eventName, params);
+        eventEmitter.dispatchEventSynchronously(eventName, params, eventTimestamp);
       }
     } else {
       if (canCoalesceEvent) {
-        eventEmitter.dispatchUnique(eventName, params);
+        eventEmitter.dispatchUnique(eventName, params, eventTimestamp);
       } else {
-        eventEmitter.dispatch(eventName, params, eventCategory);
+        eventEmitter.dispatch(eventName, params, eventCategory, eventTimestamp);
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.kt
@@ -27,33 +27,49 @@ internal class EventEmitterWrapper private constructor() : HybridClassBase() {
       eventName: String,
       params: NativeMap?,
       @EventCategoryDef category: Int,
+      eventTimestamp: Long,
   )
 
-  private external fun dispatchEventSynchronously(eventName: String, params: NativeMap?)
+  private external fun dispatchEventSynchronously(
+      eventName: String,
+      params: NativeMap?,
+      eventTimestamp: Long,
+  )
 
-  private external fun dispatchUniqueEvent(eventName: String, params: NativeMap?)
+  private external fun dispatchUniqueEvent(
+      eventName: String,
+      params: NativeMap?,
+      eventTimestamp: Long,
+  )
 
   /**
    * Invokes the execution of the C++ EventEmitter.
    *
    * @param eventName [String] name of the event to execute.
    * @param params [WritableMap] payload of the event
+   * @param eventCategory event category
+   * @param eventTimestamp timestamp when the event was triggered (in milliseconds since boot)
    */
   @Synchronized
-  fun dispatch(eventName: String, params: WritableMap?, @EventCategoryDef eventCategory: Int) {
+  fun dispatch(
+      eventName: String,
+      params: WritableMap?,
+      @EventCategoryDef eventCategory: Int,
+      eventTimestamp: Long,
+  ) {
     if (!isValid) {
       return
     }
-    dispatchEvent(eventName, params as NativeMap?, eventCategory)
+    dispatchEvent(eventName, params as NativeMap?, eventCategory, eventTimestamp)
   }
 
   @Synchronized
-  fun dispatchEventSynchronously(eventName: String, params: WritableMap?) {
+  fun dispatchEventSynchronously(eventName: String, params: WritableMap?, eventTimestamp: Long) {
     if (!isValid) {
       return
     }
     UiThreadUtil.assertOnUiThread()
-    dispatchEventSynchronously(eventName, params as NativeMap?)
+    dispatchEventSynchronously(eventName, params as NativeMap?, eventTimestamp)
   }
 
   /**
@@ -62,13 +78,14 @@ internal class EventEmitterWrapper private constructor() : HybridClassBase() {
    *
    * @param eventName [String] name of the event to execute.
    * @param params [WritableMap] payload of the event
+   * @param eventTimestamp timestamp when the event was triggered (in milliseconds since boot)
    */
   @Synchronized
-  fun dispatchUnique(eventName: String, params: WritableMap?) {
+  fun dispatchUnique(eventName: String, params: WritableMap?, eventTimestamp: Long) {
     if (!isValid) {
       return
     }
-    dispatchUniqueEvent(eventName, params as NativeMap?)
+    dispatchUniqueEvent(eventName, params as NativeMap?, eventTimestamp)
   }
 
   @Synchronized

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.fabric.events
 
+import android.os.SystemClock
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.events.EventCategoryDef
@@ -14,6 +15,7 @@ import com.facebook.react.uimanager.events.RCTModernEventEmitter
 import com.facebook.systrace.Systrace
 
 internal class FabricEventEmitter(private val uiManager: FabricUIManager) : RCTModernEventEmitter {
+  @Deprecated("Use the overload with eventTimestamp parameter instead.")
   override fun receiveEvent(
       surfaceId: Int,
       targetTag: Int,
@@ -23,9 +25,40 @@ internal class FabricEventEmitter(private val uiManager: FabricUIManager) : RCTM
       params: WritableMap?,
       @EventCategoryDef category: Int,
   ) {
+    receiveEvent(
+        surfaceId,
+        targetTag,
+        eventName,
+        canCoalesceEvent,
+        customCoalesceKey,
+        params,
+        category,
+        SystemClock.uptimeMillis(),
+    )
+  }
+
+  override fun receiveEvent(
+      surfaceId: Int,
+      targetTag: Int,
+      eventName: String,
+      canCoalesceEvent: Boolean,
+      customCoalesceKey: Int,
+      params: WritableMap?,
+      @EventCategoryDef category: Int,
+      eventTimestamp: Long,
+  ) {
     Systrace.beginSection(Systrace.TRACE_TAG_REACT, "FabricEventEmitter.receiveEvent('$eventName')")
     try {
-      uiManager.receiveEvent(surfaceId, targetTag, eventName, canCoalesceEvent, params, category)
+      uiManager.receiveEvent(
+          surfaceId,
+          targetTag,
+          eventName,
+          canCoalesceEvent,
+          params,
+          category,
+          false,
+          eventTimestamp,
+      )
     } finally {
       Systrace.endSection(Systrace.TRACE_TAG_REACT)
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.kt
@@ -334,6 +334,7 @@ internal class MountingManager(
       canCoalesceEvent: Boolean,
       params: WritableMap?,
       @EventCategoryDef eventCategory: Int,
+      eventTimestamp: Long,
   ) {
     val smm = getSurfaceMountingManager(surfaceId, reactTag)
     if (smm == null) {
@@ -345,7 +346,14 @@ internal class MountingManager(
       )
       return
     }
-    smm.enqueuePendingEvent(reactTag, eventName, canCoalesceEvent, params, eventCategory)
+    smm.enqueuePendingEvent(
+        reactTag,
+        eventName,
+        canCoalesceEvent,
+        params,
+        eventCategory,
+        eventTimestamp,
+    )
   }
 
   private fun getSurfaceMountingManager(surfaceId: Int, reactTag: Int): SurfaceMountingManager? =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.fabric.mounting
 
 import android.annotation.SuppressLint
+import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewParent
@@ -1083,6 +1084,25 @@ internal constructor(
       params: WritableMap?,
       @EventCategoryDef eventCategory: Int,
   ): Unit {
+    enqueuePendingEvent(
+        reactTag,
+        eventName,
+        canCoalesceEvent,
+        params,
+        eventCategory,
+        SystemClock.uptimeMillis(),
+    )
+  }
+
+  @AnyThread
+  public fun enqueuePendingEvent(
+      reactTag: Int,
+      eventName: String,
+      canCoalesceEvent: Boolean,
+      params: WritableMap?,
+      @EventCategoryDef eventCategory: Int,
+      eventTimestamp: Long,
+  ): Unit {
     // When the surface stopped we will reset the view state map. We are not going to enqueue
     // pending events as they are not expected to be dispatched anyways.
     val viewState = tagToViewState[reactTag]
@@ -1092,7 +1112,8 @@ internal constructor(
       return
     }
 
-    val viewEvent = PendingViewEvent(eventName, params, eventCategory, canCoalesceEvent)
+    val viewEvent =
+        PendingViewEvent(eventName, params, eventCategory, canCoalesceEvent, eventTimestamp)
     UiThreadUtil.runOnUiThread {
       val eventEmitter = viewState.eventEmitter
       if (eventEmitter != null) {
@@ -1145,12 +1166,13 @@ internal constructor(
       private val params: WritableMap?,
       @field:EventCategoryDef private val eventCategory: Int,
       private val canCoalesceEvent: Boolean,
+      private val eventTimestamp: Long,
   ) {
     fun dispatch(eventEmitter: EventEmitterWrapper) {
       if (canCoalesceEvent) {
-        eventEmitter.dispatchUnique(eventName, params)
+        eventEmitter.dispatchUnique(eventName, params, eventTimestamp)
       } else {
-        eventEmitter.dispatch(eventName, params, eventCategory)
+        eventEmitter.dispatch(eventName, params, eventCategory, eventTimestamp)
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
@@ -72,6 +72,7 @@ internal class FabricEventDispatcher(
             event.internal_getEventData(),
             event.internal_getEventCategory(),
             true,
+            event.timestampMs,
         )
       } else {
         ReactSoftExceptionLogger.logSoftException(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.kt
@@ -283,6 +283,7 @@ internal class PointerEvent private constructor() : Event<PointerEvent>() {
           coalescingKey.toInt(),
           eventData,
           getEventCategory(_eventName),
+          timestampMs,
       )
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTModernEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTModernEventEmitter.kt
@@ -28,11 +28,13 @@ public interface RCTModernEventEmitter : RCTEventEmitter {
     receiveEvent(-1, targetTag, eventName, params)
   }
 
+  @Deprecated("Use the overload with eventTimestamp parameter instead.")
   public fun receiveEvent(surfaceId: Int, targetTag: Int, eventName: String, params: WritableMap?) {
     // We assume this event can't be coalesced. `customCoalesceKey` has no meaning in Fabric.
     receiveEvent(surfaceId, targetTag, eventName, false, 0, params, EventCategoryDef.UNSPECIFIED)
   }
 
+  @Deprecated("Use the overload with eventTimestamp parameter instead.")
   public fun receiveEvent(
       surfaceId: Int,
       targetTag: Int,
@@ -42,4 +44,32 @@ public interface RCTModernEventEmitter : RCTEventEmitter {
       params: WritableMap?,
       @EventCategoryDef category: Int,
   )
+
+  /**
+   * Receives an event with a specific timestamp. The default implementation delegates to the
+   * non-timestamped version for backward compatibility with existing implementations.
+   *
+   * @param eventTimestamp The timestamp when the event was triggered (in milliseconds since boot,
+   *   from SystemClock.uptimeMillis())
+   */
+  public fun receiveEvent(
+      surfaceId: Int,
+      targetTag: Int,
+      eventName: String,
+      canCoalesceEvent: Boolean,
+      customCoalesceKey: Int,
+      params: WritableMap?,
+      @EventCategoryDef category: Int,
+      eventTimestamp: Long,
+  ) {
+    receiveEvent(
+        surfaceId,
+        targetTag,
+        eventName,
+        canCoalesceEvent,
+        customCoalesceKey,
+        params,
+        category,
+    )
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/SynchronousEventReceiver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/SynchronousEventReceiver.kt
@@ -21,4 +21,32 @@ internal interface SynchronousEventReceiver {
       @EventCategoryDef eventCategory: Int,
       experimentalIsSynchronous: Boolean,
   )
+
+  /**
+   * Receives an event with a specific timestamp. The default implementation delegates to the
+   * non-timestamped version for backward compatibility with existing implementations.
+   *
+   * @param eventTimestamp timestamp when the event was triggered (in milliseconds since boot, from
+   *   SystemClock.uptimeMillis())
+   */
+  fun receiveEvent(
+      surfaceId: Int,
+      reactTag: Int,
+      eventName: String,
+      canCoalesceEvent: Boolean,
+      params: WritableMap?,
+      @EventCategoryDef eventCategory: Int,
+      experimentalIsSynchronous: Boolean,
+      eventTimestamp: Long,
+  ) {
+    receiveEvent(
+        surfaceId,
+        reactTag,
+        eventName,
+        canCoalesceEvent,
+        params,
+        eventCategory,
+        experimentalIsSynchronous,
+    )
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.kt
@@ -150,6 +150,7 @@ internal object TouchesHelper {
             0,
             eventData,
             event.getEventCategory(),
+            event.timestampMs,
         )
       }
     } finally {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventEmitterWrapper.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventEmitterWrapper.cpp
@@ -7,6 +7,7 @@
 
 #include "EventEmitterWrapper.h"
 #include <fbjni/fbjni.h>
+#include <react/timing/primitives.h>
 
 #include <utility>
 
@@ -14,10 +15,24 @@ using namespace facebook::jni;
 
 namespace facebook::react {
 
+namespace {
+
+/*
+ * Converts a Java timestamp (milliseconds since boot from
+ * SystemClock.uptimeMillis()) to a HighResTimeStamp.
+ */
+HighResTimeStamp highResTimeStampFromMillis(jlong millis) {
+  return HighResTimeStamp::fromChronoSteadyClockTimePoint(
+      std::chrono::steady_clock::time_point(std::chrono::milliseconds(millis)));
+}
+
+} // namespace
+
 void EventEmitterWrapper::dispatchEvent(
     std::string eventName,
     NativeMap* payload,
-    int category) {
+    int category,
+    jlong eventTimestamp) {
   // It is marginal, but possible for this to be constructed without a valid
   // EventEmitter. In those cases, make sure we noop/blackhole events instead of
   // crashing.
@@ -25,13 +40,15 @@ void EventEmitterWrapper::dispatchEvent(
     eventEmitter->dispatchEvent(
         std::move(eventName),
         (payload != nullptr) ? payload->consume() : folly::dynamic::object(),
-        static_cast<RawEvent::Category>(category));
+        static_cast<RawEvent::Category>(category),
+        highResTimeStampFromMillis(eventTimestamp));
   }
 }
 
 void EventEmitterWrapper::dispatchEventSynchronously(
     std::string eventName,
-    NativeMap* params) {
+    NativeMap* params,
+    jlong eventTimestamp) {
   // It is marginal, but possible for this to be constructed without a valid
   // EventEmitter. In those cases, make sure we noop/blackhole events instead of
   // crashing.
@@ -40,21 +57,24 @@ void EventEmitterWrapper::dispatchEventSynchronously(
       eventEmitter->dispatchEvent(
           std::move(eventName),
           (params != nullptr) ? params->consume() : folly::dynamic::object(),
-          RawEvent::Category::Discrete);
+          RawEvent::Category::Discrete,
+          highResTimeStampFromMillis(eventTimestamp));
     });
   }
 }
 
 void EventEmitterWrapper::dispatchUniqueEvent(
     std::string eventName,
-    NativeMap* payload) {
+    NativeMap* payload,
+    jlong eventTimestamp) {
   // It is marginal, but possible for this to be constructed without a valid
   // EventEmitter. In those cases, make sure we noop/blackhole events instead of
   // crashing.
   if (eventEmitter != nullptr) {
     eventEmitter->dispatchUniqueEvent(
         std::move(eventName),
-        (payload != nullptr) ? payload->consume() : folly::dynamic::object());
+        (payload != nullptr) ? payload->consume() : folly::dynamic::object(),
+        highResTimeStampFromMillis(eventTimestamp));
   }
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventEmitterWrapper.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventEmitterWrapper.h
@@ -25,9 +25,9 @@ class EventEmitterWrapper : public jni::HybridClass<EventEmitterWrapper> {
 
   SharedEventEmitter eventEmitter;
 
-  void dispatchEvent(std::string eventName, NativeMap *payload, int category);
-  void dispatchEventSynchronously(std::string eventName, NativeMap *params);
-  void dispatchUniqueEvent(std::string eventName, NativeMap *payload);
+  void dispatchEvent(std::string eventName, NativeMap *payload, int category, jlong eventTimestamp);
+  void dispatchEventSynchronously(std::string eventName, NativeMap *params, jlong eventTimestamp);
+  void dispatchUniqueEvent(std::string eventName, NativeMap *payload, jlong eventTimestamp);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
@@ -546,6 +546,7 @@ class TouchEventDispatchTest {
             anyInt(),
             argument.capture(),
             anyInt(),
+            anyLong(),
         )
     assertThat(startMoveEndExpectedSequence).isEqualTo(argument.allValues)
   }
@@ -565,6 +566,7 @@ class TouchEventDispatchTest {
             anyInt(),
             argument.capture(),
             anyInt(),
+            anyLong(),
         )
     assertThat(startMoveCancelExpectedSequence).isEqualTo(argument.allValues)
   }
@@ -584,6 +586,7 @@ class TouchEventDispatchTest {
             anyInt(),
             argument.capture(),
             anyInt(),
+            anyLong(),
         )
     assertThat(startPointerMoveUpExpectedSequence).isEqualTo(argument.allValues)
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.cpp
@@ -21,7 +21,8 @@ void setTouchPayloadOnObject(
   object.setProperty(runtime, "screenY", touch.screenPoint.y);
   object.setProperty(runtime, "identifier", touch.identifier);
   object.setProperty(runtime, "target", touch.target);
-  object.setProperty(runtime, "timestamp", touch.timestamp * 1000);
+  object.setProperty(
+      runtime, "timestamp", touch.timeStamp.toDOMHighResTimeStamp());
   object.setProperty(runtime, "force", touch.force);
 }
 
@@ -41,7 +42,7 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
       {"identifier", getDebugDescription(touch.identifier, options)},
       {"target", getDebugDescription(touch.target, options)},
       {"force", getDebugDescription(touch.force, options)},
-      {"timestamp", getDebugDescription(touch.timestamp, options)},
+      {"timeStamp", getDebugDescription(touch.timeStamp, options)},
   };
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
@@ -11,6 +11,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Point.h>
+#include <react/timing/primitives.h>
 
 namespace facebook::react {
 
@@ -53,8 +54,14 @@ struct BaseTouch {
 
   /*
    * The time in seconds when the touch occurred or when it was last mutated.
+   * @deprecated Use timeStamp instead.
    */
   Float timestamp{0.0f};
+
+  /*
+   * The time when the touch occurred.
+   */
+  HighResTimeStamp timeStamp{};
 
   /*
    * The particular implementation of `Hasher` and (especially) `Comparator`

--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.cpp
@@ -98,6 +98,8 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
        .value = getDebugDescription(pointerEvent.isPrimary, options)},
       {.name = "button",
        .value = getDebugDescription(pointerEvent.button, options)},
+      {.name = "timeStamp",
+       .value = getDebugDescription(pointerEvent.timeStamp, options)},
   };
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
@@ -11,6 +11,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Point.h>
+#include <react/timing/primitives.h>
 
 namespace facebook::react {
 
@@ -110,6 +111,10 @@ struct PointerEvent : public EventPayload {
    * was fired.
    */
   int button;
+  /*
+   * The time when the event occurred.
+   */
+  HighResTimeStamp timeStamp{};
 
   /*
    * EventPayload implementations

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
@@ -9,8 +9,6 @@
 
 #include <react/renderer/debug/DebugStringConvertible.h>
 
-#include <unordered_set>
-
 #include <react/renderer/components/view/Touch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -42,26 +42,38 @@ static jsi::Value touchEventPayload(
   return object;
 }
 
+static HighResTimeStamp getTimestampFromTouchEvent(const TouchEvent& event) {
+  if (!event.changedTouches.empty()) {
+    const auto& firstChangedTouch = *event.changedTouches.begin();
+    return firstChangedTouch.timeStamp;
+  }
+  return HighResTimeStamp::now();
+}
+
 void TouchEventEmitter::dispatchTouchEvent(
     std::string type,
     TouchEvent event,
     RawEvent::Category category) const {
+  auto eventTimestamp = getTimestampFromTouchEvent(event);
   dispatchEvent(
       std::move(type),
       [event = std::move(event)](jsi::Runtime& runtime) {
         return touchEventPayload(runtime, event);
       },
-      category);
+      category,
+      eventTimestamp);
 }
 
 void TouchEventEmitter::dispatchPointerEvent(
     std::string type,
     PointerEvent event,
     RawEvent::Category category) const {
+  auto eventTimestamp = event.timeStamp;
   dispatchEvent(
       std::move(type),
       std::make_shared<PointerEvent>(std::move(event)),
-      category);
+      category,
+      eventTimestamp);
 }
 
 void TouchEventEmitter::onTouchStart(TouchEvent event) const {
@@ -70,10 +82,13 @@ void TouchEventEmitter::onTouchStart(TouchEvent event) const {
 }
 
 void TouchEventEmitter::onTouchMove(TouchEvent event) const {
+  auto eventTimestamp = getTimestampFromTouchEvent(event);
   dispatchUniqueEvent(
-      "touchMove", [event = std::move(event)](jsi::Runtime& runtime) {
+      "touchMove",
+      [event = std::move(event)](jsi::Runtime& runtime) {
         return touchEventPayload(runtime, event);
-      });
+      },
+      eventTimestamp);
 }
 
 void TouchEventEmitter::onTouchEnd(TouchEvent event) const {
@@ -101,8 +116,11 @@ void TouchEventEmitter::onPointerDown(PointerEvent event) const {
 }
 
 void TouchEventEmitter::onPointerMove(PointerEvent event) const {
+  auto eventTimestamp = event.timeStamp;
   dispatchUniqueEvent(
-      "pointerMove", std::make_shared<PointerEvent>(std::move(event)));
+      "pointerMove",
+      std::make_shared<PointerEvent>(std::move(event)),
+      eventTimestamp);
 }
 
 void TouchEventEmitter::onPointerUp(PointerEvent event) const {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -13,6 +13,7 @@
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
+#include <react/timing/primitives.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -63,11 +63,33 @@ void EventEmitter::dispatchEvent(
       category);
 }
 
+void EventEmitter::dispatchEvent(
+    std::string type,
+    folly::dynamic&& payload,
+    RawEvent::Category category,
+    HighResTimeStamp eventTimestamp) const {
+  dispatchEvent(
+      std::move(type),
+      DynamicEventPayload::create(std::move(payload)),
+      category,
+      eventTimestamp);
+}
+
 void EventEmitter::dispatchUniqueEvent(
     std::string type,
     folly::dynamic&& payload) const {
   dispatchUniqueEvent(
       std::move(type), DynamicEventPayload::create(std::move(payload)));
+}
+
+void EventEmitter::dispatchUniqueEvent(
+    std::string type,
+    folly::dynamic&& payload,
+    HighResTimeStamp eventTimestamp) const {
+  dispatchUniqueEvent(
+      std::move(type),
+      DynamicEventPayload::create(std::move(payload)),
+      eventTimestamp);
 }
 
 void EventEmitter::dispatchEvent(
@@ -82,8 +104,29 @@ void EventEmitter::dispatchEvent(
 
 void EventEmitter::dispatchEvent(
     std::string type,
+    const ValueFactory& payloadFactory,
+    RawEvent::Category category,
+    HighResTimeStamp eventTimestamp) const {
+  dispatchEvent(
+      std::move(type),
+      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
+      category,
+      eventTimestamp);
+}
+
+void EventEmitter::dispatchEvent(
+    std::string type,
     SharedEventPayload payload,
     RawEvent::Category category) const {
+  dispatchEvent(
+      std::move(type), std::move(payload), category, HighResTimeStamp::now());
+}
+
+void EventEmitter::dispatchEvent(
+    std::string type,
+    SharedEventPayload payload,
+    RawEvent::Category category,
+    HighResTimeStamp eventTimestamp) const {
   TraceSection s("EventEmitter::dispatchEvent", "type", type);
 
   auto eventDispatcher = eventDispatcher_.lock();
@@ -96,7 +139,9 @@ void EventEmitter::dispatchEvent(
       std::move(payload),
       eventTarget_,
       shadowNodeFamily_,
-      category));
+      category,
+      false,
+      eventTimestamp));
 }
 
 void EventEmitter::dispatchUniqueEvent(
@@ -109,7 +154,25 @@ void EventEmitter::dispatchUniqueEvent(
 
 void EventEmitter::dispatchUniqueEvent(
     std::string type,
+    const ValueFactory& payloadFactory,
+    HighResTimeStamp eventTimestamp) const {
+  dispatchUniqueEvent(
+      std::move(type),
+      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
+      eventTimestamp);
+}
+
+void EventEmitter::dispatchUniqueEvent(
+    std::string type,
     SharedEventPayload payload) const {
+  dispatchUniqueEvent(
+      std::move(type), std::move(payload), HighResTimeStamp::now());
+}
+
+void EventEmitter::dispatchUniqueEvent(
+    std::string type,
+    SharedEventPayload payload,
+    HighResTimeStamp eventTimestamp) const {
   TraceSection s("EventEmitter::dispatchUniqueEvent");
 
   auto eventDispatcher = eventDispatcher_.lock();
@@ -122,7 +185,9 @@ void EventEmitter::dispatchUniqueEvent(
       std::move(payload),
       eventTarget_,
       shadowNodeFamily_,
-      RawEvent::Category::Continuous));
+      RawEvent::Category::Continuous,
+      true,
+      eventTimestamp));
 }
 
 void EventEmitter::setEnabled(bool enabled) {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -16,6 +16,7 @@
 #include <react/renderer/core/EventTarget.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ValueFactoryEventPayload.h>
+#include <react/timing/primitives.h>
 
 namespace facebook::react {
 
@@ -88,6 +89,12 @@ class EventEmitter {
 
   void dispatchEvent(
       std::string type,
+      const ValueFactory &payloadFactory,
+      RawEvent::Category category,
+      HighResTimeStamp eventTimestamp) const;
+
+  void dispatchEvent(
+      std::string type,
       folly::dynamic &&payload,
       RawEvent::Category category = RawEvent::Category::Unspecified) const;
 
@@ -96,12 +103,30 @@ class EventEmitter {
       SharedEventPayload payload,
       RawEvent::Category category = RawEvent::Category::Unspecified) const;
 
+  void dispatchEvent(
+      std::string type,
+      folly::dynamic &&payload,
+      RawEvent::Category category,
+      HighResTimeStamp eventTimestamp) const;
+
+  void dispatchEvent(
+      std::string type,
+      SharedEventPayload payload,
+      RawEvent::Category category,
+      HighResTimeStamp eventTimestamp) const;
+
   void dispatchUniqueEvent(std::string type, folly::dynamic &&payload) const;
 
   void dispatchUniqueEvent(std::string type, const ValueFactory &payloadFactory = EventEmitter::defaultPayloadFactory())
       const;
 
+  void dispatchUniqueEvent(std::string type, const ValueFactory &payloadFactory, HighResTimeStamp eventTimestamp) const;
+
   void dispatchUniqueEvent(std::string type, SharedEventPayload payload) const;
+
+  void dispatchUniqueEvent(std::string type, folly::dynamic &&payload, HighResTimeStamp eventTimestamp) const;
+
+  void dispatchUniqueEvent(std::string type, SharedEventPayload payload, HighResTimeStamp eventTimestamp) const;
 
  private:
   friend class UIManagerBinding;

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPipe.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPipe.h
@@ -15,6 +15,7 @@
 #include <react/renderer/core/EventTarget.h>
 #include <react/renderer/core/ReactEventPriority.h>
 #include <react/renderer/core/ValueFactory.h>
+#include <react/timing/primitives.h>
 
 namespace facebook::react {
 
@@ -23,7 +24,8 @@ using EventPipe = std::function<void(
     EventTarget *eventTarget,
     const std::string &type,
     ReactEventPriority priority,
-    const EventPayload &payload)>;
+    const EventPayload &payload,
+    HighResTimeStamp eventTimestamp)>;
 
 using EventPipeConclusion = std::function<void(jsi::Runtime &runtime)>;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -96,7 +96,8 @@ void EventQueueProcessor::flushEvents(
         event.eventTarget.get(),
         event.type,
         reactPriority,
-        *event.eventPayload);
+        *event.eventPayload,
+        event.eventStartTimeStamp);
 
     if (eventLogger != nullptr) {
       eventLogger->onEventProcessingEnd(event.loggingTag);

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
@@ -15,12 +15,14 @@ RawEvent::RawEvent(
     SharedEventTarget eventTarget,
     std::weak_ptr<const ShadowNodeFamily> shadowNodeFamily,
     Category category,
-    bool isUnique)
+    bool isUnique,
+    HighResTimeStamp eventStartTimeStamp)
     : type(std::move(type)),
       eventPayload(std::move(eventPayload)),
       eventTarget(std::move(eventTarget)),
       shadowNodeFamily(std::move(shadowNodeFamily)),
       category(category),
-      isUnique(isUnique) {}
+      isUnique(isUnique),
+      eventStartTimeStamp(eventStartTimeStamp) {}
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 #include <string>
 
 #include <react/renderer/core/EventLogger.h>
@@ -74,7 +73,8 @@ struct RawEvent {
       SharedEventTarget eventTarget,
       std::weak_ptr<const ShadowNodeFamily> shadowNodeFamily,
       Category category = Category::Unspecified,
-      bool isUnique = false);
+      bool isUnique = false,
+      HighResTimeStamp eventStartTimeStamp = HighResTimeStamp::now());
 
   std::string type;
   SharedEventPayload eventPayload;
@@ -84,10 +84,10 @@ struct RawEvent {
   EventTag loggingTag{0};
   bool isUnique{false};
 
-  // The client may specify a platform-specific timestamp for the event start
-  // time, for example when MotionEvent was triggered on the Android native
-  // side.
-  std::optional<HighResTimeStamp> eventStartTimeStamp = std::nullopt;
+  // The timestamp for the event start time. This defaults to the current
+  // time if not specified by the client (e.g., when MotionEvent was triggered
+  // on the Android native side).
+  HighResTimeStamp eventStartTimeStamp;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
@@ -42,7 +42,8 @@ class EventQueueProcessorTest : public testing::Test {
                          const EventTarget* /*eventTarget*/,
                          const std::string& type,
                          ReactEventPriority priority,
-                         const EventPayload& /*payload*/) {
+                         const EventPayload& /*payload*/,
+                         HighResTimeStamp /*eventTimestamp*/) {
       eventTypes_.push_back(type);
       eventPriorities_.push_back(priority);
     };

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -88,11 +88,12 @@ Scheduler::Scheduler(
                        EventTarget* eventTarget,
                        const std::string& type,
                        ReactEventPriority priority,
-                       const EventPayload& payload) {
+                       const EventPayload& payload,
+                       HighResTimeStamp eventTimestamp) {
     uiManager->visitBinding(
         [&](const UIManagerBinding& uiManagerBinding) {
           uiManagerBinding.dispatchEvent(
-              runtime, eventTarget, type, priority, payload);
+              runtime, eventTarget, type, priority, payload, eventTimestamp);
         },
         runtime);
   };

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -65,12 +65,13 @@ void UIManagerBinding::dispatchEvent(
     EventTarget* eventTarget,
     const std::string& type,
     ReactEventPriority priority,
-    const EventPayload& eventPayload) const {
+    const EventPayload& eventPayload,
+    HighResTimeStamp eventTimestamp) const {
   TraceSection s("UIManagerBinding::dispatchEvent", "type", type);
 
   if (eventPayload.getType() == EventPayloadType::PointerEvent) {
     auto pointerEvent = static_cast<const PointerEvent&>(eventPayload);
-    auto dispatchCallback = [this, &runtime](
+    auto dispatchCallback = [this, &runtime, eventTimestamp](
                                 const ShadowNode& targetNode,
                                 const std::string& type,
                                 ReactEventPriority priority,
@@ -79,7 +80,12 @@ void UIManagerBinding::dispatchEvent(
       if (eventTarget != nullptr) {
         eventTarget->retain(runtime);
         this->dispatchEventToJS(
-            runtime, eventTarget.get(), type, priority, eventPayload);
+            runtime,
+            eventTarget.get(),
+            type,
+            priority,
+            eventPayload,
+            eventTimestamp);
         eventTarget->release(runtime);
       }
     };
@@ -95,7 +101,8 @@ void UIManagerBinding::dispatchEvent(
           *uiManager_);
     }
   } else {
-    dispatchEventToJS(runtime, eventTarget, type, priority, eventPayload);
+    dispatchEventToJS(
+        runtime, eventTarget, type, priority, eventPayload, eventTimestamp);
   }
 }
 
@@ -104,7 +111,8 @@ void UIManagerBinding::dispatchEventToJS(
     EventTarget* eventTarget,
     const std::string& type,
     ReactEventPriority priority,
-    const EventPayload& eventPayload) const {
+    const EventPayload& eventPayload,
+    HighResTimeStamp eventTimestamp) const {
   auto payload = eventPayload.asJSIValue(runtime);
 
   // If a payload is null, the factory has decided to cancel the event
@@ -134,6 +142,15 @@ void UIManagerBinding::dispatchEventToJS(
     // Do not log all missing instanceHandles to avoid log spam
     LOG_EVERY_N(INFO, 10) << "instanceHandle is null, event of type " << type
                           << " will be dropped";
+  }
+
+  // Add timestamp to payload if not already set
+  if (payload.isObject()) {
+    auto payloadObject = payload.asObject(runtime);
+    if (!payloadObject.hasProperty(runtime, "timeStamp")) {
+      payloadObject.setProperty(
+          runtime, "timeStamp", eventTimestamp.toDOMHighResTimeStamp());
+    }
   }
 
   currentEventPriority_ = priority;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -13,6 +13,7 @@
 #include <react/renderer/uimanager/PointerEventsProcessor.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/primitives.h>
+#include <react/timing/primitives.h>
 
 namespace facebook::react {
 
@@ -47,7 +48,8 @@ class UIManagerBinding : public jsi::HostObject {
       EventTarget *eventTarget,
       const std::string &type,
       ReactEventPriority priority,
-      const EventPayload &payload) const;
+      const EventPayload &payload,
+      HighResTimeStamp eventTimestamp) const;
 
   /*
    * Invalidates the binding and underlying UIManager.
@@ -76,7 +78,8 @@ class UIManagerBinding : public jsi::HostObject {
       EventTarget *eventTarget,
       const std::string &type,
       ReactEventPriority priority,
-      const EventPayload &payload) const;
+      const EventPayload &payload,
+      HighResTimeStamp eventTimestamp) const;
 
   std::shared_ptr<UIManager> uiManager_;
   std::unique_ptr<jsi::Function> eventHandler_;

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -184,6 +184,44 @@ describe('Event Timing API', () => {
     expect(entry.interactionId).toBeGreaterThanOrEqual(0);
   });
 
+  it('provides the event timeStamp as startTime', () => {
+    const callback = jest.fn();
+
+    const observer = new PerformanceObserver(callback);
+    observer.observe({entryTypes: ['event']});
+
+    let eventTimeStamp;
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          onClick={event => {
+            eventTimeStamp = event.timeStamp;
+          }}
+        />,
+      );
+    });
+
+    const element = nullthrows(root.document.documentElement.firstElementChild);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    Fantom.dispatchNativeEvent(element, 'click');
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    const entryList = callback.mock.lastCall[0] as PerformanceObserverEntryList;
+    const entries = entryList.getEntries();
+
+    expect(entries.length).toBe(1);
+
+    const entry = ensurePerformanceEventTiming(entries[0]);
+
+    expect(eventTimeStamp).not.toBeUndefined();
+    expect(entry.startTime).toBe(eventTimeStamp);
+  });
+
   it('reports number of dispatched events via performance.eventCounts', () => {
     NativePerformance.clearEventCountsForTesting?.();
 


### PR DESCRIPTION
Summary:
Changelog: [General][Fixed] - Fix event timestamp propagation from host platforms to JS

This adds event timestamps as a first class concept in Fabric during dispatch, and uses the new methods to dispatch events to pass the values from the host platform (Android and iOS). If the value isn't pass, the current timestamp at the time of dispatch is used (which is close enough).

This fixes several problems:
1. Makes event timestamps account for native event dispatch delay.
2. Normalizes event timestamps across APIs (event timestamp property, Event Timing API information, etc.).

NOTE: I had to implement clock correction on iOS because the timing we get from UITouch objects doesn't use the same clock as we do in C++.

Differential Revision: D94669354
