### PR TITLE
Handle template variables in the API snapshot (#56068)

### DIFF
--- a/scripts/cxx-api/parser/builders.py
+++ b/scripts/cxx-api/parser/builders.py
@@ -249,7 +249,7 @@ def get_variable_member(
         if initializer_type == InitializerType.BRACE:
             is_brace_initializer = True
 
-    return VariableMember(
+    member = VariableMember(
         variable_name,
         variable_type,
         visibility,
@@ -262,6 +262,10 @@ def get_variable_member(
         variable_argstring,
         is_brace_initializer,
     )
+
+    member.add_template(get_template_params(member_def))
+
+    return member
 
 
 def get_doxygen_params(

--- a/scripts/cxx-api/parser/member.py
+++ b/scripts/cxx-api/parser/member.py
@@ -162,6 +162,9 @@ class VariableMember(Member):
 
         result = " " * indent
 
+        if self.template_list is not None:
+            result += self.template_list.to_string() + "\n" + " " * indent
+
         if not hide_visibility:
             result += self.visibility + " "
 

--- a/scripts/cxx-api/tests/snapshots/should_handle_template_variable/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_template_variable/snapshot.api
@@ -1,0 +1,7 @@
+template <typename T>
+const test::Strct<T> test::Strct<T>::VALUE;
+
+template <typename T>
+struct test::Strct {
+  public static const test::Strct<T> VALUE;
+}

--- a/scripts/cxx-api/tests/snapshots/should_handle_template_variable/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_template_variable/test.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+template <typename T>
+struct Strct {
+  static const Strct<T> VALUE;
+};
+
+template <typename T>
+const Strct<T> Strct<T>::VALUE = {};
+
+} // namespace test

--- a/scripts/cxx-api/tests/snapshots/should_qualify_variable_template_specialization/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_qualify_variable_template_specialization/snapshot.api
@@ -1,5 +1,7 @@
-constexpr T test::default_value;
 constexpr test::MyType test::default_value<test::MyType>;
+template <typename T>
+constexpr T test::default_value;
+template <typename T>
 T* test::null_ptr;
 test::MyType* test::null_ptr<test::MyType>;
 


### PR DESCRIPTION
Summary:

Changelog: [Internal]

Adds support for templates in variable declaration to the c++ API snapshot generator

Reviewed By: cipolleschi

Differential Revision: D96279463
