### PR TITLE
Exclude Internal and Private categories

### DIFF
--- a/scripts/cxx-api/config.yml
+++ b/scripts/cxx-api/config.yml
@@ -60,6 +60,8 @@ ReactApple:
     - "*/platform/windows/*"
     - "*/platform/macos/*"
     - "*/platform/android/*"
+    - "*+Private.h"
+    - "*+Internal.h"
   definitions:
     __cplusplus: 1
   variants:


### PR DESCRIPTION
Summary:
Excludes files with `*+Internal.h` and `*+Private.h` categories from the public API `ReactApple` snapshot.

Changelog:
[Internal]

Differential Revision: D95953096


