### PR TITLE
Fix NSRangeException crash in TextInput delegate adapters

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
@@ -96,6 +96,15 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
     return YES;
   }
 
+  // Clamp the range to the current text length to avoid NSRangeException.
+  NSUInteger textLength = _backedTextInputView.attributedText.length;
+  if (range.location > textLength) {
+    return NO;
+  }
+  if (range.location + range.length > textLength) {
+    range = NSMakeRange(range.location, textLength - range.location);
+  }
+
   NSMutableAttributedString *attributedString = [_backedTextInputView.attributedText mutableCopy];
   [attributedString replaceCharactersInRange:range withString:newText];
   [_backedTextInputView setAttributedText:[attributedString copy]];
@@ -292,8 +301,13 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
     return NO;
   }
 
-  if (range.location + range.length > _backedTextInputView.text.length) {
-    range = NSMakeRange(range.location, _backedTextInputView.text.length - range.location);
+  // Clamp the range to the current text length to avoid NSRangeException.
+  NSUInteger textLength = _backedTextInputView.attributedText.length;
+  if (range.location > textLength) {
+    return NO;
+  }
+  if (range.location + range.length > textLength) {
+    range = NSMakeRange(range.location, textLength - range.location);
   } else if ([newText isEqualToString:text]) {
     _textDidChangeIsComing = YES;
     return YES;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The existing range guard in the UITextView delegate (added in #24084) only checks range.location + range.length > text.length. It doesn't handle range.location > text.length, which causes an unsigned integer underflow in the clamped length, still crashing with NSRangeException. See #45050 for another report of this.

The UITextField delegate has no range validation at all.

This PR adds a range.location > textLength early return to both delegate adapters, ahead of the existing length clamping.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Fix NSRangeException crash in RCTBackedTextInputDelegateAdapter when text range is out of bounds

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This is a race condition between iOS computing the text range and React Native updating the backing text (e.g. controlled TextInput state updates, maxLength truncation, autocorrect). It's difficult to reproduce deterministically but shows up in production crash logs. The fix is straightforward defensive bounds checking before calling replaceCharactersInRange:.