### PR TITLE
Fix lint running on node 20 instead of 22

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -552,6 +552,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Lint file structure


### PR DESCRIPTION
## Summary:

CI is currently red, this fixes it.

## Changelog:

[INTERNAL] -

## Test Plan:

CI