### PR TITLE
Add ArrayBuffer and Uint8Array support to C++ TurboModules

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -238,7 +238,7 @@ export type CommandParamTypeAnnotation =
 
 export interface ReservedTypeAnnotation {
   readonly type: 'ReservedTypeAnnotation';
-  readonly name: 'RootTag'; // Union with more custom types.
+  readonly name: 'RootTag' | 'ArrayBuffer' | 'Uint8Array'; // Union with more custom types.
 }
 
 /**

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -259,7 +259,7 @@ export type CommandParamTypeAnnotation =
 
 export type ReservedTypeAnnotation = Readonly<{
   type: 'ReservedTypeAnnotation',
-  name: 'RootTag', // Union with more custom types.
+  name: 'RootTag' | 'ArrayBuffer' | 'Uint8Array', // Union with more custom types.
 }>;
 
 /**

--- a/packages/react-native-codegen/src/generators/components/GenerateComponentHObjCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateComponentHObjCpp.js
@@ -157,6 +157,11 @@ function getObjCParamType(param: Param): string {
       switch (typeAnnotation.name) {
         case 'RootTag':
           return 'double';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
@@ -187,6 +192,11 @@ function getObjCExpectedKindParamType(param: Param): string {
       switch (typeAnnotation.name) {
         case 'RootTag':
           return '[NSNumber class]';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
@@ -217,6 +227,11 @@ function getReadableExpectedKindParamType(param: Param): string {
       switch (typeAnnotation.name) {
         case 'RootTag':
           return 'double';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
@@ -250,6 +265,11 @@ function getObjCRightHandAssignmentParamType(
       switch (typeAnnotation.name) {
         case 'RootTag':
           return `[(NSNumber *)arg${index} doubleValue]`;
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
@@ -189,6 +189,11 @@ function getCommandArgJavaType(
       switch (typeAnnotation.name) {
         case 'RootTag':
           return `args.getDouble(${index})`;
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaInterface.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaInterface.js
@@ -157,6 +157,11 @@ function getCommandArgJavaType(param: NamedShape<CommandParamTypeAnnotation>) {
       switch (typeAnnotation.name) {
         case 'RootTag':
           return 'double';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -87,6 +87,10 @@ function serializeArg(
       switch (realTypeAnnotation.name) {
         case 'RootTag':
           return wrap(val => `${val}.asNumber()`);
+        case 'ArrayBuffer':
+          return wrap(val => `${val}.asObject(rt).getArrayBuffer(rt)`);
+        case 'Uint8Array':
+          return wrap(val => `${val}.asObject(rt)`);
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(
@@ -248,6 +252,10 @@ function translatePrimitiveJSTypeToCpp(
       switch (realTypeAnnotation.name) {
         case 'RootTag':
           return wrapOptional('double', isRequired);
+        case 'ArrayBuffer':
+          return wrapOptional('jsi::ArrayBuffer', isRequired);
+        case 'Uint8Array':
+          return wrapOptional('jsi::Object', isRequired);
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(createErrorMessage(realTypeAnnotation.name));

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -207,6 +207,9 @@ function translateFunctionParamToJavaType(
       switch (realTypeAnnotation.name) {
         case 'RootTag':
           return wrapOptional('double', isRequired);
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(createErrorMessage(realTypeAnnotation.name));
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(createErrorMessage(realTypeAnnotation.name));
@@ -301,6 +304,9 @@ function translateFunctionReturnTypeToJavaType(
       switch (realTypeAnnotation.name) {
         case 'RootTag':
           return wrapOptional('double', isRequired);
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(createErrorMessage(realTypeAnnotation.name));
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(createErrorMessage(realTypeAnnotation.name));
@@ -387,6 +393,9 @@ function getFalsyReturnStatementFromReturnType(
       switch (realTypeAnnotation.name) {
         case 'RootTag':
           return 'return 0.0;';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(createErrorMessage(realTypeAnnotation.name));
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(createErrorMessage(realTypeAnnotation.name));

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -156,6 +156,11 @@ function translateReturnTypeToKind(
       switch (realTypeAnnotation.name) {
         case 'RootTag':
           return 'NumberKind';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${realTypeAnnotation.name}.`,
+          );
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(
@@ -245,6 +250,11 @@ function translateParamTypeToJniType(
       switch (realTypeAnnotation.name) {
         case 'RootTag':
           return !isRequired ? 'Ljava/lang/Double;' : 'D';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${realTypeAnnotation.name}.`,
+          );
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(
@@ -327,6 +337,11 @@ function translateReturnTypeToJniType(
       switch (realTypeAnnotation.name) {
         case 'RootTag':
           return nullable ? 'Ljava/lang/Double;' : 'D';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${realTypeAnnotation.name}.`,
+          );
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
@@ -91,6 +91,11 @@ function toObjCType(
       switch (typeAnnotation.name) {
         case 'RootTag':
           return wrapCxxOptional('double', isRequired);
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Unknown prop type, found: ${typeAnnotation.name}"`);
@@ -177,6 +182,11 @@ function toObjCValue(
       switch (typeAnnotation.name) {
         case 'RootTag':
           return wrapPrimitive('double');
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
@@ -79,6 +79,11 @@ function toObjCType(
       switch (typeAnnotation.name) {
         case 'RootTag':
           return wrapCxxOptional('double', isRequired);
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Unknown prop type, found: ${typeAnnotation.name}"`);
@@ -164,6 +169,11 @@ function toObjCValue(
       switch (typeAnnotation.name) {
         case 'RootTag':
           return RCTBridgingTo('Double');
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -249,6 +249,11 @@ function getParamObjCType(
       switch (structTypeAnnotation.name) {
         case 'RootTag':
           return notStruct(isRequired ? 'double' : 'NSNumber *');
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${structTypeAnnotation.name}.`,
+          );
         default:
           (structTypeAnnotation.name: empty);
           throw new Error(
@@ -329,6 +334,11 @@ function getReturnObjCType(
       switch (typeAnnotation.name) {
         case 'RootTag':
           return wrapOptional('NSNumber *', isRequired);
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
         default:
           (typeAnnotation.name: empty);
           throw new Error(
@@ -412,7 +422,20 @@ function getReturnJSType(
     case 'ArrayTypeAnnotation':
       return 'ArrayKind';
     case 'ReservedTypeAnnotation':
-      return 'NumberKind';
+      switch (typeAnnotation.name) {
+        case 'RootTag':
+          return 'NumberKind';
+        case 'ArrayBuffer':
+        case 'Uint8Array':
+          throw new Error(
+            `ArrayBuffer and Uint8Array are only supported in cxx-only modules. Got ${typeAnnotation.name}.`,
+          );
+        default:
+          (typeAnnotation.name: empty);
+          throw new Error(
+            `Unsupported return type for ${methodName}. Found: ${typeAnnotation.name}`,
+          );
+      }
     case 'StringTypeAnnotation':
       return 'StringKind';
     case 'StringLiteralTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
@@ -2629,6 +2629,48 @@ const CXX_ONLY_NATIVE_MODULES: SchemaType = {
               ],
             },
           },
+          {
+            name: 'getArrayBuffer',
+            optional: false,
+            typeAnnotation: {
+              type: 'FunctionTypeAnnotation',
+              returnTypeAnnotation: {
+                type: 'ReservedTypeAnnotation',
+                name: 'ArrayBuffer',
+              },
+              params: [
+                {
+                  name: 'input',
+                  optional: false,
+                  typeAnnotation: {
+                    type: 'ReservedTypeAnnotation',
+                    name: 'ArrayBuffer',
+                  },
+                },
+              ],
+            },
+          },
+          {
+            name: 'getUint8Array',
+            optional: false,
+            typeAnnotation: {
+              type: 'FunctionTypeAnnotation',
+              returnTypeAnnotation: {
+                type: 'ReservedTypeAnnotation',
+                name: 'Uint8Array',
+              },
+              params: [
+                {
+                  name: 'input',
+                  optional: false,
+                  typeAnnotation: {
+                    type: 'ReservedTypeAnnotation',
+                    name: 'Uint8Array',
+                  },
+                },
+              ],
+            },
+          },
         ],
       },
       moduleName: 'SampleTurboModuleCxx',

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -629,6 +629,8 @@ protected:
     methodMap_[\\"getObjectThrows\\"] = MethodMetadata {.argCount = 1, .invoker = __getObjectThrows};
     methodMap_[\\"voidFuncAssert\\"] = MethodMetadata {.argCount = 0, .invoker = __voidFuncAssert};
     methodMap_[\\"getObjectAssert\\"] = MethodMetadata {.argCount = 1, .invoker = __getObjectAssert};
+    methodMap_[\\"getArrayBuffer\\"] = MethodMetadata {.argCount = 1, .invoker = __getArrayBuffer};
+    methodMap_[\\"getUint8Array\\"] = MethodMetadata {.argCount = 1, .invoker = __getUint8Array};
   }
   
 private:
@@ -845,6 +847,22 @@ private:
       bridging::getParameterCount(&T::getObjectAssert) == 2,
       \\"Expected getObjectAssert(...) to have 2 parameters\\");
     return bridging::callFromJs<jsi::Object>(rt, &T::getObjectAssert,  static_cast<NativeSampleTurboModuleCxxSpec*>(&turboModule)->jsInvoker_, static_cast<T*>(&turboModule),
+      count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asObject(rt));
+  }
+
+  static jsi::Value __getArrayBuffer(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+    static_assert(
+      bridging::getParameterCount(&T::getArrayBuffer) == 2,
+      \\"Expected getArrayBuffer(...) to have 2 parameters\\");
+    return bridging::callFromJs<jsi::ArrayBuffer>(rt, &T::getArrayBuffer,  static_cast<NativeSampleTurboModuleCxxSpec*>(&turboModule)->jsInvoker_, static_cast<T*>(&turboModule),
+      count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asObject(rt).getArrayBuffer(rt));
+  }
+
+  static jsi::Value __getUint8Array(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+    static_assert(
+      bridging::getParameterCount(&T::getUint8Array) == 2,
+      \\"Expected getUint8Array(...) to have 2 parameters\\");
+    return bridging::callFromJs<jsi::Object>(rt, &T::getUint8Array,  static_cast<NativeSampleTurboModuleCxxSpec*>(&turboModule)->jsInvoker_, static_cast<T*>(&turboModule),
       count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asObject(rt));
   }
 };

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -18,6 +18,7 @@ const {MockedParser} = require('../parserMock');
 const {emitUnion} = require('../parsers-primitives');
 const {
   Visitor,
+  emitArrayBuffer,
   emitArrayType,
   emitBoolean,
   emitBoolProp,
@@ -39,6 +40,7 @@ const {
   emitString,
   emitStringish,
   emitStringProp,
+  emitUint8Array,
   emitUnionProp,
   emitVoid,
   typeAliasResolution,
@@ -180,6 +182,58 @@ describe('emitRootTag', () => {
   describe('when nullable is false', () => {
     it('returns non nullable type annotation', () => {
       const result = emitRootTag(false);
+
+      expect(result).toEqual(reservedTypeAnnotation);
+    });
+  });
+});
+
+describe('emitArrayBuffer', () => {
+  const reservedTypeAnnotation = {
+    type: 'ReservedTypeAnnotation',
+    name: 'ArrayBuffer',
+  };
+
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitArrayBuffer(true);
+
+      expect(result).toEqual({
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: reservedTypeAnnotation,
+      });
+    });
+  });
+
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitArrayBuffer(false);
+
+      expect(result).toEqual(reservedTypeAnnotation);
+    });
+  });
+});
+
+describe('emitUint8Array', () => {
+  const reservedTypeAnnotation = {
+    type: 'ReservedTypeAnnotation',
+    name: 'Uint8Array',
+  };
+
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitUint8Array(true);
+
+      expect(result).toEqual({
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: reservedTypeAnnotation,
+      });
+    });
+  });
+
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitUint8Array(false);
 
       expect(result).toEqual(reservedTypeAnnotation);
     });
@@ -1727,6 +1781,7 @@ describe('emitUnion', () => {
     function emitCommonTypesForUnitTest(
       typeAnnotation: $FlowFixMe,
       nullable: boolean,
+      cxxOnly: boolean = false,
     ): $FlowFixMe {
       return emitCommonTypes(
         hasteModuleName,
@@ -1743,7 +1798,7 @@ describe('emitUnion', () => {
           return null;
         },
         /* cxxOnly: boolean */
