### PR TITLE
Fix build_debugger_shell job by passing --prepack to yarn build

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -623,7 +623,7 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Build packages
         shell: bash
-        run: yarn build
+        run: yarn build --prepack
       - name: Verify debugger-shell build
         shell: bash
         run: node scripts/debugger-shell/build-binary.js


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The build_debugger_shell CI job was failing because build-binary.js
expects pkg.main to start with ./dist/, but without --prepack the
prepack.js script never runs, so main stays as ./src/index.js.

This was caused by a series of PRs:
- PR #54857 refactored debugger-shell/package.json to use the
  publishConfig pattern, moving main from ./dist/index.js to
  ./src/index.js.
- PR #55415 added the --prepack flag to build.js to support this.
- PR #55416 added the build_debugger_shell CI job but ran yarn build
  without --prepack.

The fix passes --prepack to yarn build so that prepack.js rewrites
package.json main to ./dist/index.js before build-binary.js runs.

Reviewed By: huntie

Differential Revision: D95818417


