### PR TITLE
Round debug float output to 4 decimal places

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -332,7 +332,7 @@ test('moving box by 50 points with offset 10', () => {
   // TODO(T232605345): The following line won't be necessary once race condition on Android is fixed.
   Fantom.runWorkLoop();
   expect(root.getRenderedOutput({props: ['transform']}).toJSX()).toEqual(
-    <rn-view transform='[{"translateX": 60.000000}]' />,
+    <rn-view transform='[{"translateX": 60}]' />,
   );
 
   expect(finishValue?.finished).toBe(true);
@@ -579,7 +579,7 @@ test('animate layout props', () => {
   }
 
   expect(root.getRenderedOutput({props: ['height']}).toJSX()).toEqual(
-    <rn-view height="100.000000" />,
+    <rn-view height="100" />,
   );
 });
 

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedBackend-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedBackend-itest.js
@@ -117,7 +117,7 @@ test('animate layout props', () => {
   // TODO: getFabricUpdateProps is not working with the cloneMutliple method
   // expect(Fantom.unstable_getFabricUpdateProps(viewElement).height).toBe(100);
   expect(root.getRenderedOutput({props: ['height']}).toJSX()).toEqual(
-    <rn-view height="50.000000" />,
+    <rn-view height="50" />,
   );
 
   Fantom.unstable_produceFramesForDuration(100);
@@ -128,7 +128,7 @@ test('animate layout props', () => {
   });
 
   expect(root.getRenderedOutput({props: ['height']}).toJSX()).toEqual(
-    <rn-view height="100.000000" />,
+    <rn-view height="100" />,
   );
 });
 
@@ -174,7 +174,7 @@ test('animate layout props and rerender', () => {
 
   Fantom.unstable_produceFramesForDuration(500);
   expect(root.getRenderedOutput({props: ['height', 'width']}).toJSX()).toEqual(
-    <rn-view height="50.000000" width="100.000000" />,
+    <rn-view height="50" width="100" />,
   );
 
   Fantom.runTask(() => {
@@ -184,7 +184,7 @@ test('animate layout props and rerender', () => {
   // TODO: getFabricUpdateProps is not working with the cloneMutliple method
   // expect(Fantom.unstable_getFabricUpdateProps(viewElement).height).toBe(50);
   expect(root.getRenderedOutput({props: ['height', 'width']}).toJSX()).toEqual(
-    <rn-view height="50.000000" width="200.000000" />,
+    <rn-view height="50" width="200" />,
   );
 
   Fantom.unstable_produceFramesForDuration(500);
@@ -195,7 +195,7 @@ test('animate layout props and rerender', () => {
   });
 
   expect(root.getRenderedOutput({props: ['height', 'width']}).toJSX()).toEqual(
-    <rn-view height="100.000000" width="200.000000" />,
+    <rn-view height="100" width="200" />,
   );
 
   Fantom.runTask(() => {
@@ -203,7 +203,7 @@ test('animate layout props and rerender', () => {
   });
 
   expect(root.getRenderedOutput({props: ['height', 'width']}).toJSX()).toEqual(
-    <rn-view height="100.000000" width="300.000000" />,
+    <rn-view height="100" width="300" />,
   );
 });
 
@@ -250,9 +250,9 @@ test('animate non-layout props and rerender', () => {
 
   Fantom.unstable_produceFramesForDuration(500);
 
-  // TODO: rendered output should be <rn-view opacity="0,5" width="100.000000" /> at this point, but synchronous updates are not captured by fantom
+  // TODO: rendered output should be <rn-view opacity="0,5" width="100" /> at this point, but synchronous updates are not captured by fantom
   expect(root.getRenderedOutput({props: ['width']}).toJSX()).toEqual(
-    <rn-view width="100.000000" />,
+    <rn-view width="100" />,
   );
 
   expect(
@@ -265,7 +265,7 @@ test('animate non-layout props and rerender', () => {
   });
 
   expect(root.getRenderedOutput({props: ['opacity', 'width']}).toJSX()).toEqual(
-    <rn-view opacity="0.25" width="150.000000" />,
+    <rn-view opacity="0.25" width="150" />,
   );
 
   Fantom.runTask(() => {
@@ -275,7 +275,7 @@ test('animate non-layout props and rerender', () => {
   // TODO: getFabricUpdateProps is not working with the cloneMutliple method
   // expect(Fantom.unstable_getFabricUpdateProps(viewElement).height).toBe(50);
   expect(root.getRenderedOutput({props: ['opacity', 'width']}).toJSX()).toEqual(
-    <rn-view opacity="0.25" width="200.000000" />,
+    <rn-view opacity="0.25" width="200" />,
   );
 
   Fantom.unstable_produceFramesForDuration(500);
@@ -287,7 +287,7 @@ test('animate non-layout props and rerender', () => {
 
   // TODO: T246961305 rendered output should be <rn-view opacity="1" /> at this point
   expect(root.getRenderedOutput({props: ['width']}).toJSX()).toEqual(
-    <rn-view width="200.000000" />,
+    <rn-view width="200" />,
   );
 
   expect(Fantom.unstable_getDirectManipulationProps(viewElement).opacity).toBe(
@@ -300,7 +300,7 @@ test('animate non-layout props and rerender', () => {
   });
 
   expect(root.getRenderedOutput({props: ['opacity', 'width']}).toJSX()).toEqual(
-    <rn-view opacity="0.5" width="300.000000" />,
+    <rn-view opacity="0.5" width="300" />,
   );
 });
 
@@ -373,9 +373,9 @@ test('animate layout props and rerender in many components', () => {
 
   Fantom.unstable_produceFramesForDuration(500);
   expect(root.getRenderedOutput({props: ['height', 'width']}).toJSX()).toEqual(
-    <rn-view height="50.000000" width="100.000000">
+    <rn-view height="50" width="100">
       {Array.from({length: N}, (_, i) => (
-        <rn-view key={i} height="50.000000" width="100.000000" />
+        <rn-view key={i} height="50" width="100" />
       ))}
     </rn-view>,
   );
@@ -392,9 +392,9 @@ test('animate layout props and rerender in many components', () => {
   // TODO: getFabricUpdateProps is not working with the cloneMutliple method
   // expect(Fantom.unstable_getFabricUpdateProps(viewElement).height).toBe(50);
   expect(root.getRenderedOutput({props: ['height', 'width']}).toJSX()).toEqual(
-    <rn-view height="50.000000" width="200.000000">
+    <rn-view height="50" width="200">
       {Array.from({length: N}, (_, i) => (
-        <rn-view key={i} height="50.000000" width="100.000000" />
+        <rn-view key={i} height="50" width="100" />
       ))}
     </rn-view>,
   );
@@ -466,7 +466,7 @@ test('animate width, height and opacity at once', () => {
 
   expect(
     root.getRenderedOutput({props: ['width', 'height', 'opacity']}).toJSX(),
-  ).toEqual(<rn-view height="200.000000" opacity="0.5" width="200.000000" />);
+  ).toEqual(<rn-view height="200" opacity="0.5" width="200" />);
 });
 
 test('animate width with memo and rerender (js sync test)', () => {
@@ -532,7 +532,7 @@ test('animate width with memo and rerender (js sync test)', () => {
   });
 
   expect(root.getRenderedOutput({props: ['width', 'height']}).toJSX()).toEqual(
-    <rn-view height="100.000000" width="100.000000" />,
+    <rn-view height="100" width="100" />,
   );
 
   Fantom.unstable_produceFramesForDuration(1000);
@@ -543,7 +543,7 @@ test('animate width with memo and rerender (js sync test)', () => {
   });
 
   expect(root.getRenderedOutput({props: ['width']}).toJSX()).toEqual(
-    <rn-view width="200.000000" />,
+    <rn-view width="200" />,
   );
 
   // Trigger rerender after animation completes to see if animation state gets overwritten
@@ -552,6 +552,6 @@ test('animate width with memo and rerender (js sync test)', () => {
   });
 
   expect(root.getRenderedOutput({props: ['width']}).toJSX()).toEqual(
-    <rn-view width="200.000000" />,
+    <rn-view width="200" />,
   );
 });

--- a/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-itest.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-itest.js
@@ -28,7 +28,7 @@ describe('<ActivityIndicator>', () => {
         });
 
         expect(root.getRenderedOutput().toJSX()).toEqual(
-          <rn-androidProgressBar height="20.000000" width="20.000000" />,
+          <rn-androidProgressBar height="20" width="20" />,
         );
       });
 
@@ -40,7 +40,7 @@ describe('<ActivityIndicator>', () => {
         });
 
         expect(root.getRenderedOutput().toJSX()).toEqual(
-          <rn-androidProgressBar height="20.000000" width="20.000000" />,
+          <rn-androidProgressBar height="20" width="20" />,
         );
       });
 
@@ -52,7 +52,7 @@ describe('<ActivityIndicator>', () => {
         });
 
         expect(root.getRenderedOutput().toJSX()).toEqual(
-          <rn-androidProgressBar height="36.000000" width="36.000000" />,
+          <rn-androidProgressBar height="36" width="36" />,
         );
       });
 
@@ -64,7 +64,7 @@ describe('<ActivityIndicator>', () => {
         });
 
         expect(root.getRenderedOutput().toJSX()).toEqual(
-          <rn-androidProgressBar height="48.000000" width="48.000000" />,
+          <rn-androidProgressBar height="48" width="48" />,
         );
       });
     });
@@ -80,7 +80,7 @@ describe('<ActivityIndicator>', () => {
         // Color is a native prop not serialized as a view attribute,
         // but the component still renders correctly
         expect(root.getRenderedOutput().toJSX()).toEqual(
-          <rn-androidProgressBar height="20.000000" width="20.000000" />,
+          <rn-androidProgressBar height="20" width="20" />,
         );
       });
     });
@@ -95,7 +95,7 @@ describe('<ActivityIndicator>', () => {
 
         // Component renders normally when animating (default)
         expect(root.getRenderedOutput().toJSX()).toEqual(
-          <rn-androidProgressBar height="20.000000" width="20.000000" />,
+          <rn-androidProgressBar height="20" width="20" />,
         );
       });
 
@@ -108,7 +108,7 @@ describe('<ActivityIndicator>', () => {
 
         // Component still renders when not animating
         expect(root.getRenderedOutput().toJSX()).toEqual(
-          <rn-androidProgressBar height="20.000000" width="20.000000" />,
+          <rn-androidProgressBar height="20" width="20" />,
         );
       });
     });

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-itest.js
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-itest.js
@@ -48,10 +48,10 @@ describe('<Pressable>', () => {
             accessible="true"
             accessibilityState="{disabled:false,selected:false,checked:None,busy:false,expanded:null}"
             backgroundColor="rgba(0, 0, 255, 1)"
-            borderWidth="3.000000"
-            height="50.000000"
+            borderWidth="3"
+            height="50"
             opacity="40"
-            width="100.000000"
+            width="100"
           />,
         );
       });
@@ -148,8 +148,8 @@ describe('<Pressable>', () => {
             <rn-paragraph
               allowFontScaling="true"
               ellipsizeMode="tail"
-              fontSize="NaN"
-              fontSizeMultiplier="NaN"
+              fontSize="nan"
+              fontSizeMultiplier="nan"
               foregroundColor="rgba(0, 0, 0, 0)"
               overflow="hidden">
               the quick brown fox

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-itest.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-itest.js
@@ -77,8 +77,8 @@ describe('<TouchableHighlight>', () => {
         ).toEqual(
           <rn-view
             backgroundColor="rgba(0, 0, 255, 1)"
-            height="50.000000"
-            width="100.000000"
+            height="50"
+            width="100"
           />,
         );
       });
@@ -130,7 +130,7 @@ describe('<TouchableHighlight>', () => {
 
         expect(root.getRenderedOutput({props: ['opacity']}).toJSX()).toEqual(
           <rn-view>
-            <rn-view opacity="0.8500000238418579" />
+            <rn-view opacity="0.85" />
           </rn-view>,
         );
       });

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableOpacity-itest.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableOpacity-itest.js
@@ -61,8 +61,8 @@ describe('<TouchableOpacity>', () => {
         ).toEqual(
           <rn-view
             backgroundColor="rgba(0, 0, 255, 1)"
-            height="50.000000"
-            width="100.000000"
+            height="50"
+            width="100"
           />,
         );
       });

--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -43,14 +43,14 @@ describe('<View>', () => {
           ).toEqual(
             <rn-view
               layoutMetrics-frame="{x:0,y:0,width:20,height:50}"
-              height="50.000000%"
+              height="50%"
               layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
               layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
               layoutMetrics-displayType="Flex"
               layoutMetrics-layoutDirection="LeftToRight"
               layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
               layoutMetrics-pointScaleFactor="3"
-              width="20.000000%"
+              width="20%"
             />,
           );
         });
@@ -69,14 +69,14 @@ describe('<View>', () => {
           ).toEqual(
             <rn-view
               layoutMetrics-frame="{x:0,y:0,width:5,height:10}"
-              height="10.000000"
+              height="10"
               layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
               layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
               layoutMetrics-displayType="Flex"
               layoutMetrics-layoutDirection="LeftToRight"
               layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
               layoutMetrics-pointScaleFactor="3"
-              width="5.000000"
+              width="5"
             />,
           );
         });
@@ -134,15 +134,15 @@ describe('<View>', () => {
           ).toEqual(
             <rn-view
               layoutMetrics-frame="{x:50,y:50,width:5,height:10}"
-              height="10.000000"
+              height="10"
               layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
               layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
               layoutMetrics-displayType="Flex"
               layoutMetrics-layoutDirection="LeftToRight"
               layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
               layoutMetrics-pointScaleFactor="3"
-              margin="50.000000%"
-              width="5.000000"
+              margin="50%"
+              width="5"
             />,
           );
         });
