### PR TITLE
[0.85] fix(ci): Add prepack argument to `Verify debugger-shell build` step

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -623,7 +623,7 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Build packages
         shell: bash
-        run: yarn build
+        run: yarn build --prepack debugger-shell
       - name: Verify debugger-shell build
         shell: bash
         run: node scripts/debugger-shell/build-binary.js


### PR DESCRIPTION
## Summary:

Same as https://github.com/facebook/react-native/pull/56011 but targeting 0.85-stable

CI is failing on `Verify debugger-shell build` step https://github.com/facebook/react-native/actions/runs/22646341688/job/65635185262

## Changelog:



[INTERNAL] [FIXED|SECURITY] - Add prepack argument to `Verify debugger-shell build` step
 

## Test Plan:

Verify debugger-shell CI should be green
