### PR TITLE
Fix bugprone-use-after-move in JSINativeModules.cpp and bugprone-optional-value-conversion in TextAttributes.cpp

### DIFF
--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
@@ -58,7 +58,7 @@ Value JSINativeModules::getModule(Runtime& rt, const PropNameID& name) {
       m_objects.emplace(std::move(moduleName), std::move(*module)).first;
 
   Value ret = Value(rt, result->second);
-  BridgeNativeModulePerfLogger::moduleJSRequireEndingEnd(moduleName.c_str());
+  BridgeNativeModulePerfLogger::moduleJSRequireEndingEnd(result->first.c_str());
   return ret;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -88,7 +88,7 @@ void TextAttributes::apply(TextAttributes textAttributes) {
 
   // Shadow
   textShadowOffset = textAttributes.textShadowOffset.has_value()
-      ? textAttributes.textShadowOffset.value()
+      ? textAttributes.textShadowOffset
       : textShadowOffset;
   textShadowRadius = !std::isnan(textAttributes.textShadowRadius)
       ? textAttributes.textShadowRadius


### PR DESCRIPTION
Summary:
Fix critical clang-tidy static analysis findings (P0) across ReactCommon C++ code, identified by running clang-tidy with the xplat/js/.clang-tidy config (200+ checks) on all 469 .cpp files.

Fixes:

1. **bugprone-use-after-move** (JSINativeModules.cpp:61): `moduleName` was used
   after being moved into `m_objects.emplace()`. The perf logger call now reads
   the module name from the map iterator (`result->first`) instead of the
   moved-from string.

2. **bugprone-optional-value-conversion** (TextAttributes.cpp:91): Unnecessary
   `optional<Size> -> Size -> optional<Size>` round-trip via `.value()`. Changed
   to assign the optional directly, matching the pattern used by all surrounding
   fields.



Changelog: [Internal]

Differential Revision: D95760414


