### PR TITLE
Strip leading `::` for globally qualified identifiers

### DIFF
--- a/scripts/cxx-api/parser/utils/type_qualification.py
+++ b/scripts/cxx-api/parser/utils/type_qualification.py
@@ -70,8 +70,8 @@ def _qualify_type_str_impl(type_str: str, scope: Scope, qualify_base: bool) -> s
         return type_str
 
     # Names starting with "::" are already globally qualified - skip re-qualification
-    if type_str.lstrip().startswith("::"):
-        return type_str
+    if type_str.lstrip().startswith("::") and qualify_base:
+        return type_str[2:]
 
     # Handle template arguments first: qualify types inside angle brackets
     angle_start = type_str.find("<")
@@ -105,7 +105,9 @@ def _qualify_type_str_impl(type_str: str, scope: Scope, qualify_base: bool) -> s
 
             # Recursively qualify the suffix (handles nested templates, pointers, etc.)
             qualified_suffix = (
-                _qualify_type_str_impl(suffix, scope, qualify_base) if suffix else ""
+                _qualify_type_str_impl(suffix, scope, qualify_base=False)
+                if suffix
+                else ""
             )
 
             return qualified_prefix + qualified_template + qualified_suffix

--- a/scripts/cxx-api/tests/snapshots/should_not_requalify_globally_qualified_type/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_not_requalify_globally_qualified_type/snapshot.api
@@ -1,7 +1,7 @@
 struct other::Consumer {
-  public ::test::inner::MyType create();
-  public void process(const ::test::inner::MyType& param);
-  public void processPtr(::test::inner::MyType* param);
+  public test::inner::MyType create();
+  public void process(const test::inner::MyType& param);
+  public void processPtr(test::inner::MyType* param);
 }
 
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Currently, if the source code uses globally qualified identifiers, those will be kept in the snapshot without changes. Since in the output, everything is fully qualified, the leading `::` can be stripped from those.

Differential Revision: D95947334


