### PR TITLE
fix: `RCTViewComponentView` can become first responder only when `enableImperativeFocus` flag is enabled

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1673,7 +1673,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 
 - (BOOL)canBecomeFirstResponder
 {
-  return YES;
+  return ReactNativeFeatureFlags::enableImperativeFocus();
 }
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In [RN 0.83](https://github.com/facebook/react-native/pull/53825), `RCTViewComponentView.canBecomeFirstResponder` was changed to unconditionally return `YES` as part of the `enableImperativeFocus` feature. This causes UIKit to promote parent views to first responder after navigation transitions complete (via `_promoteSelfOrDescendantToFirstResponderIfNecessary`), stealing focus from text inputs and triggering an immediate focus→blur cycle.

This fix gates `canBecomeFirstResponder` behind the `enableImperativeFocus` feature flag (which defaults to false), so views only become eligible for first responder when imperative focus is actually enabled.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Fixed RCTViewComponentView unconditionally returning YES from canBecomeFirstResponder, which caused focus to be stolen from text inputs after navigation transitions

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

 1. Create a screen with a TextInput that receives focus on mount (e.g. via autoFocus or a useEffect calling .focus()).
  2. Navigate to that screen using a navigation library (e.g. React Navigation).
  3. Verify the TextInput retains focus and the keyboard stays visible after the transition completes — previously the input would briefly gain then lose focus (focus→blur cycle).