### PR TITLE
Fix AccessibilityInfo.prefersCrossFadeTransitions unresolved promise

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -269,10 +269,10 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo#prefersCrossFadeTransitions
    */
   prefersCrossFadeTransitions(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (Platform.OS === 'android') {
-        return Promise.resolve(false);
-      } else {
+    if (Platform.OS === 'android') {
+      return Promise.resolve(false);
+    } else {
+      return new Promise((resolve, reject) => {
         if (
           NativeAccessibilityManagerIOS?.getCurrentPrefersCrossFadeTransitionsState !=
           null
@@ -288,8 +288,8 @@ const AccessibilityInfo = {
             ),
           );
         }
-      }
-    });
+      });
+    }
   },
 
   /**

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/__tests__/AccessibilityInfo-test.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/__tests__/AccessibilityInfo-test.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+jest.unmock('../AccessibilityInfo');
+
+const mockGetCurrentPrefersCrossFadeTransitionsState = jest.fn(
+  (onSuccess, onError) => onSuccess(true),
+);
+const mockNativeAccessibilityManagerDefault: {
+  getCurrentPrefersCrossFadeTransitionsState: JestMockFn<
+    [
+      onSuccess: (prefersCrossFadeTransitions: boolean) => void,
+      onError: (error: Error) => void,
+    ],
+    void,
+  > | null,
+} = {
+  getCurrentPrefersCrossFadeTransitionsState:
+    mockGetCurrentPrefersCrossFadeTransitionsState,
+};
+
+jest.mock('../NativeAccessibilityManager', () => ({
+  __esModule: true,
+  default: mockNativeAccessibilityManagerDefault,
+}));
+
+const Platform = require('../../../Utilities/Platform').default;
+const AccessibilityInfo = require('../AccessibilityInfo').default;
+const invariant = require('invariant');
+
+describe('AccessibilityInfo', () => {
+  let originalPlatform;
+
+  beforeEach(() => {
+    originalPlatform = Platform.OS;
+    mockGetCurrentPrefersCrossFadeTransitionsState.mockClear();
+  });
+
+  describe('prefersCrossFadeTransitions', () => {
+    describe('Android', () => {
+      it('should return immediately', async () => {
+        /* $FlowFixMe[incompatible-type] */
+        Platform.OS = 'android';
+
+        const prefersCrossFadeTransitions =
+          await AccessibilityInfo.prefersCrossFadeTransitions();
+
+        expect(prefersCrossFadeTransitions).toBe(false);
+      });
+    });
+
+    describe('iOS', () => {
+      it('should call getCurrentPrefersCrossFadeTransitionsState if available', async () => {
+        /* $FlowFixMe[incompatible-type] */
+        Platform.OS = 'ios';
+
+        const prefersCrossFadeTransitions =
+          await AccessibilityInfo.prefersCrossFadeTransitions();
+
+        expect(
+          mockGetCurrentPrefersCrossFadeTransitionsState,
+        ).toHaveBeenCalled();
+        expect(prefersCrossFadeTransitions).toBe(true);
+      });
+
+      it('should throw error if getCurrentPrefersCrossFadeTransitionsState is not available', async () => {
+        /* $FlowFixMe[incompatible-type] */
+        Platform.OS = 'ios';
+
+        mockNativeAccessibilityManagerDefault.getCurrentPrefersCrossFadeTransitionsState =
+          null;
+
+        const result: mixed =
+          await AccessibilityInfo.prefersCrossFadeTransitions().catch(e => e);
+
+        invariant(
+          result instanceof Error,
+          'Expected prefersCrossFadeTransitions to reject',
+        );
+        expect(result.message).toEqual(
+          'NativeAccessibilityManagerIOS.getCurrentPrefersCrossFadeTransitionsState is not available',
+        );
+      });
+    });
+  });
+
+  afterEach(() => {
+    mockNativeAccessibilityManagerDefault.getCurrentPrefersCrossFadeTransitionsState =
+      mockGetCurrentPrefersCrossFadeTransitionsState;
+    /* $FlowFixMe[incompatible-type] */
+    Platform.OS = originalPlatform;
+  });
+});


### PR DESCRIPTION
## Summary:

This PR fixes a bug I found while exploring the codebase in the `Components` folder. 

`AccessibilityInfo` exposes the method `prefersCrossFadeTransitions`. In the android branch, `Promise.resolve(false)` as return value was creating a new unrelated promise that never calls the resolve function provided by the promise executor constructor, so it was hangs indefinitely.

This means that if a user calls this method on android without any `Platform.OS === ios` guard, it will result in a unresolved promise.

I fixed the bug by aligning the implementation  of `prefersCrossFadeTransitions` to the one of other methods (eg. `isBoldTextEnabled`).

I also added the tests to avoid regression, and additionally verify that the iOS method is doing what we are expecting (in both cases for when `NativeAccessibilityManagerIOS.getCurrentPrefersCrossFadeTransitionsState` is available or not).
The mock of the `Platform` object has been done the same way I saw while doing another contribution in the `Pressability-test` (see #55378 ).

I noticed the same bug in `isHighTextContrastEnabled` and `isDarkerSystemColorsEnabled` and I plan/would like to address them in follow-up PRs (and adding all the missing tests).

## Changelog:

[GENERAL] [FIXED] - Fix AccessibilityInfo.prefersCrossFadeTransitions unresolved (never ending) promise

## Test Plan:

This fix has been develop in TDD. I first added a failing test to reproduce that the android branch of the `prefersCrossFadeTransitions` method was acting as described above (resulting in failure due to jest timeout because the promise was not returning). Then I applied the fix, and finally added also the test for the iOS counterpart.

One final note: `AccessibilityInfo` is mocked globally in `setup.js` (via `setupFiles` in the Jest preset). 
So to test the real implementation I had to use `jest.unmock` (pattern that I saw is already used in other component test files like View-test.js and TextInput-test.js).