### PR TITLE
Add two-phase @@symbol → [Symbol.*] transform for TS type generation

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -17,6 +17,7 @@ const {
   getBuildOptions,
   getTypeScriptCompilerOptions,
 } = require('./config');
+const translateFlowToTSDef = require('./translateFlowToTSDef');
 const babel = require('@babel/core');
 const {spawn} = require('child_process');
 const translate = require('flow-api-translator');
@@ -213,7 +214,7 @@ async function buildFile(
         emitTypeScriptDefs
           ? fs.writeFile(
               buildPath.replace(/\.js$/, '') + '.d.ts',
-              await translate.translateFlowToTSDef(source, prettierConfig),
+              await translateFlowToTSDef(source, prettierConfig),
             )
           : null,
       ]);

--- a/scripts/build/transforms/flow/__tests__/replaceSymbolSyntax-test.js
+++ b/scripts/build/transforms/flow/__tests__/replaceSymbolSyntax-test.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const replaceSymbolSyntax = require('../replaceSymbolSyntax');
+const {parse, print} = require('hermes-transform');
+
+const prettierOptions = {parser: 'babel'};
+
+async function translate(code: string): Promise<string> {
+  const parsed = await parse(code);
+  const result = await replaceSymbolSyntax(parsed);
+  return print(result.ast, result.mutatedCode, prettierOptions);
+}
+
+describe('replaceSymbolSyntax', () => {
+  test('replaces @@iterator in an interface', async () => {
+    const result = await translate(
+      'interface Foo { @@iterator(): Iterator<[string, string]> }',
+    );
+
+    expect(result).toBe(
+      'interface Foo {\n  __iterator(): Iterator<[string, string]>;\n}\n',
+    );
+  });
+
+  test('replaces @@asyncIterator in an interface', async () => {
+    const result = await translate(
+      'interface Foo { @@asyncIterator(): AsyncIterator<string> }',
+    );
+
+    expect(result).toBe(
+      'interface Foo {\n  __asyncIterator(): AsyncIterator<string>;\n}\n',
+    );
+  });
+
+  test('replaces @@dispose in an interface', async () => {
+    const result = await translate('interface Foo { @@dispose(): void }');
+
+    expect(result).toBe('interface Foo {\n  __dispose(): void;\n}\n');
+  });
+
+  test('replaces @@asyncDispose in an interface', async () => {
+    const result = await translate(
+      'interface Foo { @@asyncDispose(): Promise<void> }',
+    );
+
+    expect(result).toBe(
+      'interface Foo {\n  __asyncDispose(): Promise<void>;\n}\n',
+    );
+  });
+
+  test('replaces @@iterator in a declare class', async () => {
+    const result = await translate(
+      'declare class Foo { @@iterator(): Iterator<[string, string]> }',
+    );
+
+    expect(result).toBe(
+      'declare class Foo {\n  __iterator(): Iterator<[string, string]>;\n}\n',
+    );
+  });
+
+  test('replaces @@iterator in a type alias', async () => {
+    const result = await translate(
+      'type Foo = { @@iterator(): Iterator<[string, string]> }',
+    );
+
+    expect(result).toBe(
+      'type Foo = { __iterator(): Iterator<[string, string]> };\n',
+    );
+  });
+
+  test('does not replace @@iterator when it is not a method', async () => {
+    const result = await translate(
+      'type Foo = { @@iterator: () => Iterator<[string, string]> }',
+    );
+
+    expect(result).toBe(
+      'type Foo = { @@iterator: () => Iterator<[string, string]> };\n',
+    );
+  });
+});

