### PR TITLE
Add BigInt Support to Objective-C Turbo Module (#56020)

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -42,6 +42,10 @@ export type Int32TypeAnnotation = Readonly<{
   type: 'Int32TypeAnnotation',
 }>;
 
+export type BigIntTypeAnnotation = Readonly<{
+  type: 'BigIntTypeAnnotation',
+}>;
+
 export type NumberLiteralTypeAnnotation = Readonly<{
   type: 'NumberLiteralTypeAnnotation',
   value: number,
@@ -423,6 +427,7 @@ export type NativeModuleBaseTypeAnnotation =
   | NumberLiteralTypeAnnotation
   | BooleanLiteralTypeAnnotation
   | Int32TypeAnnotation
+  | BigIntTypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation
   | BooleanTypeAnnotation

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -119,6 +119,8 @@ function serializeArg(
       return wrap(val => `${val}.asNumber()`);
     case 'Int32TypeAnnotation':
       return wrap(val => `${val}.asNumber()`);
+    case 'BigIntTypeAnnotation':
+      return wrap(val => `jsi::Value(rt, ${val})`);
     case 'NumberLiteralTypeAnnotation':
       return wrap(val => `${val}.asNumber()`);
     case 'ArrayTypeAnnotation':
@@ -269,6 +271,8 @@ function translatePrimitiveJSTypeToCpp(
       return wrapOptional('double', isRequired);
     case 'Int32TypeAnnotation':
       return wrapOptional('int', isRequired);
+    case 'BigIntTypeAnnotation':
+      return wrapOptional('BigInt', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapOptional('bool', isRequired);
     case 'BooleanLiteralTypeAnnotation':
@@ -613,6 +617,12 @@ function translateFunctionToCpp(
     enumMap,
   );
 
+  // BigInt methods return BigInt from C++, but the callFromJs template
+  // parameter must be jsi::BigInt so the bridging layer converts via
+  // Bridging<BigInt>::toJs -> jsi::BigInt -> jsi::Value.
+  const callFromJsReturnType =
+    returnType === 'BigInt' ? 'jsi::BigInt' : returnType;
+
   let methodCallArgs = [...args].join(',\n      ');
   if (methodCallArgs.length > 0) {
     methodCallArgs = `,\n      ${methodCallArgs}`;
@@ -622,7 +632,7 @@ function translateFunctionToCpp(
     static_assert(
       bridging::getParameterCount(&T::${prop.name}) == ${paramTypes.length},
       "Expected ${prop.name}(...) to have ${paramTypes.length} parameters");
-    ${!isVoid ? (!isNullable ? 'return ' : 'auto result = ') : ''}bridging::callFromJs<${returnType}>(rt, &T::${prop.name},  static_cast<${hasteModuleName}CxxSpec*>(&turboModule)->jsInvoker_, static_cast<T*>(&turboModule)${methodCallArgs});${!isVoid ? (!isNullable ? '' : 'return result ? jsi::Value(std::move(*result)) : jsi::Value::null();') : 'return jsi::Value::undefined();'}\n  }`;
+    ${!isVoid ? (!isNullable ? 'return ' : 'auto result = ') : ''}bridging::callFromJs<${callFromJsReturnType}>(rt, &T::${prop.name},  static_cast<${hasteModuleName}CxxSpec*>(&turboModule)->jsInvoker_, static_cast<T*>(&turboModule)${methodCallArgs});${!isVoid ? (!isNullable ? '' : 'return result ? jsi::Value(std::move(*result)) : jsi::Value::null();') : 'return jsi::Value::undefined();'}\n  }`;
 }
 
 type EventEmitterCpp = {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -271,11 +271,8 @@ function translateFunctionParamToJavaType(
       imports.add('com.facebook.react.bridge.Callback');
       return wrapOptional('Callback', isRequired);
     case 'BigIntTypeAnnotation':
-      throw new Error(
-        createErrorMessage(
-          `${realTypeAnnotation.type} is not supported in Java TurboModules yet`,
-        ),
-      );
+      imports.add('java.math.BigInteger');
+      return wrapOptional('BigInteger', isRequired);
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
       throw new Error(createErrorMessage(realTypeAnnotation.type));
@@ -371,11 +368,8 @@ function translateFunctionReturnTypeToJavaType(
       imports.add('com.facebook.react.bridge.WritableArray');
       return wrapOptional('WritableArray', isRequired);
     case 'BigIntTypeAnnotation':
-      throw new Error(
-        createErrorMessage(
-          `${realTypeAnnotation.type} is not supported in Java TurboModules yet`,
-        ),
-      );
+      imports.add('java.math.BigInteger');
+      return wrapOptional('BigInteger', isRequired);
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
       throw new Error(createErrorMessage(realTypeAnnotation.type));
@@ -459,7 +453,7 @@ function getFalsyReturnStatementFromReturnType(
     case 'ArrayTypeAnnotation':
       return 'return null;';
     case 'BigIntTypeAnnotation':
-      throw new Error(createErrorMessage(realTypeAnnotation.type));
+      return nullable ? 'return null;' : 'return BigInteger.ZERO;';
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
       throw new Error(createErrorMessage(realTypeAnnotation.type));

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -155,6 +155,9 @@ function translateEventEmitterTypeToJavaType(
     case 'DoubleTypeAnnotation':
     case 'Int32TypeAnnotation':
       return 'double';
+    case 'BigIntTypeAnnotation':
+      imports.add('java.math.BigInteger');
+      return 'BigInteger';
     case 'BooleanTypeAnnotation':
     case 'BooleanLiteralTypeAnnotation':
       return 'boolean';
@@ -267,9 +270,11 @@ function translateFunctionParamToJavaType(
     case 'FunctionTypeAnnotation':
       imports.add('com.facebook.react.bridge.Callback');
       return wrapOptional('Callback', isRequired);
-    case 'ArrayBufferTypeAnnotation':
+    case 'BigIntTypeAnnotation':
       throw new Error(
-        `${createErrorMessage(realTypeAnnotation.type)} ArrayBuffer is only supported for C++ TurboModules.`,
+        createErrorMessage(
+          `${realTypeAnnotation.type} is not supported in Java TurboModules yet`,
+        ),
       );
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
@@ -365,9 +370,11 @@ function translateFunctionReturnTypeToJavaType(
     case 'ArrayTypeAnnotation':
       imports.add('com.facebook.react.bridge.WritableArray');
       return wrapOptional('WritableArray', isRequired);
-    case 'ArrayBufferTypeAnnotation':
+    case 'BigIntTypeAnnotation':
       throw new Error(
-        `${createErrorMessage(realTypeAnnotation.type)} ArrayBuffer is only supported for C++ TurboModules.`,
+        createErrorMessage(
+          `${realTypeAnnotation.type} is not supported in Java TurboModules yet`,
+        ),
       );
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
@@ -451,10 +458,8 @@ function getFalsyReturnStatementFromReturnType(
       return 'return null;';
     case 'ArrayTypeAnnotation':
       return 'return null;';
-    case 'ArrayBufferTypeAnnotation':
-      throw new Error(
-        `${createErrorMessage(realTypeAnnotation.type)} ArrayBuffer is only supported for C++ TurboModules.`,
-      );
+    case 'BigIntTypeAnnotation':
+      throw new Error(createErrorMessage(realTypeAnnotation.type));
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
       throw new Error(createErrorMessage(realTypeAnnotation.type));

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -33,6 +33,7 @@ type JSReturnType =
   | 'StringKind'
   | 'BooleanKind'
   | 'NumberKind'
+  | 'BigIntKind'
   | 'PromiseKind'
   | 'ObjectKind'
   | 'ArrayKind';
@@ -208,6 +209,8 @@ function translateReturnTypeToKind(
       return 'NumberKind';
     case 'Int32TypeAnnotation':
       return 'NumberKind';
+    case 'BigIntTypeAnnotation':
+      return 'BigIntKind';
     case 'PromiseTypeAnnotation':
       return 'PromiseKind';
     case 'GenericObjectTypeAnnotation':
@@ -297,6 +300,10 @@ function translateParamTypeToJniType(
       return !isRequired ? 'Ljava/lang/Double;' : 'D';
     case 'Int32TypeAnnotation':
       return !isRequired ? 'Ljava/lang/Double;' : 'D';
+    case 'BigIntTypeAnnotation':
+      throw new Error(
+        `${realTypeAnnotation.type} is not supported in Java TurboModules yet`,
+      );
     case 'GenericObjectTypeAnnotation':
       return 'Lcom/facebook/react/bridge/ReadableMap;';
     case 'ObjectTypeAnnotation':
@@ -383,6 +390,10 @@ function translateReturnTypeToJniType(
       return nullable ? 'Ljava/lang/Double;' : 'D';
     case 'Int32TypeAnnotation':
       return nullable ? 'Ljava/lang/Double;' : 'D';
+    case 'BigIntTypeAnnotation':
+      throw new Error(
+        `${realTypeAnnotation.type} is not supported in Java TurboModules yet`,
+      );
     case 'PromiseTypeAnnotation':
       return 'Lcom/facebook/react/bridge/Promise;';
     case 'GenericObjectTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -301,9 +301,7 @@ function translateParamTypeToJniType(
     case 'Int32TypeAnnotation':
       return !isRequired ? 'Ljava/lang/Double;' : 'D';
     case 'BigIntTypeAnnotation':
-      throw new Error(
-        `${realTypeAnnotation.type} is not supported in Java TurboModules yet`,
-      );
+      return 'Ljava/math/BigInteger;';
     case 'GenericObjectTypeAnnotation':
       return 'Lcom/facebook/react/bridge/ReadableMap;';
     case 'ObjectTypeAnnotation':
@@ -391,9 +389,7 @@ function translateReturnTypeToJniType(
     case 'Int32TypeAnnotation':
       return nullable ? 'Ljava/lang/Double;' : 'D';
     case 'BigIntTypeAnnotation':
-      throw new Error(
-        `${realTypeAnnotation.type} is not supported in Java TurboModules yet`,
-      );
+      return 'Ljava/math/BigInteger;';
     case 'PromiseTypeAnnotation':
       return 'Lcom/facebook/react/bridge/Promise;';
     case 'GenericObjectTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {
+  BigIntTypeAnnotation,
   BooleanLiteralTypeAnnotation,
   BooleanTypeAnnotation,
   DoubleTypeAnnotation,
@@ -72,6 +73,7 @@ export type StructTypeAnnotation =
   | NumberLiteralTypeAnnotation
   | BooleanLiteralTypeAnnotation
   | Int32TypeAnnotation
+  | BigIntTypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation
   | BooleanTypeAnnotation

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
@@ -115,6 +115,8 @@ function toObjCValue(
       return wrapPrimitive('double');
     case 'Int32TypeAnnotation':
       return wrapPrimitive('double');
+    case 'BigIntTypeAnnotation':
+      return value;
     case 'DoubleTypeAnnotation':
       return wrapPrimitive('double');
     case 'BooleanTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
@@ -106,6 +106,8 @@ function toObjCValue(
       return RCTBridgingTo('Double');
     case 'Int32TypeAnnotation':
       return RCTBridgingTo('Double');
+    case 'BigIntTypeAnnotation':
+      return RCTBridgingTo('NSNumber');
     case 'DoubleTypeAnnotation':
       return RCTBridgingTo('Double');
     case 'BooleanTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeStructUtils.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeStructUtils.js
@@ -56,6 +56,8 @@ function toObjCType(
       return wrapCxxOptional('double', isRequired);
     case 'DoubleTypeAnnotation':
       return wrapCxxOptional('double', isRequired);
+    case 'BigIntTypeAnnotation':
+      return wrapObjCOptional('NSNumber *', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapCxxOptional('bool', isRequired);
     case 'BooleanLiteralTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -51,6 +51,7 @@ type ReturnJSType =
   | 'ObjectKind'
   | 'ArrayKind'
   | 'NumberKind'
+  | 'BigIntKind'
   | 'StringKind'
   | 'ArrayBufferKind';
 
@@ -276,6 +277,8 @@ function getParamObjCType(
       return notStruct(isRequired ? 'double' : 'NSNumber *');
     case 'Int32TypeAnnotation':
       return notStruct(isRequired ? 'NSInteger' : 'NSNumber *');
+    case 'BigIntTypeAnnotation':
+      return notStruct(wrapOptional('NSNumber *', !nullable));
     case 'BooleanTypeAnnotation':
       return notStruct(isRequired ? 'BOOL' : 'NSNumber *');
     case 'BooleanLiteralTypeAnnotation':
@@ -357,6 +360,8 @@ function getReturnObjCType(
       return wrapOptional('NSNumber *', isRequired);
     case 'Int32TypeAnnotation':
       return wrapOptional('NSNumber *', isRequired);
+    case 'BigIntTypeAnnotation':
+      return wrapOptional('NSNumber *', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapOptional('NSNumber *', isRequired);
     case 'BooleanLiteralTypeAnnotation':
@@ -433,6 +438,8 @@ function getReturnJSType(
       return 'NumberKind';
     case 'Int32TypeAnnotation':
       return 'NumberKind';
+    case 'BigIntTypeAnnotation':
+      return 'BigIntKind';
     case 'BooleanTypeAnnotation':
       return 'BooleanKind';
     case 'BooleanLiteralTypeAnnotation':

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {
-  ArrayBufferTypeAnnotation,
+  BigIntTypeAnnotation,
   BooleanLiteralTypeAnnotation,
   BooleanTypeAnnotation,
   DoubleTypeAnnotation,
@@ -86,6 +86,12 @@ function emitInt32Prop(
       type: 'Int32TypeAnnotation',
     },
   };
+}
+
+function emitBigInt(nullable: boolean): Nullable<BigIntTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'BigIntTypeAnnotation',
+  });
 }
 
 function emitNumber(
@@ -664,6 +670,8 @@ function emitCommonTypes(
   const typeMap = {
     Stringish: emitStringish,
     Int32: emitInt32,
+    BigInt: emitBigInt,
+    BigIntTypeAnnotation: emitBigInt,
     Double: emitDouble,
     Float: emitFloat,
     UnsafeObject: emitGenericObject,

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -393,6 +393,8 @@ class TypeScriptParser implements Parser {
         return 'ArrayTypeAnnotation';
       case 'TSBooleanKeyword':
         return 'BooleanTypeAnnotation';
+      case 'TSBigIntKeyword':
+        return 'BigIntTypeAnnotation';
       case 'TSNumberKeyword':
         return 'NumberTypeAnnotation';
       case 'TSVoidKeyword':

--- a/packages/react-native-compatibility-check/src/ErrorFormatting.js
+++ b/packages/react-native-compatibility-check/src/ErrorFormatting.js
@@ -172,6 +172,8 @@ function formatTypeAnnotation(annotation: CompleteTypeAnnotation): string {
       return 'float';
     case 'Int32TypeAnnotation':
       return 'int';
+    case 'BigIntTypeAnnotation':
+      return 'bigint';
     case 'NumberLiteralTypeAnnotation':
       return annotation.value.toString();
     case 'BooleanLiteralTypeAnnotation':

--- a/packages/react-native-compatibility-check/src/SortTypeAnnotations.js
+++ b/packages/react-native-compatibility-check/src/SortTypeAnnotations.js
@@ -113,6 +113,7 @@ export function compareTypeAnnotationForSorting(
       );
     case 'NumberTypeAnnotation':
     case 'Int32TypeAnnotation':
+    case 'BigIntTypeAnnotation':
     case 'FloatTypeAnnotation':
     case 'DoubleTypeAnnotation':
       return 0;
@@ -284,7 +285,7 @@ function typeAnnotationArbitraryOrder(annotation: CompleteTypeAnnotation) {
       return 28;
     case 'UnionTypeAnnotation':
       return 30;
-    case 'ArrayBufferTypeAnnotation':
+    case 'BigIntTypeAnnotation':
       return 31;
     default:
       annotation.type as empty;

--- a/packages/react-native-compatibility-check/src/TypeDiffing.js
+++ b/packages/react-native-compatibility-check/src/TypeDiffing.js
@@ -180,6 +180,7 @@ export function compareTypeAnnotation(
     case 'DoubleTypeAnnotation':
     case 'FloatTypeAnnotation':
     case 'Int32TypeAnnotation':
+    case 'BigIntTypeAnnotation':
     case 'BooleanTypeAnnotation':
     case 'NumberTypeAnnotation':
     case 'StringTypeAnnotation':

--- a/packages/react-native/ReactCommon/react/bridging/BigInt.h
+++ b/packages/react-native/ReactCommon/react/bridging/BigInt.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/bridging/Base.h>
+
+#include <cstdint>
+#include <variant>
+
+namespace facebook::react {
+
+class BigInt {
+ public:
+  BigInt(jsi::Runtime &rt, const jsi::BigInt &bigint)
+  {
+    if (bigint.isInt64(rt)) {
+      value_ = bigint.asInt64(rt);
+    } else if (bigint.isUint64(rt)) {
+      value_ = bigint.asUint64(rt);
+    } else {
+      throw jsi::JSError(rt, "BigInt value cannot be losslessly represented as int64_t or uint64_t");
+    }
+  }
+
+  /* implicit */ BigInt(int64_t value) : value_(value) {}
+  /* implicit */ BigInt(uint64_t value) : value_(value) {}
+
+  bool isInt64() const
+  {
+    return std::holds_alternative<int64_t>(value_);
+  }
+
+  bool isUint64() const
+  {
+    return std::holds_alternative<uint64_t>(value_);
+  }
+
+  int64_t asInt64() const
+  {
+    return std::get<int64_t>(value_);
+  }
+
+  uint64_t asUint64() const
+  {
+    return std::get<uint64_t>(value_);
+  }
+
+  jsi::BigInt toJSBigInt(jsi::Runtime &rt) const
+  {
+    if (isInt64()) {
+      return jsi::BigInt::fromInt64(rt, asInt64());
+    } else {
+      return jsi::BigInt::fromUint64(rt, asUint64());
+    }
+  }
+
+  bool operator==(const BigInt &other) const = default;
+
+ private:
+  std::variant<int64_t, uint64_t> value_;
+};
+
+template <>
+struct Bridging<BigInt> {
+  static BigInt fromJs(jsi::Runtime &rt, const jsi::Value &value)
+  {
+    return {rt, value.getBigInt(rt)};
+  }
+
+  static jsi::BigInt toJs(jsi::Runtime &rt, const BigInt &value)
+  {
+    return value.toJSBigInt(rt);
+  }
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridging/Bridging.h
+++ b/packages/react-native/ReactCommon/react/bridging/Bridging.h
@@ -10,6 +10,7 @@
 #include <react/bridging/AString.h>
 #include <react/bridging/Array.h>
 #include <react/bridging/ArrayBuffer.h>
+#include <react/bridging/BigInt.h>
 #include <react/bridging/Bool.h>
 #include <react/bridging/Class.h>
 #include <react/bridging/Dynamic.h>

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -10,6 +10,10 @@
 
 #include "BridgingTest.h"
 
+#include <cstdint>
+#include <limits>
+#include <utility>
+
 namespace facebook::react {
 
 using namespace std::literals;
@@ -970,6 +974,89 @@ TEST_F(BridgingTest, highResTimeStampTest) {
   EXPECT_EQ(1.0, bridging::toJs(rt, HighResDuration::fromNanoseconds(1e6)));
   EXPECT_EQ(
       1.000001, bridging::toJs(rt, HighResDuration::fromNanoseconds(1e6 + 1)));
+}
+
+TEST_F(BridgingTest, bigintTest) {
+  // Test BigInt construction from int64_t
+  BigInt fromSigned(static_cast<int64_t>(42));
+  EXPECT_TRUE(fromSigned.isInt64());
+  EXPECT_FALSE(fromSigned.isUint64());
+  EXPECT_EQ(42, fromSigned.asInt64());
+
+  // Test BigInt construction from uint64_t
+  BigInt fromUnsigned(static_cast<uint64_t>(42));
+  EXPECT_FALSE(fromUnsigned.isInt64());
+  EXPECT_TRUE(fromUnsigned.isUint64());
+  EXPECT_EQ(42ULL, fromUnsigned.asUint64());
+
+  // Test BigInt construction from jsi::BigInt with signed value
+  auto jsiBigint = jsi::BigInt::fromInt64(rt, -123456789012345LL);
+  BigInt fromJsi(rt, jsiBigint);
+  EXPECT_TRUE(fromJsi.isInt64());
+  EXPECT_EQ(-123456789012345LL, fromJsi.asInt64());
+
+  // Test BigInt construction from jsi::BigInt with large unsigned value
+  // (doesn't fit in int64_t, so should be stored as uint64_t)
+  constexpr uint64_t uint64Max = std::numeric_limits<uint64_t>::max();
+  auto jsiUnsigned = jsi::BigInt::fromUint64(rt, uint64Max);
+  BigInt fromJsiUnsigned(rt, jsiUnsigned);
+  EXPECT_TRUE(fromJsiUnsigned.isUint64());
+  EXPECT_EQ(uint64Max, fromJsiUnsigned.asUint64());
+
+  // Test BigInt construction from jsi::BigInt with small positive value
+  // (fits in both int64_t and uint64_t — should prefer int64_t)
+  auto jsiSmall = jsi::BigInt::fromInt64(rt, 5);
+  BigInt fromJsiSmall(rt, jsiSmall);
+  EXPECT_TRUE(fromJsiSmall.isInt64());
+  EXPECT_EQ(5, fromJsiSmall.asInt64());
+
+  // Test toJSBigInt roundtrip for signed value
+  BigInt signedVal(static_cast<int64_t>(-42));
+  auto jsResult = signedVal.toJSBigInt(rt);
+  EXPECT_EQ(-42, jsResult.asInt64(rt));
+
+  // Test toJSBigInt roundtrip for unsigned value
+  BigInt unsignedVal(uint64Max);
+  auto jsUnsignedResult = unsignedVal.toJSBigInt(rt);
+  EXPECT_EQ(uint64Max, jsUnsignedResult.asUint64(rt));
+
+  // Test Bridging<BigInt>::fromJs
+  constexpr int64_t int64Max = std::numeric_limits<int64_t>::max();
+  auto jsBigint = jsi::BigInt::fromInt64(rt, int64Max);
+  auto bridged =
+      bridging::fromJs<BigInt>(rt, jsi::Value(rt, jsBigint), invoker);
+  EXPECT_TRUE(bridged.isInt64());
+  EXPECT_EQ(int64Max, bridged.asInt64());
+
+  // Test Bridging<BigInt>::toJs
+  BigInt toConvert(static_cast<int64_t>(123456789012345LL));
+  auto jsConverted = bridging::toJs(rt, toConvert);
+  EXPECT_EQ(123456789012345LL, jsConverted.asInt64(rt));
+
+  // Test roundtrip at extreme values via bridging
+  constexpr int64_t int64Min = std::numeric_limits<int64_t>::min();
+
+  auto roundtripMin = bridging::fromJs<BigInt>(
+      rt, jsi::Value(rt, bridging::toJs(rt, BigInt(int64Min))), invoker);
+  EXPECT_TRUE(roundtripMin.isInt64());
+  EXPECT_EQ(int64Min, roundtripMin.asInt64());
+
+  auto roundtripMax = bridging::fromJs<BigInt>(
+      rt, jsi::Value(rt, bridging::toJs(rt, BigInt(int64Max))), invoker);
+  EXPECT_TRUE(roundtripMax.isInt64());
+  EXPECT_EQ(int64Max, roundtripMax.asInt64());
+
+  auto roundtripUmax = bridging::fromJs<BigInt>(
+      rt, jsi::Value(rt, bridging::toJs(rt, BigInt(uint64Max))), invoker);
+  EXPECT_TRUE(roundtripUmax.isUint64());
+  EXPECT_EQ(uint64Max, roundtripUmax.asUint64());
+
+  // Test equality
+  EXPECT_EQ(BigInt(static_cast<int64_t>(42)), BigInt(static_cast<int64_t>(42)));
+  EXPECT_EQ(BigInt(uint64Max), BigInt(uint64Max));
+  // Same numeric value but different variant type are not equal
+  EXPECT_NE(
+      BigInt(static_cast<int64_t>(42)), BigInt(static_cast<uint64_t>(42)));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp
@@ -21,6 +21,8 @@ TurboModuleMethodValueKind getTurboModuleMethodValueKind(
     return NumberKind;
   } else if (value->isString()) {
     return StringKind;
+  } else if (value->isBigInt()) {
+    return BigIntKind;
   } else if (value->isObject()) {
     auto object = value->asObject(rt);
     if (object.isArray(rt)) {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -26,6 +26,7 @@ enum TurboModuleMethodValueKind {
   VoidKind,
   BooleanKind,
   NumberKind,
+  BigIntKind,
   StringKind,
   ObjectKind,
   ArrayKind,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <array>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -169,6 +172,53 @@ struct JPromiseImpl : public jni::JavaClass<JPromiseImpl> {
   }
 };
 
+struct JBigInteger : public jni::JavaClass<JBigInteger> {
+  constexpr static auto kJavaDescriptor = "Ljava/math/BigInteger;";
+
+  static jni::local_ref<javaobject> valueOf(jlong val) {
+    static const auto cls = javaClassStatic();
+    static const auto method =
+        cls->getStaticMethod<javaobject(jlong)>("valueOf");
+    return method(cls, val);
+  }
+
+  static jni::local_ref<javaobject> fromUint64(uint64_t val) {
+    // For values that fit in int64, use the fast path.
+    if (val <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+      return valueOf(static_cast<jlong>(val));
+    }
+    // For values with the high bit set, construct from a big-endian byte
+    // array with a leading zero byte to ensure a positive signum.
+    std::array<jbyte, 9> bytes{};
+    bytes[0] = 0; // sign byte: ensures BigInteger treats this as positive
+    for (int i = 8; i >= 1; --i) {
+      bytes[i] = static_cast<jbyte>(val & 0xFF);
+      val >>= 8;
+    }
+    auto env = jni::Environment::current();
+    auto byteArray = env->NewByteArray(9);
+    env->SetByteArrayRegion(byteArray, 0, 9, bytes.data());
+    return newInstance(byteArray);
+  }
+
+  jlong longValue() const {
+    static const auto method =
+        javaClassStatic()->getMethod<jlong()>("longValue");
+    return method(self());
+  }
+
+  jint bitLength() const {
+    static const auto method =
+        javaClassStatic()->getMethod<jint()>("bitLength");
+    return method(self());
+  }
+
+  jint signum() const {
+    static const auto method = javaClassStatic()->getMethod<jint()>("signum");
+    return method(self());
+  }
+};
+
 // This is used for generating short exception strings.
 std::string stringifyJSIValue(const jsi::Value& v, jsi::Runtime* rt = nullptr) {
   if (v.isUndefined()) {
@@ -322,7 +372,7 @@ JNIArgs convertJSIArgsToJNIArgs(
     return obj;
   };
 
-  for (unsigned int argIndex = 0; argIndex < count; argIndex += 1) {
+  for (int argIndex = 0; argIndex < static_cast<int>(count); argIndex += 1) {
     const std::string& type = methodArgTypes.at(argIndex);
 
     const jsi::Value* arg = &args[argIndex];
@@ -397,6 +447,23 @@ JNIArgs convertJSIArgsToJNIArgs(
       jarg->l = makeGlobalIfNecessary(
           jni::JBoolean::valueOf(static_cast<unsigned char>(arg->getBool()))
               .release());
+    } else if (type == "Ljava/math/BigInteger;") {
+      if (!arg->isBigInt()) {
+        throw JavaTurboModuleArgumentConversionException(
+            "bigint", argIndex, methodName, arg, &rt);
+      }
+      auto bigint = arg->getBigInt(rt);
+      jni::local_ref<JBigInteger::javaobject> javaBigInt;
+      if (bigint.isInt64(rt)) {
+        javaBigInt = JBigInteger::valueOf(bigint.getInt64(rt));
+      } else if (bigint.isUint64(rt)) {
+        javaBigInt = JBigInteger::fromUint64(bigint.getUint64(rt));
+      } else {
+        throw jsi::JSError(
+            rt,
+            "BigInt value cannot be losslessly represented as int64_t or uint64_t");
+      }
+      jarg->l = makeGlobalIfNecessary(javaBigInt.release());
     } else if (type == "Ljava/lang/String;") {
       if (!arg->isString()) {
         throw JavaTurboModuleArgumentConversionException(
@@ -962,6 +1029,42 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
           });
       TMPL::asyncMethodCallEnd(moduleName, methodName);
       return jsPromise;
+    }
+    case BigIntKind: {
+      auto returnObject =
+          env->CallObjectMethodA(instance, methodID, jargs.data());
+      checkJNIErrorForMethodCall();
+
+      TMPL::syncMethodCallExecutionEnd(moduleName, methodName);
+      TMPL::syncMethodCallReturnConversionStart(moduleName, methodName);
+
+      auto returnValue = jsi::Value::null();
+      if (returnObject != nullptr) {
+        auto bigIntObj = jni::adopt_local(
+            static_cast<JBigInteger::javaobject>(returnObject));
+
+        // bitLength() returns bits excluding sign bit.
+        // A value fits in int64_t when bitLength() <= 63.
+        // A positive value fits in uint64_t when bitLength() <= 64.
+        auto bits = bigIntObj->bitLength();
+        if (bits <= 63) {
+          returnValue = jsi::BigInt::fromInt64(
+              runtime, static_cast<int64_t>(bigIntObj->longValue()));
+        } else if (bits <= 64 && bigIntObj->signum() >= 0) {
+          // Unsigned 64-bit value: extract low 64 bits via longValue()
+          // and reinterpret as uint64_t.
+          returnValue = jsi::BigInt::fromUint64(
+              runtime, static_cast<uint64_t>(bigIntObj->longValue()));
+        } else {
+          throw jsi::JSError(
+              runtime,
+              "BigInt value cannot be losslessly represented as int64_t or uint64_t");
+        }
+      }
+
+      TMPL::syncMethodCallReturnConversionEnd(moduleName, methodName);
+      TMPL::syncMethodCallEnd(moduleName, methodName);
+      return returnValue;
     }
     default:
       throw std::runtime_error(

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -25,6 +25,7 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import <atomic>
+#import <cstring>
 #import <iostream>
 #import <mutex>
 
@@ -231,6 +232,16 @@ id convertJSIValueToObjCObject(
   }
   if (value.isString()) {
     return convertJSIStringToNSString(runtime, value.getString(runtime));
+  }
+  if (value.isBigInt()) {
+    auto bigint = value.getBigInt(runtime);
+    if (bigint.isInt64(runtime)) {
+      return @(bigint.getInt64(runtime));
+    }
+    if (bigint.isUint64(runtime)) {
+      return @(bigint.getUint64(runtime));
+    }
+    throw jsi::JSError(runtime, "BigInt value is too large for int64_t or uint64_t");
   }
   if (value.isObject()) {
     jsi::Object o = value.getObject(runtime);
@@ -583,7 +594,14 @@ jsi::Value ObjCTurboModule::convertReturnIdToJSIValue(
     case PromiseKind:
       throw jsi::JSError(runtime, "convertReturnIdToJSIValue: PromiseKind wasn't handled properly.");
     case BigIntKind: {
-      returnValue = jsi::BigInt::fromInt64(runtime, [(NSNumber *)result longLongValue]);
+      auto num = (NSNumber *)result;
+      const char *type = [num objCType];
+      if (type != nullptr &&
+          (strcmp(type, @encode(unsigned long long)) == 0 || strcmp(type, @encode(unsigned long)) == 0)) {
+        returnValue = jsi::BigInt::fromUint64(runtime, [num unsignedLongLongValue]);
+      } else {
+        returnValue = jsi::BigInt::fromInt64(runtime, [num longLongValue]);
+      }
       break;
     }
   }
@@ -687,9 +705,40 @@ void ObjCTurboModule::setInvocationArg(
       [retainedObjectsForInvocation addObject:objCArg];
     } else if (objCArgType == @encode(NSInteger)) {
       NSInteger integer = v;
-      [inv setArgument:&integer atIndex:i + 2];
+      [inv setArgument:&integer atIndex:static_cast<NSInteger>(i + 2)];
     } else {
-      [inv setArgument:(void *)&v atIndex:i + 2];
+      [inv setArgument:(void *)&v atIndex:static_cast<NSInteger>(i + 2)];
+    }
+
+    return;
+  }
+
+  if (arg.isBigInt()) {
+    auto bigint = arg.getBigInt(runtime);
+
+    /**
+     * JS type checking ensures the Objective C argument here is either a long long or NSNumber*.
+     */
+    if (bigint.isInt64(runtime)) {
+      int64_t v = bigint.getInt64(runtime);
+      if (objCArgType == @encode(id)) {
+        id objCArg = @(v);
+        [inv setArgument:(void *)&objCArg atIndex:static_cast<NSInteger>(i + 2)];
+        [retainedObjectsForInvocation addObject:objCArg];
+      } else {
+        [inv setArgument:(void *)&v atIndex:static_cast<NSInteger>(i + 2)];
+      }
+    } else if (bigint.isUint64(runtime)) {
+      uint64_t v = bigint.getUint64(runtime);
+      if (objCArgType == @encode(id)) {
+        id objCArg = @(v);
+        [inv setArgument:(void *)&objCArg atIndex:static_cast<NSInteger>(i + 2)];
+        [retainedObjectsForInvocation addObject:objCArg];
+      } else {
+        [inv setArgument:(void *)&v atIndex:static_cast<NSInteger>(i + 2)];
+      }
+    } else {
+      throw jsi::JSError(runtime, "BigInt value is too large for int64_t or uint64_t");
     }
 
     return;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -582,6 +582,10 @@ jsi::Value ObjCTurboModule::convertReturnIdToJSIValue(
       throw jsi::JSError(runtime, "convertReturnIdToJSIValue: FunctionKind is not supported yet.");
     case PromiseKind:
       throw jsi::JSError(runtime, "convertReturnIdToJSIValue: PromiseKind wasn't handled properly.");
+    case BigIntKind: {
+      returnValue = jsi::BigInt::fromInt64(runtime, [(NSNumber *)result longLongValue]);
+      break;
+    }
   }
 
   return returnValue;
@@ -870,7 +874,9 @@ jsi::Value ObjCTurboModule::invokeObjCMethod(
     case ObjectKind:
     case ArrayKind:
     case FunctionKind:
-    case ArrayBufferKind: {
+    case ArrayBufferKind:
+    case FunctionKind:
+    case BigIntKind: {
       id result = performMethodInvocation(runtime, true, methodName, inv, retainedObjectsForInvocation);
       TurboModulePerfLogger::syncMethodCallReturnConversionStart(moduleName, methodName);
       returnValue = convertReturnIdToJSIValue(runtime, methodName, returnType, result);

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.kt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.kt
@@ -27,6 +27,7 @@ import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.turbomodule.core.interfaces.BindingsInstallerHolder
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings
+import java.math.BigInteger
 import java.util.UUID
 
 @DoNotStrip
@@ -223,6 +224,12 @@ public class SampleTurboModule(private val context: ReactApplicationContext) :
   @Suppress("unused")
   override fun promiseAssert(promise: Promise) {
     assert(false) { "Intentional assert from JVM promiseAssert" }
+  }
+
+  @DoNotStrip
+  override fun getBigInt(arg: BigInteger): BigInteger {
+    log("getBigInt", arg, arg)
+    return arg
   }
 
   @DoNotStrip

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -210,6 +210,11 @@ RCT_EXPORT_METHOD(promiseAssert : (RCTPromiseResolveBlock)resolve reject : (RCTP
   RCTAssert(false, @"Intentional assert from ObjC promiseAssert");
 }
 
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getBigInt : (NSNumber *)arg)
+{
+  return arg;
+}
+
 @end
 
 Class _Nonnull RCTSampleTurboModuleCls(void)

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeSampleTurboModule.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeSampleTurboModule.js
@@ -43,8 +43,9 @@ export interface Spec extends TurboModule {
   };
   readonly voidFunc: () => void;
   readonly getBool: (arg: boolean) => boolean;
-  readonly getEnum?: (arg: EnumInt) => EnumInt;
+  readonly getEnum: (arg: EnumInt) => EnumInt;
   readonly getNumber: (arg: number) => number;
+  readonly getBigInt: (arg: bigint) => bigint;
   readonly getString: (arg: string) => string;
   readonly getArray: (arg: Array<any>) => Array<any>;
   readonly getObject: (arg: Object) => Object;

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -8,6 +8,7 @@
 #include "NativeCxxModuleExample.h"
 #include <react/bridging/ArrayBuffer.h>
 #include <react/debug/react_native_assert.h>
+#include <cstdint>
 #include <iomanip>
 #include <numeric>
 #include <ostream>
@@ -326,5 +327,9 @@ AsyncPromise<> NativeCxxModuleExample::promiseAssert(jsi::Runtime& rt) {
   promise.reject("Asserts disabled");
   return promise;
 };
+
+BigInt NativeCxxModuleExample::getBigInt(jsi::Runtime& /*rt*/, BigInt arg) {
+  return arg;
+}
 
 } // namespace facebook::react

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -190,6 +190,8 @@ class NativeCxxModuleExample : public NativeCxxModuleExampleCxxSpec<NativeCxxMod
 
   AsyncPromise<> promiseAssert(jsi::Runtime &rt);
 
+  BigInt getBigInt(jsi::Runtime &rt, BigInt arg);
+
  private:
   std::optional<AsyncCallback<std::string>> valueCallback_;
 };

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -122,6 +122,7 @@ export interface Spec extends TurboModule {
   readonly voidFuncAssert: () => void;
   readonly getObjectAssert: (arg: ObjectStruct) => ObjectStruct;
   readonly promiseAssert: () => Promise<void>;
+  +getBigInt: (arg: bigint) => bigint;
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -53,6 +53,7 @@ type Examples =
   | 'getStrEnum'
   | 'getMap'
   | 'getNumber'
+  | 'getBigInt'
   | 'getObject'
   | 'getSet'
   | 'getString'
@@ -150,7 +151,10 @@ class NativeCxxModuleExampleExample extends React.Component<{}, State> {
       }),
     getNumEnum: () => NativeCxxModuleExample?.getNumEnum(EnumInt.IB),
     getStrEnum: () => NativeCxxModuleExample?.getStrEnum(EnumNone.NB),
+    getMap: () => NativeCxxModuleExample?.getMap({one: 1, two: 2, three: null}),
     getNumber: () => NativeCxxModuleExample?.getNumber(99.95),
+    getBigInt: () =>
+      NativeCxxModuleExample?.getBigInt(BigInt('9223372036854775807')),
     getObject: () =>
       NativeCxxModuleExample?.getObject({a: 1, b: 'foo', c: null}),
     getSet: () => NativeCxxModuleExample?.getSet([1, 1.1, 1.1, 1.1, 2]),
@@ -287,7 +291,9 @@ class NativeCxxModuleExampleExample extends React.Component<{}, State> {
     return (
       <View style={styles.result}>
         <RNTesterText style={[styles.value]}>
-          {JSON.stringify(result.value)}
+          {typeof result.value === 'bigint'
+            ? result.value.toString()
+            : JSON.stringify(result.value)}
         </RNTesterText>
         <RNTesterText style={[styles.type]}>{result.type}</RNTesterText>
       </View>

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -41,6 +41,7 @@ type Examples =
   | 'getStrEnum'
   | 'getMap'
   | 'getNumber'
+  | 'getBigInt'
   | 'getObject'
   | 'getSet'
   | 'getString'
@@ -94,6 +95,8 @@ class SampleTurboModuleExample extends React.Component<{}, State> {
         ? NativeSampleTurboModule.getEnum(EnumInt.A)
         : null,
     getNumber: () => NativeSampleTurboModule.getNumber(99.95),
+    getBigInt: () =>
+      NativeSampleTurboModule?.getBigInt(BigInt('9223372036854775807')),
     getString: () => NativeSampleTurboModule.getString('Hello'),
     getArray: () =>
       NativeSampleTurboModule.getArray([
@@ -195,7 +198,9 @@ class SampleTurboModuleExample extends React.Component<{}, State> {
     return (
       <View style={styles.result}>
         <RNTesterText style={[styles.value]}>
-          {JSON.stringify(result.value)}
+          {typeof result.value === 'bigint'
+            ? result.value.toString()
+            : JSON.stringify(result.value)}
         </RNTesterText>
         <RNTesterText style={[styles.type]}>{result.type}</RNTesterText>
       </View>

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -6591,6 +6591,7 @@ enum facebook::react::TransformOperationType : uint8_t {
 enum facebook::react::TurboModuleMethodValueKind {
   ArrayBufferKind,
   ArrayKind,
+  BigIntKind,
   BooleanKind,
   FunctionKind,
   NumberKind,

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1847,6 +1847,18 @@ class facebook::react::BaseViewProps : public facebook::react::YogaStylableProps
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
 }
 
+class facebook::react::BigInt {
+  public BigInt(facebook::jsi::Runtime& rt, const facebook::jsi::BigInt& bigint);
+  public BigInt(int64_t value);
+  public BigInt(uint64_t value);
+  public bool isInt64() const;
+  public bool isUint64() const;
+  public bool operator==(const facebook::react::BigInt& other) const = default;
+  public facebook::jsi::BigInt toJSBigInt(facebook::jsi::Runtime& rt) const;
+  public int64_t asInt64() const;
+  public uint64_t asUint64() const;
+}
+
 class facebook::react::BigStringBuffer : public facebook::jsi::Buffer {
   public BigStringBuffer(std::unique_ptr<const facebook::react::JSBigString> script);
   public virtual const uint8_t* data() const override;
@@ -9630,8 +9642,9 @@ struct facebook::react::Bridging<facebook::jsi::WeakObject> {
   public static facebook::jsi::WeakObject fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value);
 }
 
-struct facebook::react::Bridging<facebook::react::AsyncArrayBuffer> {
-  public static facebook::jsi::Value toJs(facebook::jsi::Runtime& rt, facebook::react::AsyncArrayBuffer buffer);
+struct facebook::react::Bridging<facebook::react::BigInt> {
+  public static facebook::jsi::BigInt toJs(facebook::jsi::Runtime& rt, const facebook::react::BigInt& value);
+  public static facebook::react::BigInt fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Value& value);
 }
 
 struct facebook::react::Bridging<facebook::react::EndResult> : public facebook::react::NativeAnimatedTurboModuleEndResultBridging<facebook::react::EndResult> {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1845,6 +1845,18 @@ class facebook::react::BaseViewProps : public facebook::react::YogaStylableProps
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
 }
 
+class facebook::react::BigInt {
+  public BigInt(facebook::jsi::Runtime& rt, const facebook::jsi::BigInt& bigint);
+  public BigInt(int64_t value);
+  public BigInt(uint64_t value);
+  public bool isInt64() const;
+  public bool isUint64() const;
+  public bool operator==(const facebook::react::BigInt& other) const = default;
+  public facebook::jsi::BigInt toJSBigInt(facebook::jsi::Runtime& rt) const;
+  public int64_t asInt64() const;
+  public uint64_t asUint64() const;
+}
+
 class facebook::react::BigStringBuffer : public facebook::jsi::Buffer {
   public BigStringBuffer(std::unique_ptr<const facebook::react::JSBigString> script);
   public virtual const uint8_t* data() const override;
@@ -9483,8 +9495,9 @@ struct facebook::react::Bridging<facebook::jsi::WeakObject> {
   public static facebook::jsi::WeakObject fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value);
 }
 
-struct facebook::react::Bridging<facebook::react::AsyncArrayBuffer> {
-  public static facebook::jsi::Value toJs(facebook::jsi::Runtime& rt, facebook::react::AsyncArrayBuffer buffer);
+struct facebook::react::Bridging<facebook::react::BigInt> {
+  public static facebook::jsi::BigInt toJs(facebook::jsi::Runtime& rt, const facebook::react::BigInt& value);
+  public static facebook::react::BigInt fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Value& value);
 }
 
 struct facebook::react::Bridging<facebook::react::EndResult> : public facebook::react::NativeAnimatedTurboModuleEndResultBridging<facebook::react::EndResult> {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -6582,6 +6582,7 @@ enum facebook::react::TransformOperationType : uint8_t {
 enum facebook::react::TurboModuleMethodValueKind {
   ArrayBufferKind,
   ArrayKind,
+  BigIntKind,
   BooleanKind,
   FunctionKind,
   NumberKind,

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -8781,6 +8781,7 @@ enum facebook::react::TransformOperationType : uint8_t {
 enum facebook::react::TurboModuleMethodValueKind {
   ArrayBufferKind,
   ArrayKind,
+  BigIntKind,
   BooleanKind,
   FunctionKind,
   NumberKind,

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -2501,6 +2501,7 @@ protocol NativeSampleTurboModuleSpec : public NSObjectRCTBridgeModule, public RC
   public virtual NSDictionary* getObjectThrows:(NSDictionary* arg);
   public virtual NSDictionary* getUnsafeObject:(NSDictionary* arg);
   public virtual NSDictionary* getValue:y:z:(double x, NSString* y, NSDictionary* z);
+  public virtual NSNumber* getBigInt:(NSNumber* arg);
   public virtual NSNumber* getBool:(BOOL arg);
   public virtual NSNumber* getEnum:(double arg);
   public virtual NSNumber* getNumber:(double arg);

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -4434,6 +4434,18 @@ class facebook::react::BaseViewProps : public facebook::react::YogaStylableProps
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
 }
 
+class facebook::react::BigInt {
+  public BigInt(facebook::jsi::Runtime& rt, const facebook::jsi::BigInt& bigint);
+  public BigInt(int64_t value);
+  public BigInt(uint64_t value);
+  public bool isInt64() const;
+  public bool isUint64() const;
+  public bool operator==(const facebook::react::BigInt& other) const = default;
+  public facebook::jsi::BigInt toJSBigInt(facebook::jsi::Runtime& rt) const;
+  public int64_t asInt64() const;
+  public uint64_t asUint64() const;
+}
+
 class facebook::react::BigStringBuffer : public facebook::jsi::Buffer {
   public BigStringBuffer(std::unique_ptr<const facebook::react::JSBigString> script);
   public virtual const uint8_t* data() const override;
@@ -11533,8 +11545,9 @@ struct facebook::react::Bridging<facebook::jsi::WeakObject> {
   public static facebook::jsi::WeakObject fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value);
 }
 
-struct facebook::react::Bridging<facebook::react::AsyncArrayBuffer> {
-  public static facebook::jsi::Value toJs(facebook::jsi::Runtime& rt, facebook::react::AsyncArrayBuffer buffer);
+struct facebook::react::Bridging<facebook::react::BigInt> {
+  public static facebook::jsi::BigInt toJs(facebook::jsi::Runtime& rt, const facebook::react::BigInt& value);
+  public static facebook::react::BigInt fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Value& value);
 }
 
 struct facebook::react::Bridging<facebook::react::EndResult> : public facebook::react::NativeAnimatedTurboModuleEndResultBridging<facebook::react::EndResult> {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -8772,6 +8772,7 @@ enum facebook::react::TransformOperationType : uint8_t {
 enum facebook::react::TurboModuleMethodValueKind {
   ArrayBufferKind,
   ArrayKind,
+  BigIntKind,
   BooleanKind,
   FunctionKind,
   NumberKind,

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -4432,6 +4432,18 @@ class facebook::react::BaseViewProps : public facebook::react::YogaStylableProps
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
 }
 
+class facebook::react::BigInt {
+  public BigInt(facebook::jsi::Runtime& rt, const facebook::jsi::BigInt& bigint);
+  public BigInt(int64_t value);
+  public BigInt(uint64_t value);
+  public bool isInt64() const;
+  public bool isUint64() const;
+  public bool operator==(const facebook::react::BigInt& other) const = default;
+  public facebook::jsi::BigInt toJSBigInt(facebook::jsi::Runtime& rt) const;
+  public int64_t asInt64() const;
+  public uint64_t asUint64() const;
+}
+
 class facebook::react::BigStringBuffer : public facebook::jsi::Buffer {
   public BigStringBuffer(std::unique_ptr<const facebook::react::JSBigString> script);
   public virtual const uint8_t* data() const override;
@@ -11396,8 +11408,9 @@ struct facebook::react::Bridging<facebook::jsi::WeakObject> {
   public static facebook::jsi::WeakObject fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value);
 }
 
-struct facebook::react::Bridging<facebook::react::AsyncArrayBuffer> {
-  public static facebook::jsi::Value toJs(facebook::jsi::Runtime& rt, facebook::react::AsyncArrayBuffer buffer);
+struct facebook::react::Bridging<facebook::react::BigInt> {
+  public static facebook::jsi::BigInt toJs(facebook::jsi::Runtime& rt, const facebook::react::BigInt& value);
+  public static facebook::react::BigInt fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Value& value);
 }
 
 struct facebook::react::Bridging<facebook::react::EndResult> : public facebook::react::NativeAnimatedTurboModuleEndResultBridging<facebook::react::EndResult> {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -2501,6 +2501,7 @@ protocol NativeSampleTurboModuleSpec : public NSObjectRCTBridgeModule, public RC
   public virtual NSDictionary* getObjectThrows:(NSDictionary* arg);
   public virtual NSDictionary* getUnsafeObject:(NSDictionary* arg);
   public virtual NSDictionary* getValue:y:z:(double x, NSString* y, NSDictionary* z);
+  public virtual NSNumber* getBigInt:(NSNumber* arg);
   public virtual NSNumber* getBool:(BOOL arg);
   public virtual NSNumber* getEnum:(double arg);
   public virtual NSNumber* getNumber:(double arg);

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -4928,6 +4928,7 @@ enum facebook::react::TransformOperationType : uint8_t {
 enum facebook::react::TurboModuleMethodValueKind {
   ArrayBufferKind,
   ArrayKind,
+  BigIntKind,
   BooleanKind,
   FunctionKind,
   NumberKind,

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -1171,6 +1171,18 @@ class facebook::react::BaseViewProps : public facebook::react::YogaStylableProps
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
 }
 
+class facebook::react::BigInt {
+  public BigInt(facebook::jsi::Runtime& rt, const facebook::jsi::BigInt& bigint);
+  public BigInt(int64_t value);
+  public BigInt(uint64_t value);
+  public bool isInt64() const;
+  public bool isUint64() const;
+  public bool operator==(const facebook::react::BigInt& other) const = default;
+  public facebook::jsi::BigInt toJSBigInt(facebook::jsi::Runtime& rt) const;
+  public int64_t asInt64() const;
+  public uint64_t asUint64() const;
+}
+
 class facebook::react::BigStringBuffer : public facebook::jsi::Buffer {
   public BigStringBuffer(std::unique_ptr<const facebook::react::JSBigString> script);
   public virtual const uint8_t* data() const override;
@@ -6700,8 +6712,9 @@ struct facebook::react::Bridging<facebook::jsi::WeakObject> {
   public static facebook::jsi::WeakObject fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value);
 }
 
-struct facebook::react::Bridging<facebook::react::AsyncArrayBuffer> {
-  public static facebook::jsi::Value toJs(facebook::jsi::Runtime& rt, facebook::react::AsyncArrayBuffer buffer);
+struct facebook::react::Bridging<facebook::react::BigInt> {
+  public static facebook::jsi::BigInt toJs(facebook::jsi::Runtime& rt, const facebook::react::BigInt& value);
+  public static facebook::react::BigInt fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Value& value);
 }
 
 struct facebook::react::Bridging<facebook::react::EndResult> : public NativeAnimatedTurboModuleEndResultBridging<facebook::react::EndResult> {

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -1169,6 +1169,18 @@ class facebook::react::BaseViewProps : public facebook::react::YogaStylableProps
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
 }
 
+class facebook::react::BigInt {
+  public BigInt(facebook::jsi::Runtime& rt, const facebook::jsi::BigInt& bigint);
+  public BigInt(int64_t value);
+  public BigInt(uint64_t value);
+  public bool isInt64() const;
+  public bool isUint64() const;
+  public bool operator==(const facebook::react::BigInt& other) const = default;
+  public facebook::jsi::BigInt toJSBigInt(facebook::jsi::Runtime& rt) const;
+  public int64_t asInt64() const;
+  public uint64_t asUint64() const;
+}
+
 class facebook::react::BigStringBuffer : public facebook::jsi::Buffer {
   public BigStringBuffer(std::unique_ptr<const facebook::react::JSBigString> script);
   public virtual const uint8_t* data() const override;
@@ -6691,8 +6703,9 @@ struct facebook::react::Bridging<facebook::jsi::WeakObject> {
   public static facebook::jsi::WeakObject fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value);
 }
 
-struct facebook::react::Bridging<facebook::react::AsyncArrayBuffer> {
-  public static facebook::jsi::Value toJs(facebook::jsi::Runtime& rt, facebook::react::AsyncArrayBuffer buffer);
+struct facebook::react::Bridging<facebook::react::BigInt> {
+  public static facebook::jsi::BigInt toJs(facebook::jsi::Runtime& rt, const facebook::react::BigInt& value);
+  public static facebook::react::BigInt fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Value& value);
 }
 
 struct facebook::react::Bridging<facebook::react::EndResult> : public NativeAnimatedTurboModuleEndResultBridging<facebook::react::EndResult> {

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -4919,6 +4919,7 @@ enum facebook::react::TransformOperationType : uint8_t {
 enum facebook::react::TurboModuleMethodValueKind {
   ArrayBufferKind,
   ArrayKind,
+  BigIntKind,
   BooleanKind,
   FunctionKind,
   NumberKind,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebook/react-native/pull/56020

This diff adds BigInt method support to the Objective-C sample Turbo Module,
demonstrating how to use 64-bit integers with BigInt bridging on iOS.

Changes:
- Added getBigInt method declaration in RCTNativeSampleTurboModuleSpec.h
  using C++ int64_t type
- Added host function binding in RCTNativeSampleTurboModuleSpec.mm using BigIntKind
- Implemented getBigInt in RCTSampleTurboModule.mm using
  RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD
- Fixed BigInt rendering in NativeCxxModuleExampleExample.js and
  SampleTurboModuleExample.js — JSON.stringify() cannot serialize BigInt,
  so bigint values are now rendered via .toString()

The ObjC bridge maps getBigInt to an NSNumber* return with BigIntKind, which
instructs the TurboModule infrastructure to convert via
jsi::BigInt::fromInt64().

## Conversion Table
| NSNumber Method | Underlying Type | Min | Max |
| --- | --- | --- | --- |
| numberWithChar: | char | -128 | 127 |
| numberWithShort: | short | -32,768 | 32,767 |
| numberWithInt: | int | -2,147,483,648 | 2,147,483,647 |
| numberWithLongLong: | long long | -9,223,372,036,854,775,808 | 9,223,372,036,854,775,807 |
| numberWithUnsignedLongLong: | unsigned long long | 0 | 18,446,744,073,709,551,615 |

Changelog: [iOS][Added] - Add BigInt Support to Objective-C Turbo Module

Reviewed By: sammy-SC

Differential Revision: D95232266
