### PR TITLE
Add react_renderer_viewtransition to prefab preprocessing entries

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -275,6 +275,11 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/animationbackend/",
                           "react/renderer/animationbackend/",
                       ),
+                      // react_renderer_viewtransition
+                      Pair(
+                          "../ReactCommon/react/renderer/viewtransition/",
+                          "react/renderer/viewtransition/",
+                      ),
                   ),
               ),
               PrefabPreprocessingEntry(


### PR DESCRIPTION
## Summary 

This fixes some of the nightlies that just broke:
https://github.com/react-native-community/nightly-tests/actions/runs/22656098468/job/65666129759#step:4:1766

## Changelog

[Internal] -