--- a/scripts/build/transforms/flow/replaceSymbolSyntax.js
+++ b/scripts/build/transforms/flow/replaceSymbolSyntax.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {TransformVisitor} from 'hermes-transform';
+import type {ParseResult} from 'hermes-transform/dist/transform/parse';
+import type {TransformASTResult} from 'hermes-transform/dist/transform/transformAST';
+
+const {transformAST} = require('hermes-transform/dist/transform/transformAST');
+
+const symbolReplacements: {[string]: string} = {
+  '@@iterator': '__iterator',
+  '@@asyncIterator': '__asyncIterator',
+  '@@dispose': '__dispose',
+  '@@asyncDispose': '__asyncDispose',
+};
+
+const visitors: TransformVisitor = context => ({
+  Identifier(node): void {
+    const replacement = symbolReplacements[node.name];
+
+    if (
+      replacement != null &&
+      node.parent.type === 'ObjectTypeProperty' &&
+      node.parent.method
+    ) {
+      context.modifyNodeInPlace(node, {name: replacement});
+    }
+  },
+});
+
+/**
+ * Replaces Flow @@symbol syntax (e.g. @@iterator) with __symbol prefixed
+ * identifiers (e.g. __iterator).
+ *
+ * This is the first phase of a two-phase transform. Flow uses @@symbol
+ * syntax to represent well-known symbols, but this syntax is not valid in
+ * TypeScript. Since flow-api-translator doesn't understand @@symbol syntax
+ * either, we first rewrite them to __symbol identifiers that survive the
+ * translation pass. A second transform (transforms/typescript/replaceSymbolSyntax)
+ * then converts __symbol to the final [Symbol.*] computed property syntax.
+ */
+async function replaceSymbolSyntax(
+  source: ParseResult,
+): Promise<TransformASTResult> {
+  return transformAST(source, visitors);
+}
+
+module.exports = replaceSymbolSyntax;

--- a/scripts/build/transforms/typescript/__tests__/replaceSymbolSyntax-test.js
+++ b/scripts/build/transforms/typescript/__tests__/replaceSymbolSyntax-test.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const replaceSymbolSyntax = require('../replaceSymbolSyntax');
+const babel = require('@babel/core');
+
+async function translate(code: string): Promise<string> {
+  const result = await babel.transformAsync(code, {
+    plugins: ['@babel/plugin-syntax-typescript', replaceSymbolSyntax],
+  });
+
+  return result.code;
+}
+
+describe('replaceSymbolSyntax', () => {
+  test('replaces __iterator in an interface', async () => {
+    const result = await translate(
+      'interface Foo { __iterator(): Iterator<[string, string]> }',
+    );
+
+    expect(result).toBe(
+      'interface Foo {\n  [Symbol.iterator](): Iterator<[string, string]>;\n}',
+    );
+  });
+
+  test('replaces __asyncIterator in an interface', async () => {
+    const result = await translate(
+      'interface Foo { __asyncIterator(): AsyncIterator<string> }',
+    );
+
+    expect(result).toBe(
+      'interface Foo {\n  [Symbol.asyncIterator](): AsyncIterator<string>;\n}',
+    );
+  });
+
+  test('replaces __dispose in an interface', async () => {
+    const result = await translate('interface Foo { __dispose(): void }');
+
+    expect(result).toBe(
+      'interface Foo {\n  [Symbol.dispose](): void;\n}',
+    );
+  });
+
+  test('replaces __asyncDispose in an interface', async () => {
+    const result = await translate(
+      'interface Foo { __asyncDispose(): Promise<void> }',
+    );
+
+    expect(result).toBe(
+      'interface Foo {\n  [Symbol.asyncDispose](): Promise<void>;\n}',
+    );
+  });
+
+  test('replaces __iterator in a declare class', async () => {
+    const result = await translate(
+      'declare class Foo { __iterator(): Iterator<[string, string]> }',
+    );
+
+    expect(result).toBe(
+      'declare class Foo {\n  __iterator(): Iterator<[string, string]>;\n}',
+    );
+  });
+
+  test('replaces __iterator in a type alias', async () => {
+    const result = await translate(
+      'type Foo = { __iterator(): Iterator<[string, string]> }',
+    );
+
+    expect(result).toBe(
+      'type Foo = {\n  [Symbol.iterator](): Iterator<[string, string]>;\n};',
+    );
+  });
+
+  test('does not replace __iterator when it is not a method', async () => {
+    const result = await translate(
+      'interface Foo { __iterator: () => Iterator<[string, string]> }',
+    );
+
+    expect(result).toBe(
+      'interface Foo {\n  __iterator: () => Iterator<[string, string]>;\n}',
+    );
+  });
+});

