### PR TITLE
Boot latest available iOS simulator instead of hardcoded iPhone 16 Pro

### DIFF
--- a/scripts/release-testing/test-release-local.js
+++ b/scripts/release-testing/test-release-local.js
@@ -327,7 +327,30 @@ function bootSimulatorIfNeeded() {
     console.info('An iOS simulator is already booted, skipping boot.');
     return;
   }
-  exec('xcrun simctl boot "iPhone 16 Pro"');
+
+  // Find the latest available iPhone simulator by picking the last iOS runtime
+  // and the first iPhone device listed under it.
+  const devicesJson = JSON.parse(
+    String(
+      exec('xcrun simctl list devices iPhone available -j', {silent: true}),
+    ),
+  );
+  const runtimes = Object.keys(devicesJson.devices)
+    .filter(r => r.startsWith('com.apple.CoreSimulator.SimRuntime.iOS'))
+    .sort();
+  const latestRuntime = runtimes[runtimes.length - 1];
+  const device =
+    latestRuntime != null
+      ? devicesJson.devices[latestRuntime].find(d => d.name.includes('iPhone'))
+      : null;
+
+  if (device != null) {
+    console.info(`Booting ${device.name} (${latestRuntime})...`);
+    exec(`xcrun simctl boot "${device.udid}"`);
+  } else {
+    console.error('No available iPhone simulator found.');
+    process.exit(1);
+  }
 }
 
 async function main() {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

When no simulator is already booted, dynamically discover the latest
available iOS runtime and boot the first iPhone device under it, instead
of hardcoding "iPhone 16 Pro". This uses `xcrun simctl list devices
iPhone available -j` to query available devices and picks the last iOS
runtime alphabetically (i.e. the newest).

Also moved the `bootSimulatorIfNeeded` call before the `xcodebuild`
invocation on the local build path, since `xcodebuild -destination
"generic/platform=iOS Simulator"` can itself trigger a new simulator
boot.

Reviewed By: cipolleschi

Differential Revision: D95371266


