### PR TITLE
fix(ios): devsupport IPv6 host parsing for packager and inspector

### DIFF
--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -28,6 +28,10 @@ static NSString *getServerHost(NSURL *bundleURL)
   if (host == nullptr) {
     host = @"localhost";
   }
+  // NSURL.host strips IPv6 brackets, but URL authority requires them.
+  if ([host containsString:@":"] && ![host hasPrefix:@"["] && ![host hasSuffix:@"]"]) {
+    host = [NSString stringWithFormat:@"[%@]", host];
+  }
 
   // Use explicit port from URL if available
   if ([bundleURL port] != nullptr) {

--- a/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
+++ b/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
@@ -64,22 +64,24 @@ struct Registration {
 
 static RCTReconnectingWebSocket *socketForLocation(NSString *const serverHostPort, NSString *scheme)
 {
-  NSString *serverHost;
-  NSString *serverPort;
-  NSArray *locationComponents = [serverHostPort componentsSeparatedByString:@":"];
-  if ([locationComponents count] > 0) {
-    serverHost = locationComponents[0];
-  }
-  if ([locationComponents count] > 1) {
-    serverPort = locationComponents[1];
-  }
   if (![scheme length]) {
     scheme = @"http";
   }
+
+  NSString *location = serverHostPort;
+  if (![location length]) {
+    location = @"localhost";
+  }
+
+  NSString *locationURLString = [location rangeOfString:@"://"].location == NSNotFound
+      ? [NSString stringWithFormat:@"%@://%@/", scheme, location]
+      : location;
+  NSURLComponents *locationURL = [NSURLComponents componentsWithString:locationURLString];
+
   NSURLComponents *const components = [NSURLComponents new];
-  components.host = serverHost ?: @"localhost";
+  components.host = locationURL.host ?: @"localhost";
   components.scheme = scheme;
-  components.port = serverPort ? @(serverPort.integerValue) : @(kRCTBundleURLProviderDefaultPort);
+  components.port = locationURL.port ?: @(kRCTBundleURLProviderDefaultPort);
   components.path = @"/message";
   components.queryItems = @[ [NSURLQueryItem queryItemWithName:@"role" value:RCTPlatformName] ];
   static dispatch_queue_t queue;


### PR DESCRIPTION
## Summary:

When Metro host is an IPv6, iOS dev-support had two parsing issues, causing SIGABRTs:

1. `RCTPackagerConnection` parsed `host:port` by splitting on `:`, which breaks IPv6 literals and can build an invalid websocket URL for `/message`.
2. `RCTInspectorDevServerHelper` used `NSURL.host` directly to compose `host[:port]`. For IPv6, `NSURL.host` is unbracketed, producing an invalid authority for inspector endpoints.

Changes:
- `RCTPackagerConnection`: parse host/port via `NSURLComponents` from a synthesized URL instead of splitting by `:`.
- `RCTInspectorDevServerHelper`: re-add IPv6 brackets when composing authority strings from `NSURL.host`.

## Changelog:

[IOS] [FIXED] - Fix iOS dev-support IPv6 handling for packager and inspector connections.

## Test Plan:

- Built RNTester Debug (Hermes + New Architecture) for iOS simulator.
- Started Metro on IPv6:
  - `RCT_METRO_PORT=8088 yarn --cwd packages/rn-tester start --host :: --port 8088`
- Launched RNTester with IPv6 Metro host in settings:
  - `RCT_packager_scheme = http`
  - `RCT_jsLocation = [2a02:...]:8088`
- Verified in logs:
  - `http://[2a02:...]:8088/status` returns 200
  - bundle loads from `http://[2a02:...]:8088/js/RNTesterApp.ios.bundle?...`
- Verified app remains running and renders RNTester UI (no SIGABRT in packager/inspector startup paths).