--- a/scripts/build/transforms/typescript/replaceSymbolSyntax.js
+++ b/scripts/build/transforms/typescript/replaceSymbolSyntax.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {PluginObj} from '@babel/core';
+
+const symbolReplacements: {[string]: string} = {
+  __iterator: 'iterator',
+  __asyncIterator: 'asyncIterator',
+  __dispose: 'dispose',
+  __asyncDispose: 'asyncDispose',
+};
+
+/**
+ * Replaces __symbol prefixed method identifiers (e.g. __iterator) with
+ * computed [Symbol.*] syntax (e.g. [Symbol.iterator]) in TypeScript
+ * definitions.
+ *
+ * This is the second phase of a two-phase transform. Flow uses @@symbol
+ * syntax (e.g. @@iterator) to represent well-known symbols, but this syntax
+ * is not valid in TypeScript. Since flow-api-translator doesn't understand
+ * @@symbol syntax either, we split the conversion into two steps:
+ *
+ * 1. Pre-translation (Flow → Flow): replaceSymbolSyntax in transforms/flow
+ *    rewrites @@symbol to __symbol identifiers, which are valid Flow
+ *    identifiers that survive the flow-api-translator pass.
+ * 2. Post-translation (TS → TS): this transform rewrites __symbol identifiers
+ *    to computed [Symbol.*] properties, which is the correct TypeScript syntax.
+ */
+const replaceSymbolSyntax: PluginObj<unknown> = {
+  visitor: {
+    TSMethodSignature(path) {
+      const {key} = path.node;
+
+      if (key.type === 'Identifier') {
+        const replacement = symbolReplacements[key.name];
+
+        if (replacement != null) {
+          // $FlowFixMe[incompatible-type]
+          path.replaceWith({
+            ...path.node,
+            computed: true,
+            key: {
+              type: 'MemberExpression',
+              object: {type: 'Identifier', name: 'Symbol'},
+              property: {type: 'Identifier', name: replacement},
+              computed: false,
+            },
+          });
+        }
+      }
+    },
+  },
+};
+
+module.exports = replaceSymbolSyntax;

--- a/scripts/build/translateFlowToTSDef.js
+++ b/scripts/build/translateFlowToTSDef.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {ParseResult} from 'hermes-transform/dist/transform/parse';
+import type {TransformASTResult} from 'hermes-transform/dist/transform/transformAST';
+
+const applyBabelTransformsSeq = require('./utils/applyBabelTransformsSeq');
+const translate = require('flow-api-translator');
+const {parse, print} = require('hermes-transform');
+
+type PreTransformFn = ParseResult => Promise<TransformASTResult>;
+
+const preTransforms: Array<PreTransformFn> = [
+  require('./transforms/flow/replaceSymbolSyntax'),
+];
+const postTransforms = [require('./transforms/typescript/replaceSymbolSyntax')];
+
+/**
+ * Translate the public API of a Flow source file to TypeScript definition.
+ *
+ * This uses [flow-api-translator](https://www.npmjs.com/package/flow-api-translator),
+ * and applies extra transformations such as stripping private properties.
+ */
+async function translateFlowToTSDef(
+  source: string,
+  prettierOptions: {...},
+): Promise<string> {
+  // Parse Flow source
+  const parsed = await parse(source);
+
+  // Apply pre-transforms
+  const preTransformResult = await applyPreTransforms(parsed, prettierOptions);
+
+  // Translate to Flow defs (prunes non-type imports)
+  const flowDefResult = await translate.translateFlowToFlowDef(
+    preTransformResult.code,
+    prettierOptions,
+  );
+
+  // Translate to TypeScript defs
+  const tsDefResult = await translate.translateFlowDefToTSDef(
+    flowDefResult,
+    prettierOptions,
+  );
+
+  // Apply post-transforms
+  const result = await applyBabelTransformsSeq(tsDefResult, postTransforms);
+
+  return result;
+}
+
+async function applyPreTransforms(
+  source: ParseResult,
+  prettierOptions: {...},
+): Promise<ParseResult> {
+  return preTransforms.reduce((input, transform) => {
+    return input.then(async result => {
+      const transformed = await transform(result);
+      const code = transformed.astWasMutated
+        ? await print(transformed.ast, transformed.mutatedCode, prettierOptions)
+        : transformed.mutatedCode;
+      return parse(code);
+    });
+  }, Promise.resolve(source));
+}
+
+module.exports = translateFlowToTSDef;

