### PR TITLE
enable copy button for mhs logview errors

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import Clipboard from '../../Components/Clipboard/Clipboard';
 import Keyboard from '../../Components/Keyboard/Keyboard';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
@@ -59,6 +60,47 @@ export default function LogBoxInspector(props: Props): React.Node {
     LogBoxData.retrySymbolicateLogNow(log);
   }
 
+  function _handleCopy() {
+    const headerTitleMap = {
+      warn: 'Console Warning',
+      error: 'Console Error',
+      fatal: 'Uncaught Error',
+      syntax: 'Syntax Error',
+      component: 'Render Error',
+    };
+
+    const title =
+      log.type ??
+      headerTitleMap[log.isComponentError ? 'component' : log.level];
+
+    const parts = [title, '', log.message.content];
+
+    if (log.codeFrame != null) {
+      const location = log.codeFrame.location;
+      parts.push(
+        '',
+        'Source:',
+        location != null
+          ? `${log.codeFrame.fileName} (${location.row}:${location.column})`
+          : log.codeFrame.fileName,
+      );
+    }
+
+    const stack = log.getAvailableStack();
+    if (stack.length > 0) {
+      parts.push('', 'Call Stack:');
+      for (const frame of stack) {
+        const methodName = frame.methodName ?? '?';
+        const file = frame.file ?? '?';
+        const lineNumber =
+          frame.lineNumber != null ? `:${frame.lineNumber}` : '';
+        parts.push(`${methodName} (${file}${lineNumber})`);
+      }
+    }
+
+    Clipboard.setString(parts.join('\n'));
+  }
+
   if (log == null) {
     return null;
   }
@@ -75,6 +117,7 @@ export default function LogBoxInspector(props: Props): React.Node {
       <LogBoxInspectorFooter
         onDismiss={props.onDismiss}
         onMinimize={props.onMinimize}
+        onCopy={_handleCopy}
         level={log.level}
       />
     </View>

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooter.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooter.js
@@ -20,6 +20,7 @@ import * as React from 'react';
 type Props = Readonly<{
   onDismiss: () => void,
   onMinimize: () => void,
+  onCopy: () => void,
   level?: ?LogLevel,
 }>;
 
@@ -47,6 +48,11 @@ export default function LogBoxInspectorFooter(props: Props): React.Node {
         id="logbox_footer_button_minimize"
         text="Minimize"
         onPress={props.onMinimize}
+      />
+      <LogBoxInspectorFooterButton
+        id="logbox_footer_button_copy"
+        text="Copy"
+        onPress={props.onCopy}
       />
     </View>
   );

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
@@ -27,6 +27,7 @@ describe('LogBoxInspectorFooter', () => {
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
+        onCopy={() => {}}
         level="warn"
       />,
     );
@@ -39,6 +40,7 @@ describe('LogBoxInspectorFooter', () => {
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
+        onCopy={() => {}}
         level="error"
       />,
     );
@@ -51,6 +53,7 @@ describe('LogBoxInspectorFooter', () => {
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
+        onCopy={() => {}}
         level="fatal"
       />,
     );
@@ -63,6 +66,7 @@ describe('LogBoxInspectorFooter', () => {
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
+        onCopy={() => {}}
         level="syntax"
       />,
     );

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
@@ -49,6 +49,7 @@ exports[`LogBoxContainer should render fatal with selectedIndex 2 1`] = `
   />
   <LogBoxInspectorFooter
     level="fatal"
+    onCopy={[Function]}
     onDismiss={[Function]}
     onMinimize={[Function]}
   />
@@ -106,6 +107,7 @@ exports[`LogBoxContainer should render warning with selectedIndex 0 1`] = `
   />
   <LogBoxInspectorFooter
     level="warn"
+    onCopy={[Function]}
     onDismiss={[Function]}
     onMinimize={[Function]}
   />

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorFooter-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorFooter-test.js.snap
@@ -71,6 +71,11 @@ exports[`LogBoxInspectorFooter should render two buttons for error 1`] = `
     onPress={[Function]}
     text="Minimize"
   />
+  <LogBoxInspectorFooterButton
+    id="logbox_footer_button_copy"
+    onPress={[Function]}
+    text="Copy"
+  />
 </View>
 `;
 
@@ -100,6 +105,11 @@ exports[`LogBoxInspectorFooter should render two buttons for fatal 1`] = `
     onPress={[Function]}
     text="Minimize"
   />
+  <LogBoxInspectorFooterButton
+    id="logbox_footer_button_copy"
+    onPress={[Function]}
+    text="Copy"
+  />
 </View>
 `;
 
@@ -128,6 +138,11 @@ exports[`LogBoxInspectorFooter should render two buttons for warning 1`] = `
     id="logbox_footer_button_minimize"
     onPress={[Function]}
     text="Minimize"
+  />
+  <LogBoxInspectorFooterButton
+    id="logbox_footer_button_copy"
+    onPress={[Function]}
+    text="Copy"
   />
 </View>
 `;


### PR DESCRIPTION
Summary: when I view an error in Log inspector mode and I want to debug with ai, I am frustrated by the inability to copy the error right then and there. This adds copy functionality to the log view.

Changelog: [LogBox] Add "Copy" button to Log Inspector in LogBox for easier error copying.


Reviewed By: jdlehman

Differential Revision: D95277489


