### PR TITLE
make ReactInternal compatible with Swift

### DIFF
--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -67,7 +67,7 @@
 #endif
 
 #ifndef RCT_ENABLE_INSPECTOR
-#if (RCT_DEV || RCT_REMOTE_PROFILE) && __has_include(<React/RCTInspectorDevServerHelper.h>)
+#if (RCT_DEV || RCT_REMOTE_PROFILE)
 #define RCT_ENABLE_INSPECTOR 1
 #else
 #define RCT_ENABLE_INSPECTOR 0

--- a/packages/react-native/React/Base/RCTRootView.h
+++ b/packages/react-native/React/Base/RCTRootView.h
@@ -47,6 +47,8 @@ extern
  * like any ordinary UIView. You can have multiple RCTRootViews on screen at
  * once, all controlled by the same JavaScript application.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wdeprecated"
 __deprecated_msg("This API will be removed along with the legacy architecture.") @interface RCTRootView : UIView
 
 /**
@@ -177,5 +179,7 @@ __deprecated_msg("This API will be removed along with the legacy architecture.")
 - (void)cancelTouches;
 
 @end
+
+#pragma clang diagnostic pop
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/RCTRootViewDelegate.h
+++ b/packages/react-native/React/Base/RCTRootViewDelegate.h
@@ -6,8 +6,7 @@
  */
 
 #import <Foundation/Foundation.h>
-
-@class RCTRootView;
+#import <React/RCTRootView.h>
 
 @protocol RCTRootViewDelegate <NSObject>
 
@@ -25,6 +24,10 @@
  * The new intrinsic content size is available via the `intrinsicContentSize`
  * property of the root view. The view will not resize itself.
  */
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 - (void)rootViewDidChangeIntrinsicSize:(RCTRootView *)rootView;
+#pragma clang diagnostic pop
 
 @end

--- a/packages/react-native/React/Base/Surface/RCTSurface.h
+++ b/packages/react-native/React/Base/Surface/RCTSurface.h
@@ -32,8 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  * ability to create a UIView instance on demand (later);
  *  * ability to communicate the current stage of the surface granularly.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wdeprecated"
 __deprecated_msg("This API will be removed along with the legacy architecture.") @interface RCTSurface
     : NSObject<RCTSurfaceProtocol>
+#pragma clang diagnostic pop
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge
                     moduleName:(NSString *)moduleName

--- a/packages/react-native/React/Base/Surface/RCTSurfaceDelegate.h
+++ b/packages/react-native/React/Base/Surface/RCTSurfaceDelegate.h
@@ -7,11 +7,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <React/RCTSurface.h>
 #import <React/RCTSurfaceStage.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-@class RCTSurface;
 
 @protocol RCTSurfaceDelegate <NSObject>
 
@@ -21,13 +20,18 @@ NS_ASSUME_NONNULL_BEGIN
  * Notifies a receiver that a surface transitioned to a new stage.
  * See `RCTSurfaceStage` for more details.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 - (void)surface:(RCTSurface *)surface didChangeStage:(RCTSurfaceStage)stage;
-
+#pragma clang diagnostic pop
 /**
  * Notifies a receiver that root view got a new (intrinsic) size during the last
  * layout pass.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 - (void)surface:(RCTSurface *)surface didChangeIntrinsicSize:(CGSize)intrinsicSize;
+#pragma clang diagnostic pop
 
 @end
 

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -12,9 +12,6 @@
 #import <React/RCTSurfaceSizeMeasureMode.h>
 #import <React/RCTSurfaceStage.h>
 
-@class RCTBridge;
-@class RCTSurface;
-
 typedef UIView *_Nullable (^RCTSurfaceHostingViewActivityIndicatorViewFactory)(void);
 
 NS_ASSUME_NONNULL_BEGIN

--- a/packages/react-native/React/CoreModules/RCTDevMenuConfigurationDecorator.h
+++ b/packages/react-native/React/CoreModules/RCTDevMenuConfigurationDecorator.h
@@ -15,8 +15,8 @@
 
 @property (nonatomic, strong, readonly) RCTDevMenuConfiguration *__nullable devMenuConfiguration;
 
-- (instancetype)initWithDevMenuConfiguration:(RCTDevMenuConfiguration *__nullable)devMenuConfiguration;
-- (void)decorate:(id<RCTBridgeModule>)devMenuModule;
+- (instancetype _Nonnull)initWithDevMenuConfiguration:(RCTDevMenuConfiguration *__nullable)devMenuConfiguration;
+- (void)decorate:(id<RCTBridgeModule> _Nonnull)devMenuModule;
 
 #endif
 

--- a/packages/react-native/React/Profiler/RCTProfile.h
+++ b/packages/react-native/React/Profiler/RCTProfile.h
@@ -19,6 +19,9 @@
  * using it.
  */
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+
 RCT_EXTERN __deprecated_msg("This API will be removed along with the legacy architecture.") NSString *const
     RCTProfileDidStartProfiling;
 RCT_EXTERN __deprecated_msg("This API will be removed along with the legacy architecture.") NSString *const
@@ -261,3 +264,5 @@ RCT_EXTERN void RCTProfileHideControls(void)
 #define RCTProfileHideControls(...)
 
 #endif
+
+#pragma clang diagnostic pop

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.h
@@ -17,8 +17,11 @@
 
 @protocol UIScrollViewDelegate;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wdeprecated"
 __attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTScrollView : RCTView<UIScrollViewDelegate, RCTScrollableProtocol, RCTAutoInsetsProtocol>
+#pragma clang diagnostic pop
 
 - (instancetype)initWithEventDispatcher:(id<RCTEventDispatcherProtocol>)eventDispatcher NS_DESIGNATED_INITIALIZER;
 
@@ -69,9 +72,10 @@ __attribute__((deprecated("This API will be removed along with the legacy archit
 @end
 
 @interface UIView (RCTScrollView)
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 - (void)reactUpdateResponderOffsetForScrollView:(RCTScrollView *)scrollView;
-
+#pragma clang diagnostic pop
 @end
 
 @interface RCTScrollView (Internal)


### PR DESCRIPTION
Summary:
This change enables modules for the ReactInternal target, and correctly specifies the exported_deps. There are a few associated fixes required to unblock this change, such as adding missing deps and fixing headers for module compatibility.

Changelog:
[iOS][Fixed] - Made ReactInteral compatible with Swift

Reviewed By: cipolleschi

Differential Revision: D95434258


