### PR TITLE
Rename TurboModuleManager to ReactCxxTurboModuleProvider

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactCxxTurboModuleProvider.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactCxxTurboModuleProvider.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "TurboModuleManager.h"
+#include "ReactCxxTurboModuleProvider.h"
 
 #include <react/coremodules/AppStateModule.h>
 #include <react/coremodules/DeviceInfoModule.h>
@@ -27,7 +27,7 @@
 
 using namespace facebook::react;
 
-TurboModuleManager::TurboModuleManager(
+ReactCxxTurboModuleProvider::ReactCxxTurboModuleProvider(
     TurboModuleProviders turboModuleProviders,
     std::shared_ptr<CallInvoker> jsInvoker,
     JsErrorHandler::OnJsError onJsError,
@@ -50,7 +50,7 @@ TurboModuleManager::TurboModuleManager(
       webSocketClientFactory_(std::move(webSocketClientFactory)),
       liveReloadCallback_(std::move(liveReloadCallback)) {}
 
-std::shared_ptr<TurboModule> TurboModuleManager::operator()(
+std::shared_ptr<TurboModule> ReactCxxTurboModuleProvider::operator()(
     const std::string& name) const {
   react_native_assert(!name.empty() && "TurboModule name must not be empty");
 

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactCxxTurboModuleProvider.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactCxxTurboModuleProvider.h
@@ -21,9 +21,9 @@ class NativeAnimatedNodesManagerProvider;
 class SurfaceDelegate;
 struct IDevUIDelegate;
 
-class TurboModuleManager final {
+class ReactCxxTurboModuleProvider final {
  public:
-  TurboModuleManager(
+  ReactCxxTurboModuleProvider(
       TurboModuleProviders turboModuleProviders,
       std::shared_ptr<CallInvoker> jsInvoker,
       JsErrorHandler::OnJsError onJsError,

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -35,7 +35,7 @@
 #include <react/runtime/hermes/HermesInstance.h>
 #include <react/threading/MessageQueueThreadImpl.h>
 
-#include "TurboModuleManager.h"
+#include "ReactCxxTurboModuleProvider.h"
 
 namespace facebook::react {
 
@@ -251,7 +251,7 @@ void ReactHost::createReactInstance() {
   }
 
   auto liveReloadCallback = [this]() { reloadReactInstance(); };
-  TurboModuleManager turboModuleManager(
+  ReactCxxTurboModuleProvider turboModuleManager(
       reactInstanceData_->turboModuleProviders,
       jsInvoker,
       reactInstanceData_->onJsError,


### PR DESCRIPTION
Summary:
Rename the class and files from TurboModuleManager to ReactCxxTurboModuleProvider to better reflect its role and avoid name collision with the Android/iOS TurboModuleManager classes.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D95255535
