### PR TITLE
Fix ClipboardUsage: Suppress lint in ClipboardModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.modules.clipboard
 
+import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -22,6 +23,7 @@ internal class ClipboardModule(context: ReactApplicationContext) : NativeClipboa
   private val clipboardService: ClipboardManager
     get() = reactApplicationContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
+  @SuppressLint("ClipboardUsage")
   override fun getString(promise: Promise) {
     try {
       val clipboard = clipboardService
@@ -37,6 +39,7 @@ internal class ClipboardModule(context: ReactApplicationContext) : NativeClipboa
     }
   }
 
+  @SuppressLint("ClipboardUsage")
   override fun setString(text: String?) {
     val clipdata: ClipData = ClipData.newPlainText(null, text)
     clipboardService.setPrimaryClip(clipdata)


### PR DESCRIPTION
Summary:
Fixed ClipboardUsage androidlint error in ClipboardModule.kt by adding
SuppressLint("ClipboardUsage") annotations to the getString() and
setString() methods.

ClipboardModule is a React Native module whose sole purpose is to
provide clipboard read/write functionality to JavaScript. Accessing
the system ClipboardManager is fundamental to its operation, so the
lint suppression is the appropriate fix. This follows the same pattern
used by other clipboard-accessing code in the codebase (e.g.,
MobileHomeClipboardManager, WorkCopyPasteManager, SystemClipboardReader).

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D95008585