--- a/scripts/build/utils/applyBabelTransformsSeq.js
+++ b/scripts/build/utils/applyBabelTransformsSeq.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {PluginObj} from '@babel/core';
+
+import * as babel from '@babel/core';
+
+/**
+ * Apply an array of Babel transforms to a TypeScript source in order.
+ */
+async function applyBabelTransformsSeq(
+  source: string,
+  transforms: ReadonlyArray<PluginObj<unknown>>,
+): Promise<string> {
+  const parsed = await babel.parseAsync(source, {
+    plugins: ['@babel/plugin-syntax-typescript'],
+  });
+
+  const finalAST = await transforms.reduce((input, transform) => {
+    return input.then(async ast => {
+      const result = await babel.transformFromAstAsync(ast, source, {
+        plugins: [transform],
+        ast: true,
+        code: false,
+      });
+      if (result == null) {
+        throw new Error('Unexpected null result from Babel transform');
+      }
+      // $FlowFixMe[incompatible-type]
+      return result.ast as BabelNodeFile;
+    });
+  }, Promise.resolve(parsed));
+
+  const result = await babel.transformFromAstAsync(finalAST, source, {
+    code: true,
+    ast: false,
+  });
+
+  return result.code;
+}
+
+module.exports = applyBabelTransformsSeq;


### PR DESCRIPTION
## Summary:

Flow uses `@@symbol` syntax (e.g. `@@iterator`, `@@asyncIterator`, `@@dispose`, `@@asyncDispose`) to represent well-known symbols in type definitions. This syntax is neither valid TypeScript nor understood by `flow-api-translator`, so it was previously dropped during the Flow → TypeScript definition generation.

This PR adds a two-phase transform pipeline to `translateFlowToTSDef` that correctly converts these symbols:

1. **Pre-translation** (Flow → Flow): Rewrites `@@symbol` to `__symbol` identifiers (e.g. `@@iterator` → `__iterator`), which are valid Flow identifiers that survive the `flow-api-translator` pass.
2. **Post-translation** (TS → TS): Rewrites `__symbol` method signatures to computed `[Symbol.*]` properties (e.g. `__iterator` → `[Symbol.iterator]`), which is the correct TypeScript syntax.

This enables generated `.d.ts` files to correctly expose well-known symbol methods like `[Symbol.iterator]()`.

## Changelog:

[GENERAL] [ADDED] - Add well-known symbol support (`@@iterator`, `@@asyncIterator`, `@@dispose`, `@@asyncDispose`) to generated TypeScript definitions

## Test Plan:

Added unit tests for both transforms covering:
- All four symbol types (`iterator`, `asyncIterator`, `dispose`, `asyncDispose`)
- Multiple declaration forms (`interface`, `declare class`, `type` alias)
- Negative case: symbol as a non-method property is left untouched

```sh
yarn jest scripts/build/transforms/flow/__tests__/replaceSymbolSyntax-test.js scripts/build/transforms/typescript/__tests__/replaceSymbolSyntax-test.js --no-coverage
```

```
PASS scripts/build/transforms/flow/__tests__/replaceSymbolSyntax-test.js (7 tests)
PASS scripts/build/transforms/typescript/__tests__/replaceSymbolSyntax-test.js (7 tests)

Test Suites: 2 passed, 2 total
Tests:       14 passed, 14 total
```
