### PR TITLE
Fix MissingSoLoaderLibrary: Add @SoLoaderLibrary to ReactNativeJNISoLoader

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJNISoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJNISoLoader.kt
@@ -9,7 +9,9 @@ package com.facebook.react.bridge
 
 import com.facebook.react.common.annotations.internal.InteropLegacyArchitecture
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
+@SoLoaderLibrary("reactnativejni")
 @InteropLegacyArchitecture
 internal object ReactNativeJNISoLoader {
 


### PR DESCRIPTION
Summary:
Fixed MissingSoLoaderLibrary lint error in ReactNativeJNISoLoader.kt.

Added SoLoaderLibrary("reactnativejni") annotation to the class which calls SoLoader.loadLibrary("reactnativejni") but was missing the annotation needed for build tools to sanity check JNI merging.

changelog: [internal] internal

Differential Revision: D95412950


