### PR TITLE
Support ReadOnly/Readonly wrapped custom structs in C++ TurboModule codegen

### DIFF
--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -189,30 +189,42 @@ function getObjectTypeAnnotations(
     if (!isTypeAlias) {
       return;
     }
-    const parent = parser.nextNodeForTypeAlias(value);
+    let parent = parser.nextNodeForTypeAlias(value);
+    // Unwrap $ReadOnly/Readonly wrappers to get the inner object type
+    if (
+      parent.type === 'GenericTypeAnnotation' &&
+      (parent.id?.name === '$ReadOnly' || parent.id?.name === 'Readonly') &&
+      parent.typeParameters?.params?.length === 1
+    ) {
+      parent = parent.typeParameters.params[0];
+    } else if (
+      parent.type === 'TSTypeReference' &&
+      parent.typeName?.name === 'Readonly' &&
+      parent.typeParameters?.params?.length === 1
+    ) {
+      parent = parent.typeParameters.params[0];
+    }
     if (
       parent.type !== 'ObjectTypeAnnotation' &&
       parent.type !== 'TSTypeLiteral'
     ) {
       return;
     }
-    const typeProperties = parser
-      .getAnnotatedElementProperties(value)
-      .map(prop =>
-        parseObjectProperty(
-          parent,
-          prop,
-          hasteModuleName,
-          types,
-          aliasMap,
-          {}, // enumMap
-          tryParse,
-          true, // cxxOnly
-          prop?.optional || false,
-          translateTypeAnnotation,
-          parser,
-        ),
-      );
+    const typeProperties = (parent.properties ?? parent.members).map(prop =>
+      parseObjectProperty(
+        parent,
+        prop,
+        hasteModuleName,
+        types,
+        aliasMap,
+        {}, // enumMap
+        tryParse,
+        true, // cxxOnly
+        prop?.optional || false,
+        translateTypeAnnotation,
+        parser,
+      ),
+    );
     aliasMap[key] = {
       type: 'ObjectTypeAnnotation',
       properties: typeProperties,

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -31,11 +31,11 @@ export type UnionFloat = 1.44 | 2.88 | 5.76;
 export type UnionString = 'One' | 'Two' | 'Three';
 export type UnionObject = {value: number} | {low: string};
 
-export type ConstantsStruct = {
+export type ConstantsStruct = Readonly<{
   const1: boolean,
   const2: number,
   const3: string,
-};
+}>;
 
 export type ObjectStruct = {
   a: number,


### PR DESCRIPTION
Summary:
When parsing custom struct types in RN TurboModule flow specs for C++ (cxxOnly) codegen, the `getObjectTypeAnnotations` function in `parsers-commons.js` silently dropped types wrapped in `$ReadOnly<{...}>` or `Readonly<{...}>`.

The root cause: `parser.nextNodeForTypeAlias(value)` returns the raw right-hand side of a type alias. For `export type Foo = Readonly<{...}>`, this returns a `GenericTypeAnnotation` node (the `Readonly<...>` wrapper), not an `ObjectTypeAnnotation`. The existing guard check (`parent.type !== 'ObjectTypeAnnotation'`) then rejects the type, causing it to be silently skipped from the alias map.

The fix unwraps `$ReadOnly`/`Readonly` `GenericTypeAnnotation` wrappers (Flow) and `Readonly` `TSTypeReference` wrappers (TypeScript) before performing the type check, then obtains properties directly from the unwrapped node.

Also updates `NativeCxxModuleExample.js` to use `Readonly<{...}>` on `ConstantsStruct` as a demonstration and build-time validation of the fix.

Changelog: [Internal]

Differential Revision: D96044884


