### PR TITLE
Fix Crash When Measuring Text in Stopped Surface

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -27,7 +27,6 @@ import android.view.accessibility.AccessibilityEvent;
 import androidx.annotation.AnyThread;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
-import androidx.core.util.Preconditions;
 import androidx.core.view.ViewCompat.FocusDirection;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
@@ -537,7 +536,7 @@ public class FabricUIManager
 
     return (NativeArray)
         TextLayoutManager.measureLines(
-            mReactApplicationContext,
+            mReactApplicationContext.getAssets(),
             attributedString,
             paragraphAttributes,
             PixelUtil.toPixelFromDIP(width),
@@ -611,7 +610,6 @@ public class FabricUIManager
   @ThreadConfined(ANY)
   @UnstableReactNativeAPI
   public long measureText(
-      int surfaceId,
       ReadableMapBuffer attributedString,
       ReadableMapBuffer paragraphAttributes,
       float minWidth,
@@ -620,24 +618,10 @@ public class FabricUIManager
       float maxHeight,
       @Nullable float[] attachmentsPositions) {
 
-    ReactContext context;
-    if (surfaceId > 0) {
-      SurfaceMountingManager surfaceMountingManager =
-          mMountingManager.getSurfaceManagerEnforced(surfaceId, "measureText");
-      if (surfaceMountingManager.isStopped()) {
-        return 0;
-      }
-      context = surfaceMountingManager.getContext();
-      Assertions.assertNotNull(
-          context, "Context in SurfaceMountingManager is null. surfaceId: " + surfaceId);
-    } else {
-      context = mReactApplicationContext;
-    }
-
     ViewManager textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
 
     return TextLayoutManager.measureText(
-        context,
+        mReactApplicationContext.getAssets(),
         attributedString,
         paragraphAttributes,
         getYogaSize(minWidth, maxWidth),
@@ -654,19 +638,16 @@ public class FabricUIManager
   @ThreadConfined(ANY)
   @UnstableReactNativeAPI
   public PreparedLayout prepareTextLayout(
-      int surfaceId,
       ReadableMapBuffer attributedString,
       ReadableMapBuffer paragraphAttributes,
       float minWidth,
       float maxWidth,
       float minHeight,
       float maxHeight) {
-    SurfaceMountingManager surfaceMountingManager =
-        mMountingManager.getSurfaceManagerEnforced(surfaceId, "prepareTextLayout");
     ViewManager textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
 
     return TextLayoutManager.createPreparedLayout(
-        Preconditions.checkNotNull(surfaceMountingManager.getContext()),
+        mReactApplicationContext.getAssets(),
         attributedString,
         paragraphAttributes,
         getYogaSize(minWidth, maxWidth),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.kt
@@ -7,10 +7,10 @@
 
 package com.facebook.react.views.text
 
-import android.content.Context
 import android.graphics.Rect
 import android.text.Layout
 import android.text.TextPaint
+import android.util.DisplayMetrics
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.buildReadableMap
@@ -22,8 +22,7 @@ internal object FontMetricsUtil {
   private const val AMPLIFICATION_FACTOR = 100f
 
   @JvmStatic
-  fun getFontMetrics(text: CharSequence, layout: Layout, context: Context): WritableArray {
-    val dm = context.resources.displayMetrics
+  fun getFontMetrics(text: CharSequence, layout: Layout, dm: DisplayMetrics): WritableArray {
     val lines = Arguments.createArray()
 
     // To calculate xHeight and capHeight we have to render an "x" and "T" and manually measure

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
@@ -157,7 +157,7 @@ public constructor(
         state.getMapBuffer(TX_STATE_KEY_PARAGRAPH_ATTRIBUTES.toInt())
     val spanned: Spannable =
         TextLayoutManager.getOrCreateSpannableForText(
-            view.context,
+            view.context.assets,
             attributedString,
             reactTextViewManagerCallback,
         )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -7,7 +7,7 @@
 
 package com.facebook.react.views.text
 
-import android.content.Context
+import android.content.res.AssetManager
 import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Build
@@ -31,6 +31,7 @@ import com.facebook.react.common.ReactConstants
 import com.facebook.react.common.mapbuffer.MapBuffer
 import com.facebook.react.common.mapbuffer.ReadableMapBuffer
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.PixelUtil.pxToDp
@@ -217,7 +218,7 @@ internal object TextLayoutManager {
   }
 
   private fun buildSpannableFromFragments(
-      context: Context,
+      assets: AssetManager,
       fragments: MapBuffer,
       sb: SpannableStringBuilder,
       ops: MutableList<SetSpanOperation>,
@@ -296,7 +297,7 @@ internal object TextLayoutManager {
                       textAttributes.fontWeight,
                       textAttributes.fontFeatureSettings,
                       textAttributes.fontFamily,
-                      context.assets,
+                      assets,
                   ),
               )
           )
@@ -352,7 +353,7 @@ internal object TextLayoutManager {
   )
 
   private fun buildSpannableFromFragmentsOptimized(
-      context: Context,
+      assets: AssetManager,
       fragments: MapBuffer,
       outputReactTags: IntArray?,
   ): Spannable {
@@ -472,7 +473,7 @@ internal object TextLayoutManager {
                   fragment.props.fontWeight,
                   fragment.props.fontFeatureSettings,
                   fragment.props.fontFamily,
-                  context.assets,
+                  assets,
               ),
               start,
               end,
@@ -528,7 +529,7 @@ internal object TextLayoutManager {
   }
 
   fun getOrCreateSpannableForText(
-      context: Context,
+      assets: AssetManager,
       attributedString: MapBuffer,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
   ): Spannable {
@@ -539,7 +540,7 @@ internal object TextLayoutManager {
     } else {
       text =
           createSpannableFromAttributedString(
-              context,
+              assets,
               attributedString.getMapBuffer(AS_KEY_FRAGMENTS),
               reactTextViewManagerCallback,
               null,
@@ -550,13 +551,13 @@ internal object TextLayoutManager {
   }
 
   private fun createSpannableFromAttributedString(
-      context: Context,
+      assets: AssetManager,
       fragments: MapBuffer,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
       outputReactTags: IntArray?,
   ): Spannable {
     if (ReactNativeFeatureFlags.enableAndroidTextMeasurementOptimizations()) {
-      val spannable = buildSpannableFromFragmentsOptimized(context, fragments, outputReactTags)
+      val spannable = buildSpannableFromFragmentsOptimized(assets, fragments, outputReactTags)
 
       reactTextViewManagerCallback?.onPostProcessSpannable(spannable)
       return spannable
@@ -568,7 +569,7 @@ internal object TextLayoutManager {
       // a new spannable will be wiped out
       val ops: MutableList<SetSpanOperation> = ArrayList()
 
-      buildSpannableFromFragments(context, fragments, sb, ops, outputReactTags)
+      buildSpannableFromFragments(assets, fragments, sb, ops, outputReactTags)
 
       // TODO T31905686: add support for inline Images
       // While setting the Spans on the final text, we also check whether any of them are images.
@@ -740,7 +741,7 @@ internal object TextLayoutManager {
   private fun updateTextPaint(
       paint: TextPaint,
       baseTextAttributes: TextAttributeProps,
-      context: Context,
+      assets: AssetManager,
   ) {
     if (baseTextAttributes.fontSize != ReactConstants.UNSET) {
       paint.textSize = baseTextAttributes.fontSize.toFloat()
@@ -757,7 +758,7 @@ internal object TextLayoutManager {
               baseTextAttributes.fontStyle,
               baseTextAttributes.fontWeight,
               baseTextAttributes.fontFamily,
-              context.assets,
+              assets,
           )
       paint.setTypeface(typeface)
 
@@ -779,28 +780,28 @@ internal object TextLayoutManager {
    */
   private fun scratchPaintWithAttributes(
       baseTextAttributes: TextAttributeProps,
-      context: Context,
+      assets: AssetManager,
   ): TextPaint {
     val paint = checkNotNull(textPaintInstance.get())
     paint.setTypeface(null)
     paint.textSize = 12f
     paint.isFakeBoldText = false
     paint.textSkewX = 0f
-    updateTextPaint(paint, baseTextAttributes, context)
+    updateTextPaint(paint, baseTextAttributes, assets)
     return paint
   }
 
   private fun newPaintWithAttributes(
       baseTextAttributes: TextAttributeProps,
-      context: Context,
+      assets: AssetManager,
   ): TextPaint {
     val paint = TextPaint(TextPaint.ANTI_ALIAS_FLAG)
-    updateTextPaint(paint, baseTextAttributes, context)
+    updateTextPaint(paint, baseTextAttributes, assets)
     return paint
   }
 
   private fun createLayoutForMeasurement(
-      context: Context,
+      assets: AssetManager,
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
@@ -809,7 +810,7 @@ internal object TextLayoutManager {
       heightYogaMeasureMode: YogaMeasureMode,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
   ): Layout {
-    val text = getOrCreateSpannableForText(context, attributedString, reactTextViewManagerCallback)
+    val text = getOrCreateSpannableForText(assets, attributedString, reactTextViewManagerCallback)
 
     val paint: TextPaint
     if (attributedString.contains(AS_KEY_CACHE_ID)) {
@@ -817,7 +818,7 @@ internal object TextLayoutManager {
     } else {
       val baseTextAttributes =
           TextAttributeProps.fromMapBuffer(attributedString.getMapBuffer(AS_KEY_BASE_ATTRIBUTES))
-      paint = scratchPaintWithAttributes(baseTextAttributes, context)
+      paint = scratchPaintWithAttributes(baseTextAttributes, assets)
     }
 
     return createLayout(
@@ -922,7 +923,7 @@ internal object TextLayoutManager {
 
   @JvmStatic
   fun createPreparedLayout(
-      context: Context,
+      assets: AssetManager,
       attributedString: ReadableMapBuffer,
       paragraphAttributes: ReadableMapBuffer,
       width: Float,
@@ -935,7 +936,7 @@ internal object TextLayoutManager {
     val reactTags = IntArray(fragments.count)
     val text =
         createSpannableFromAttributedString(
-            context,
+            assets,
             fragments,
             reactTextViewManagerCallback,
             reactTags,
@@ -945,7 +946,7 @@ internal object TextLayoutManager {
     val result =
         createLayout(
             text,
-            newPaintWithAttributes(baseTextAttributes, context),
+            newPaintWithAttributes(baseTextAttributes, assets),
             attributedString,
             paragraphAttributes,
             width,
@@ -1085,7 +1086,7 @@ internal object TextLayoutManager {
 
   @JvmStatic
   fun measureText(
-      context: Context,
+      assets: AssetManager,
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
@@ -1098,7 +1099,7 @@ internal object TextLayoutManager {
     // TODO(5578671): Handle text direction (see View#getTextDirectionHeuristic)
     val layout =
         createLayoutForMeasurement(
-            context,
+            assets,
             attributedString,
             paragraphAttributes,
             width,
@@ -1355,7 +1356,7 @@ internal object TextLayoutManager {
 
   @JvmStatic
   fun measureLines(
-      context: Context,
+      assetManager: AssetManager,
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
@@ -1364,7 +1365,7 @@ internal object TextLayoutManager {
   ): WritableArray {
     val layout =
         createLayoutForMeasurement(
-            context,
+            assetManager,
             attributedString,
             paragraphAttributes,
             width,
@@ -1373,7 +1374,11 @@ internal object TextLayoutManager {
             YogaMeasureMode.EXACTLY,
             reactTextViewManagerCallback,
         )
-    return FontMetricsUtil.getFontMetrics(layout.text, layout, context)
+    return FontMetricsUtil.getFontMetrics(
+        layout.text,
+        layout,
+        DisplayMetricsHolder.getWindowDisplayMetrics(),
+    )
   }
 
   private fun isBoring(text: Spannable, paint: TextPaint): BoringLayout.Metrics? =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -1015,7 +1015,7 @@ public open class ReactTextInputManager public constructor() :
 
     val spanned =
         TextLayoutManager.getOrCreateSpannableForText(
-            view.context,
+            view.context.assets,
             attributedString,
             reactTextViewManagerCallback,
         )

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -41,7 +41,6 @@ int countAttachments(const AttributedString& attributedString) {
 
 Size measureText(
     const std::shared_ptr<const ContextContainer>& contextContainer,
-    Tag rootTag,
     MapBuffer attributedString,
     MapBuffer paragraphAttributes,
     float minWidth,
@@ -55,7 +54,6 @@ Size measureText(
   static auto measure =
       jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
           ->getMethod<jlong(
-              jint,
               JReadableMapBuffer::javaobject,
               JReadableMapBuffer::javaobject,
               jfloat,
@@ -71,7 +69,6 @@ Size measureText(
 
   return yogaMeassureToSize(measure(
       fabricUIManager,
-      rootTag,
       attributedStringBuffer.get(),
       paragraphAttributesBuffer.get(),
       minWidth,
@@ -105,7 +102,6 @@ TextMeasurement doMeasure(
 
   auto size = measureText(
       contextContainer,
-      layoutContext.surfaceId,
       std::move(attributedStringMap),
       std::move(paragraphAttributesMap),
       minimumSize.width,
@@ -221,7 +217,6 @@ TextMeasurement TextLayoutManager::measureCachedSpannableById(
 
   auto size = measureText(
       contextContainer_,
-      layoutContext.surfaceId,
       localDataBuilder.build(),
       toMapBuffer(paragraphAttributes),
       minimumSize.width,
@@ -304,7 +299,6 @@ TextLayoutManager::PreparedTextLayout TextLayoutManager::prepareLayout(
   static auto prepareTextLayout =
       jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
           ->getMethod<JPreparedLayout::javaobject(
-              jint,
               JReadableMapBuffer::javaobject,
               JReadableMapBuffer::javaobject,
               jfloat,
@@ -335,7 +329,6 @@ TextLayoutManager::PreparedTextLayout TextLayoutManager::prepareLayout(
 
         return PreparedTextLayout{jni::make_global(prepareTextLayout(
             fabricUIManager,
-            layoutContext.surfaceId,
             attributedStringMB.get(),
             paragraphAttributesMB.get(),
             minimumSize.width,


### PR DESCRIPTION
Summary:
`FabricUIManager.prepareTextLayout()` crashes when measuring text for a surface that has already been stopped. It looks up the surface's `ThemedReactContext` via `surfaceMountingManager.getContext()`, which returns `null` after `stopSurface()` completes.

The only thing the `Context` is used for downstream is `context.assets` (the `AssetManager`) for custom font resolution. Since `AssetManager` from the application context is equivalent for this purpose (fonts are app-global, not activity-specific), we refactor the API to pass `AssetManager` directly from `mReactApplicationContext`, eliminating the surface lookup entirely.

This also makes the API clearer: the prepared layout does not depend on activity context (e.g. for light/dark theme).

Changelog: [Android][Fixed] - Fix crash when measuring text in a stopped surface

Differential Revision: D95763252


