### PR TITLE
Requalify incorrect references produced by doxygen

### DIFF
--- a/scripts/cxx-api/parser/scope.py
+++ b/scripts/cxx-api/parser/scope.py
@@ -409,16 +409,18 @@ class Scope(Generic[ScopeKindT]):
                     if anchor_prefix:
                         return f"{anchor_prefix}::{suffix}"
                     return suffix
-            elif any(
-                isinstance(m, FriendMember) and m.name == base_name
-                for m in current_scope._members
-            ):
-                # The name matches a friend declaration, not a real member.
-                # Re-qualify from the remaining segments so the type resolves
-                # to its actual definition rather than the friend's owning class.
-                remaining = "::".join(path[i:])
-                return self.qualify_name(remaining)
             else:
+                # Segment not found as an inner scope or a real member of
+                # the current scope.  When inside a struct-like scope this
+                # typically means Doxygen's refid-based qualification
+                # incorrectly placed a type under a compound that does not
+                # actually contain it — for example a friend declaration or
+                # an inherited constructor reported as a member ref. Try
+                # to re-qualify from the remaining unmatched segments so the
+                # type resolves against the broader scope hierarchy.
+                if isinstance(current_scope.kind, StructLikeScopeKind):
+                    remaining = "::".join(path[i:])
+                    return self.qualify_name(remaining)
                 return None
 
         # Return qualified name with preserved template arguments

--- a/scripts/cxx-api/tests/snapshots/should_not_scope_base_class_typedef_under_derived_class/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_not_scope_base_class_typedef_under_derived_class/snapshot.api
@@ -1,0 +1,9 @@
+class test::Derived : public test::Base<int> {
+  public Derived(int value);
+  public using BaseAlias = test::Base<int>;
+}
+
+template <typename T>
+class test::Base {
+  public Base(int value);
+}

--- a/scripts/cxx-api/tests/snapshots/should_not_scope_base_class_typedef_under_derived_class/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_not_scope_base_class_typedef_under_derived_class/test.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+template <typename T>
+class Base {
+ public:
+  Base(int value);
+};
+
+class Derived : public Base<int> {
+ public:
+  using BaseAlias = Base<int>;
+  using Base::Base;
+};
+
+} // namespace test

--- a/scripts/cxx-api/tests/snapshots/should_not_scope_friend_class_under_compound/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_not_scope_friend_class_under_compound/snapshot.api
@@ -1,0 +1,7 @@
+class test::ProviderRegistry {
+}
+
+class test::Registry {
+  public Registry(const test::ProviderRegistry& provider);
+  public bool hasItem(int handle) const;
+}

--- a/scripts/cxx-api/tests/snapshots/should_not_scope_friend_class_under_compound/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_not_scope_friend_class_under_compound/test.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+class ProviderRegistry;
+
+class Registry {
+ public:
+  Registry(const ProviderRegistry &provider);
+  bool hasItem(int handle) const;
+
+ private:
+  friend class ProviderRegistry;
+};
+
+class ProviderRegistry {};
+
+} // namespace test


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Doxygen may incorrectly resolve reference to a friend declaration or inherited constructor instead of the actual friend or the base class.

This diff updates the qualification algorithm to try to requalify cases like these.

Differential Revision: D96129278


