### PR TITLE
Fix test jobs skipping when only one platform is selected in PRs (#55915)

### DIFF
--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -10,6 +10,10 @@ inputs:
     default: ''
   gradle-cache-encryption-key:
     description: The encryption key needed to store the Gradle Configuration cache
+  skip-apple-prebuilts:
+    description: When true, skip downloading prebuilt Apple artifacts (use when Apple prebuild jobs were skipped)
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -18,18 +22,21 @@ runs:
       shell: bash
       run: git config --global --add safe.directory '*'
     - name: Download ReactNativeDependencies
+      if: ${{ inputs.skip-apple-prebuilts != 'true' }}
       uses: actions/download-artifact@v7
       with:
         pattern: ReactNativeDependencies*
         path: ./packages/react-native/ReactAndroid/external-artifacts/artifacts
         merge-multiple: true
     - name: Download ReactCore artifacts
+      if: ${{ inputs.skip-apple-prebuilts != 'true' }}
       uses: actions/download-artifact@v7
       with:
         pattern: ReactCore*
         path: ./packages/react-native/ReactAndroid/external-artifacts/artifacts
         merge-multiple: true
     - name: Print Artifacts Directory
+      if: ${{ inputs.skip-apple-prebuilts != 'true' }}
       shell: bash
       run: ls -lR ./packages/react-native/ReactAndroid/external-artifacts/artifacts/
     - name: Setup gradle

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -99,6 +99,7 @@ jobs:
 
   prebuild_react_native_core:
     uses: ./.github/workflows/prebuild-ios-core.yml
+    if: ${{ needs.prebuild_apple_dependencies.result == 'success' }}
     with:
       use-hermes-prebuilt: ${{ !endsWith(github.ref_name, '-stable') }}
     secrets: inherit
@@ -108,6 +109,7 @@ jobs:
     runs-on: macos-15
     needs:
       [prebuild_apple_dependencies, prebuild_react_native_core]
+    if: ${{ needs.prebuild_react_native_core.result == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -141,6 +143,7 @@ jobs:
     runs-on: macos-15-large
     needs:
       [prebuild_apple_dependencies, prebuild_react_native_core]
+    if: ${{ needs.prebuild_react_native_core.result == 'success' }}
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -158,6 +161,7 @@ jobs:
 
   test_e2e_ios_rntester:
     needs: test_ios_rntester
+    if: ${{ needs.test_ios_rntester.result == 'success' }}
     uses: ./.github/workflows/e2e-ios-rntester.yml
     secrets: inherit
 
@@ -176,7 +180,8 @@ jobs:
     secrets: inherit
 
   test_e2e_ios_templateapp:
-    needs: [build_npm_package, prebuild_apple_dependencies]
+    needs: [build_npm_package, prebuild_apple_dependencies, check_code_changes]
+    if: needs.check_code_changes.outputs.should_test_ios == 'true'
     uses: ./.github/workflows/e2e-ios-templateapp.yml
     secrets: inherit
 
@@ -195,7 +200,8 @@ jobs:
     secrets: inherit
 
   test_e2e_android_templateapp:
-    needs: build_npm_package
+    needs: [build_npm_package, build_android]
+    if: ${{ always() && needs.build_android.result == 'success' && needs.build_npm_package.result == 'success' }}
     uses: ./.github/workflows/e2e-android-templateapp.yml
     secrets: inherit
 
@@ -284,6 +290,7 @@ jobs:
 
   test_e2e_android_rntester:
     needs: build_android
+    if: ${{ needs.build_android.result == 'success' }}
     uses: ./.github/workflows/e2e-android-rntester.yml
     secrets: inherit
 
@@ -306,10 +313,15 @@ jobs:
     needs:
       [
         set_release_type,
+        check_code_changes,
         build_android,
         prebuild_apple_dependencies,
         prebuild_react_native_core,
       ]
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     container:
       image: reactnativecommunity/react-native-android:latest
       env:
@@ -327,10 +339,12 @@ jobs:
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+          skip-apple-prebuilts: ${{ needs.check_code_changes.outputs.should_test_ios == 'false' }}
 
   test_android_helloworld:
     runs-on: 4-core-ubuntu
-    needs: build_npm_package
+    needs: [build_npm_package, build_android]
+    if: ${{ always() && needs.build_android.result == 'success' && needs.build_npm_package.result == 'success' }}
     container:
       image: reactnativecommunity/react-native-android:latest
     env:
@@ -396,6 +410,7 @@ jobs:
   test_ios_helloworld_with_ruby_3_2_0:
     runs-on: macos-15
     needs: [prebuild_apple_dependencies, prebuild_react_native_core]
+    if: ${{ needs.prebuild_react_native_core.result == 'success' }}
     env:
       PROJECT_NAME: iOSTemplateProject
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -410,6 +425,7 @@ jobs:
   test_ios_helloworld:
     runs-on: macos-15
     needs: [prebuild_apple_dependencies, prebuild_react_native_core]
+    if: ${{ needs.prebuild_react_native_core.result == 'success' }}
     strategy:
       matrix:
         flavor: [Debug, Release]
@@ -510,4 +526,3 @@ jobs:
       - name: Verify debugger-shell build
         shell: bash
         run: node scripts/debugger-shell/build-binary.js
-


### PR DESCRIPTION
Summary:

Addresses a design gap with conditional Android/iOS test runs ([#55449](https://github.com/facebook/react-native/pull/55449)). `build_npm_package` depended on both Android and iOS prebuilds, causing platform-specific E2E tests to be skipped unnecessarily.

Fixed by allowing `build_npm_package` to optionally skip bundling Apple prebuilts, and updating the dependencies of the E2E test jobs.

Changelog: [Internal]

Differential Revision: D95218910


