### PR TITLE
[RN][iOS] Add RCTDevSupportHeaders in React Umbrella

### DIFF
--- a/packages/react-native/scripts/ios-prebuild/React-umbrella.h
+++ b/packages/react-native/scripts/ios-prebuild/React-umbrella.h
@@ -86,6 +86,7 @@
 #import "React/RCTDevLoadingViewProtocol.h"
 #import "React/RCTDevLoadingViewSetEnabled.h"
 #import "React/RCTDevMenu.h"
+#import "React/RCTDevSupportHttpHeaders.h"
 #import "React/RCTDevSettings.h"
 #import "React/RCTDevToolsRuntimeSettingsModule.h"
 #import "React/RCTDeviceInfo.h"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5158,10 +5158,10 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-hermes-compiler@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/hermes-compiler/-/hermes-compiler-0.14.0.tgz#ec0ec83132ab5954e7bd2c74e6331752742f188f"
-  integrity sha512-clxa193o+GYYwykWVFfpHduCATz8fR5jvU7ngXpfKHj+E9hr9vjLNtdLSEe8MUbObvVexV3wcyxQ00xTPIrB1Q==
+hermes-compiler@0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/hermes-compiler/-/hermes-compiler-0.14.1.tgz#5381d2bb88454027d16736b8cb7fddaaf1556538"
+  integrity sha512-+RPPQlayoZ9n6/KXKt5SFILWXCGJ/LV5d24L5smXrvTDrPS4L6dSctPczXauuvzFP3QEJbD1YO7Z3Ra4a+4IhA==
 
 hermes-eslint@0.32.0:
   version "0.32.0"


### PR DESCRIPTION
## Summary

Add the RCTDevSupportHTTPHeaders to the React-Core-umbrella.h header

## Changelog:
[Internal] - 

## Test Plan
WIP