-        false,
+        cxxOnly,
         nullable,
         parser,
       );
@@ -1886,6 +1941,60 @@ describe('emitUnion', () => {
 
       it("returns 'GenericObjectTypeAnnotation'", () => {
         expect(result).toEqual(expected);
+      });
+    });
+
+    describe("when 'typeAnnotation.id.name' is 'ArrayBuffer'", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1],
+          type: 'GenericObjectTypeAnnotation',
+        },
+        id: {
+          name: 'ArrayBuffer',
+        },
+      };
+
+      it('returns null for non-cxx modules', () => {
+        expect(
+          emitCommonTypesForUnitTest(typeAnnotation, false, false),
+        ).toBeNull();
+      });
+
+      it('returns a reserved annotation for cxx-only modules', () => {
+        expect(emitCommonTypesForUnitTest(typeAnnotation, false, true)).toEqual(
+          {
+            type: 'ReservedTypeAnnotation',
+            name: 'ArrayBuffer',
+          },
+        );
+      });
+    });
+
+    describe("when 'typeAnnotation.id.name' is 'Uint8Array'", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1],
+          type: 'GenericObjectTypeAnnotation',
+        },
+        id: {
+          name: 'Uint8Array',
+        },
+      };
+
+      it('returns null for non-cxx modules', () => {
+        expect(
+          emitCommonTypesForUnitTest(typeAnnotation, false, false),
+        ).toBeNull();
+      });
+
+      it('returns a reserved annotation for cxx-only modules', () => {
+        expect(emitCommonTypesForUnitTest(typeAnnotation, false, true)).toEqual(
+          {
+            type: 'ReservedTypeAnnotation',
+            name: 'Uint8Array',
+          },
+        );
       });
     });
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -845,6 +845,8 @@ export type CustomDeviceEvent = {
 export interface Spec extends TurboModule {
   +getCallback: () => () => void;
   +getMixed: (arg: mixed) => mixed;
+  +getArrayBuffer: (input: ArrayBuffer) => ArrayBuffer;
+  +getUint8Array: (input: Uint8Array) => Uint8Array;
   +getEnums: (quality: Quality, resolution?: Resolution, stringOptions: StringOptions) => Quality;
   +getBinaryTreeNode: (arg: BinaryTreeNode) => BinaryTreeNode;
   +getGraphNode: (arg: GraphNode) => GraphNode;

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -256,6 +256,48 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
             }
           },
           {
+            'name': 'getArrayBuffer',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ReservedTypeAnnotation',
+                'name': 'ArrayBuffer'
+              },
+              'params': [
+                {
+                  'name': 'input',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ReservedTypeAnnotation',
+                    'name': 'ArrayBuffer'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'getUint8Array',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ReservedTypeAnnotation',
+                'name': 'Uint8Array'
+              },
+              'params': [
+                {
+                  'name': 'input',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ReservedTypeAnnotation',
+                    'name': 'Uint8Array'
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'getEnums',
             'optional': false,
             'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
@@ -90,6 +90,54 @@ describe('Flow Module Parser', () => {
       expect(parser).toThrow(UnsupportedTypeAnnotationParserError);
     });
 
+    it('should parse ArrayBuffer and Uint8Array in cxx-only modules', () => {
+      const module = parseCxxModule(`
+        import type {TurboModule} from 'RCTExport';
+        import * as TurboModuleRegistry from 'TurboModuleRegistry';
+        export interface Spec extends TurboModule {
+          +useArrayBuffer: (arg: ArrayBuffer) => ArrayBuffer;
+          +useUint8Array: (arg: Uint8Array) => Uint8Array;
+        }
+        export default TurboModuleRegistry.get<Spec>('FooCxx');
+      `);
+
+      const [{params, returnTypeAnnotation: returnArrayBuffer}] =
+        unwrapNullable(module.spec.methods[0].typeAnnotation);
+      expect(params[0].typeAnnotation).toEqual({
+        type: 'ReservedTypeAnnotation',
+        name: 'ArrayBuffer',
+      });
+      expect(returnArrayBuffer).toEqual({
+        type: 'ReservedTypeAnnotation',
+        name: 'ArrayBuffer',
+      });
+
+      const [{params: uint8Params, returnTypeAnnotation: returnUint8Array}] =
+        unwrapNullable(module.spec.methods[1].typeAnnotation);
+      expect(uint8Params[0].typeAnnotation).toEqual({
+        type: 'ReservedTypeAnnotation',
+        name: 'Uint8Array',
+      });
+      expect(returnUint8Array).toEqual({
+        type: 'ReservedTypeAnnotation',
+        name: 'Uint8Array',
+      });
+    });
+
+    it('should fail parsing ArrayBuffer in non-cxx modules', () => {
+      const parser = () =>
+        parseModule(`
+          import type {TurboModule} from 'RCTExport';
+          import * as TurboModuleRegistry from 'TurboModuleRegistry';
+          export interface Spec extends TurboModule {
+            +useArrayBuffer: (arg: ArrayBuffer) => ArrayBuffer;
+          }
+          export default TurboModuleRegistry.get<Spec>('Foo');
+        `);
+
+      expect(parser).toThrow(UnsupportedGenericParserError);
+    });
+
     it('should fail parsing when a function param type is unamed', () => {
       const parser = () =>
         parseModule(`
@@ -1248,6 +1296,16 @@ function parseModule(source: string) {
   invariant(
     module.type === 'NativeModule',
     "'nativeModules' in Spec NativeFoo shouldn't be null",
+  );
+  return module;
+}
+
+function parseCxxModule(source: string) {
+  const schema = flowParser.parseString(source, `${MODULE_NAME}Cxx.js`);
+  const module = schema.modules.NativeFooCxx;
+  invariant(
+    module.type === 'NativeModule',
+    "'nativeModules' in Spec NativeFooCxx shouldn't be null",
   );
   return module;
 }

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -102,6 +102,20 @@ function emitRootTag(nullable: boolean): Nullable<ReservedTypeAnnotation> {
   });
 }
 
+function emitArrayBuffer(nullable: boolean): Nullable<ReservedTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'ReservedTypeAnnotation',
+    name: 'ArrayBuffer',
+  });
+}
+
+function emitUint8Array(nullable: boolean): Nullable<ReservedTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'ReservedTypeAnnotation',
+    name: 'Uint8Array',
+  });
+}
+
 function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'DoubleTypeAnnotation',
@@ -666,6 +680,12 @@ function emitCommonTypes(
     UnsafeMixed: cxxOnly ? emitMixed : emitGenericObject,
     unknown: cxxOnly ? emitMixed : emitGenericObject,
     UnknownTypeAnnotation: cxxOnly ? emitMixed : emitGenericObject,
+    ...(cxxOnly
+      ? {
+          ArrayBuffer: emitArrayBuffer,
+          Uint8Array: emitUint8Array,
+        }
+      : {}),
   };
 
   const typeAnnotationName = parser.convertKeywordToTypeAnnotation(
@@ -783,6 +803,8 @@ module.exports = {
   emitObject,
   emitPromise,
   emitRootTag,
+  emitArrayBuffer,
+  emitUint8Array,
   emitVoid,
   emitString,
   emitStringish,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -903,6 +903,8 @@ export type CustomDeviceEvent = {
 export interface Spec extends TurboModule {
   readonly getCallback: () => () => void;
   readonly getMixed: (arg: unknown) => unknown;
+  readonly getArrayBuffer: (input: ArrayBuffer) => ArrayBuffer;
+  readonly getUint8Array: (input: Uint8Array) => Uint8Array;
   readonly getEnums: (quality: Quality, resolution?: Resolution, stringOptions: StringOptions) => Quality;
   readonly getBinaryTreeNode: (arg: BinaryTreeNode) => BinaryTreeNode;
   readonly getGraphNode: (arg: GraphNode) => GraphNode;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -243,6 +243,48 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
             }
           },
           {
+            'name': 'getArrayBuffer',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ReservedTypeAnnotation',
+                'name': 'ArrayBuffer'
+              },
+              'params': [
+                {
+                  'name': 'input',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ReservedTypeAnnotation',
+                    'name': 'ArrayBuffer'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'getUint8Array',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ReservedTypeAnnotation',
+                'name': 'Uint8Array'
+              },
+              'params': [
+                {
+                  'name': 'input',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ReservedTypeAnnotation',
+                    'name': 'Uint8Array'
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'getEnums',
             'optional': false,
             'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
@@ -90,6 +90,54 @@ describe('TypeScript Module Parser', () => {
       expect(parser).toThrow(UnsupportedTypeAnnotationParserError);
     });
 
+    it('should parse ArrayBuffer and Uint8Array in cxx-only modules', () => {
+      const module = parseCxxModule(`
+        import type {TurboModule} from 'RCTExport';
+        import * as TurboModuleRegistry from 'TurboModuleRegistry';
+        export interface Spec extends TurboModule {
+          useArrayBuffer(arg: ArrayBuffer): ArrayBuffer;
+          useUint8Array(arg: Uint8Array): Uint8Array;
+        }
+        export default TurboModuleRegistry.get<Spec>('FooCxx');
+      `);
+
+      const [{params, returnTypeAnnotation: returnArrayBuffer}] =
+        unwrapNullable(module.spec.methods[0].typeAnnotation);
+      expect(params[0].typeAnnotation).toEqual({
+        type: 'ReservedTypeAnnotation',
+        name: 'ArrayBuffer',
+      });
+      expect(returnArrayBuffer).toEqual({
+        type: 'ReservedTypeAnnotation',
+        name: 'ArrayBuffer',
+      });
+
+      const [{params: uint8Params, returnTypeAnnotation: returnUint8Array}] =
+        unwrapNullable(module.spec.methods[1].typeAnnotation);
+      expect(uint8Params[0].typeAnnotation).toEqual({
+        type: 'ReservedTypeAnnotation',
+        name: 'Uint8Array',
+      });
+      expect(returnUint8Array).toEqual({
+        type: 'ReservedTypeAnnotation',
+        name: 'Uint8Array',
+      });
+    });
+
+    it('should fail parsing ArrayBuffer in non-cxx modules', () => {
+      const parser = () =>
+        parseModule(`
+          import type {TurboModule} from 'RCTExport';
+          import * as TurboModuleRegistry from 'TurboModuleRegistry';
+          export interface Spec extends TurboModule {
+            useArrayBuffer(arg: ArrayBuffer): ArrayBuffer;
+          }
+          export default TurboModuleRegistry.get<Spec>('Foo');
+        `);
+
+      expect(parser).toThrow(UnsupportedGenericParserError);
+    });
+
     it('should fail parsing when a function param type is unamed', () => {
       const parser = () =>
         parseModule(`
@@ -1323,6 +1371,16 @@ function parseModule(source: string) {
   invariant(
     module.type === 'NativeModule',
     "'nativeModules' in Spec NativeFoo shouldn't be null",
+  );
+  return module;
+}
+
+function parseCxxModule(source: string) {
+  const schema = typescriptParser.parseString(source, `${MODULE_NAME}Cxx.ts`);
+  const module = schema.modules.NativeFooCxx;
+  invariant(
+    module.type === 'NativeModule',
+    "'nativeModules' in Spec NativeFooCxx shouldn't be null",
   );
   return module;
 }

--- a/packages/react-native-compatibility-check/src/TypeDiffing.js
+++ b/packages/react-native-compatibility-check/src/TypeDiffing.js
@@ -1624,6 +1624,8 @@ function compareReservedTypeAnnotation(
 
   switch (newerAnnotation.name) {
     case 'RootTag':
+    case 'ArrayBuffer':
+    case 'Uint8Array':
     case 'ColorPrimitive':
     case 'ImageSourcePrimitive':
     case 'PointPrimitive':

--- a/packages/react-native/ReactCommon/react/bridging/Bridging.h
+++ b/packages/react-native/ReactCommon/react/bridging/Bridging.h
@@ -19,4 +19,5 @@
 #include <react/bridging/Number.h>
 #include <react/bridging/Object.h>
 #include <react/bridging/Promise.h>
+#include <react/bridging/Uint8Array.h>
 #include <react/bridging/Value.h>

--- a/packages/react-native/ReactCommon/react/bridging/Convert.h
+++ b/packages/react-native/ReactCommon/react/bridging/Convert.h
@@ -61,6 +61,8 @@ struct ConverterBase {
         return std::move(value).getObject(rt_);
       } else if constexpr (std::is_same_v<BaseT, jsi::Array>) {
         return std::move(value).getObject(rt_).getArray(rt_);
+      } else if constexpr (std::is_same_v<BaseT, jsi::ArrayBuffer>) {
+        return std::move(value).getObject(rt_).getArrayBuffer(rt_);
       } else if constexpr (std::is_same_v<BaseT, jsi::Function>) {
         return std::move(value).getObject(rt_).getFunction(rt_);
       }
@@ -113,6 +115,11 @@ struct Converter<jsi::Value> : public ConverterBase<jsi::Value> {
     return std::move(value_).asObject(rt_).asArray(rt_);
   }
 
+  operator jsi::ArrayBuffer() &&
+  {
+    return std::move(value_).asObject(rt_).getArrayBuffer(rt_);
+  }
+
   operator jsi::Function() &&
   {
     return std::move(value_).asObject(rt_).asFunction(rt_);
@@ -126,6 +133,11 @@ struct Converter<jsi::Object> : public ConverterBase<jsi::Object> {
   operator jsi::Array() &&
   {
     return std::move(value_).asArray(rt_);
+  }
+
+  operator jsi::ArrayBuffer() &&
+  {
+    return std::move(value_).getArrayBuffer(rt_);
   }
 
   operator jsi::Function() &&

--- a/packages/react-native/ReactCommon/react/bridging/Uint8Array.h
+++ b/packages/react-native/ReactCommon/react/bridging/Uint8Array.h
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/bridging/Base.h>
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace facebook::react {
+
+// Uint8Array supports three backing modes:
+// 1) owned bytes (std::vector<uint8_t>)
+// 2) native shared storage (jsi::MutableBuffer)
+// 3) JS ArrayBuffer-backed borrowed storage (zero-copy fromJs)
+//
+// JS-backed borrowed storage is only safe to consume on the JS runtime thread.
+// If data must outlive the synchronous call boundary or be used cross-thread,
+// call toOwned() first to materialize a native copy.
+class Uint8Array {
+ public:
+  Uint8Array() = default;
+
+  explicit Uint8Array(std::vector<uint8_t> bytes)
+      : bytes_(std::move(bytes)), byteLength_(bytes_.size()) {}
+
+  Uint8Array(std::initializer_list<uint8_t> bytes)
+      : bytes_(bytes), byteLength_(bytes_.size()) {}
+
+  explicit Uint8Array(size_t size) : bytes_(size), byteLength_(bytes_.size()) {}
+
+  Uint8Array(const uint8_t* data, size_t size)
+      : bytes_(data, data + size), byteLength_(bytes_.size()) {}
+
+  Uint8Array(const char* data, size_t size)
+      : Uint8Array(reinterpret_cast<const uint8_t*>(data), size) {}
+
+  explicit Uint8Array(std::shared_ptr<jsi::MutableBuffer> mutableBuffer)
+      : mutableBuffer_(std::move(mutableBuffer)),
+        byteOffset_(0),
+        byteLength_(mutableBuffer_ ? mutableBuffer_->size() : 0)
+  {
+  }
+
+  Uint8Array(
+      std::shared_ptr<jsi::MutableBuffer> mutableBuffer,
+      size_t byteOffset,
+      size_t byteLength)
+      : mutableBuffer_(std::move(mutableBuffer)),
+        byteOffset_(byteOffset),
+        byteLength_(byteLength)
+  {
+    if (!mutableBuffer_) {
+      throw std::invalid_argument("Uint8Array mutableBuffer must not be null");
+    }
+    auto bufferSize = mutableBuffer_->size();
+    if (byteOffset_ > bufferSize || byteLength_ > bufferSize - byteOffset_) {
+      throw std::invalid_argument("Uint8Array mutableBuffer view is out of range");
+    }
+  }
+
+  Uint8Array(
+      jsi::Runtime& rt,
+      jsi::ArrayBuffer arrayBuffer,
+      size_t byteOffset,
+      size_t byteLength)
+      : jsArrayBuffer_(std::make_shared<jsi::ArrayBuffer>(std::move(arrayBuffer))),
+        byteOffset_(byteOffset),
+        byteLength_(byteLength)
+  {
+    auto bufferSize = jsArrayBuffer_->size(rt);
+    if (byteOffset_ > bufferSize || byteLength_ > bufferSize - byteOffset_) {
+      throw std::invalid_argument("Uint8Array JS ArrayBuffer view is out of range");
+    }
+    jsBorrowedData_ = jsArrayBuffer_->data(rt) + byteOffset_;
+  }
+
+  size_t size() const
+  {
+    return byteLength_;
+  }
+
+  bool empty() const
+  {
+    return byteLength_ == 0;
+  }
+
+  uint8_t* data()
+  {
+    if (mutableBuffer_) {
+      return mutableBuffer_->data() + byteOffset_;
+    }
+    if (jsArrayBuffer_) {
+      return jsBorrowedData_;
+    }
+    return bytes_.data();
+  }
+
+  const uint8_t* data() const
+  {
+    if (mutableBuffer_) {
+      return mutableBuffer_->data() + byteOffset_;
+    }
+    if (jsArrayBuffer_) {
+      return jsBorrowedData_;
+    }
+    return bytes_.data();
+  }
+
+  bool isMutableBufferBacked() const
+  {
+    return static_cast<bool>(mutableBuffer_);
+  }
+
+  bool isJsArrayBufferBacked() const
+  {
+    return static_cast<bool>(jsArrayBuffer_);
+  }
+
+  const std::shared_ptr<jsi::MutableBuffer>& mutableBuffer() const
+  {
+    return mutableBuffer_;
+  }
+
+  const std::shared_ptr<jsi::ArrayBuffer>& jsArrayBuffer() const
+  {
+    return jsArrayBuffer_;
+  }
+
+  size_t byteOffset() const
+  {
+    return byteOffset_;
+  }
+
+  Uint8Array toOwned() const
+  {
+    Uint8Array owned(size());
+    if (!empty()) {
+      std::memcpy(owned.data(), data(), size());
+    }
+    return owned;
+  }
+
+ private:
+  std::vector<uint8_t> bytes_;
+  std::shared_ptr<jsi::MutableBuffer> mutableBuffer_;
+  std::shared_ptr<jsi::ArrayBuffer> jsArrayBuffer_;
+  uint8_t* jsBorrowedData_{nullptr};
+  size_t byteOffset_{0};
+  size_t byteLength_{0};
+};
+
+template <>
+struct Bridging<Uint8Array> {
+  static Uint8Array fromJs(jsi::Runtime& rt, jsi::Object value)
+  {
+    auto uint8ArrayConstructor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
+    if (!value.instanceOf(rt, uint8ArrayConstructor)) {
+      throw jsi::JSError(rt, "Expected Uint8Array");
+    }
+
+    auto byteOffsetValue = value.getProperty(rt, "byteOffset").asNumber();
+    auto byteLengthValue = value.getProperty(rt, "byteLength").asNumber();
+    constexpr auto kMaxSizeTAsDouble =
+        static_cast<double>(std::numeric_limits<size_t>::max());
+    if (
+        !std::isfinite(byteOffsetValue) || !std::isfinite(byteLengthValue) ||
+        byteOffsetValue < 0 || std::floor(byteOffsetValue) != byteOffsetValue ||
+        byteOffsetValue > kMaxSizeTAsDouble ||
+        byteLengthValue < 0 || std::floor(byteLengthValue) != byteLengthValue ||
+        byteLengthValue > kMaxSizeTAsDouble) {
+      throw jsi::JSError(rt, "Invalid Uint8Array view");
+    }
+
+    auto byteOffset = static_cast<size_t>(byteOffsetValue);
+    auto byteLength = static_cast<size_t>(byteLengthValue);
+    auto arrayBuffer =
+        value.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
+
+    auto bufferSize = arrayBuffer.size(rt);
+    if (byteOffset > bufferSize || byteLength > bufferSize - byteOffset) {
+      throw jsi::JSError(rt, "Invalid Uint8Array view");
+    }
+
+    // Zero-copy from JS: keep a reference to the ArrayBuffer and expose a view.
+    return Uint8Array(rt, std::move(arrayBuffer), byteOffset, byteLength);
+  }
+
+  static jsi::Object toJs(jsi::Runtime& rt, const Uint8Array& value)
+  {
+    auto uint8ArrayConstructor =
+        rt.global().getPropertyAsFunction(rt, "Uint8Array");
+
+    if (value.isMutableBufferBacked()) {
+      auto mutableBuffer = value.mutableBuffer();
+      if (!mutableBuffer) {
+        throw jsi::JSError(rt, "Invalid Uint8Array mutable buffer");
+      }
+
+      auto bufferSize = mutableBuffer->size();
+      auto byteOffset = value.byteOffset();
+      auto byteLength = value.size();
+      if (byteOffset > bufferSize || byteLength > bufferSize - byteOffset) {
+        throw jsi::JSError(rt, "Invalid Uint8Array mutable buffer view");
+      }
+
+      auto arrayBuffer = jsi::ArrayBuffer(rt, mutableBuffer);
+      if (byteOffset == 0 && byteLength == bufferSize) {
+        return uint8ArrayConstructor.callAsConstructor(rt, std::move(arrayBuffer))
+            .asObject(rt);
+      }
+      return uint8ArrayConstructor
+          .callAsConstructor(
+              rt,
+              std::move(arrayBuffer),
+              static_cast<double>(byteOffset),
+              static_cast<double>(byteLength))
+          .asObject(rt);
+    }
+
+    if (value.isJsArrayBufferBacked()) {
+      auto arrayBufferRef = value.jsArrayBuffer();
+      if (!arrayBufferRef) {
+        throw jsi::JSError(rt, "Invalid Uint8Array JS ArrayBuffer");
+      }
+
+      auto arrayBuffer =
+          jsi::Value(rt, *arrayBufferRef).asObject(rt).getArrayBuffer(rt);
+      auto bufferSize = arrayBuffer.size(rt);
+      auto byteOffset = value.byteOffset();
+      auto byteLength = value.size();
+      if (byteOffset > bufferSize || byteLength > bufferSize - byteOffset) {
+        throw jsi::JSError(rt, "Invalid Uint8Array JS ArrayBuffer view");
+      }
+
+      if (byteOffset == 0 && byteLength == bufferSize) {
+        return uint8ArrayConstructor.callAsConstructor(rt, std::move(arrayBuffer))
+            .asObject(rt);
+      }
+      return uint8ArrayConstructor
+          .callAsConstructor(
+              rt,
+              std::move(arrayBuffer),
+              static_cast<double>(byteOffset),
+              static_cast<double>(byteLength))
+          .asObject(rt);
+    }
+
+    auto arrayBufferConstructor =
+        rt.global().getPropertyAsFunction(rt, "ArrayBuffer");
+    auto arrayBuffer = arrayBufferConstructor
+                           .callAsConstructor(rt, static_cast<double>(value.size()))
+                           .asObject(rt)
+                           .getArrayBuffer(rt);
+
+    if (!value.empty()) {
+      std::memcpy(arrayBuffer.data(rt), value.data(), value.size());
+    }
+
+    return uint8ArrayConstructor.callAsConstructor(rt, std::move(arrayBuffer))
+        .asObject(rt);
+  }
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -16,6 +16,7 @@ TEST_F(BridgingTest, jsiTest) {
   jsi::Value string = jsi::String::createFromAscii(rt, "hello");
   jsi::Value object = jsi::Object(rt);
   jsi::Value array = jsi::Array::createWithElements(rt, value, object);
+  jsi::Value arrayBuffer = eval("new ArrayBuffer(4)");
   jsi::Value func = function("() => {}");
 
   // The bridging mechanism needs to know how to copy and downcast values.
@@ -23,6 +24,7 @@ TEST_F(BridgingTest, jsiTest) {
   EXPECT_NO_THROW(bridging::fromJs<jsi::String>(rt, string, invoker));
   EXPECT_NO_THROW(bridging::fromJs<jsi::Object>(rt, object, invoker));
   EXPECT_NO_THROW(bridging::fromJs<jsi::Array>(rt, array, invoker));
+  EXPECT_NO_THROW(bridging::fromJs<jsi::ArrayBuffer>(rt, arrayBuffer, invoker));
   EXPECT_NO_THROW(bridging::fromJs<jsi::Function>(rt, func, invoker));
 
   // Should throw when attempting an invalid cast.
@@ -31,12 +33,15 @@ TEST_F(BridgingTest, jsiTest) {
   EXPECT_JSI_THROW(bridging::fromJs<jsi::Array>(rt, object, invoker));
   EXPECT_JSI_THROW(bridging::fromJs<jsi::Array>(rt, string, invoker));
   EXPECT_JSI_THROW(bridging::fromJs<jsi::Array>(rt, func, invoker));
+  EXPECT_JSI_THROW(bridging::fromJs<jsi::ArrayBuffer>(rt, object, invoker));
 
   // Should be able to generically no-op convert JSI.
   EXPECT_NO_THROW(bridging::toJs(rt, value, invoker));
   EXPECT_NO_THROW(bridging::toJs(rt, string.asString(rt), invoker));
   EXPECT_NO_THROW(bridging::toJs(rt, object.asObject(rt), invoker));
   EXPECT_NO_THROW(bridging::toJs(rt, array.asObject(rt).asArray(rt), invoker));
+  EXPECT_NO_THROW(
+      bridging::toJs(rt, arrayBuffer.asObject(rt).getArrayBuffer(rt), invoker));
   EXPECT_NO_THROW(
       bridging::toJs(rt, func.asObject(rt).asFunction(rt), invoker));
 }
@@ -645,6 +650,11 @@ TEST_F(BridgingTest, supportTest) {
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Array, jsi::Array&>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Array, jsi::Object>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Array, jsi::Object&>));
+  EXPECT_TRUE((bridging::supportsFromJs<jsi::ArrayBuffer>));
+  EXPECT_TRUE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::ArrayBuffer>));
+  EXPECT_TRUE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::ArrayBuffer&>));
+  EXPECT_TRUE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::Object>));
+  EXPECT_TRUE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::Object&>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Function>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Function, jsi::Function>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Function, jsi::Function&>));
@@ -654,6 +664,8 @@ TEST_F(BridgingTest, supportTest) {
   // Ensure incorrect casts will fail.
   EXPECT_FALSE((bridging::supportsFromJs<jsi::Array, jsi::Function>));
   EXPECT_FALSE((bridging::supportsFromJs<jsi::Array, jsi::Function&>));
+  EXPECT_FALSE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::Function>));
+  EXPECT_FALSE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::Function&>));
   EXPECT_FALSE((bridging::supportsFromJs<jsi::Function, jsi::Array>));
   EXPECT_FALSE((bridging::supportsFromJs<jsi::Function, jsi::Array&>));
 
@@ -677,6 +689,8 @@ TEST_F(BridgingTest, supportTest) {
   EXPECT_TRUE((bridging::supportsToJs<std::map<std::string, int>>));
   EXPECT_TRUE(
       (bridging::supportsToJs<std::map<std::string, int>, jsi::Object>));
+  EXPECT_TRUE((bridging::supportsToJs<jsi::ArrayBuffer>));
+  EXPECT_TRUE((bridging::supportsToJs<jsi::ArrayBuffer, jsi::ArrayBuffer>));
   EXPECT_TRUE((bridging::supportsToJs<void (*)()>));
   EXPECT_TRUE((bridging::supportsToJs<void (*)(), jsi::Function>));
 

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -11,6 +11,31 @@ namespace facebook::react {
 
 using namespace std::literals;
 
+namespace {
+
+class TestMutableBuffer : public jsi::MutableBuffer {
+ public:
+  explicit TestMutableBuffer(std::vector<uint8_t> bytes)
+      : bytes_(std::move(bytes))
+  {
+  }
+
+  size_t size() const override
+  {
+    return bytes_.size();
+  }
+
+  uint8_t* data() override
+  {
+    return bytes_.data();
+  }
+
+ private:
+  std::vector<uint8_t> bytes_;
+};
+
+} // namespace
+
 TEST_F(BridgingTest, jsiTest) {
   jsi::Value value = true;
   jsi::Value string = jsi::String::createFromAscii(rt, "hello");
@@ -199,6 +224,72 @@ TEST_F(BridgingTest, arrayTest) {
       {"foo", "bar"}, {"baz", "qux"}};
   auto jsiHeaders = bridging::toJs(rt, headers, invoker);
   EXPECT_EQ(headers.size(), jsiHeaders.size(rt));
+}
+
+TEST_F(BridgingTest, uint8ArrayTest) {
+  auto input = eval(
+                   "(() => {"
+                   "  global.__rnTmpBuffer = new ArrayBuffer(8);"
+                   "  const all = new Uint8Array(global.__rnTmpBuffer);"
+                   "  all.set([9, 8, 7, 6, 5, 4, 3, 2]);"
+                   "  global.__rnTmpInput = new Uint8Array(global.__rnTmpBuffer, 2, 4);"
+                   "  return global.__rnTmpInput;"
+                   "})()")
+                   .asObject(rt);
+  auto output = bridging::fromJs<Uint8Array>(rt, input, invoker);
+  ASSERT_EQ(output.size(), 4);
+  EXPECT_EQ(output.data()[0], 7);
+  EXPECT_EQ(output.data()[1], 6);
+  EXPECT_EQ(output.data()[2], 5);
+  EXPECT_EQ(output.data()[3], 4);
+
+  eval("global.__rnTmpInput[0] = 0xCC");
+  EXPECT_EQ(output.data()[0], 0xCC);
+
+  output.data()[1] = 0xAA;
+  EXPECT_EQ(eval("global.__rnTmpInput[1]").asNumber(), 0xAA);
+
+  auto outputJs = bridging::toJs(rt, output, invoker);
+  auto outputObject = outputJs.asObject(rt);
+  auto uint8ArrayConstructor =
+      rt.global().getPropertyAsFunction(rt, "Uint8Array");
+  EXPECT_TRUE(outputObject.instanceOf(rt, uint8ArrayConstructor));
+  EXPECT_EQ(outputObject.getProperty(rt, "byteOffset").asNumber(), 2);
+  EXPECT_EQ(outputObject.getProperty(rt, "byteLength").asNumber(), 4);
+  EXPECT_EQ(outputObject.getProperty(rt, "0").asNumber(), 0xCC);
+  EXPECT_EQ(outputObject.getProperty(rt, "1").asNumber(), 0xAA);
+  auto inputBuffer = input.getProperty(rt, "buffer").asObject(rt);
+  auto outputBuffer = outputObject.getProperty(rt, "buffer").asObject(rt);
+  EXPECT_TRUE(jsi::Object::strictEquals(rt, inputBuffer, outputBuffer));
+
+  auto mutableBuffer =
+      std::make_shared<TestMutableBuffer>(std::vector<uint8_t>{1, 2, 3, 4});
+  auto zeroCopy = Uint8Array(mutableBuffer, 1, 2);
+  auto zeroCopyJs = bridging::toJs(rt, zeroCopy, invoker).asObject(rt);
+  EXPECT_EQ(zeroCopyJs.getProperty(rt, "0").asNumber(), 2);
+  EXPECT_EQ(zeroCopyJs.getProperty(rt, "1").asNumber(), 3);
+  mutableBuffer->data()[1] = 42;
+  EXPECT_EQ(zeroCopyJs.getProperty(rt, "0").asNumber(), 42);
+
+  auto infiniteOffset = eval(
+                            "(() => {"
+                            "  class BadOffset extends Uint8Array {"
+                            "    get byteOffset() { return Infinity; }"
+                            "  }"
+                            "  return new BadOffset(4);"
+                            "})()")
+                            .asObject(rt);
+  EXPECT_JSI_THROW(bridging::fromJs<Uint8Array>(rt, infiniteOffset, invoker));
+
+  auto hugeLength = eval(
+                        "(() => {"
+                        "  class BadLength extends Uint8Array {"
+                        "    get byteLength() { return Number.MAX_VALUE; }"
+                        "  }"
+                        "  return new BadLength(4);"
+                        "})()")
+                        .asObject(rt);
+  EXPECT_JSI_THROW(bridging::fromJs<Uint8Array>(rt, hugeLength, invoker));
 }
 
 TEST_F(BridgingTest, functionTest) {
@@ -655,6 +746,8 @@ TEST_F(BridgingTest, supportTest) {
   EXPECT_TRUE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::ArrayBuffer&>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::Object>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::ArrayBuffer, jsi::Object&>));
+  EXPECT_TRUE((bridging::supportsFromJs<Uint8Array, jsi::Object>));
+  EXPECT_TRUE((bridging::supportsFromJs<Uint8Array, jsi::Object&>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Function>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Function, jsi::Function>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Function, jsi::Function&>));
@@ -689,6 +782,8 @@ TEST_F(BridgingTest, supportTest) {
   EXPECT_TRUE((bridging::supportsToJs<std::map<std::string, int>>));
   EXPECT_TRUE(
       (bridging::supportsToJs<std::map<std::string, int>, jsi::Object>));
+  EXPECT_TRUE((bridging::supportsToJs<Uint8Array>));
+  EXPECT_TRUE((bridging::supportsToJs<Uint8Array, jsi::Object>));
   EXPECT_TRUE((bridging::supportsToJs<jsi::ArrayBuffer>));
   EXPECT_TRUE((bridging::supportsToJs<jsi::ArrayBuffer, jsi::ArrayBuffer>));
   EXPECT_TRUE((bridging::supportsToJs<void (*)()>));

--- a/packages/rn-tester/NativeCxxModuleExample/CMakeLists.txt
+++ b/packages/rn-tester/NativeCxxModuleExample/CMakeLists.txt
@@ -9,7 +9,10 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 file(GLOB nativecxxmoduleexample_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(nativecxxmoduleexample STATIC ${nativecxxmoduleexample_SRC})
 
-target_include_directories(nativecxxmoduleexample PUBLIC .)
+target_include_directories(nativecxxmoduleexample PUBLIC
+        .
+        ${REACT_COMMON_DIR}
+)
 target_compile_reactnative_options(nativecxxmoduleexample PRIVATE)
 
 target_link_libraries(nativecxxmoduleexample

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -46,6 +46,18 @@ std::function<void()> NativeCxxModuleExample::setValueCallbackWithSubscription(
   };
 }
 
+jsi::ArrayBuffer NativeCxxModuleExample::getArrayBuffer(
+    jsi::Runtime& /*rt*/,
+    jsi::ArrayBuffer input) {
+  return input;
+}
+
+Uint8Array NativeCxxModuleExample::getUint8Array(
+    jsi::Runtime& /*rt*/,
+    Uint8Array input) {
+  return input;
+}
+
 std::vector<std::optional<ObjectStruct>> NativeCxxModuleExample::getArray(
     jsi::Runtime& /*rt*/,
     std::vector<std::optional<ObjectStruct>> arg) {

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -14,6 +14,7 @@
 #else // BUCK headers
 #include <AppSpecs/AppSpecsJSI.h>
 #endif
+#include <react/bridging/Uint8Array.h>
 #include <memory>
 #include <optional>
 #include <set>
@@ -121,6 +122,10 @@ class NativeCxxModuleExample : public NativeCxxModuleExampleCxxSpec<NativeCxxMod
   void getValueWithCallback(jsi::Runtime &rt, const AsyncCallback<std::string> &callback);
 
   std::function<void()> setValueCallbackWithSubscription(jsi::Runtime &rt, AsyncCallback<std::string> callback);
+
+  jsi::ArrayBuffer getArrayBuffer(jsi::Runtime &rt, jsi::ArrayBuffer input);
+
+  Uint8Array getUint8Array(jsi::Runtime &rt, Uint8Array input);
 
   std::vector<std::optional<ObjectStruct>> getArray(jsi::Runtime &rt, std::vector<std::optional<ObjectStruct>> arg);
 

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -81,6 +81,8 @@ export interface Spec extends TurboModule {
   +onChange: CodegenTypes.EventEmitter<ObjectStruct>;
   +onSubmit: CodegenTypes.EventEmitter<ObjectStruct[]>;
   +onEvent: CodegenTypes.EventEmitter<EnumNone>;
+  +getArrayBuffer: (input: ArrayBuffer) => ArrayBuffer;
+  +getUint8Array: (input: Uint8Array) => Uint8Array;
   +getArray: (arg: Array<ObjectStruct | null>) => Array<ObjectStruct | null>;
   +getBool: (arg: boolean) => boolean;
   +getConstants: () => ConstantsStruct;

--- a/packages/rn-tester/NativeCxxModuleExample/tests/NativeCxxModuleExampleTests.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/tests/NativeCxxModuleExampleTests.cpp
@@ -17,6 +17,26 @@ namespace facebook::react {
 class NativeCxxModuleExampleTests
     : public TurboModuleTestFixture<NativeCxxModuleExample> {};
 
+namespace {
+class TestMutableBuffer : public jsi::MutableBuffer {
+ public:
+  explicit TestMutableBuffer(size_t size) : bytes_(size, 0) {}
+
+  size_t size() const override
+  {
+    return bytes_.size();
+  }
+
+  uint8_t* data() override
+  {
+    return bytes_.data();
+  }
+
+ private:
+  std::vector<uint8_t> bytes_;
+};
+} // namespace
+
 TEST_F(NativeCxxModuleExampleTests, GetArrayReturnsCorrectValues) {
   std::vector<std::optional<facebook::react::ObjectStruct>> empty;
   EXPECT_EQ(module_->getArray(*runtime_, empty), empty);
@@ -29,6 +49,24 @@ TEST_F(NativeCxxModuleExampleTests, GetArrayReturnsCorrectValues) {
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0]->a, 1);
   EXPECT_EQ(result[0]->b, "2");
+}
+
+TEST_F(NativeCxxModuleExampleTests, GetArrayBufferReturnsSameBuffer) {
+  auto input = jsi::ArrayBuffer(*runtime_, std::make_shared<TestMutableBuffer>(8));
+  auto inputCopy = jsi::Value(*runtime_, input).asObject(*runtime_);
+  auto result = module_->getArrayBuffer(*runtime_, std::move(input));
+  EXPECT_TRUE(jsi::Object::strictEquals(*runtime_, inputCopy, result));
+  EXPECT_EQ(result.size(*runtime_), 8);
+}
+
+TEST_F(NativeCxxModuleExampleTests, GetUint8ArrayReturnsInput) {
+  auto result = module_->getUint8Array(*runtime_, Uint8Array({1, 2, 3, 4}));
+  ASSERT_EQ(result.size(), 4);
+  auto* data = result.data();
+  EXPECT_EQ(data[0], 1);
+  EXPECT_EQ(data[1], 2);
+  EXPECT_EQ(data[2], 3);
+  EXPECT_EQ(data[3], 4);
 }
 
 TEST_F(NativeCxxModuleExampleTests, GetBoolReturnsCorrectValues) {

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -39,6 +39,8 @@ type State = {
 type Examples =
   | 'callback'
   | 'callbackWithSubscription'
+  | 'getArrayBuffer'
+  | 'getUint8Array'
   | 'getArray'
   | 'getBool'
   | 'getConstants'
@@ -95,6 +97,21 @@ class NativeCxxModuleExampleExample extends React.Component<{}, State> {
       if (subscription) {
         subscription();
       }
+    },
+    getArrayBuffer: () => {
+      const input = new ArrayBuffer(4);
+      const inputView = new Uint8Array(input);
+      inputView[0] = 9;
+      inputView[1] = 8;
+      inputView[2] = 7;
+      inputView[3] = 6;
+      const output = NativeCxxModuleExample?.getArrayBuffer(input);
+      return output == null ? null : Array.from(new Uint8Array(output));
+    },
+    getUint8Array: () => {
+      const input = new Uint8Array([1, 2, 3, 4]);
+      const output = NativeCxxModuleExample?.getUint8Array(input);
+      return output == null ? null : Array.from(output);
     },
     getArray: () =>
       NativeCxxModuleExample?.getArray([


### PR DESCRIPTION
## Summary:

Hi. This pull request adds support for `ArrayBuffer` and `Uint8Array` to C++ TurboModules.

This is useful for native modules that need to pass raw byte data back and forth, where the alternative would otherwise be base64 encoding or other suboptimal solutions.

`ArrayBuffer` support uses the existing JSI type directly, so C++ module methods can accept and return `jsi::ArrayBuffer`.

`Uint8Array` support adds a new C++ helper class, `facebook::react::Uint8Array`, together with bridging logic:
- `JS -> native`: borrowed zero-copy over the JS-backed bytes
- `native -> JS`: copy from owned native bytes when using `std::vector<uint8_t>`, or zero-copy when backed by `jsi::MutableBuffer`

Note: zero-copy `JS -> native` does not use `MutableBuffer`, as Hermes API changes such as https://github.com/facebook/hermes/pull/1733 would need to land first. Lib authors are expected to copy data if they need the bytes to outlive the synchronous call or use them off-thread.
If reviewers prefer, this can instead be changed to use `memcpy` in the bridging path.

This PR intentionally only focuses on C++ TurboModules, as I think this is a good starting point. It also keeps the scope lower.
Java/Kotlin and ObjC support can be followed up later.

## Changelog:

`[GENERAL] [ADDED] - Add ArrayBuffer and Uint8Array support to C++ TurboModules`

## Test Plan:

I added and tested `ArrayBuffer` and `Uint8Array` in RNTester via `NativeCxxModuleExample`.

There are parser/codegen tests for the new reserved types.

I have written C++ unit tests, but I can't find targets for C++ tests in React Native OSS.

I also tested `Uint8Array` support in my own [lib](https://github.com/hsjoberg/react-native-turbo-lnd).

## Usage examples

```cpp
// Copied Uint8Array:
facebook::react::Uint8Array copied(std::vector<uint8_t>{0xDE, 0xAD, 0xBE, 0xEF});

// Zero-copy Uint8Array via MutableBuffer:
class VectorMutableBuffer final : public jsi::MutableBuffer {
public:
  explicit VectorMutableBuffer(std::vector<uint8_t> bytes) : bytes_(std::move(bytes)) {}

  size_t size() const override { return bytes_.size(); }
  uint8_t* data() override { return bytes_.data(); }

private:
  std::vector<uint8_t> bytes_;
};

facebook::react::Uint8Array zeroCopy(
  std::make_shared<VectorMutableBuffer>(std::vector<uint8_t>{0xDE, 0xAD, 0xBE, 0xEF})
);

// Copy an incoming Uint8Array:
auto owned = input.toOwned();

// ArrayBuffer backed by MutableBuffer.
// Alternatively, invoke the JS ArrayBuffer constructor through JSI.
auto buffer = std::make_shared<VectorMutableBuffer>(std::vector<uint8_t>{0xDE, 0xAD, 0xBE, 0xEF});
jsi::ArrayBuffer arrayBuffer(rt, buffer);
```