### PR TITLE
Use the derived class name in inherited constructors in the API snapshot

### DIFF
--- a/scripts/cxx-api/parser/builders.py
+++ b/scripts/cxx-api/parser/builders.py
@@ -42,6 +42,37 @@ from .utils import (
 
 
 ######################
+# Inherited constructor fixup
+######################
+
+
+def _fix_inherited_constructor_name(
+    func_member: FunctionMember,
+    compound_name: str,
+) -> None:
+    """
+    Fix inherited constructor names reported by Doxygen.
+
+    When a class inherits constructors via ``using Base::Base;``, Doxygen
+    reports them with the base class name instead of the derived class name.
+    This function detects such constructors and renames them.
+    """
+    if (
+        func_member.type != ""
+        or func_member.name.startswith("~")
+        or func_member.name.startswith("operator")
+    ):
+        return
+
+    class_unqualified_name = parse_qualified_path(compound_name)[-1]
+    # Strip template args for comparison
+    class_base_name = class_unqualified_name.split("<")[0]
+
+    if func_member.name != class_base_name:
+        func_member.name = class_unqualified_name
+
+
+######################
 # Member extraction
 ######################
 
@@ -601,9 +632,13 @@ def create_class_scope(
                             )
             elif member_type == "func":
                 for function_def in section_def.memberdef:
-                    class_scope.add_member(
-                        get_function_member(function_def, visibility, is_static)
+                    func_member = get_function_member(
+                        function_def, visibility, is_static
                     )
+                    _fix_inherited_constructor_name(
+                        func_member, compound_object.compoundname
+                    )
+                    class_scope.add_member(func_member)
             elif member_type == "type":
                 for member_def in section_def.memberdef:
                     if member_def.kind == "enum":

--- a/scripts/cxx-api/tests/snapshots/should_handle_constructor_inheritance/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_constructor_inheritance/snapshot.api
@@ -1,0 +1,11 @@
+class test::Base {
+  public Base() = default;
+  public Base(const test::Base& other);
+  public Base(int test);
+}
+
+class test::Derived : public test::Base {
+  public Derived() = default;
+  public Derived(const test::Base& other);
+  public Derived(int test);
+}

--- a/scripts/cxx-api/tests/snapshots/should_handle_constructor_inheritance/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_constructor_inheritance/test.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+class Base {
+ public:
+  Base() = default;
+  Base(int test);
+  Base(const Base &other);
+};
+
+class Derived : public Base {
+ public:
+  using Base::Base;
+};
+
+} // namespace test

--- a/scripts/cxx-api/tests/snapshots/should_handle_conversion_operators/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_conversion_operators/snapshot.api
@@ -1,0 +1,6 @@
+class test::Clss {
+  public operator Other() const;
+}
+
+class test::Other {
+}

--- a/scripts/cxx-api/tests/snapshots/should_handle_conversion_operators/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_conversion_operators/test.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+class Other {};
+
+class Clss {
+ public:
+  operator Other() const;
+};
+
+} // namespace test


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Doxygen uses base class name for inherited constructors. This diff adds a guard to replace them with the derived class name in the final API snapshot.

Differential Revision: D95939080


