### PR TITLE
Add error when running build script after prepack

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -85,6 +85,10 @@ async function build() {
 
 async function buildPackage(packageName /*: string */, prepack /*: boolean */) {
   try {
+    process.stdout.write(
+      `${packageName} ${styleText('dim', '.').repeat(72 - packageName.length)} `,
+    );
+
     const {emitTypeScriptDefs} = getBuildOptions(packageName);
     const entryPoints = await getEntryPoints(packageName);
 
@@ -96,10 +100,6 @@ async function buildPackage(packageName /*: string */, prepack /*: boolean */) {
       file =>
         !entryPoints.has(file) &&
         !entryPoints.has(file.replace(/\.js$/, '.flow.js')),
-    );
-
-    process.stdout.write(
-      `${packageName} ${styleText('dim', '.').repeat(72 - packageName.length)} `,
     );
 
     // Build regular files
@@ -297,6 +297,15 @@ async function getEntryPoints(
       // Skip non-JS files
       if (!target.endsWith('.js')) {
         continue;
+      }
+
+      if (target.startsWith('./' + BUILD_DIR + '/')) {
+        throw new Error(
+          `Found ./${BUILD_DIR}/* entry in package.json exports for ` +
+            `${packageName}. This is either a misconfiguration, or the ` +
+            `prepack script was previously run and the package.json state ` +
+            `is dirty. Please re-run against a clean working copy.`,
+        );
       }
 
       if (target.includes('*')) {


### PR DESCRIPTION
Summary:
Introduce a clear error message if running `yarn build` again after `yarn prepack` (which will have applied the `"publishConfig"` field to each `package.json`, just ahead of publishing to npm). This state should never happen in CI or local dev, but can occur if repeat-running `yarn test-release-local` without `yarn test-release-local-clean`.

Introducing a validation error is preferable over making this idempotent (logic would be complex + fragile) for this rare + out-of-design edge case.

Changelog: [Internal]

Differential Revision: D95215735