@@ -166,15 +166,15 @@ describe('<View>', () => {
           ).toEqual(
             <rn-view
               layoutMetrics-frame="{x:5,y:5,width:5,height:10}"
-              height="10.000000"
+              height="10"
               layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
               layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
               layoutMetrics-displayType="Flex"
               layoutMetrics-layoutDirection="LeftToRight"
               layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
               layoutMetrics-pointScaleFactor="3"
-              margin="5.000000"
-              width="5.000000"
+              margin="5"
+              width="5"
             />,
           );
         });
@@ -190,7 +190,7 @@ describe('<View>', () => {
 
           expect(
             root.getRenderedOutput({props: ['transform']}).toJSX(),
-          ).toEqual(<rn-view transform='[{"translateX": 10.000000}]' />);
+          ).toEqual(<rn-view transform='[{"translateX": 10}]' />);
         });
 
         [

--- a/packages/react-native/Libraries/Image/__tests__/Image-itest.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-itest.js
@@ -154,7 +154,7 @@ describe('<Image>', () => {
         });
 
         expect(root.getRenderedOutput({props: ['height']}).toJSX()).toEqual(
-          <rn-image height="100.000000" />,
+          <rn-image height="100" />,
         );
       });
     });
@@ -168,7 +168,7 @@ describe('<Image>', () => {
         });
 
         expect(root.getRenderedOutput({props: ['width']}).toJSX()).toEqual(
-          <rn-image width="100.000000" />,
+          <rn-image width="100" />,
         );
       });
     });
