### PR TITLE
Update file paths to use rootProject reference

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,7 +116,7 @@ var hermesSubstitution: Pair<String, String>? = null
 if (project.findProperty("react.internal.useHermesStable")?.toString()?.toBoolean() == true) {
   val hermesVersions = java.util.Properties()
   val hermesVersionPropertiesFile =
-      File("./packages/react-native/sdks/hermes-engine/version.properties")
+      rootProject.file("./packages/react-native/sdks/hermes-engine/version.properties")
   hermesVersionPropertiesFile.inputStream().use { hermesVersions.load(it) }
   val selectedHermesVersion = hermesVersions["HERMES_V1_VERSION_NAME"] as String
 
@@ -124,7 +124,7 @@ if (project.findProperty("react.internal.useHermesStable")?.toString()?.toBoolea
 } else if (
     project.findProperty("react.internal.useHermesNightly")?.toString()?.toBoolean() == true
 ) {
-  val reactNativePackageJson = File("./packages/react-native/package.json")
+  val reactNativePackageJson = rootProject.file("./packages/react-native/package.json")
   val reactNativePackageJsonContent = reactNativePackageJson.readText()
   val packageJson = groovy.json.JsonSlurper().parseText(reactNativePackageJsonContent) as Map<*, *>
 


### PR DESCRIPTION
## Summary:
A recent commit created a regression in what can be done with `build.gradle.kts` by what looks like non intentional usage of File() over rootProject.file(). 

It is very useful for out-of-tree platforms (such as my react native for unreal engine) to be able to wrap this build gradle file, and using File() breaks things because it breaks lookup in that use case.

This PR fixes this unintentional regression by using `rootProject.file`, as it is used elsewhere in this file.

## Changelog:

Changed `File()` to `rootProject.file()` in lines introduced by new commit (https://github.com/facebook/react-native/commit/076e6a1d53467ca1ff00399971bb333477abcc48)

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Fix build regression by using rootProject.file

## Test Plan:

Build project as usual.