### PR TITLE
Add request interceptor API to RCTMultipartDataTask

### DIFF
--- a/packages/react-native/React/Base/RCTMultipartDataTask.h
+++ b/packages/react-native/React/Base/RCTMultipartDataTask.h
@@ -7,6 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <React/RCTDefines.h>
 #import <React/RCTMultipartStreamReader.h>
 
 typedef void (^RCTMultipartDataTaskCallback)(
@@ -15,6 +16,14 @@ typedef void (^RCTMultipartDataTaskCallback)(
     NSData *content,
     NSError *error,
     BOOL done);
+
+typedef NSURLRequest *_Nullable (^RCTMultipartDataTaskRequestInterceptor)(NSURLRequest *request);
+/**
+ * The block provided via this function can inspect/modify multipart data task
+ * requests before they are sent. Return a modified request to override, or nil
+ * to use the original request unchanged.
+ */
+RCT_EXTERN void RCTSetCustomMultipartDataTaskRequestInterceptor(RCTMultipartDataTaskRequestInterceptor /*interceptor*/);
 
 @interface RCTMultipartDataTask : NSObject
 

--- a/packages/react-native/React/Base/RCTMultipartDataTask.m
+++ b/packages/react-native/React/Base/RCTMultipartDataTask.m
@@ -7,7 +7,12 @@
 
 #import "RCTMultipartDataTask.h"
 
-#import "RCTDevSupportHttpHeaders.h"
+static RCTMultipartDataTaskRequestInterceptor multipartRequestInterceptor;
+
+void RCTSetCustomMultipartDataTaskRequestInterceptor(RCTMultipartDataTaskRequestInterceptor interceptor)
+{
+  multipartRequestInterceptor = interceptor;
+}
 
 @interface RCTMultipartDataTask () <NSURLSessionDataDelegate, NSURLSessionDataDelegate>
 
@@ -42,8 +47,15 @@
                                                    delegateQueue:nil];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:_url];
   [request addValue:@"multipart/mixed" forHTTPHeaderField:@"Accept"];
-  [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:request];
-  NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request];
+  NSURLRequest *finalRequest = request;
+  if (multipartRequestInterceptor != nil) {
+    NSURLRequest *intercepted = multipartRequestInterceptor(request);
+    if (intercepted != nil) {
+      finalRequest = intercepted;
+    }
+  }
+  NSLog(@"[RCTMultipartDataTask] %@ %@", finalRequest.HTTPMethod ?: @"GET", finalRequest.URL.absoluteString);
+  NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:finalRequest];
   [dataTask resume];
   [session finishTasksAndInvalidate];
 }


### PR DESCRIPTION
Summary:
## Summary:
Replace the hardcoded `RCTDevSupportHttpHeaders` integration in `RCTMultipartDataTask` with a generic request interceptor API. This allows consumers to register a block via `RCTSetCustomMultipartDataTaskRequestInterceptor` that can inspect and modify multipart data task requests before they are sent, without coupling `RCTMultipartDataTask` to any specific header injection mechanism.

## Changelog:
[IOS][ADDED] - Add `RCTSetCustomMultipartDataTaskRequestInterceptor` API to allow custom modification of multipart data task requests before they are sent

Differential Revision: D95219954