@@ -483,8 +483,8 @@ describe('<Image>', () => {
               source-type="remote"
               source-size="{40, 40}"
               source-uri="https://reactnative.dev/img/tiny_logo.png"
-              width="40.000000"
-              height="40.000000"
+              width="40"
+              height="40"
             />
           ) : (
             <rn-image
@@ -599,13 +599,7 @@ describe('<Image>', () => {
           root
             .getRenderedOutput({props: ['width', 'height', 'resizeMode']})
             .toJSX(),
-        ).toEqual(
-          <rn-image
-            height="100.000000"
-            resizeMode="contain"
-            width="100.000000"
-          />,
-        );
+        ).toEqual(<rn-image height="100" resizeMode="contain" width="100" />);
       });
     });
 

--- a/packages/react-native/Libraries/Image/__tests__/ImageBackground-itest.js
+++ b/packages/react-native/Libraries/Image/__tests__/ImageBackground-itest.js
@@ -107,7 +107,7 @@ describe('<ImageBackground>', () => {
 
         expect(
           root.getRenderedOutput({props: ['width|height']}).toJSX(),
-        ).toEqual(<rn-image width="100.000000" height="100.000000" />);
+        ).toEqual(<rn-image width="100" height="100" />);
       });
     });
   });

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
@@ -19,12 +19,7 @@ import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureI
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 const DEFAULT_MODAL_CHILD_VIEW = (
-  <rn-view
-    backgroundColor="rgba(255, 255, 255, 1)"
-    flex="1.000000"
-    left="0.000000"
-    top="0.000000"
-  />
+  <rn-view backgroundColor="rgba(255, 255, 255, 1)" flex="1" left="0" top="0" />
 );
 
 describe('<Modal>', () => {

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -40,8 +40,8 @@ describe('<Text>', () => {
           <rn-paragraph
             allowFontScaling="true"
             ellipsizeMode="tail"
-            fontSize="NaN"
-            fontSizeMultiplier="NaN"
+            fontSize="nan"
+            fontSizeMultiplier="nan"
             foregroundColor="rgba(0, 0, 0, 0)"
             overflow="hidden">
             {TEST_TEXT}

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -22,6 +22,7 @@
 #include <react/renderer/css/CSSTransform.h>
 #include <react/renderer/css/CSSTransformOrigin.h>
 #include <react/renderer/css/CSSValueParser.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/debug/flags.h>
 #include <react/renderer/graphics/BackgroundPosition.h>
 #include <react/renderer/graphics/BackgroundRepeat.h>
@@ -1592,9 +1593,9 @@ inline std::string toString(const std::array<float, N> vec)
 
   s.append("{");
   for (size_t i = 0; i < N - 1; i++) {
-    s.append(std::to_string(vec[i]) + ", ");
+    s.append(toString(vec[i]) + ", ");
   }
-  s.append(std::to_string(vec[N - 1]));
+  s.append(toString(vec[N - 1]));
   s.append("}");
 
   return s;
@@ -1647,9 +1648,9 @@ inline std::string toString(const yoga::Style::Length &length)
   } else if (length.isAuto()) {
     return "auto";
   } else if (length.isPoints()) {
-    return std::to_string(length.value().unwrap());
+    return toString(length.value().unwrap());
   } else if (length.isPercent()) {
-    return std::to_string(length.value().unwrap()) + "%";
+    return toString(length.value().unwrap()) + "%";
   } else {
     return "unknown";
   }
@@ -1662,9 +1663,9 @@ inline std::string toString(const yoga::Style::SizeLength &length)
   } else if (length.isAuto()) {
     return "auto";
   } else if (length.isPoints()) {
-    return std::to_string(length.value().unwrap());
+    return toString(length.value().unwrap());
   } else if (length.isPercent()) {
-    return std::to_string(length.value().unwrap()) + "%";
+    return toString(length.value().unwrap()) + "%";
   } else if (length.isMaxContent()) {
     return "max-content";
   } else if (length.isFitContent()) {
@@ -1682,7 +1683,7 @@ inline std::string toString(const yoga::FloatOptional &value)
     return "undefined";
   }
 
-  return std::to_string(value.unwrap());
+  return toString(value.unwrap());
 }
 
 inline std::string toString(const LayoutConformance &value)
@@ -1698,14 +1699,10 @@ inline std::string toString(const LayoutConformance &value)
 inline std::string toString(const std::array<Float, 16> &m)
 {
   std::string result;
-  result += "[ " + std::to_string(m[0]) + " " + std::to_string(m[1]) + " " + std::to_string(m[2]) + " " +
-      std::to_string(m[3]) + " ]\n";
-  result += "[ " + std::to_string(m[4]) + " " + std::to_string(m[5]) + " " + std::to_string(m[6]) + " " +
-      std::to_string(m[7]) + " ]\n";
-  result += "[ " + std::to_string(m[8]) + " " + std::to_string(m[9]) + " " + std::to_string(m[10]) + " " +
-      std::to_string(m[11]) + " ]\n";
-  result += "[ " + std::to_string(m[12]) + " " + std::to_string(m[13]) + " " + std::to_string(m[14]) + " " +
-      std::to_string(m[15]) + " ]";
+  result += "[ " + toString(m[0]) + " " + toString(m[1]) + " " + toString(m[2]) + " " + toString(m[3]) + " ]\n";
+  result += "[ " + toString(m[4]) + " " + toString(m[5]) + " " + toString(m[6]) + " " + toString(m[7]) + " ]\n";
+  result += "[ " + toString(m[8]) + " " + toString(m[9]) + " " + toString(m[10]) + " " + toString(m[11]) + " ]\n";
+  result += "[ " + toString(m[12]) + " " + toString(m[13]) + " " + toString(m[14]) + " " + toString(m[15]) + " ]";
   return result;
 }
 
@@ -1722,48 +1719,48 @@ inline std::string toString(const Transform &transform)
 
     switch (operation.type) {
       case TransformOperationType::Perspective: {
-        result += "{\"perspective\": " + std::to_string(operation.x.value) + "}";
+        result += "{\"perspective\": " + toString(operation.x.value) + "}";
         break;
       }
       case TransformOperationType::Rotate: {
         if (operation.x.value != 0 && operation.y.value == 0 && operation.z.value == 0) {
-          result += R"({"rotateX": ")" + std::to_string(operation.x.value) + "rad\"}";
+          result += R"({"rotateX": ")" + toString(operation.x.value) + "rad\"}";
         } else if (operation.x.value == 0 && operation.y.value != 0 && operation.z.value == 0) {
-          result += R"({"rotateY": ")" + std::to_string(operation.y.value) + "rad\"}";
+          result += R"({"rotateY": ")" + toString(operation.y.value) + "rad\"}";
         } else if (operation.x.value == 0 && operation.y.value == 0 && operation.z.value != 0) {
-          result += R"({"rotateZ": ")" + std::to_string(operation.z.value) + "rad\"}";
+          result += R"({"rotateZ": ")" + toString(operation.z.value) + "rad\"}";
         }
         break;
       }
       case TransformOperationType::Scale: {
         if (operation.x.value == operation.y.value && operation.x.value == operation.z.value) {
-          result += "{\"scale\": " + std::to_string(operation.x.value) + "}";
+          result += "{\"scale\": " + toString(operation.x.value) + "}";
         } else if (operation.y.value == 1 && operation.z.value == 1) {
-          result += "{\"scaleX\": " + std::to_string(operation.x.value) + "}";
+          result += "{\"scaleX\": " + toString(operation.x.value) + "}";
         } else if (operation.x.value == 1 && operation.z.value == 1) {
-          result += "{\"scaleY\": " + std::to_string(operation.y.value) + "}";
+          result += "{\"scaleY\": " + toString(operation.y.value) + "}";
         } else if (operation.x.value == 1 && operation.y.value == 1) {
-          result += "{\"scaleZ\": " + std::to_string(operation.z.value) + "}";
+          result += "{\"scaleZ\": " + toString(operation.z.value) + "}";
         }
         break;
       }
       case TransformOperationType::Translate: {
         if (operation.x.value != 0 && operation.y.value != 0 && operation.z.value == 0) {
           result += "{\"translate\": [";
-          result += std::to_string(operation.x.value) + ", " + std::to_string(operation.y.value);
+          result += toString(operation.x.value) + ", " + toString(operation.y.value);
           result += "]}";
         } else if (operation.x.value != 0 && operation.y.value == 0) {
-          result += "{\"translateX\": " + std::to_string(operation.x.value) + "}";
+          result += "{\"translateX\": " + toString(operation.x.value) + "}";
         } else if (operation.x.value == 0 && operation.y.value != 0) {
-          result += "{\"translateY\": " + std::to_string(operation.y.value) + "}";
+          result += "{\"translateY\": " + toString(operation.y.value) + "}";
         }
         break;
       }
       case TransformOperationType::Skew: {
         if (operation.x.value != 0 && operation.y.value == 0) {
-          result += R"({"skewX": ")" + std::to_string(operation.x.value) + "rad\"}";
+          result += R"({"skewX": ")" + toString(operation.x.value) + "rad\"}";
         } else if (operation.x.value == 0 && operation.y.value != 0) {
-          result += R"({"skewY": ")" + std::to_string(operation.y.value) + "rad\"}";
+          result += R"({"skewY": ")" + toString(operation.y.value) + "rad\"}";
         }
         break;
       }

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.cpp
@@ -7,11 +7,9 @@
 
 #include "DebugStringConvertible.h"
 
