### PR TITLE
fix: `measureInWindow` calculations for `Modal` with `formSheet` presentation

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -256,7 +256,16 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   }
 
   if (_state != nullptr) {
-    auto newState = ModalHostViewState{RCTSizeFromCGSize(newBounds.size)};
+    CGPoint viewportOffset = CGPointZero;
+    UIView *modalView = _viewController.view;
+    if (modalView && modalView.window) {
+      CGRect frameInWindow = [modalView convertRect:modalView.bounds toView:nil];
+      viewportOffset = frameInWindow.origin;
+    }
+    auto newState = ModalHostViewState{
+      RCTSizeFromCGSize(newBounds.size),
+      facebook::react::Point{(Float)viewportOffset.x, (Float)viewportOffset.y}
+    };
     _state->updateState(std::move(newState));
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.cpp
@@ -14,4 +14,9 @@ namespace facebook::react {
 
 extern const char ModalHostViewComponentName[] = "ModalHostView";
 
+Transform ModalHostViewShadowNode::getTransform() const {
+  auto viewportOffset = getStateData().viewportOffset;
+  return Transform::Translate(viewportOffset.x, viewportOffset.y, 0);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
@@ -36,6 +36,8 @@ class ModalHostViewShadowNode final : public ConcreteViewShadowNode<
     traits.set(ShadowNodeTraits::Trait::Unstable_uncullableView);
     return traits;
   }
+
+  Transform getTransform() const override;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.cpp
@@ -12,7 +12,9 @@ namespace facebook::react {
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ModalHostViewState::getDynamic() const {
   return folly::dynamic::object("screenWidth", screenSize.width)(
-      "screenHeight", screenSize.height);
+      "screenHeight", screenSize.height)(
+      "viewportOffsetX", viewportOffset.x)(
+      "viewportOffsetY", viewportOffset.y);
 }
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
@@ -26,15 +26,20 @@ class ModalHostViewState final {
 
   ModalHostViewState() : screenSize(ModalHostViewScreenSize()) {}
   ModalHostViewState(Size screenSize_) : screenSize(screenSize_) {};
+  ModalHostViewState(Size screenSize_, Point viewportOffset_)
+      : screenSize(screenSize_), viewportOffset(viewportOffset_) {};
 
 #ifdef RN_SERIALIZABLE_STATE
   ModalHostViewState(const ModalHostViewState &previousState, folly::dynamic data)
       : screenSize(
-            Size{.width = (Float)data["screenWidth"].getDouble(), .height = (Float)data["screenHeight"].getDouble()}) {
+            Size{.width = (Float)data["screenWidth"].getDouble(), .height = (Float)data["screenHeight"].getDouble()}),
+        viewportOffset(
+            Point{.x = (Float)data["viewportOffsetX"].getDouble(), .y = (Float)data["viewportOffsetY"].getDouble()}) {
         };
 #endif
 
   const Size screenSize{};
+  const Point viewportOffset{};
 
 #ifdef RN_SERIALIZABLE_STATE
   folly::dynamic getDynamic() const;

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
@@ -34,7 +34,8 @@ class ModalHostViewState final {
       : screenSize(
             Size{.width = (Float)data["screenWidth"].getDouble(), .height = (Float)data["screenHeight"].getDouble()}),
         viewportOffset(
-            Point{.x = (Float)data["viewportOffsetX"].getDouble(), .y = (Float)data["viewportOffsetY"].getDouble()}) {
+            Point{.x = data.count("viewportOffsetX") ? (Float)data["viewportOffsetX"].getDouble() : 0.0f,
+                  .y = data.count("viewportOffsetY") ? (Float)data["viewportOffsetY"].getDouble() : 0.0f}) {
         };
 #endif
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixed `measureInWindow` calculations for `Modal` with `formSheet` presentation.

This is **only Fabric** problem (paper works well because it relies on UIKit implementation).

### Problem

The core issue is in how `measureInWindow` works differently between **Paper** and **Fabric**.

Paper calls iOS native `[view.window convertRect:view.frame fromView:view.superview]` which uses **UIKit's actual view hierarchy**. When a `formSheet` modal is presented, the modal's view controller lives in a separate `UIWindow` or has a known offset from the top of the screen. UIKit's `convertRect:fromView:` correctly accounts for this because it works with the **real rendered view positions**.

Fabric's `measureInWindow `(in `DOM.cpp`) works entirely in the **shadow tree**, not the native view hierarchy. It calls `getLayoutMetricsFromRoot` which walks up the shadow node ancestors accumulating frame origins. The critical logic is at `LayoutableShadowNode.cpp`:

```cpp
auto shouldApplyTransformation = (policy.includeTransform && !isRootNode) ||
    (policy.includeViewportOffset && isRootNode);
```

The `includeViewportOffset` flag only applies the **root node's transform**. For a `formSheet` modal, the Y offset from the top of the screen (the ~62pt gap where the modal doesn't cover the full screen) would need to be represented as a transform on the root shadow node. But **the modal's screen position is a UIKit concern** — it's the `UIViewController` presentation that positions the modal content on screen, not a shadow tree transform.

The key is at `ModalHostViewShadowNode.h`:

```cpp
traits.set(ShadowNodeTraits::Trait::RootNodeKind);
```

The `ModalHostViewShadowNode` has the `RootNodeKind` trait. This means when `computeRelativeLayoutMetrics` walks up from the view, it stops **at the modal node** (see `LayoutableShadowNode.cpp`):

```cpp
if (shadowNode.getTraits().check(ShadowNodeTraits::Trait::RootNodeKind)) {
  // If this is a node with a `RootNodeKind` trait, we need to stop right there.
  break;
}
```

Then at the "apply transform" step:

```cpp
auto shouldApplyTransformation = (policy.includeTransform && !isRootNode) ||
    (policy.includeViewportOffset && isRootNode);
```

For the Modal's root node, `includeViewportOffset && isRootNode` is `true`, so it applies `getTransform()`. But `ModalHostViewShadowNode` **doesn't override `getTransform()`** — only `RootShadowNode` does (which translates by `viewportOffset`). The default `getTransform()` returns `Transform::Identity()`.

So the modal's screen position (the formSheet top inset) is simply **never encoded anywhere in the shadow tree**.

### Solution

The fix is in `RCTModalHostViewComponentView.mm`. In `boundsDidChange`, when the modal's bounds change, the state is updated with just the size:

```cpp
auto newState = ModalHostViewState{RCTSizeFromCGSize(newBounds.size)};
```

The fix needs to:

1. Extend `ModalHostViewState` to include a `viewportOffset` (the modal's origin on screen)
2. In `boundsDidChange` compute the modal view controller's actual screen position (e.g., `self.viewController.view.frame.origin` in window coordinates) and pass it as the viewport offset
3. Override `getTransform()` on `ModalHostViewShadowNode` to apply the viewport offset from state.

This way, when `measureInWindow` walks up to the modal (which is a `RootNodeKind`), `includeViewportOffset` triggers `getTransform()`, which now returns **the actual screen offset instead of identity**.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] `measureInWindow` calculations for `Modal` with `formSheet` presentation

## Test Plan:

I used this code in RNTester:

<details>

<summary>Click to expand</summary>

```js
/**
 * Copyright (c) Meta Platforms, Inc. and affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 *
 * @flow strict-local
 * @format
 */

/* eslint-disable no-alert */

import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
import type {ModalProps} from 'react-native';

import RNTesterButton from '../../components/RNTesterButton';
import RNTesterText from '../../components/RNTesterText';
import {RNTesterThemeContext} from '../../components/RNTesterTheme';
import RNTOption from '../../components/RNTOption';
import * as React from 'react';
import {useCallback, useContext, useState, useRef} from 'react';
import {Modal, Platform, StyleSheet, Switch, Text, TouchableOpacity, View} from 'react-native';

const animationTypes = ['slide', 'none', 'fade'] as const;
const presentationStyles = [
  'fullScreen',
  'pageSheet',
  'formSheet',
  'overFullScreen',
] as const;
const supportedOrientations = [
  'portrait',
  'portrait-upside-down',
  'landscape',
  'landscape-left',
  'landscape-right',
] as const;

const backdropColors = ['red', 'blue', undefined];

function ModalPresentation() {
  const onDismiss = useCallback(() => {
    alert('onDismiss');
  }, []);

  const onShow = useCallback(() => {
    alert('onShow');
  }, []);

  const onRequestClose = useCallback(() => {
    console.log('onRequestClose');
    setProps(prev => ({...prev, visible: false}));
  }, []);

  const [props, setProps] = useState<ModalProps>({
    allowSwipeDismissal: false,
    animationType: 'none',
    backdropColor: undefined,
    hardwareAccelerated: false,
    navigationBarTranslucent: false,
    onDismiss: undefined,
    onShow: undefined,
    presentationStyle: Platform.select({
      default: undefined,
      ios: 'fullScreen',
    }),
    statusBarTranslucent: false,
    supportedOrientations: Platform.select({
      default: undefined,
      ios: ['portrait'],
    }),
    transparent: false,
    visible: false,
  });
  const presentationStyle = props.presentationStyle;
  const hardwareAccelerated = props.hardwareAccelerated;
  const statusBarTranslucent = props.statusBarTranslucent;
  const navigationBarTranslucent = props.navigationBarTranslucent;
  const allowSwipeDismissal = props.allowSwipeDismissal;
  const backdropColor = props.backdropColor;
  const backgroundColor = useContext(RNTesterThemeContext).BackgroundColor;

  const [currentOrientation, setCurrentOrientation] = useState('unknown');

  type OrientationChangeEvent = Parameters<
    NonNullable<ModalProps['onOrientationChange']>,
  >[0];
  const onOrientationChange = (event: OrientationChangeEvent) =>
    setCurrentOrientation(event.nativeEvent.orientation);

  const controls = (
    <>
      <View style={styles.inlineBlock}>
        <RNTesterText style={styles.title}>
          Status Bar Translucent 🟢
        </RNTesterText>
        <Switch
          value={statusBarTranslucent}
          onValueChange={enabled =>
            setProps(prev => ({
              ...prev,
              navigationBarTranslucent: false,
              statusBarTranslucent: enabled,
            }))
          }
        />
      </View>
      <View style={styles.inlineBlock}>
        <RNTesterText style={styles.title}>
          Navigation Bar Translucent 🟢
        </RNTesterText>
        <Switch
          value={navigationBarTranslucent}
          onValueChange={enabled => {
            setProps(prev => ({
              ...prev,
              navigationBarTranslucent: enabled,
              statusBarTranslucent: enabled,
            }));
          }}
        />
      </View>
      <View style={styles.inlineBlock}>
        <RNTesterText style={styles.title}>
          Hardware Acceleration 🟢
        </RNTesterText>
        <Switch
          value={hardwareAccelerated}
          onValueChange={enabled =>
            setProps(prev => ({
              ...prev,
              hardwareAccelerated: enabled,
            }))
          }
        />
      </View>

      <View style={styles.inlineBlock}>
        <RNTesterText style={styles.title}>
          Allow Swipe Dismissal ⚫️
        </RNTesterText>
        <Switch
          value={allowSwipeDismissal}
          onValueChange={enabled =>
            setProps(prev => ({
              ...prev,
              allowSwipeDismissal: enabled,
            }))
          }
        />
      </View>
      <View style={styles.block}>
        <RNTesterText style={styles.title}>Presentation Style ⚫️</RNTesterText>
        <View style={styles.row}>
          {presentationStyles.map(type => (
            <RNTOption
              key={type}
              disabled={Platform.OS !== 'ios'}
              style={styles.option}
              label={type}
              multiSelect={true}
              onPress={() =>
                setProps(prev => {
                  if (type === 'overFullScreen' && prev.transparent === true) {
                    return {
                      ...prev,
                      presentationStyle: type,
                      transparent: false,
                    };
                  }
                  return {
                    ...prev,
                    presentationStyle:
                      type === prev.presentationStyle ? undefined : type,
                  };
                })
              }
              selected={type === presentationStyle}
            />
          ))}
        </View>
      </View>
      <View style={styles.block}>
        <View style={styles.rowWithSpaceBetween}>
          <RNTesterText style={styles.title}>Transparent</RNTesterText>
          <Switch
            value={props.transparent}
            onValueChange={enabled =>
              setProps(prev => ({...prev, transparent: enabled}))
            }
          />
        </View>
        {Platform.OS === 'ios' && presentationStyle !== 'overFullScreen' ? (
          <RNTesterText style={styles.warning}>
            iOS Modal can only be transparent with 'overFullScreen' Presentation
            Style
          </RNTesterText>
        ) : null}
      </View>
      <View style={styles.block}>
        <RNTesterText style={styles.title}>
          Supported Orientation ⚫️
        </RNTesterText>
        <View style={styles.row}>
          {supportedOrientations.map(orientation => (
            <RNTOption
              key={orientation}
              disabled={Platform.OS !== 'ios'}
              style={styles.option}
              label={orientation}
              multiSelect={true}
              onPress={() =>
                setProps(prev => {
                  if (prev.supportedOrientations?.includes(orientation)) {
                    return {
                      ...prev,
                      supportedOrientations: prev.supportedOrientations?.filter(
                        o => o !== orientation,
                      ),
                    };
                  }
                  return {
                    ...prev,
                    supportedOrientations: [
                      ...(prev.supportedOrientations ?? []),
                      orientation,
                    ],
                  };
                })
              }
              selected={props.supportedOrientations?.includes(orientation)}
            />
          ))}
        </View>
      </View>
      <View style={styles.block}>
        <RNTesterText style={styles.title}>Actions</RNTesterText>
        <View style={styles.row}>
          <RNTOption
            key="onShow"
            style={styles.option}
            label="onShow"
            multiSelect={true}
            onPress={() =>
              setProps(prev => ({
                ...prev,
                onShow: prev.onShow ? undefined : onShow,
              }))
            }
            selected={!!props.onShow}
          />
          <RNTOption
            key="onDismiss"
            style={styles.option}
            label="onDismiss ⚫️"
            disabled={Platform.OS !== 'ios'}
            onPress={() =>
              setProps(prev => ({
                ...prev,
                onDismiss: prev.onDismiss ? undefined : onDismiss,
              }))
            }
            selected={!!props.onDismiss}
          />
        </View>
      </View>
      <View style={styles.block}>
        <RNTesterText style={styles.title}>Backdrop Color ⚫️</RNTesterText>
        <View style={styles.row}>
          {backdropColors.map(type => (
            <RNTOption
              key={type ?? 'default'}
              style={styles.option}
              label={type ?? 'default'}
              multiSelect={true}
              onPress={() =>
                setProps(prev => ({
                  ...prev,
                  backdropColor: type,
                }))
              }
              selected={type === backdropColor}
            />
          ))}
        </View>
      </View>
    </>
  );

  const measureRef = useRef<View>(null);

  return (
    <View>
      <RNTesterButton
        onPress={() => setProps(prev => ({...prev, visible: true}))}>
        Show Modal
      </RNTesterButton>
      <Modal
        {...props}
        onRequestClose={onRequestClose}
        onOrientationChange={onOrientationChange}>
        <View style={styles.modalContainer}>
          <View style={[styles.modalInnerContainer, {backgroundColor}]}>
            <TouchableOpacity onPress={() => measureRef.current.measureInWindow((x, y, width, height) => {
              console.log(x, y, width, height);
            })}>
              <View ref={measureRef} style={{width: 200, height: 50, backgroundColor: "red"}} />
            </TouchableOpacity>
            <Text testID="modal_animationType_text">
              This modal was presented with animationType: '
              {props.animationType}'
            </Text>
            {Platform.OS === 'ios' ? (
              <Text>
                It is currently displayed in {currentOrientation} mode.
              </Text>
            ) : null}
            <RNTesterButton
              onPress={() => setProps(prev => ({...prev, visible: false}))}>
              Close
            </RNTesterButton>
            {controls}
          </View>
        </View>
      </Modal>
      <View style={styles.block}>
        <RNTesterText style={styles.title}>Animation Type</RNTesterText>
        <View style={styles.row}>
          {animationTypes.map(type => (
            <RNTOption
              key={type}
              style={styles.option}
              label={type}
              onPress={() => setProps(prev => ({...prev, animationType: type}))}
              selected={type === props.animationType}
            />
          ))}
        </View>
      </View>
      {controls}
    </View>
  );
}

const styles = StyleSheet.create({
  block: {
    borderBottomWidth: 1,
    borderColor: 'rgba(0,0,0, 0.1)',
    padding: 6,
  },
  inlineBlock: {
    alignItems: 'center',
    borderBottomWidth: 1,
    borderColor: 'rgba(0,0,0, 0.1)',
    flexDirection: 'row',
    justifyContent: 'space-between',
    padding: 6,
  },
  modalContainer: {
    flex: 1,
    justifyContent: 'center',
    padding: 20,
  },
  modalInnerContainer: {
    borderRadius: 10,
    padding: 10,
  },
  option: {
    marginRight: 8,
    marginTop: 6,
  },
  row: {
    flexDirection: 'row',
    flexWrap: 'wrap',
  },
  rowWithSpaceBetween: {
    flexDirection: 'row',
    justifyContent: 'space-between',
  },
  title: {
    fontWeight: 'bold',
    margin: 3,
  },
  warning: {
    color: 'red',
    fontSize: 12,
    margin: 3,
  },
});

export default ({
  description: 'Modals can be presented with or without animation',
  name: 'basic',
  render: (): React.Node => <ModalPresentation />,
  title: 'Modal Presentation',
}: RNTesterModuleExample);
```

</details>

If you press on a red rectangle with a fix you will see a correct `y=72` (10pt padding in container + 62pt safe area padding):

<img width="1529" height="971" alt="Screenshot 2026-03-11 at 18 46 03" src="https://github.com/user-attachments/assets/23d21d2e-d93e-4317-8484-a571d6640c36" />

Without a fix the `y=10` (**which is incorrect**).
