### PR TITLE
introduce isPackagerRunningAsync

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.h
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.h
@@ -58,6 +58,23 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)isPackagerRunning:(NSString *)hostPort scheme:(NSString *__nullable)scheme;
 
 /**
+ * Asynchronously checks if there's a packager running at the given host:port.
+ * The port is optional, if not specified, kRCTBundleURLProviderDefaultPort will be used
+ * The completion handler is called on an arbitrary queue.
+ */
++ (void)isPackagerRunningAsync:(NSString *)hostPort completion:(void (^)(BOOL isRunning))completion;
+
+/**
+ * Asynchronously checks if there's a packager running at the given scheme://host:port.
+ * The port is optional, if not specified, kRCTBundleURLProviderDefaultPort will be used
+ * The scheme is also optional, if not specified, a default http protocol will be used
+ * The completion handler is called on an arbitrary queue.
+ */
++ (void)isPackagerRunningAsync:(NSString *)hostPort
+                        scheme:(NSString *__nullable)scheme
+                    completion:(void (^)(BOOL isRunning))completion;
+
+/**
  * Returns the jsBundleURL for a given bundle entrypoint and
  * the fallback offline JS bundle if the packager is not running.
  */

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -94,6 +94,9 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
   }
 
   NSURL *url = [serverRootWithHostPort(hostPort, scheme) URLByAppendingPathComponent:@"status"];
+  if (url == nil) {
+    return NO;
+  }
 
   NSURLSession *session = [NSURLSession sharedSession];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
@@ -133,6 +136,73 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
   return isRunning;
 }
 
++ (void)isPackagerRunningAsync:(NSString *)hostPort completion:(void (^)(BOOL isRunning))completion
+{
+  [RCTBundleURLProvider isPackagerRunningAsync:hostPort scheme:nil completion:completion];
+}
+
++ (void)isPackagerRunningAsync:(NSString *)hostPort
+                        scheme:(NSString *)scheme
+                    completion:(void (^)(BOOL isRunning))completion
+{
+  if (!kRCTAllowPackagerAccess) {
+    completion(NO);
+    return;
+  }
+
+  NSURL *url = [serverRootWithHostPort(hostPort, scheme) URLByAppendingPathComponent:@"status"];
+  if (url == nil) {
+    completion(NO);
+    return;
+  }
+
+  NSURLSession *session = [NSURLSession sharedSession];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
+                                                         cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                     timeoutInterval:kRCTPackagerStatusRequestTimeout];
+  [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:request];
+
+  __block BOOL hasCompleted = NO;
+  NSObject *lock = [[NSObject alloc] init];
+
+  void (^safeCompletion)(BOOL) = ^(BOOL isRunning) {
+    @synchronized(lock) {
+      if (!hasCompleted) {
+        hasCompleted = YES;
+        completion(isRunning);
+      }
+    }
+  };
+
+  NSURLSessionDataTask *task = [session dataTaskWithRequest:request
+                                          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                            if (error != nil || data == nil) {
+                                              safeCompletion(NO);
+                                              return;
+                                            }
+                                            NSString *status = [[NSString alloc] initWithData:data
+                                                                                     encoding:NSUTF8StringEncoding];
+                                            BOOL isRunning = [status isEqualToString:@"packager-status:running"];
+                                            safeCompletion(isRunning);
+                                          }];
+  [task resume];
+
+  dispatch_after(
+      dispatch_time(
+          DISPATCH_TIME_NOW,
+          (int64_t)((kRCTPackagerStatusRequestTimeout + kRCTPackagerStatusRequestTimeoutGraceTime) * NSEC_PER_SEC)),
+      dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
+      ^{
+        @synchronized(lock) {
+          if (!hasCompleted) {
+            hasCompleted = YES;
+            [task cancel];
+            completion(NO);
+          }
+        }
+      });
+}
+
 - (NSString *)guessPackagerHost
 {
   static NSString *ipGuess;
@@ -159,6 +229,18 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
 + (BOOL)isPackagerRunning:(NSString *)hostPort scheme:(NSString *)scheme
 {
   return false;
+}
+
++ (void)isPackagerRunningAsync:(NSString *)hostPort completion:(void (^)(BOOL isRunning))completion
+{
+  completion(NO);
+}
+
++ (void)isPackagerRunningAsync:(NSString *)hostPort
+                        scheme:(NSString *)scheme
+                    completion:(void (^)(BOOL isRunning))completion
+{
+  completion(NO);
 }
 #endif
 


### PR DESCRIPTION
Summary:
Changelog: [iOS][Added] Introduce "isPackagerRunningAsync" that does not block the ui thread waiting on the request to DevServer ("Packager") validating that it is running 

The previous behavior was getting the UI blocked when the network conditions meant that a request was taking some time to result in success / fail / timeout.

Differential Revision: D94430009