-#include <array>
-#include <cinttypes>
-#include <cstdio>
-
-#include <double-conversion/double-conversion.h>
+#include <cstdint>
+#include <iomanip>
+#include <sstream>
 
 namespace facebook::react {
 
@@ -129,33 +127,30 @@ SharedDebugStringConvertibleList DebugStringConvertible::getDebugProps() const {
  * `toString`-family implementation.
  */
 std::string toString(const double& value) {
-  // Format taken from folly's toString
-  static double_conversion::DoubleToStringConverter conv(
-      0,
-      "Infinity",
-      "NaN",
-      'E',
-      -6, // detail::kConvMaxDecimalInShortestLow,
-      21, // detail::kConvMaxDecimalInShortestHigh,
-      6, // max leading padding zeros
-      1); // max trailing padding zeros
-  std::array<char, 256> buffer{};
-  double_conversion::StringBuilder builder(buffer.data(), buffer.size());
-  conv.ToShortest(value, &builder);
-  return builder.Finalize();
+  std::ostringstream stream;
+  stream << std::fixed << std::setprecision(4) << value;
+  std::string result = stream.str();
+
+  // Strip trailing zeros and unnecessary decimal point
+  if (auto dotPos = result.find('.'); dotPos != std::string::npos) {
+    auto lastNonZero = result.find_last_not_of('0');
+    if (lastNonZero == dotPos) {
+      result.erase(dotPos);
+    } else {
+      result.erase(lastNonZero + 1);
+    }
+  }
+  return result;
 }
 
 std::string toString(const void* value) {
   if (value == nullptr) {
     return "null";
   }
-  std::array<char, 20> buffer{};
-  std::snprintf(
-      buffer.data(),
-      buffer.size(),
-      "0x%" PRIXPTR,
-      reinterpret_cast<uintptr_t>(value));
-  return buffer.data();
+  std::ostringstream stream;
+  stream << "0x" << std::uppercase << std::hex
+         << reinterpret_cast<uintptr_t>(value);
+  return stream.str();
 }
 
 #endif

--- a/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-itest.js
+++ b/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-itest.js
@@ -158,12 +158,7 @@ describe('styles', () => {
 
     expect(
       root.getRenderedOutput({props: ['minHeight', 'minWidth']}).toJSX(),
-    ).toEqual(
-      <rn-virtualViewExperimental
-        minHeight="100.000000"
-        minWidth="100.000000"
-      />,
-    );
+    ).toEqual(<rn-virtualViewExperimental minHeight="100" minWidth="100" />);
   });
 });
 

