### PR TITLE
Fix 2 spelling typos in DrawCommandSpan.kt

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/DrawCommandSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/DrawCommandSpan.kt
@@ -12,7 +12,7 @@ import android.text.Layout
 import android.text.style.UpdateAppearance
 
 /**
- * May be overriden to implement charater styles which are applied by [PreparedLayoutTextView]
+ * May be overridden to implement character styles which are applied by [PreparedLayoutTextView]
  * during the drawing of text, against the underlying Android canvas
  */
 public abstract class DrawCommandSpan : UpdateAppearance, ReactSpan {


### PR DESCRIPTION
Summary:
Changelog[internal]: Fixed 2 spelling errors in DrawCommandSpan.kt:

- `DrawCommandSpan.kt:15`: `overriden` → `overridden` (comment)
- `DrawCommandSpan.kt:15`: `charater` → `character` (comment)

Differential Revision: D95366188


