### PR TITLE
Include `packages/react-native/Libraries` path in ReactApple snapshot

### DIFF
--- a/scripts/cxx-api/config.yml
+++ b/scripts/cxx-api/config.yml
@@ -54,6 +54,7 @@ ReactApple:
     - packages/react-native/ReactCommon
     - packages/react-native/React
     - packages/react-native/ReactApple
+    - packages/react-native/Libraries
   exclude_patterns:
     - "*/test_utils/*"
     - "*/jni/*"
@@ -63,6 +64,8 @@ ReactApple:
     - "*/platform/android/*"
     - "*+Private.h"
     - "*+Internal.h"
+    - "*/scripts/*"
+    - "*/templates/*"
   definitions:
     __cplusplus: 1
   variants:

--- a/scripts/cxx-api/parser/snapshot.py
+++ b/scripts/cxx-api/parser/snapshot.py
@@ -90,14 +90,18 @@ class Snapshot:
     def create_protocol(self, qualified_name: str) -> Scope[ProtocolScopeKind]:
         """
         Create a protocol in the snapshot.
+        In Objective-C, a protocol and interface can share the same name,
+        so protocols are stored with a '-p' suffix to differentiate them.
         """
         path = parse_qualified_path(qualified_name)
         scope_path = path[0:-1]
         scope_name = path[-1]
+        # Use '-p' suffix to allow protocols to coexist with interfaces of the same name
+        scope_key = f"{scope_name}-p"
         current_scope = self.ensure_scope(scope_path)
 
-        if scope_name in current_scope.inner_scopes:
-            scope = current_scope.inner_scopes[scope_name]
+        if scope_key in current_scope.inner_scopes:
+            scope = current_scope.inner_scopes[scope_key]
             if scope.kind.name == "temporary":
                 scope.kind = ProtocolScopeKind()
             else:
@@ -108,7 +112,7 @@ class Snapshot:
         else:
             new_scope = Scope(ProtocolScopeKind(), scope_name)
             new_scope.parent_scope = current_scope
-            current_scope.inner_scopes[scope_name] = new_scope
+            current_scope.inner_scopes[scope_key] = new_scope
             return new_scope
 
     def create_interface(self, qualified_name: str) -> Scope[InterfaceScopeKind]:


### PR DESCRIPTION
Summary:
There are Objective-C files located in the `packages/react-native/Libraries` paths. This diff modifies the config to tell doxygen to parse them and fixes problem with parsing interfaces and protocols that share the same name.

Changelog:
[Internal]

Differential Revision: D96141632


