### PR TITLE
Do not use hermesNightly on the release branch

### DIFF
--- a/scripts/releases/create-release-commit.js
+++ b/scripts/releases/create-release-commit.js
@@ -9,6 +9,9 @@
  */
 
 const {setVersion} = require('../releases/set-version');
+const {
+  setStableHermesForReleaseBranch,
+} = require('../releases/utils/hermes-utils');
 const {getBranchName} = require('../releases/utils/scm-utils');
 const {
   writeReleaseAssetUrlsToDotSlashFiles,
@@ -51,6 +54,9 @@ async function main() {
 
   console.info('Setting version for monorepo packages and react-native');
   await setVersion(version, false); // version, skip-react-native
+
+  console.info('Set stable Hermes for release branch');
+  await setStableHermesForReleaseBranch();
 
   console.info('Writing release asset URLs to DotSlash files');
   await writeReleaseAssetUrlsToDotSlashFiles(version);

--- a/scripts/releases/utils/hermes-utils.js
+++ b/scripts/releases/utils/hermes-utils.js
@@ -25,6 +25,13 @@ const MAVEN_VERSIONS_FILE_PATH = path.join(
   'version.properties',
 );
 
+const GRADLE_PROPERTIES_PATH = path.join(
+  REACT_NATIVE_PACKAGE_DIR,
+  '..',
+  '..',
+  'gradle.properties',
+);
+
 async function getLatestHermesNightlyVersion() /*: Promise<{
   compilerVersion: string,
   compilerV1Version: string,
@@ -49,6 +56,27 @@ async function getLatestHermesNightlyVersion() /*: Promise<{
     runtimeVersion: compilerVersion,
     runtimeV1Version: compilerV1Version,
   };
+}
+
+/**
+ * Updates gradle.properties to use stable Hermes instead of nightly.
+ * This is needed because main uses nightly Hermes, but release branches
+ * should use stable Hermes from Maven Central.
+ */
+async function setStableHermesForReleaseBranch() {
+  let content = await fs.readFile(GRADLE_PROPERTIES_PATH, 'utf8');
+
+  content = content.replace(
+    'react.internal.useHermesStable=false',
+    'react.internal.useHermesStable=true',
+  );
+  content = content.replace(
+    'react.internal.useHermesNightly=true',
+    'react.internal.useHermesNightly=false',
+  );
+
+  await fs.writeFile(GRADLE_PROPERTIES_PATH, content, 'utf8');
+  console.info('Switched gradle.properties to use stable Hermes');
 }
 
 async function updateHermesCompilerVersionInDependencies(
@@ -95,6 +123,7 @@ async function updateHermesVersionsToNightly() {
 }
 
 module.exports = {
+  setStableHermesForReleaseBranch,
   updateHermesVersionsToNightly,
   updateHermesCompilerVersionInDependencies,
   updateHermesRuntimeDependenciesVersions,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This was done manually on `0.84-stable` and `0.85-stable`.

Discovered due to the failure when pushing the new `0.85-stable` branch:
https://github.com/facebook/react-native/actions/runs/22592250332/job/65471130298.

Reviewed By: cortinico

Differential Revision: D95051387


