### PR TITLE
Prevent Crashes by Guarding babel.env Access in RN Babel Preset

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -51,7 +51,7 @@ const getPreset = (src, options, babel) => {
   const transformProfile =
     options?.unstable_transformProfile ?? babel?.caller(getTransformProfile);
 
-  const dev = options?.dev ?? babel.env('development');
+  const dev = options?.dev ?? babel?.env('development') ?? false;
 
   // Hermes V1 (aka Static Hermes) uses more optimised profiles.
   // There is currently no difference between stable and canary, but canary


### PR DESCRIPTION
Summary:
To prevent crashes when a Babel plugin or preset is invoked without a Babel API object, ensure that any access to Babel-specific properties (such as babel.env) is guarded. Some build tools or environments may call Babel plugins without providing the full Babel API instance, leading to runtime errors if the code assumes its presence. By using optional chaining and providing safe fallbacks, you can maintain compatibility across different build systems (such as Metro and others) without introducing breaking changes.

Changelog:
[General][Fixed] Prevent errorrs by handling contexts where the Babel API object is not provided

Reviewed By: robhogan, rubennorte

Differential Revision: D94952379


