### PR TITLE
Add reverse mapping for default values in base class specialization

### DIFF
--- a/scripts/cxx-api/parser/builders.py
+++ b/scripts/cxx-api/parser/builders.py
@@ -39,6 +39,65 @@ from .utils import (
     parse_qualified_path,
     resolve_linked_text_name,
 )
+from .utils.argument_parsing import _find_matching_angle, _split_arguments
+
+
+######################
+# Base class fixups
+######################
+
+
+def _fix_base_class_default_substitution(
+    base_name: str,
+    template_params: list[Template],
+) -> str:
+    """
+    Workaround for Doxygen's substitution of template parameters with their
+    defaults in base class template arguments. For example, given:
+
+        template <typename BazT = Baz>
+        class Foo : public Bar<BazT> {};
+
+    Doxygen emits ``Bar<Baz>`` instead of ``Bar<BazT>``.
+
+    This function builds a reverse mapping (default_value -> param_name) and
+    replaces matching template arguments in base_name with the parameter names.
+    """
+    angle_start = base_name.find("<")
+    if angle_start == -1:
+        return base_name
+
+    angle_end = _find_matching_angle(base_name, angle_start)
+    if angle_end == -1:
+        return base_name
+
+    # Build reverse mapping: default_value -> param_name.
+    # Map both fully qualified and unqualified names.
+    default_to_param: dict[str, str] = {}
+    for param in template_params:
+        if param.value is not None and param.name is not None:
+            default_to_param[param.value] = param.name
+            last_sep = param.value.rfind("::")
+            if last_sep != -1:
+                default_to_param[param.value[last_sep + 2 :]] = param.name
+
+    if not default_to_param:
+        return base_name
+
+    prefix = base_name[:angle_start]
+    inner = base_name[angle_start + 1 : angle_end]
+    suffix = base_name[angle_end + 1 :]
+
+    args = _split_arguments(inner)
+    fixed_args = []
+    for arg in args:
+        stripped = arg.strip()
+        if stripped in default_to_param:
+            fixed_args.append(default_to_param[stripped])
+        else:
+            fixed_args.append(stripped)
+
+    return f"{prefix}<{', '.join(fixed_args)}>{suffix}"
 
 
 ######################
@@ -604,7 +663,14 @@ def create_class_scope(
         )
 
     class_scope.kind.add_base(get_base_classes(compound_object))
-    class_scope.kind.add_template(get_template_params(compound_object))
+    template_params = get_template_params(compound_object)
+
+    # Fix Doxygen's substitution of template param defaults in base classes
+    if template_params:
+        for base in class_scope.kind.base_classes:
+            base.name = _fix_base_class_default_substitution(base.name, template_params)
+
+    class_scope.kind.add_template(template_params)
     class_scope.location = compound_object.location.file
 
     for section_def in compound_object.sectiondef:

--- a/scripts/cxx-api/tests/snapshots/should_handle_inheritance_specialized_class/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_inheritance_specialized_class/snapshot.api
@@ -1,0 +1,8 @@
+template <typename T = int>
+class test::Derived : public test::Base<T> {
+}
+
+template <typename T>
+class test::Base {
+  public T value;
+}

--- a/scripts/cxx-api/tests/snapshots/should_handle_inheritance_specialized_class/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_inheritance_specialized_class/test.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+template <typename T>
+class Base {
+ public:
+  T value;
+};
+
+template <typename T = int>
+class Derived : public Base<T> {};
+
+} // namespace test


### PR DESCRIPTION
Summary:
Changelog: [Internal]

When generating xml output, doxygen replaces template arguments in specialized base classes with the default values:

```
template <typename T = int>
class Test : public Base<T> {};
```

becomes

```
template <typename T = int>
class Test : public Base<int> {};
```

To work around this issue, this diff adds reverse mapping for template params in the base classes. In the above case, the map would be: `{ "int" -> "T" }`, and `int` in `Base<int>` would be replaced with T.

This approach assumes that none of the default values are used directly in the base class specialization, which holds for the React Native codebase.

Differential Revision: D95933835


