### PR TITLE
Restore a single method for text parsing

### DIFF
--- a/scripts/cxx-api/parser/builders.py
+++ b/scripts/cxx-api/parser/builders.py
@@ -26,12 +26,7 @@ from .member import (
     TypedefMember,
     VariableMember,
 )
-from .scope import (
-    CategoryScopeKind,
-    InterfaceScopeKind,
-    ProtocolScopeKind,
-    StructLikeScopeKind,
-)
+from .scope import InterfaceScopeKind, ProtocolScopeKind, StructLikeScopeKind
 from .snapshot import Snapshot
 from .template import Template
 from .utils import (
@@ -40,7 +35,6 @@ from .utils import (
     InitializerType,
     parse_qualified_path,
     resolve_linked_text_name,
-    resolve_ref_text_name,
 )
 
 
@@ -281,7 +275,7 @@ def get_typedef_member(
     typedef_def: compound.memberdefType, visibility: str
 ) -> TypedefMember:
     typedef_name = typedef_def.get_name()
-    typedef_type = resolve_ref_text_name(typedef_def.get_type())
+    typedef_type = resolve_linked_text_name(typedef_def.get_type())[0]
     typedef_argstring = typedef_def.get_argsstring()
     typedef_definition = typedef_def.definition
 
@@ -338,7 +332,7 @@ def get_property_member(
     Get the property member from a member definition.
     """
     property_name = member_def.get_name()
-    property_type = resolve_ref_text_name(member_def.get_type()).strip()
+    property_type = resolve_linked_text_name(member_def.get_type())[0].strip()
     accessor = member_def.accessor if hasattr(member_def, "accessor") else None
     is_readable = getattr(member_def, "readable", "no") == "yes"
     is_writable = getattr(member_def, "writable", "no") == "yes"
@@ -364,7 +358,7 @@ def create_enum_scope(snapshot: Snapshot, enum_def: compound.EnumdefType) -> Non
     Create an enum scope in the snapshot.
     """
     scope = snapshot.create_enum(enum_def.qualifiedname)
-    scope.kind.type = resolve_ref_text_name(enum_def.get_type())
+    scope.kind.type = resolve_linked_text_name(enum_def.get_type())[0]
     scope.location = enum_def.location.file
 
     for enum_value_def in enum_def.enumvalue:

--- a/scripts/cxx-api/parser/utils/__init__.py
+++ b/scripts/cxx-api/parser/utils/__init__.py
@@ -19,7 +19,6 @@ from .text_resolution import (
     InitializerType,
     normalize_angle_brackets,
     resolve_linked_text_name,
-    resolve_ref_text_name,
 )
 from .type_qualification import qualify_arguments, qualify_parsed_type, qualify_type_str
 
@@ -40,5 +39,4 @@ __all__ = [
     "qualify_parsed_type",
     "qualify_type_str",
     "resolve_linked_text_name",
-    "resolve_ref_text_name",
 ]

--- a/scripts/cxx-api/parser/utils/text_resolution.py
+++ b/scripts/cxx-api/parser/utils/text_resolution.py
@@ -90,28 +90,6 @@ def normalize_angle_brackets(text: str) -> str:
     return text
 
 
-def resolve_ref_text_name(type_def: compound.refTextType) -> str:
-    """Resolve the text content of a refTextType."""
-    if hasattr(type_def, "content_") and type_def.content_:
-        name = ""
-        for part in type_def.content_:
-            if part.category == 1:  # MixedContainer.CategoryText
-                name += part.value
-            elif part.category == 3:  # MixedContainer.CategoryComplex (ref element)
-                if hasattr(part.value, "get_valueOf_"):
-                    name += part.value.get_valueOf_()
-                elif hasattr(part.value, "valueOf_"):
-                    name += part.value.valueOf_
-                else:
-                    name += str(part.value)
-        return normalize_angle_brackets(name)
-
-    if type_def.ref:
-        return normalize_angle_brackets(type_def.ref[0].get_valueOf_())
-
-    return normalize_angle_brackets(type_def.get_valueOf_())
-
-
 class InitializerType(Enum):
     NONE = (0,)
     ASSIGNMENT = (1,)


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Restores the single path for doxygen ref parsing that was lost in refactor in D94072940

Differential Revision: D95206764


