### PR TITLE
Strip `__deprecated_msg` in the preprocessing

### DIFF
--- a/scripts/cxx-api/input_filters/doxygen_strip_comments.py
+++ b/scripts/cxx-api/input_filters/doxygen_strip_comments.py
@@ -36,6 +36,28 @@ def strip_block_comments(content: str) -> str:
     return comment_pattern.sub(replace_with_newlines, content)
 
 
+def strip_deprecated_msg(content: str) -> str:
+    """
+    Remove __deprecated_msg(...) macros and standalone __deprecated annotations
+    from content.
+
+    These macros cause Doxygen to produce malformed XML output when they appear
+    before @interface declarations, creating __pad0__ artifacts and missing
+    members. Standalone __deprecated on method declarations causes the annotation
+    to be parsed as a parameter name. Since the macros are stripped, deprecation
+    info won't appear in the API snapshot output.
+    """
+    # Pattern to match __deprecated_msg("...") with any content inside quotes
+    pattern = re.compile(r'__deprecated_msg\s*\(\s*"[^"]*"\s*\)\s*')
+    content = pattern.sub("", content)
+
+    # Pattern to match standalone __deprecated (not followed by _msg or other suffix)
+    standalone_pattern = re.compile(r"\b__deprecated\b(?!_)\s*")
+    content = standalone_pattern.sub("", content)
+
+    return content
+
+
 def main():
     if len(sys.argv) < 2:
         print("Usage: doxygen_strip_comments.py <filename>", file=sys.stderr)
@@ -48,6 +70,7 @@ def main():
             content = f.read()
 
         filtered = strip_block_comments(content)
+        filtered = strip_deprecated_msg(filtered)
         print(filtered, end="")
     except Exception as e:
         # On error, output original content to not break the build

