### PR TITLE
Inline private type aliases in the API snapshot

### DIFF
--- a/scripts/cxx-api/parser/builders.py
+++ b/scripts/cxx-api/parser/builders.py
@@ -434,7 +434,11 @@ def _process_objc_sections(
         member_type = parts[-1]
 
         if visibility == "private":
-            pass
+            if member_type == "type":
+                for member_def in section_def.memberdef:
+                    if member_def.kind == "typedef":
+                        typedef_member = get_typedef_member(member_def, visibility)
+                        scope.add_private_typedef(typedef_member)
         elif visibility in ("public", "protected"):
             if member_type == "attrib":
                 for member_def in section_def.memberdef:
@@ -580,7 +584,11 @@ def create_class_scope(
         member_type = parts[-1]
 
         if visibility == "private":
-            pass
+            if member_type == "type":
+                for member_def in section_def.memberdef:
+                    if member_def.kind == "typedef":
+                        typedef_member = get_typedef_member(member_def, visibility)
+                        class_scope.add_private_typedef(typedef_member)
         elif visibility in ("public", "protected"):
             if member_type == "attrib":
                 for member_def in section_def.memberdef:

--- a/scripts/cxx-api/parser/member.py
+++ b/scripts/cxx-api/parser/member.py
@@ -334,6 +334,19 @@ class TypedefMember(Member):
         """Check if this typedef is a function pointer type."""
         return self.argstring is not None and self.argstring.startswith(")(")
 
+    def get_value(self) -> str:
+        if self.keyword == "using":
+            return format_parsed_type(self._parsed_type)
+        elif self._is_function_pointer():
+            formatted_args = format_arguments(self._fp_arguments)
+            qualified_type = format_parsed_type(self._parsed_type)
+            if "(*" in qualified_type:
+                return f"{qualified_type})({formatted_args})"
+            else:
+                return f"{qualified_type}(*)({formatted_args})"
+        else:
+            return self.type
+
     def to_string(
         self,
         indent: int = 0,

--- a/scripts/cxx-api/parser/scope.py
+++ b/scripts/cxx-api/parser/scope.py
@@ -11,7 +11,7 @@ from typing import Generic, TypeVar
 
 from natsort import natsort_keygen, natsorted
 
-from .member import FriendMember, Member, MemberKind
+from .member import FriendMember, Member, MemberKind, TypedefMember
 from .template import Template, TemplateList
 from .utils import parse_qualified_path, qualify_template_args_only, qualify_type_str
 
@@ -311,8 +311,9 @@ class Scope(Generic[ScopeKindT]):
         self.kind: ScopeKindT = kind
         self.parent_scope: Scope | None = None
         self.inner_scopes: dict[str, Scope] = {}
-        self._members: list[Member] = []
         self.location: str | None = None
+        self._members: list[Member] = []
+        self._private_typedefs: dict[str, TypedefMember] = {}
 
     def get_qualified_name(self) -> str:
         """
@@ -372,6 +373,10 @@ class Scope(Generic[ScopeKindT]):
                     prefix = current_scope.get_qualified_name()
                     return f"{prefix}::{name}" if prefix else name
 
+            # Check private typedefs: substitute with the expanded definition
+            if len(path) == 1 and base_first in current_scope._private_typedefs:
+                return current_scope._private_typedefs[base_first].get_value()
+
             current_scope = current_scope.parent_scope
 
         if current_scope is None:
@@ -423,6 +428,15 @@ class Scope(Generic[ScopeKindT]):
         else:
             return "::".join(matched_segments)
 
+    def add_private_typedef(self, member: TypedefMember) -> None:
+        """
+        Store a private typedef for use during type resolution.
+
+        Private typedefs are not included in the snapshot output, but their
+        definitions are substituted for references to them in public members.
+        """
+        self._private_typedefs[member.name] = member
+
     def add_member(self, member: Member | None) -> None:
         """
         Add a member to the scope.
@@ -441,6 +455,9 @@ class Scope(Generic[ScopeKindT]):
         """
         Close the scope by setting the kind of all temporary scopes.
         """
+        for typedef in self._private_typedefs.values():
+            typedef.close(self)
+
         for member in self.get_members():
             member.close(self)
 

--- a/scripts/cxx-api/tests/snapshots/should_inline_private_type_aliases/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_inline_private_type_aliases/snapshot.api
@@ -1,0 +1,6 @@
+template <typename... ArgumentT>
+class test::Clss {
+  public void test1(std::function<void(ArgumentT...)>&& function);
+  public void test2(int val) const;
+  public void test3(void(*)(int) val) const;
+}

--- a/scripts/cxx-api/tests/snapshots/should_inline_private_type_aliases/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_inline_private_type_aliases/test.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+template <typename... ArgumentT>
+class Clss {
+  using T = void(ArgumentT...);
+  typedef int MyType;
+  typedef void (*MyFunction)(MyType);
+
+ public:
+  void test1(std::function<T> &&function);
+  void test2(MyType val) const;
+  void test3(MyFunction val) const;
+};
+
+} // namespace test


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Currently, the parser ignores all private sections, which causes private type aliases definitions not to be present in the snapshot. The refereces to those types can still appear in the public API, if they are resolvable to public types.

This diff updates the parser to track private type definitions, and inline them when referenced from the public API.

Differential Revision: D95920125


