### PR TITLE
Fix AccessibilityInfo.isHighTextContrastEnabled unresolved promise

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -213,8 +213,8 @@ const AccessibilityInfo = {
    * The result is `true` when high text contrast is enabled and `false` otherwise.
    */
   isHighTextContrastEnabled(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (Platform.OS === 'android') {
+    if (Platform.OS === 'android') {
+      return new Promise((resolve, reject) => {
         if (NativeAccessibilityInfoAndroid?.isHighTextContrastEnabled != null) {
           NativeAccessibilityInfoAndroid.isHighTextContrastEnabled(resolve);
         } else {
@@ -224,10 +224,10 @@ const AccessibilityInfo = {
             ),
           );
         }
-      } else {
-        return Promise.resolve(false);
-      }
-    });
+      });
+    } else {
+      return Promise.resolve(false);
+    }
   },
 
   /**

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/__tests__/AccessibilityInfo-test.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/__tests__/AccessibilityInfo-test.js
@@ -37,9 +37,24 @@ const mockNativeAccessibilityManagerDefault: {
   getCurrentDarkerSystemColorsState: mockGetCurrentDarkerSystemColorsState,
 };
 
+const mockIsHighTextContrastEnabled = jest.fn(onSuccess => onSuccess(true));
+const mockNativeAccessibilityInfo: {
+  isHighTextContrastEnabled: JestMockFn<
+    [onSuccess: (isHighTextContrastEnabled: boolean) => void],
+    void,
+  > | null,
+} = {
+  isHighTextContrastEnabled: mockIsHighTextContrastEnabled,
+};
+
 jest.mock('../NativeAccessibilityManager', () => ({
   __esModule: true,
   default: mockNativeAccessibilityManagerDefault,
+}));
+
+jest.mock('../NativeAccessibilityInfo', () => ({
+  __esModule: true,
+  default: mockNativeAccessibilityInfo,
 }));
 
 const Platform = require('../../../Utilities/Platform').default;
@@ -53,6 +68,7 @@ describe('AccessibilityInfo', () => {
     originalPlatform = Platform.OS;
     mockGetCurrentPrefersCrossFadeTransitionsState.mockClear();
     mockGetCurrentDarkerSystemColorsState.mockClear();
+    mockIsHighTextContrastEnabled.mockClear();
   });
 
   describe('prefersCrossFadeTransitions', () => {
@@ -149,11 +165,58 @@ describe('AccessibilityInfo', () => {
     });
   });
 
+  describe('isHighTextContrastEnabled', () => {
+    describe('Android', () => {
+      it('should call isHighTextContrastEnabled if available', async () => {
+        /* $FlowFixMe[incompatible-type] */
+        Platform.OS = 'android';
+
+        const isHighTextContrastEnabled =
+          await AccessibilityInfo.isHighTextContrastEnabled();
+
+        expect(mockIsHighTextContrastEnabled).toHaveBeenCalled();
+        expect(isHighTextContrastEnabled).toBe(true);
+      });
+
+      it('should throw error if isHighTextContrastEnabled is not available', async () => {
+        /* $FlowFixMe[incompatible-type] */
+        Platform.OS = 'android';
+
+        mockNativeAccessibilityInfo.isHighTextContrastEnabled = null;
+
+        const result: mixed =
+          await AccessibilityInfo.isHighTextContrastEnabled().catch(e => e);
+
+        invariant(
+          result instanceof Error,
+          'Expected isHighTextContrastEnabled to reject',
+        );
+        expect(result.message).toEqual(
+          'NativeAccessibilityInfoAndroid.isHighTextContrastEnabled is not available',
+        );
+      });
+    });
+
+    describe('iOS', () => {
+      it('should return false', async () => {
+        /* $FlowFixMe[incompatible-type] */
+        Platform.OS = 'ios';
+
+        const isHighTextContrastEnabled =
+          await AccessibilityInfo.isHighTextContrastEnabled();
+
+        expect(isHighTextContrastEnabled).toBe(false);
+      });
+    });
+  });
+
   afterEach(() => {
     mockNativeAccessibilityManagerDefault.getCurrentPrefersCrossFadeTransitionsState =
       mockGetCurrentPrefersCrossFadeTransitionsState;
     mockNativeAccessibilityManagerDefault.getCurrentDarkerSystemColorsState =
       mockGetCurrentDarkerSystemColorsState;
+    mockNativeAccessibilityInfo.isHighTextContrastEnabled =
+      mockIsHighTextContrastEnabled;
     /* $FlowFixMe[incompatible-type] */
     Platform.OS = originalPlatform;
   });


### PR DESCRIPTION
## Summary:

This PR fixes a bug in the `AccessibilityInfo` component.  This is a follow up of the work I started with the PRs I opened in the last weeks #55920 #56019.

`AccessibilityInfo` exposes the method `isHighTextContrastEnabled`. In the else branch, Promise.resolve(false) as return value was creating a new unrelated promise that never calls the resolve function provided by the promise executor constructor, so it hangs indefinitely (in the previous PRs the same bug affected the Android branch).

This means that if a user calls this method eg. on iOS without any `Platform.OS === 'android'` guard, it will result in an unresolved promise.

I fixed the bug in the same way as in the other PRs: by aligning the implementation of `isHighTextContrastEnabled` to the one of other methods.

I also added the tests to avoid regression, and additionally verify that the Android method is doing what we are expecting (in both cases for when `NativeAccessibilityInfoAndroid.isHighTextContrastEnabled` is available or not).
The mock of the Platform object has been done the same way I saw while doing another contribution in the Pressability-test (see #55378).

PS I will open one (or more if I see it is too big) PR to add the missing tests for the other `AccessibilityInfo methods still not tested.

## Changelog:

[GENERAL] [FIXED] - Fix AccessibilityInfo.isHighTextContrastEnabled unresolved (never ending) promise

## Test Plan:

This fix (as for the other PRs), was developed using TDD. I first added a failing test to reproduce that the iOS branch of the `isHighTextContrastEnabled` method was acting as described above (resulting in failure due to jest timeout because the promise was not returning). Then I applied the fix, and finally added also the test for the Android counterpart.