--- a/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
+++ b/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
@@ -141,7 +141,7 @@ describe('ViewFlattening', () => {
     expect(root.getRenderedOutput().toJSX()).toEqual(
       <rn-view nativeID="G">
         <rn-view nativeID="H">
-          <rn-view width="100.000000" nativeID="A" />
+          <rn-view width="100" nativeID="A" />
         </rn-view>
       </rn-view>,
     );
@@ -176,7 +176,7 @@ describe('ViewFlattening', () => {
         <rn-view nativeID="H">
           <rn-view nativeID="I">
             <rn-view key="0" nativeID="B" />
-            <rn-view key="1" nativeID="A" width="100.000000" />
+            <rn-view key="1" nativeID="A" width="100" />
           </rn-view>
         </rn-view>
       </rn-view>,
@@ -214,7 +214,7 @@ describe('ViewFlattening', () => {
         <rn-view nativeID="H">
           <rn-view nativeID="I">
             <rn-view nativeID="J">
-              <rn-view key="0" nativeID="A" width="100.000000" />
+              <rn-view key="0" nativeID="A" width="100" />
               <rn-view key="1" nativeID="B" />
             </rn-view>
           </rn-view>
@@ -378,8 +378,8 @@ describe('ViewFlattening', () => {
         .toJSX(),
     ).toEqual(
       <rn-view
-        width="100.000000"
-        height="100.000000"
+        width="100"
+        height="100"
         backgroundColor="rgba(255, 255, 255, 0.498039)"
       />,
     );

--- a/private/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/private/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -371,7 +371,7 @@ describe('Fantom', () => {
         });
 
         expect(root.getRenderedOutput().toJSX()).toEqual(
-          <rn-view height="100.000000" width="100.000000" />,
+          <rn-view height="100" width="100" />,
         );
       });
 
@@ -397,8 +397,8 @@ describe('Fantom', () => {
 
         expect(root.getRenderedOutput().toJSX()).toEqual(
           <>
-            <rn-view key="0" width="100.000000" height="100.000000" />
-            <rn-view key="1" width="100.000000" height="100.000000" />
+            <rn-view key="0" width="100" height="100" />
+            <rn-view key="1" width="100" height="100" />
           </>,
         );
       });
@@ -414,7 +414,7 @@ describe('Fantom', () => {
 
         expect(root.getRenderedOutput({includeRoot: true}).toJSX()).toEqual(
           <rn-rootView>
-            <rn-view width="100.000000" height="100.000000" />
+            <rn-view width="100" height="100" />
           </rn-rootView>,
         );
       });
@@ -432,7 +432,7 @@ describe('Fantom', () => {
           root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
         ).toEqual(
           <rn-view
-            height="100.000000"
+            height="100"
             layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
             layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
             layoutMetrics-displayType="Flex"
@@ -440,7 +440,7 @@ describe('Fantom', () => {
             layoutMetrics-layoutDirection="LeftToRight"
             layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
             layoutMetrics-pointScaleFactor="3"
-            width="100.000000"
+            width="100"
           />,
         );
       });
@@ -460,7 +460,7 @@ describe('Fantom', () => {
               props: ['width'],
             })
             .toJSX(),
-        ).toEqual(<rn-view width="100.000000" />);
+        ).toEqual(<rn-view width="100" />);
       });
 
       it('skip props', () => {
@@ -478,7 +478,7 @@ describe('Fantom', () => {
               props: ['^(?!width$).*$'],
             })
             .toJSX(),
-        ).toEqual(<rn-view height="100.000000" />);
+        ).toEqual(<rn-view height="100" />);
       });
 
       it('filter out all props', () => {


### PR DESCRIPTION
Summary:
Float values in debug layout metrics output (used by Fantom test assertions) are
subject to floating-point precision differences across platforms and compilers
(e.g., `66.6667` vs `66.66666412353516`), causing flaky test comparisons.

This changes `toString(const double&)` in `DebugStringConvertible.cpp` to format
floats with 4 decimal places using `snprintf("%.4f")` and strip trailing zeros,
replacing `double-conversion`'s `ToShortest()`. This is debug-only code (guarded
by `#if RN_DEBUG_STRING_CONVERTIBLE`) so the precision change is safe for all
consumers.

The `double-conversion` dependency is also removed from the BUCK file since it is
no longer used.

Output examples:
- `0.0` → `"0"`
- `100.0` → `"100"`
- `66.66666412353516` → `"66.6667"`
- `1.5` → `"1.5"`
- `33.333333` → `"33.3333"`

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D95041966


