### PR TITLE
Remove unused headers in ReactCommon

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
@@ -10,6 +10,7 @@
 #include <glog/logging.h>
 #include <react/bridging/Bridging.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <ostream>
 #include <string>
 #include "StackTraceParser.h"
 

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <iostream>
+#include <iosfwd>
 #include <optional>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
@@ -9,7 +9,6 @@
 
 #include "NetworkTypes.h"
 
-#include <folly/dynamic.h>
 #include <react/timing/primitives.h>
 
 #include <mutex>

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpPerfIssuesReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpPerfIssuesReporter.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/performance/timeline/PerformanceEntry.h>
 #include <react/performance/timeline/PerformanceEntryReporterListeners.h>

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <ReactCommon/CallInvoker.h>
-#include <folly/dynamic.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerAnimationBackend.h>

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <react/debug/react_native_expect.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/attributedstring/AttributedString.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -9,7 +9,6 @@
 
 #include <unordered_map>
 
-#include <folly/dynamic.h>
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
@@ -9,7 +9,6 @@
 
 #include <memory>
 
-#include <folly/dynamic.h>
 #include <react/renderer/components/scrollview/ScrollEvent.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/core/EventEmitter.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <react/renderer/components/scrollview/primitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/stateConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/stateConversions.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/text/ParagraphState.h>
 #ifdef RN_SERIALIZABLE_STATE

--- a/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <glog/logging.h>
 #include <react/debug/react_native_assert.h>
 #include <react/debug/react_native_expect.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.h
@@ -12,7 +12,10 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/ValueUnit.h>
 #include <optional>
+
+#if RN_DEBUG_STRING_CONVERTIBLE
 #include <sstream>
+#endif
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
@@ -12,7 +12,10 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/ValueUnit.h>
 
+#if RN_DEBUG_STRING_CONVERTIBLE
 #include <sstream>
+#endif
+
 #include <variant>
 #include <vector>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RadialGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RadialGradient.h
@@ -12,7 +12,11 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/ValueUnit.h>
 #include <optional>
+
+#if RN_DEBUG_STRING_CONVERTIBLE
 #include <sstream>
+#endif
+
 #include <variant>
 #include <vector>
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/uimanager/PointerEventsProcessor.h>


### PR DESCRIPTION
Summary:
Remove `folly` and `sstream` headers in places where it is not needed


Changelog: [Internal]

Differential Revision: D95709383


