### PR TITLE
Add Button E2E tests

### DIFF
--- a/packages/rn-tester/js/examples/Button/ButtonExample.js
+++ b/packages/rn-tester/js/examples/Button/ButtonExample.js
@@ -30,6 +30,7 @@ exports.description = 'Simple React Native button component.';
 exports.examples = [
   {
     title: 'Button with default styling',
+    name: 'default-styling',
     render: function (): React.Node {
       return (
         <Button
@@ -43,6 +44,7 @@ exports.examples = [
   },
   {
     title: 'Button with color="red"',
+    name: 'color-red',
     description:
       ('Note: On iOS, the color prop controls the color of the text. On ' +
         'Android, the color adjusts the background color of the button.': string),
@@ -66,6 +68,7 @@ exports.examples = [
   },
   {
     title: 'Two Buttons with Flexbox layout',
+    name: 'two-buttons-flexbox',
     description:
       ('Two buttons wrapped inside view with justifyContent: spaceBetween,' +
         'This layout strategy lets the title define the width of the button': string),
@@ -98,6 +101,7 @@ exports.examples = [
   },
   {
     title: 'Three Buttons with Flexbox layout',
+    name: 'three-buttons-flexbox',
     render: function (): React.Node {
       return (
         <RNTesterThemeContext.Consumer>
@@ -134,6 +138,7 @@ exports.examples = [
   },
   {
     title: 'Button with disabled={true}',
+    name: 'disabled',
     description:
       'By passing disabled={true} all interactions for the button are disabled.',
     render: function (): React.Node {


### PR DESCRIPTION
Summary: Add name fields to 5 Button examples in ButtonExample.js and create 5 corresponding E2E screenshot tests covering default-styling, color-red, two-buttons-flexbox, three-buttons-flexbox, and disabled variants. Skipped accessibility-only examples (no visual difference).

Reviewed By: cortinico

Differential Revision: D95311374