--- a/scripts/cxx-api/parser/__main__.py
+++ b/scripts/cxx-api/parser/__main__.py
@@ -60,7 +60,7 @@ def build_doxygen_config(
     with open(os.path.join(directory, ".doxygen.config.template")) as f:
         template = f.read()
 
-    # replace the placeholder with the actual path
+    # replace the placeholders with the actual values
     config = (
         template.replace("${INPUTS}", include_directories_str)
         .replace("${EXCLUDE_PATTERNS}", exclude_patterns_str)
@@ -103,9 +103,12 @@ def build_snapshot_for_view(
 
     if verbose:
         print("Running Doxygen")
+        if input_filter:
+            print(f"  Using input filter: {input_filter}")
 
     # Run doxygen with the config file
     doxygen_bin = os.environ.get("DOXYGEN_BIN", "doxygen")
+
     result = subprocess.run(
         [doxygen_bin, DOXYGEN_CONFIG_FILE],
         cwd=react_native_dir,
@@ -227,6 +230,7 @@ def main():
                     definitions=config.definitions,
                     output_dir=output_dir,
                     verbose=verbose,
+                    input_filter=input_filter,
                 )
         else:
             snapshot = build_snapshot_for_view(

--- a/scripts/cxx-api/tests/snapshots/should_handle_deprecated_msg/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_deprecated_msg/snapshot.api
@@ -7,6 +7,7 @@ interface RCTDeprecatedInterface {
 
 interface RCTTestInterface {
   public virtual NSArray* deprecatedMethod:(id param);
+  public virtual instancetype initWithURL:launchOptions:(NSURL* url, NSDictionary* launchOptions);
   public virtual void normalMethod:(NSString* name);
 }
 

--- a/scripts/cxx-api/tests/snapshots/should_handle_deprecated_msg/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_deprecated_msg/test.h
@@ -11,6 +11,8 @@
 
 - (NSArray *)deprecatedMethod:(id)param __deprecated_msg("Use newMethod instead.");
 
+- (instancetype)initWithURL:(NSURL *)url launchOptions:(NSDictionary *)launchOptions __deprecated;
+
 @end
 
 @interface RCTDeprecatedInterface

--- a/scripts/cxx-api/tests/snapshots/should_strip_deprecated_msg_before_interface/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_strip_deprecated_msg_before_interface/snapshot.api
@@ -1,0 +1,4 @@
+interface RCTSurface {
+  protected  __pad0__;
+  public @property (assign, readonly) CGSize minimumSize;
+}

--- a/scripts/cxx-api/tests/snapshots/should_strip_deprecated_msg_before_interface/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_strip_deprecated_msg_before_interface/test.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+__deprecated_msg("This API will be removed along with the legacy architecture.") @interface RCTSurface
+    : NSObject<RCTSurfaceProtocol>
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+                    moduleName:(NSString *)moduleName
+             initialProperties:(NSDictionary *)initialProperties;
+
+@property (atomic, assign, readonly) CGSize minimumSize;
+
+@end

--- a/scripts/cxx-api/tests/test_input_filters.py
+++ b/scripts/cxx-api/tests/test_input_filters.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 
 import unittest
 
-from ..input_filters.doxygen_strip_comments import strip_block_comments
+from ..input_filters.doxygen_strip_comments import (
+    strip_block_comments,
+    strip_deprecated_msg,
+)
 
 
 class TestDoxygenStripComments(unittest.TestCase):
@@ -65,6 +68,52 @@ class TestDoxygenStripComments(unittest.TestCase):
         content = "just code without comments"
         result = strip_block_comments(content)
         self.assertEqual(result, content)
+
+
+class TestStripDeprecatedMsg(unittest.TestCase):
+    def test_strips_deprecated_msg(self):
+        content = '- (void)oldMethod __deprecated_msg("Use newMethod instead.");'
+        result = strip_deprecated_msg(content)
+        self.assertEqual(result, "- (void)oldMethod ;")
+
+    def test_strips_standalone_deprecated(self):
+        content = "- (instancetype)initWithBundleURL:(NSURL *)bundleURL launchOptions:(nullable NSDictionary *)launchOptions __deprecated;"
+        result = strip_deprecated_msg(content)
+        self.assertEqual(
+            result,
+            "- (instancetype)initWithBundleURL:(NSURL *)bundleURL launchOptions:(nullable NSDictionary *)launchOptions ;",
+        )
+
+    def test_standalone_deprecated_does_not_match_deprecated_msg(self):
+        content = '__deprecated_msg("msg") and __deprecated'
+        result = strip_deprecated_msg(content)
+        self.assertEqual(result, "and ")
+
+    def test_preserves_deprecated_in_identifiers(self):
+        content = (
+            "- (void)findComponentViewWithTag_DO_NOT_USE_DEPRECATED:(NSInteger)tag;"
+        )
+        result = strip_deprecated_msg(content)
+        self.assertEqual(result, content)
+
+    def test_preserves_DEPRECATED_suffix_in_names(self):
+        content = "@property (weak) RCTViewRegistry *viewRegistry_DEPRECATED;"
+        result = strip_deprecated_msg(content)
+        self.assertEqual(result, content)
+
+    def test_handles_no_deprecated(self):
+        content = "- (void)normalMethod;"
+        result = strip_deprecated_msg(content)
+        self.assertEqual(result, content)
+
+    def test_handles_empty_content(self):
+        result = strip_deprecated_msg("")
+        self.assertEqual(result, "")
+
+    def test_strips_deprecated_before_interface(self):
+        content = '__deprecated_msg("This API will be removed.") @interface RCTSurface : NSObject'
+        result = strip_deprecated_msg(content)
+        self.assertEqual(result, "@interface RCTSurface : NSObject")
 
 
 if __name__ == "__main__":

--- a/scripts/cxx-api/tests/test_snapshots.py
+++ b/scripts/cxx-api/tests/test_snapshots.py
@@ -111,15 +111,16 @@ def _make_case_test(case_dir: Traversable, tests_root: Traversable):
             )
 
             # Get real filesystem path for filter script if it exists
-            filter_script_path = None
+            # IMPORTANT: Keep the context manager active while Doxygen runs,
+            # otherwise the extracted file may be cleaned up before use
             if filter_script.is_file():
                 with ir.as_file(filter_script) as fs_path:
-                    filter_script_path = str(fs_path)
-
-            # Run doxygen to generate the XML
-            _generate_doxygen_api(
-                str(case_dir_path), str(doxygen_config_path), filter_script_path
-            )
+                    _generate_doxygen_api(
+                        str(case_dir_path), str(doxygen_config_path), str(fs_path)
+                    )
+            else:
+                # No filter script available - run without filter
+                _generate_doxygen_api(str(case_dir_path), str(doxygen_config_path))
 
             # Parse the generated XML
             xml_dir = case_dir_path / "api" / "xml"


### PR DESCRIPTION
Summary:
Strips `__deprecated_msg` annotations due to incorrect parsing when in front of the interfaces (predefining does not help unfortunately). It doesn't fully solve the issue stated in the added test as doxygen also has problem with parsing interfaces for which the base class is in the new line.

```
interface Foo
           : Bar<NSObject>
end
```

This will be handled by the fix in the doxygen.

This diff also adds stripping the `__deprecated` label which is again incorrectly parsed by doxygen.


Changelog:
[Internal]

Differential Revision: D95541064


