### PR TITLE
fix: image orientation on iOS

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -79,6 +79,30 @@ static UIImageOrientation UIImageOrientationFromCGImagePropertyOrientation(CGIma
   }
 }
 
+static UIImageOrientation UIImageOrientationFromCGImagePropertyOrientation(CGImagePropertyOrientation cgOrientation)
+{
+  switch (cgOrientation) {
+    case kCGImagePropertyOrientationUp:
+      return UIImageOrientationUp;
+    case kCGImagePropertyOrientationDown:
+      return UIImageOrientationDown;
+    case kCGImagePropertyOrientationLeft:
+      return UIImageOrientationLeft;
+    case kCGImagePropertyOrientationRight:
+      return UIImageOrientationRight;
+    case kCGImagePropertyOrientationUpMirrored:
+      return UIImageOrientationUpMirrored;
+    case kCGImagePropertyOrientationDownMirrored:
+      return UIImageOrientationDownMirrored;
+    case kCGImagePropertyOrientationLeftMirrored:
+      return UIImageOrientationLeftMirrored;
+    case kCGImagePropertyOrientationRightMirrored:
+      return UIImageOrientationRightMirrored;
+    default:
+      return UIImageOrientationUp;
+  }
+}
+
 CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {
   if (CGSizeEqualToSize(destSize, CGSizeZero)) {
@@ -294,6 +318,8 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
   NSNumber *width = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelWidth);
   NSNumber *height = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight);
   NSNumber *orientationNum = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyOrientation);
+  NSNumber *exifOrientation = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyOrientation);
+  CGImagePropertyOrientation cgOrientation = exifOrientation ? (CGImagePropertyOrientation)[exifOrientation integerValue] : kCGImagePropertyOrientationUp;
   CGSize sourceSize = {width.doubleValue, height.doubleValue};
   CFRelease(imageProperties);
 
@@ -357,6 +383,10 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
   }
 
   // Return image
+  // For thumbnails, kCGImageSourceCreateThumbnailWithTransform already rotates pixels, so use Up.
+  // For full-size images, CGImageSourceCreateImageAtIndex does NOT apply EXIF transform,
+  // so we must preserve the original EXIF orientation for correct display.
+  UIImageOrientation orientation = createThumbnail ? UIImageOrientationUp : UIImageOrientationFromCGImagePropertyOrientation(cgOrientation);
   UIImage *image = [UIImage imageWithCGImage:imageRef scale:destScale orientation:orientation];
   CGImageRelease(imageRef);
   return image;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? --> 

In RN 0.83, PR https://github.com/facebook/react-native/pull/54127 changed `RCTDecodeImageWithData` to use `CGImageSourceCreateImageAtIndex` instead of `CGImageSourceCreateThumbnailAtIndex` for full-size images to fix memory crashes with large images. However, `CGImageSourceCreateImageAtIndex` does not
  apply EXIF orientation transforms to pixels, unlike the previous thumbnail API which used `kCGImageSourceCreateThumbnailWithTransform`. Since the code hardcoded `UIImageOrientationUp`, EXIF orientation was silently lost, causing camera-captured images (which rely on EXIF orientation metadata) to
  appear rotated — e.g. when processed by expo-image-manipulator.
  
  This fix reads the EXIF orientation from the image source properties and passes the correct `UIImageOrientation` to `UIImage` for the full-size code path, while keeping `UIImageOrientationUp` for the thumbnail path (which already applies the transform via `kCGImageSourceCreateThumbnailWithTransform`).

  
## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

  [IOS] [FIXED] - Fixed EXIF orientation being ignored for full-size images in `RCTDecodeImageWithData`, causing camera photos to appear rotated


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

  1. Capture a photo with the device camera (which embeds EXIF orientation metadata, typically orientation 6 = 90° CW rotation).
  2. Load the image through React Native's image pipeline at full size (no downscaling).
  3. Verify the image displays with the correct orientation — it should no longer appear rotated.
  4. Verify that downscaled/thumbnail images still display correctly (the thumbnail path is unchanged).