### PR TITLE
Add privacy manifest for mach_absolute_time usage in React-timing

### DIFF
--- a/packages/react-native/ReactCommon/react/timing/PrivacyInfo.xcprivacy
+++ b/packages/react-native/ReactCommon/react/timing/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/react-native/ReactCommon/react/timing/React-timing.podspec
+++ b/packages/react-native/ReactCommon/react/timing/React-timing.podspec
@@ -40,4 +40,6 @@ Pod::Spec.new do |s|
   resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "React_timing")
 
   add_dependency(s, "React-debug")
+
+  s.resource_bundles = {'React-timing_privacy' => 'PrivacyInfo.xcprivacy'}
 end


### PR DESCRIPTION
Summary:
Changelog: [iOS][Added] Add privacy manifest to declare the use of mach_absolute_time() API in the
React-timing module

Add privacy manifest to declare the use of mach_absolute_time() API in the
React-timing module, as required by Apple's privacy manifest requirements.

This addresses problems with https://github.com/facebook/react-native/pull/55977 about potential App Store rejections
when using mach_absolute_time() without declaring it in the privacy manifest.

Changes:
- Created PrivacyInfo.xcprivacy declaring NSPrivacyAccessedAPICategorySystemBootTime
  with reason code 35F9.1 (measuring elapsed time between events)
- Updated React-timing.podspec to include the privacy manifest via resource_bundles
- Updated reactPerformanceTimeline target to include the timing privacy manifest

Reviewed By: cipolleschi

Differential Revision: D96018599


