### PR TITLE
Bring back C++ Turbo Module example in RN Tester

### DIFF
--- a/packages/rn-tester/js/examples/TurboModule/TurboCxxModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/TurboCxxModuleExample.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
+const NativeCxxModuleExampleExample = require('./NativeCxxModuleExampleExample');
+const React = require('react');
+
+exports.displayName = (undefined: ?string);
+exports.title = 'Cxx TurboModule';
+exports.category = 'Basic';
+exports.description = 'Usage of Cxx TurboModule';
+exports.examples = [
+  {
+    title: 'TurboCxxModuleExample',
+    render: function (): React.MixedElement {
+      return <NativeCxxModuleExampleExample />;
+    },
+  },
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -374,6 +374,11 @@ const APIs: Array<RNTesterModuleInfo> = ([
     key: 'LegacyModuleExample',
     module: require('../examples/TurboModule/LegacyModuleExample'),
   },
+  {
+    key: 'TurboCxxModuleExample',
+    category: 'Basic',
+    module: require('../examples/TurboModule/TurboCxxModuleExample'),
+  },
   // Basic check to detect the availability of the IntersectionObserver API.
   // $FlowExpectedError[cannot-resolve-name]
   ...(typeof IntersectionObserver === 'function'

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -332,6 +332,10 @@ const APIs: Array<RNTesterModuleInfo> = ([
     module: require('../examples/TurboModule/LegacyModuleExample'),
   },
   {
+    key: 'TurboCxxModuleExample',
+    module: require('../examples/TurboModule/TurboCxxModuleExample'),
+  },
+  {
     key: 'VibrationExample',
     module: require('../examples/Vibration/VibrationExample'),
   },


### PR DESCRIPTION
Summary:
## Changelog:
[General] [Fixed] - Bring back C++ Turbo Module example in RN Tester

The `TurboCxxModuleExample` was accidentally deleted in https://github.com/facebook/react-native/pull/54544 (D87082461) which removed the TurboCxxModule C++ class. The JS example file and its RN Tester registrations should have been kept since they wrap `NativeCxxModuleExampleExample` which still exists.

This restores:
- `TurboCxxModuleExample.js` example file
- RNTesterList entries for iOS, Android, macOS, and Windows

Differential Revision: D95653981


