### PR TITLE
fix(ci): Add prepack argument to `Verify debugger-shell` build step

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -85,6 +85,7 @@ jobs:
             debugger_shell:
               - 'packages/debugger-shell/**'
               - 'scripts/debugger-shell/**'
+              - '.github/workflows/test-all.yml'
 
   prebuild_apple_dependencies:
     needs: check_code_changes
@@ -103,8 +104,7 @@ jobs:
 
   test_ios_rntester_ruby_3_2_0:
     runs-on: macos-15
-    needs:
-      [prebuild_apple_dependencies, prebuild_react_native_core]
+    needs: [prebuild_apple_dependencies, prebuild_react_native_core]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -136,8 +136,7 @@ jobs:
 
   test_ios_rntester:
     runs-on: macos-15-large
-    needs:
-      [prebuild_apple_dependencies, prebuild_react_native_core]
+    needs: [prebuild_apple_dependencies, prebuild_react_native_core]
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -155,8 +154,7 @@ jobs:
 
   test_e2e_ios_rntester:
     runs-on: macos-15-large
-    needs:
-      [test_ios_rntester]
+    needs: [test_ios_rntester]
     strategy:
       fail-fast: false
       matrix:
@@ -229,8 +227,8 @@ jobs:
       - name: Configure git
         shell: bash
         run: |
-            git config --global user.email "react-native-bot@meta.com"
-            git config --global user.name "React Native Bot"
+          git config --global user.email "react-native-bot@meta.com"
+          git config --global user.name "React Native Bot"
       - name: Prepare artifacts
         run: |
           REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
@@ -287,8 +285,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'zulu'
+          java-version: "17"
+          distribution: "zulu"
       - name: Download Maven Local
         uses: actions/download-artifact@v7
         with:
@@ -334,7 +332,7 @@ jobs:
           app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
           app-id: com.rntestproject
           maestro-flow: ./scripts/e2e/.maestro/
-          install-java: 'false'
+          install-java: "false"
           flavor: ${{ matrix.flavor }}
           working-directory: /tmp/RNTestProject
 
@@ -639,7 +637,14 @@ jobs:
   # This is exactly the same as rerunning failed tests from the GH UI, but automated.
   rerun-failed-jobs:
     runs-on: ubuntu-latest
-    needs: [test_e2e_ios_rntester, test_e2e_android_rntester, test_e2e_ios_templateapp, test_e2e_android_templateapp, run_fantom_tests]
+    needs:
+      [
+        test_e2e_ios_rntester,
+        test_e2e_android_rntester,
+        test_e2e_ios_templateapp,
+        test_e2e_android_templateapp,
+        run_fantom_tests,
+      ]
     if: ${{ github.ref == 'refs/heads/main' && always() }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary:

CI is failing on `Verify debugger-shell build` step https://github.com/facebook/react-native/actions/runs/22646341688/job/65635185262

## Changelog:



[INTERNAL] [FIXED|SECURITY] - Add prepack argument to `Verify debugger-shell build` step
 

## Test Plan:

Verify debugger-shell CI should be green
