### PR TITLE
Add RCTDevSupportHeaders to React Umbrella

### DIFF
--- a/packages/react-native/scripts/ios-prebuild/templates/React-umbrella.h
+++ b/packages/react-native/scripts/ios-prebuild/templates/React-umbrella.h
@@ -87,6 +87,7 @@
 #import <React/RCTDevLoadingViewSetEnabled.h>
 #import <React/RCTDevMenu.h>
 #import <React/RCTDevSettings.h>
+#import <React/RCTDevSupportHttpHeaders.h>
 #import <React/RCTDevToolsRuntimeSettingsModule.h>
 #import <React/RCTDeviceInfo.h>
 #import <React/RCTDiffClampAnimatedNode.h>


### PR DESCRIPTION
Summary:
Add RCTDevSupportHeaders in React Umbrella

This is a port to main of https://github.com/facebook/react-native/pull/55969

## Changelog:
[Internal] -

Reviewed By: fabriziocucci

Differential Revision: D95550095


