### PR TITLE
Fix measureInWindow on Android edge-to-edge

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
@@ -15,6 +15,8 @@ import android.graphics.Rect
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.facebook.common.logging.FLog
 import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.ReactContext
@@ -27,6 +29,7 @@ import com.facebook.react.uimanager.JSKeyDispatcher
 import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.JSTouchDispatcher
 import com.facebook.react.uimanager.common.UIManagerType
+import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
 import com.facebook.systrace.Systrace
 import java.util.Objects
 import kotlin.math.max
@@ -56,6 +59,21 @@ public class ReactSurfaceView(context: Context?, internal val surface: ReactSurf
       getWindowVisibleDisplayFrame(visibleWindowFrame)
       locationOnScreen[0] -= visibleWindowFrame.left
       locationOnScreen[1] -= visibleWindowFrame.top
+
+      if (isEdgeToEdgeFeatureFlagOn) {
+        // In edge-to-edge mode the viewport spans the full window, so add the top system bar
+        // insets back to convert the content-area offset above into a window-relative offset.
+        ViewCompat.getRootWindowInsets(this)?.apply {
+          val insets =
+              getInsets(
+                  WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout()
+              )
+
+          locationOnScreen[0] += insets.left
+          locationOnScreen[1] += insets.top
+        }
+      }
+
       return Point(locationOnScreen[0], locationOnScreen[1])
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
@@ -50,31 +50,24 @@ public class ReactSurfaceView(context: Context?, internal val surface: ReactSurf
 
   private val viewportOffset: Point
     get() {
-      val locationOnScreen = IntArray(2)
-      getLocationOnScreen(locationOnScreen)
+      val locationInWindow = IntArray(2)
+      getLocationInWindow(locationInWindow)
 
-      // we need to subtract visibleWindowCoords - to subtract possible window insets, split
-      // screen or multi window
-      val visibleWindowFrame = Rect()
-      getWindowVisibleDisplayFrame(visibleWindowFrame)
-      locationOnScreen[0] -= visibleWindowFrame.left
-      locationOnScreen[1] -= visibleWindowFrame.top
-
-      if (isEdgeToEdgeFeatureFlagOn) {
-        // In edge-to-edge mode the viewport spans the full window, so add the top system bar
-        // insets back to convert the content-area offset above into a window-relative offset.
+      if (!isEdgeToEdgeFeatureFlagOn) {
+        // When not in edge-to-edge mode, subtract the top system bar insets so the offset is
+        // relative to the content area (below the status bar / cutout).
         ViewCompat.getRootWindowInsets(this)?.apply {
           val insets =
               getInsets(
                   WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout()
               )
 
-          locationOnScreen[0] += insets.left
-          locationOnScreen[1] += insets.top
+          locationInWindow[0] -= insets.left
+          locationInWindow[1] -= insets.top
         }
       }
 
-      return Point(locationOnScreen[0], locationOnScreen[1])
+      return Point(locationInWindow[0], locationInWindow[1])
     }
 
   init {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewUtil.kt
@@ -8,10 +8,12 @@
 package com.facebook.react.uimanager
 
 import android.graphics.Point
-import android.graphics.Rect
 import android.view.View
 import androidx.annotation.UiThread
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.facebook.infer.annotation.Assertions
+import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
 
 public object RootViewUtil {
   /** Returns the root view of a given view in a react application. */
@@ -34,12 +36,20 @@ public object RootViewUtil {
     val locationInWindow = IntArray(2)
     v.getLocationInWindow(locationInWindow)
 
-    // we need to subtract visibleWindowCoords - to subtract possible window insets, split
-    // screen or multi window
-    val visibleWindowFrame = Rect()
-    v.getWindowVisibleDisplayFrame(visibleWindowFrame)
-    locationInWindow[0] -= visibleWindowFrame.left
-    locationInWindow[1] -= visibleWindowFrame.top
+    if (!isEdgeToEdgeFeatureFlagOn) {
+      // When not in edge-to-edge mode, subtract the top system bar insets so the offset is
+      // relative to the content area (below the status bar / cutout).
+      ViewCompat.getRootWindowInsets(v)?.apply {
+        val insets =
+            getInsets(
+                WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+
+        locationInWindow[0] -= insets.left
+        locationInWindow[1] -= insets.top
+      }
+    }
+
     return Point(locationInWindow[0], locationInWindow[1])
   }
 }


### PR DESCRIPTION
## Summary:

Fixes `measureInWindow` on Android when edge-to-edge is enabled.

Both `ReactSurfaceView.viewportOffset` and `RootViewUtil.getViewportOffset` subtract the visible window frame (status bar insets, split screen offsets) from `getLocationOnScreen` / `getLocationInWindow` coordinates. This is incorrect in edge-to-edge mode, where the content already extends behind system bars.

Related issue: https://github.com/facebook/react-native/issues/50509

## Changelog:

[ANDROID] [FIXED] - Fix `measureInWindow` returning incorrect coordinates when edge-to-edge is enabled

## Test Plan:

Tested `measureInWindow` with and without edge-to-edge enabled, in both single-window and split-screen configurations. Verified that returned coordinates correctly reflect the view's position relative to the visible content area.

For that, in `RNTesterActivity.kt`, comment:

```kt
// reactDelegate?.reactRootView?.let { rootView ->
//   val insetsType: Int =
//       WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()

//   val windowInsetsListener = { view: View, windowInsets: WindowInsetsCompat ->
//     val insets = windowInsets.getInsets(insetsType)

//     (view.layoutParams as FrameLayout.LayoutParams).apply {
//       setMargins(insets.left, insets.top, insets.right, insets.bottom)
//     }

//     WindowInsetsCompat.CONSUMED
//   }
//   ViewCompat.setOnApplyWindowInsetsListener(rootView, windowInsetsListener)
// }
```

And in `RNTesterAppShared.js` replace `export default RNTesterApp` with:

```js
export default () => {
  const ref = React.useRef<View>(null);
  const [measure, setMeasure] = React.useState<string>('');
  const [measureInWindow, setMeasureInWindow] = React.useState<string>('');
  const [onLayoutOutput, setOnLayoutOutput] = React.useState<string>('');
  React.useLayoutEffect(() => {
    ref.current?.measure(
      (
        x: number,
        y: number,
        width: number,
        height: number,
        pageX: number,
        pageY: number,
      ) => {
        setMeasure(
          `(${x}, ${y}) / ${width} x ${height}; \n  page=(${pageX}, ${pageY})`,
        );
      },
    );
  }, []);
  React.useLayoutEffect(() => {
    ref.current?.measureInWindow(
      (x: number, y: number, width: number, height: number) => {
        setMeasureInWindow(`(${x}, ${y}) / ${width} x ${height};})`);
      },
    );
  }, []);
  return (
    <View
      ref={ref}
      style={{flex: 1, justifyContent: 'center'}}
      onLayout={e => {
        setOnLayoutOutput(JSON.stringify(e.nativeEvent.layout));
      }}>
      <Text>Measure: {measure}</Text>
      <Text>measureInWindow: {measureInWindow}</Text>
      <Text>onLayout: {onLayoutOutput}</Text>
    </View>
  );
};
```


## Screenshots:

#### Android 16 / edge-to-edge on - current behavior

<img width="265" height="489" alt="Android 16 (edge-to-edge on - no fix)" src="https://github.com/user-attachments/assets/71c62742-e835-42f1-9e79-23d5fc37e9a2" />

#### Android 16 / edge-to-edge on - with fix

<img width="265" height="489" alt="Android 16 (edge-to-edge on - fixed)" src="https://github.com/user-attachments/assets/9e5b5095-3b3a-490d-bf81-2ef721a9db5e" />

#### Android 14 / edge-to-edge off - current behavior

<img width="260" height="483" alt="Android 14 (edge-to-edge off - no fix)" src="https://github.com/user-attachments/assets/31c1776b-8abc-45ac-8796-de81a62aff78" />

#### Android 14 / edge-to-edge off - with fix (no change)

<img width="260" height="483" alt="Android 14 (edge-to-edge off - fixed)" src="https://github.com/user-attachments/assets/b60e4c2f-5893-4383-8ae1-547cf07aa8c9" />