### PR TITLE
Fix StatusBar modifications not applying to Modal windows on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt
@@ -9,10 +9,11 @@ package com.facebook.react.modules.statusbar
 
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
-import android.os.Build
-import android.view.View
-import android.view.WindowInsetsController
+import android.view.Window
 import android.view.WindowManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.facebook.common.logging.FLog
 import com.facebook.fbreact.specs.NativeStatusBarManagerAndroidSpec
 import com.facebook.react.bridge.GuardedRunnable
@@ -20,17 +21,50 @@ import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.ReactConstants
+import com.facebook.react.interfaces.ExtraWindowEventListener
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.DisplayMetricsHolder.getStatusBarHeightPx
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
+import com.facebook.react.views.view.setStatusBarStyle
 import com.facebook.react.views.view.setStatusBarTranslucency
 import com.facebook.react.views.view.setStatusBarVisibility
+import java.util.Collections
+import java.util.WeakHashMap
 
 /** [NativeModule] that allows changing the appearance of the status bar. */
 @ReactModule(name = NativeStatusBarManagerAndroidSpec.NAME)
 internal class StatusBarModule(reactContext: ReactApplicationContext?) :
-    NativeStatusBarManagerAndroidSpec(reactContext) {
+    NativeStatusBarManagerAndroidSpec(reactContext), ExtraWindowEventListener {
+
+  init {
+    reactApplicationContext.addExtraWindowEventListener(this)
+  }
+
+  override fun invalidate() {
+    super.invalidate()
+    reactApplicationContext.removeExtraWindowEventListener(this)
+  }
+
+  override fun onExtraWindowCreate(window: Window) {
+    UiThreadUtil.runOnUiThread {
+      extraWindows.add(window)
+
+      reactApplicationContext.currentActivity?.window?.let {
+        val controller = WindowCompat.getInsetsController(it, it.decorView)
+        val insets = ViewCompat.getRootWindowInsets(it.decorView)
+        val style = if (controller.isAppearanceLightStatusBars) "dark-content" else "light-content"
+        val visible = insets?.isVisible(WindowInsetsCompat.Type.statusBars()) ?: true
+
+        window.setStatusBarStyle(style)
+        window.setStatusBarVisibility(!visible)
+      }
+    }
+  }
+
+  override fun onExtraWindowDestroy(window: Window) {
+    UiThreadUtil.runOnUiThread { extraWindows.remove(window) }
+  }
 
   @Suppress("DEPRECATION")
   override fun getTypedExportedConstants(): Map<String, Any> {
@@ -118,10 +152,12 @@ internal class StatusBarModule(reactContext: ReactApplicationContext?) :
       )
       return
     }
-    UiThreadUtil.runOnUiThread { activity.window?.setStatusBarVisibility(hidden) }
+    UiThreadUtil.runOnUiThread {
+      activity.window?.setStatusBarVisibility(hidden)
+      extraWindows.forEach { it.setStatusBarVisibility(hidden) }
+    }
   }
 
-  @Suppress("DEPRECATION")
   override fun setStyle(style: String?) {
     val activity = reactApplicationContext.getCurrentActivity()
     if (activity == null) {
@@ -131,41 +167,16 @@ internal class StatusBarModule(reactContext: ReactApplicationContext?) :
       )
       return
     }
-    UiThreadUtil.runOnUiThread(
-        Runnable {
-          val window = activity.window ?: return@Runnable
-          if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
-            val insetsController = window.insetsController ?: return@Runnable
-            if ("dark-content" == style) {
-              // dark-content means dark icons on a light status bar
-              insetsController.setSystemBarsAppearance(
-                  WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
-                  WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
-              )
-            } else {
-              insetsController.setSystemBarsAppearance(
-                  0,
-                  WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
-              )
-            }
-          } else {
-            val decorView = window.decorView
-            var systemUiVisibilityFlags = decorView.systemUiVisibility
-            systemUiVisibilityFlags =
-                if ("dark-content" == style) {
-                  systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                } else {
-                  systemUiVisibilityFlags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
-                }
-            decorView.systemUiVisibility = systemUiVisibilityFlags
-          }
-        }
-    )
+    UiThreadUtil.runOnUiThread {
+      activity.window?.setStatusBarStyle(style)
+      extraWindows.forEach { it.setStatusBarStyle(style) }
+    }
   }
 
   companion object {
     private const val HEIGHT_KEY = "HEIGHT"
     private const val DEFAULT_BACKGROUND_COLOR_KEY = "DEFAULT_BACKGROUND_COLOR"
     const val NAME: String = NativeStatusBarManagerAndroidSpec.NAME
+    private val extraWindows = Collections.newSetFromMap<Window>(WeakHashMap())
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -10,7 +10,9 @@ package com.facebook.react.views.view
 import android.app.Activity
 import android.graphics.Color
 import android.os.Build
+import android.view.View
 import android.view.Window
+import android.view.WindowInsetsController
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -90,6 +92,33 @@ internal fun Window.setStatusBarVisibility(isHidden: Boolean) {
     this.statusBarHide()
   } else {
     this.statusBarShow()
+  }
+}
+
+@Suppress("DEPRECATION")
+internal fun Window.setStatusBarStyle(style: String?) {
+  if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
+    if ("dark-content" == style) {
+      // dark-content means dark icons on a light status bar
+      insetsController?.setSystemBarsAppearance(
+          WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+          WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+      )
+    } else {
+      insetsController?.setSystemBarsAppearance(
+          0,
+          WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+      )
+    }
+  } else {
+    var systemUiVisibilityFlags = decorView.systemUiVisibility
+    systemUiVisibilityFlags =
+        if ("dark-content" == style) {
+          systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+        } else {
+          systemUiVisibilityFlags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
+        }
+    decorView.systemUiVisibility = systemUiVisibilityFlags
   }
 }
 


### PR DESCRIPTION
## Summary:

When a `Modal` is displayed on Android, it creates a new `Dialog` with its own `Window`. Modules like `StatusBarModule` only apply their configuration to the main Activity's window, so status bar changes (style, visibility) are not reflected in Modal windows.

This PR:
- Implement `ExtraWindowEventListener` in `StatusBarModule` to track extra windows
- Extract `Window` extension `setStatusBarStyle` function into `WindowUtil.kt` for reuse
- Omit status bar color and translucency sync, as those functions have no effect when the app is edge-to-edge

This also fixes a race condition that occurs when opening a Modal and changing the status bar state at the same time.

## Related issue

- https://github.com/zoontek/react-native-edge-to-edge/issues/98

## Changelog:

[ANDROID] [FIXED] - StatusBar configuration now applies to Modal windows, fixing visual inconsistencies

## Test Plan:

1. Open the RNTester app on Android
2. Set status bar style or visibility using the StatusBar API
3. Open a Modal - verify the status bar appearance is preserved
4. Change the status bar style / visibility while the Modal is open - verify it updates on the Modal window too
5. Dismiss the Modal - verify the status bar appearance is still correct

https://github.com/user-attachments/assets/6a1c9a7e-6100-422b-8a6f-184be8b6a007