### PR TITLE
Add option to force all codegen output into the provided directory

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateNativeCode.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateNativeCode.js
@@ -22,9 +22,16 @@ function generateNativeCode(
   schemaInfos /*: $ReadOnlyArray<$FlowFixMe> */,
   includesGeneratedCode /*: boolean */,
   platform /*: string */,
+  forceOutputPath /*: boolean */ = false,
 ) /*: Array<void> */ {
   return schemaInfos.map(schemaInfo => {
-    generateCode(outputPath, schemaInfo, includesGeneratedCode, platform);
+    generateCode(
+      outputPath,
+      schemaInfo,
+      includesGeneratedCode,
+      platform,
+      forceOutputPath,
+    );
   });
 }
 
@@ -33,6 +40,7 @@ function generateCode(
   schemaInfo /*: $FlowFixMe */,
   includesGeneratedCode /*: boolean */,
   platform /*: string */,
+  forceOutputPath /*: boolean */ = false,
 ) {
   if (shouldSkipGenerationForFBReactNativeSpec(schemaInfo, platform)) {
     codegenLog(
@@ -60,8 +68,9 @@ function generateCode(
   );
 
   // Finally, copy artifacts to the final output directory.
-  const outputDir =
-    reactNativeCoreLibraryOutputPath(libraryName, platform) ?? outputPath;
+  const outputDir = forceOutputPath
+    ? outputPath
+    : (reactNativeCoreLibraryOutputPath(libraryName, platform) ?? outputPath);
   fs.mkdirSync(outputDir, {recursive: true});
   cpSyncRecursiveIfChanged(tmpOutputDir, outputDir);
   codegenLog(`Generated artifacts: ${outputDir}`);

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
@@ -66,6 +66,7 @@ function execute(
   optionalBaseOutputPath /*: ?string */,
   source /*: string */,
   runReactNativeCodegen /*: boolean */ = true,
+  forceOutputPath /*: boolean */ = false,
 ) {
   try {
     codegenLog(`Analyzing ${path.join(projectRoot, 'package.json')}`);
@@ -146,6 +147,7 @@ function execute(
           ),
           pkgJsonIncludesGeneratedCode(pkgJson),
           platform,
+          forceOutputPath,
         );
       }
 

--- a/packages/react-native/scripts/generate-codegen-artifacts.js
+++ b/packages/react-native/scripts/generate-codegen-artifacts.js
@@ -31,8 +31,26 @@ const argv = yargs
     description: 'Whether the script is invoked from an `app` or a `library`',
     default: 'app',
   })
+  .option('f', {
+    alias: 'forceOutputPath',
+    description:
+      'Whether to force React Native Core artifacts to output to the specified path',
+    type: 'boolean',
+    default: false,
+  })
   .usage('Usage: $0 -p [path to app] -t [target platform] -o [output path]')
   .demandOption(['p', 't']).argv;
 
-// $FlowFixMe[prop-missing]
-executor.execute(argv.path, argv.targetPlatform, argv.outputPath, argv.source);
+executor.execute(
+  // $FlowFixMe[prop-missing]
+  argv.path,
+  // $FlowFixMe[prop-missing]
+  argv.targetPlatform,
+  // $FlowFixMe[prop-missing]
+  argv.outputPath,
+  // $FlowFixMe[prop-missing]
+  argv.source,
+  true, // runReactNativeCodegen
+  // $FlowFixMe[prop-missing]
+  argv.forceOutputPath,
+);


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a new, optional, flag to the `generate-codegen-artifacts` script, which forces React Native Core artifacts to be generated in the output path set from the CLI instead of inside React Native.

This will allow the C++ API snapshot generator to get entire codegen output for a given platform in a single place.

Differential Revision: D95788767


