### PR TITLE
Fix ordering of `const` and `mutable` keywords

### DIFF
--- a/scripts/cxx-api/parser/member.py
+++ b/scripts/cxx-api/parser/member.py
@@ -171,11 +171,11 @@ class VariableMember(Member):
         if self.is_constexpr:
             result += "constexpr "
 
-        if self.is_const and not self.is_constexpr:
-            result += "const "
-
         if self.is_mutable:
             result += "mutable "
+
+        if self.is_const and not self.is_constexpr:
+            result += "const "
 
         if self._is_function_pointer():
             formatted_args = format_arguments(self._fp_arguments)

--- a/scripts/cxx-api/tests/snapshots/should_handle_mutable_const_pointer_ordering/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_mutable_const_pointer_ordering/snapshot.api
@@ -1,0 +1,5 @@
+class test::Cache {
+  public const int* constPtr;
+  public mutable const int* mutableConstPtr;
+  public mutable int* mutablePtr;
+}

--- a/scripts/cxx-api/tests/snapshots/should_handle_mutable_const_pointer_ordering/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_mutable_const_pointer_ordering/test.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+class Cache {
+ public:
+  mutable int *mutablePtr;
+  const int *constPtr;
+  mutable const int *mutableConstPtr;
+};
+
+} // namespace test


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The current implementation swaps the ordering of `const` and `mutable` keywords. This diff fixes it.

Differential Revision: D95912404


