### PR TITLE
Derive WebSocket scheme and port from dev server URL for React DevTools

### DIFF
--- a/packages/react-native/Libraries/Core/setUpReactDevTools.js
+++ b/packages/react-native/Libraries/Core/setUpReactDevTools.js
@@ -146,17 +146,34 @@ if (__DEV__) {
         ? guessHostFromDevServerUrl(devServer.url)
         : 'localhost';
 
-      // Read the optional global variable for backward compatibility.
-      // It was added in https://github.com/facebook/react-native/commit/bf2b435322e89d0aeee8792b1c6e04656c2719a0.
-      const port =
+      // Derive scheme and port from the dev server URL when possible,
+      // falling back to ws://host:8097 for local development.
+      let wsScheme = 'ws';
+      let port = 8097;
+
+      if (
         // $FlowFixMe[prop-missing]
         // $FlowFixMe[incompatible-use]
         window.__REACT_DEVTOOLS_PORT__ != null
-          ? window.__REACT_DEVTOOLS_PORT__
-          : 8097;
+      ) {
+        // $FlowFixMe[prop-missing]
+        port = window.__REACT_DEVTOOLS_PORT__;
+      } else if (devServer.bundleLoadedFromServer) {
+        try {
+          const devUrl = new URL(devServer.url);
+          if (devUrl.protocol === 'https:') {
+            wsScheme = 'wss';
+          }
+          if (devUrl.port) {
+            port = parseInt(devUrl.port, 10);
+          } else if (devUrl.protocol === 'https:') {
+            port = 443;
+          }
+        } catch (e) {}
+      }
 
       const WebSocket = require('../WebSocket/WebSocket').default;
-      ws = new WebSocket('ws://' + host + ':' + port);
+      ws = new WebSocket(wsScheme + '://' + host + ':' + port);
       ws.addEventListener('close', event => {
         isWebSocketOpen = false;
       });


### PR DESCRIPTION
Summary:
## Summary:

Derive the WebSocket scheme (ws/wss) and port from the dev server URL in
`setUpReactDevTools.js` so React DevTools connections work correctly when the
dev server is accessed over HTTPS.

The Android `OkHttpClientProvider` and `WebSocketModule` changes from the
original ATOD patch are intentionally omitted because these are production
modules that cannot depend on the dev-only `DevSupportHttpClient` module
due to Buck module boundaries.

## Changelog:

[GENERAL][CHANGED] - Derive WebSocket scheme and port from dev server URL for React DevTools connections, supporting HTTPS dev servers

## Test Plan:

Validated that the JS change correctly derives ws/wss scheme and port from the
dev server URL, falling back to ws://host:8097 for local development.

## Facebook:
Partially applied from nest/mobile/apps/atod-sample/patches/react-native+0.83.1+004+atod-websocket.patch
(Android OkHttpClientProvider and WebSocketModule changes omitted — they create
an invalid Buck dependency from production modules to dev-only modules)

Differential Revision: D95043354


