### PR TITLE
Fix GCC -Werror=return-type

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
@@ -622,6 +622,7 @@ GridTrackSize gridTrackSizeFromTypeAndValue(YGGridTrackType type, float value) {
     case YGGridTrackTypeMinmax:
       return GridTrackSize::auto_();
   }
+  fatalWithMessage("Unknown YGGridTrackType");
 }
 
 StyleSizeLength styleSizeLengthFromTypeAndValue(
@@ -639,6 +640,7 @@ StyleSizeLength styleSizeLengthFromTypeAndValue(
     case YGGridTrackTypeMinmax:
       return StyleSizeLength::ofAuto();
   }
+  fatalWithMessage("Unknown YGGridTrackType");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1910

GCC emits `-Wreturn-type` for `gridTrackSizeFromTypeAndValue` and
`styleSizeLengthFromTypeAndValue` because it does not suppress the
warning for exhaustive switches over C-style enums (unlike Clang).
Add `fatalWithMessage` after each switch to satisfy `-Werror=return-type`,
matching the existing pattern used in `Style.h` for similar exhaustive
switches.

Differential Revision: D95513063


