### PR TITLE
Don't include private compound objects in the snapshot

### DIFF
--- a/scripts/cxx-api/parser/main.py
+++ b/scripts/cxx-api/parser/main.py
@@ -48,6 +48,9 @@ def build_snapshot(xml_dir: str) -> Snapshot:
         doxygen_object = compound.parse(detail_file, silence=True)
 
         for compound_object in doxygen_object.compounddef:
+            if compound_object.prot == "private":
+                continue
+
             # Check if this is an Objective-C interface by looking at the compound id
             # Doxygen reports ObjC interfaces as kind="class" but with id starting with "interface"
             is_objc_interface = (

--- a/scripts/cxx-api/tests/snapshots/should_ignore_private_enum/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_ignore_private_enum/snapshot.api
@@ -1,0 +1,3 @@
+class test::Clss {
+  public void hello();
+}

--- a/scripts/cxx-api/tests/snapshots/should_ignore_private_enum/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_ignore_private_enum/test.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+class Clss {
+  enum class PrivateEnum {
+    A,
+  };
+
+ public:
+  void hello();
+};
+
+} // namespace test

--- a/scripts/cxx-api/tests/snapshots/should_ignore_private_struct/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_ignore_private_struct/snapshot.api
@@ -1,0 +1,3 @@
+class test::Clss {
+  public void hello();
+}

--- a/scripts/cxx-api/tests/snapshots/should_ignore_private_struct/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_ignore_private_struct/test.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+class Clss {
+  struct PrivateStruct {
+    int a;
+  };
+
+ public:
+  void hello();
+};
+
+} // namespace test


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Updates the snapshot generator to ignore compound objects with visibility set to `private`.

Differential Revision: D95913606


