### PR TITLE
Restore inspector addPage listener callback

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
@@ -142,6 +142,12 @@ int InspectorImpl::addPage(
       pageId,
       Page{pageId, description, vm, std::move(connectFunc), capabilities});
 
+  for (const auto& listenerWeak : listeners_) {
+    if (auto listener = listenerWeak.lock()) {
+      listener->unstable_onHostTargetAdded();
+    }
+  }
+
   return pageId;
 }
 


### PR DESCRIPTION
Summary:
Accidentally clobbered in D93247603. This affects the `fuseboxAssertSingleHostState` feature (https://github.com/facebook/react-native-devtools-frontend/pull/218).

Changelog: [Internal]

Differential Revision: D95365621


