### PR TITLE
Add LIS-based differentiator for minimal child reordering mutations (#56094)

### DIFF
--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @fantom_flags useLISAlgorithmInDifferentiator:*
  * @flow strict-local
  * @format
  */
@@ -173,4 +174,98 @@ Fantom.unstable_benchmark
         root.destroy();
       },
     }),
+  )
+  .test.each(
+    [10, 50, 100],
+    n => `reorder ${n.toString()} children (move first to last)`,
+    () => {
+      Fantom.runTask(() => root.render(testViews));
+    },
+    n => {
+      let original: React.MixedElement;
+      let reordered: React.MixedElement;
+      return {
+        beforeAll: () => {
+          const children = [];
+          for (let i = 0; i < n; i++) {
+            children.push(
+              <View
+                key={i}
+                collapsable={false}
+                nativeID={`child-${i.toString()}`}
+                style={{width: i + 1, height: i + 1}}
+              />,
+            );
+          }
+          original = (
+            <View collapsable={false} nativeID="parent">
+              {children}
+            </View>
+          );
+          // Move first child to last
+          const reorderedChildren = [...children.slice(1), children[0]];
+          reordered = (
+            <View collapsable={false} nativeID="parent">
+              {reorderedChildren}
+            </View>
+          );
+        },
+        beforeEach: () => {
+          root = Fantom.createRoot();
+          Fantom.runTask(() => root.render(original));
+          // $FlowExpectedError[incompatible-type]
+          testViews = reordered;
+        },
+        afterEach: () => {
+          root.destroy();
+        },
+      };
+    },
+  )
+  .test.each(
+    [10, 50, 100],
+    n => `reorder ${n.toString()} children (swap first two)`,
+    () => {
+      Fantom.runTask(() => root.render(testViews));
+    },
+    n => {
+      let original: React.MixedElement;
+      let reordered: React.MixedElement;
+      return {
+        beforeAll: () => {
+          const children = [];
+          for (let i = 0; i < n; i++) {
+            children.push(
+              <View
+                key={i}
+                collapsable={false}
+                nativeID={`child-${i.toString()}`}
+                style={{width: i + 1, height: i + 1}}
+              />,
+            );
+          }
+          original = (
+            <View collapsable={false} nativeID="parent">
+              {children}
+            </View>
+          );
+          // Swap first two children — both algorithms handle this equally
+          const swapped = [children[1], children[0], ...children.slice(2)];
+          reordered = (
+            <View collapsable={false} nativeID="parent">
+              {swapped}
+            </View>
+          );
+        },
+        beforeEach: () => {
+          root = Fantom.createRoot();
+          Fantom.runTask(() => root.render(original));
+          // $FlowExpectedError[incompatible-type]
+          testViews = reordered;
+        },
+        afterEach: () => {
+          root.destroy();
+        },
+      };
+    },
   );

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5144fb0350b71394206d614c68ef87f0>>
+ * @generated SignedSource<<61964fd9ddf11ed5c2848da3f4d0b490>>
  */
 
 /**
@@ -509,6 +509,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useFabricInterop(): Boolean = accessor.useFabricInterop()
+
+  /**
+   * Use Longest Increasing Subsequence algorithm in the Differentiator to minimize REMOVE/INSERT mutations during child list reconciliation.
+   */
+  @JvmStatic
+  public fun useLISAlgorithmInDifferentiator(): Boolean = accessor.useLISAlgorithmInDifferentiator()
 
   /**
    * When enabled, the native view configs are used in bridgeless mode.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d284f066f036908977797a381a044dfa>>
+ * @generated SignedSource<<4ce2605ff71e60b6096a211ff902e994>>
  */
 
 /**
@@ -100,6 +100,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var updateRuntimeShadowNodeReferencesOnCommitThreadCache: Boolean? = null
   private var useAlwaysAvailableJSErrorHandlingCache: Boolean? = null
   private var useFabricInteropCache: Boolean? = null
+  private var useLISAlgorithmInDifferentiatorCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
   private var useNestedScrollViewAndroidCache: Boolean? = null
   private var useSharedAnimatedBackendCache: Boolean? = null
@@ -827,6 +828,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useFabricInterop()
       useFabricInteropCache = cached
+    }
+    return cached
+  }
+
+  override fun useLISAlgorithmInDifferentiator(): Boolean {
+    var cached = useLISAlgorithmInDifferentiatorCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.useLISAlgorithmInDifferentiator()
+      useLISAlgorithmInDifferentiatorCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<de1c66a540520cd88c4d358ba30f2c6d>>
+ * @generated SignedSource<<5f3573c9983cb54c5df527a3053ebbae>>
  */
 
 /**
@@ -187,6 +187,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun useAlwaysAvailableJSErrorHandling(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useFabricInterop(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun useLISAlgorithmInDifferentiator(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useNativeViewConfigsInBridgelessMode(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ab3b1d2277b8cc9db1708ef94515fb35>>
+ * @generated SignedSource<<67d638f79b7b06a087f63563c2e5ff95>>
  */
 
 /**
@@ -182,6 +182,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun useAlwaysAvailableJSErrorHandling(): Boolean = false
 
   override fun useFabricInterop(): Boolean = true
+
+  override fun useLISAlgorithmInDifferentiator(): Boolean = false
 
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7b87f5541ecf881d8ce51c5edd5b99b0>>
+ * @generated SignedSource<<e211fdbb92579b05507ea84ae42f22ff>>
  */
 
 /**
@@ -104,6 +104,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var updateRuntimeShadowNodeReferencesOnCommitThreadCache: Boolean? = null
   private var useAlwaysAvailableJSErrorHandlingCache: Boolean? = null
   private var useFabricInteropCache: Boolean? = null
+  private var useLISAlgorithmInDifferentiatorCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
   private var useNestedScrollViewAndroidCache: Boolean? = null
   private var useSharedAnimatedBackendCache: Boolean? = null
@@ -911,6 +912,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.useFabricInterop()
       accessedFeatureFlags.add("useFabricInterop")
       useFabricInteropCache = cached
+    }
+    return cached
+  }
+
+  override fun useLISAlgorithmInDifferentiator(): Boolean {
+    var cached = useLISAlgorithmInDifferentiatorCache
+    if (cached == null) {
+      cached = currentProvider.useLISAlgorithmInDifferentiator()
+      accessedFeatureFlags.add("useLISAlgorithmInDifferentiator")
+      useLISAlgorithmInDifferentiatorCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f34b257861830bae7012fc5201904831>>
+ * @generated SignedSource<<540700c0c0f3259a093a98ad639478ba>>
  */
 
 /**
@@ -182,6 +182,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun useAlwaysAvailableJSErrorHandling(): Boolean
 
   @DoNotStrip public fun useFabricInterop(): Boolean
+
+  @DoNotStrip public fun useLISAlgorithmInDifferentiator(): Boolean
 
   @DoNotStrip public fun useNativeViewConfigsInBridgelessMode(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b4670c40175b42e04eb8f03b752a0c00>>
+ * @generated SignedSource<<6c088ccf18868fc6e54d83c7483b6607>>
  */
 
 /**
@@ -519,6 +519,12 @@ class ReactNativeFeatureFlagsJavaProvider
     return method(javaProvider_);
   }
 
+  bool useLISAlgorithmInDifferentiator() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useLISAlgorithmInDifferentiator");
+    return method(javaProvider_);
+  }
+
   bool useNativeViewConfigsInBridgelessMode() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useNativeViewConfigsInBridgelessMode");
@@ -983,6 +989,11 @@ bool JReactNativeFeatureFlagsCxxInterop::useFabricInterop(
   return ReactNativeFeatureFlags::useFabricInterop();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::useLISAlgorithmInDifferentiator(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::useLISAlgorithmInDifferentiator();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::useNativeViewConfigsInBridgelessMode(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode();
@@ -1304,6 +1315,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useFabricInterop",
         JReactNativeFeatureFlagsCxxInterop::useFabricInterop),
+      makeNativeMethod(
+        "useLISAlgorithmInDifferentiator",
+        JReactNativeFeatureFlagsCxxInterop::useLISAlgorithmInDifferentiator),
       makeNativeMethod(
         "useNativeViewConfigsInBridgelessMode",
         JReactNativeFeatureFlagsCxxInterop::useNativeViewConfigsInBridgelessMode),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5433b4a2f4a0574591a38017422edac8>>
+ * @generated SignedSource<<73cfe749b34b786e25b683c499889e48>>
  */
 
 /**
@@ -268,6 +268,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useFabricInterop(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool useLISAlgorithmInDifferentiator(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useNativeViewConfigsInBridgelessMode(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bfb72cee88230c56d2c101be808ef300>>
+ * @generated SignedSource<<a33f1aaed390cc914a55bd48906f1a11>>
  */
 
 /**
@@ -344,6 +344,10 @@ bool ReactNativeFeatureFlags::useAlwaysAvailableJSErrorHandling() {
 
 bool ReactNativeFeatureFlags::useFabricInterop() {
   return getAccessor().useFabricInterop();
+}
+
+bool ReactNativeFeatureFlags::useLISAlgorithmInDifferentiator() {
+  return getAccessor().useLISAlgorithmInDifferentiator();
 }
 
 bool ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4811a81c7839f2be5c8a127e6c8e310b>>
+ * @generated SignedSource<<6c175f21aaa8d084c7b0be0625d5d77d>>
  */
 
 /**
@@ -438,6 +438,11 @@ class ReactNativeFeatureFlags {
    * Should this application enable the Fabric Interop Layer for Android? If yes, the application will behave so that it can accept non-Fabric components and render them on Fabric. This toggle is controlling extra logic such as custom event dispatching that are needed for the Fabric Interop Layer to work correctly.
    */
   RN_EXPORT static bool useFabricInterop();
+
+  /**
+   * Use Longest Increasing Subsequence algorithm in the Differentiator to minimize REMOVE/INSERT mutations during child list reconciliation.
+   */
+  RN_EXPORT static bool useLISAlgorithmInDifferentiator();
 
   /**
    * When enabled, the native view configs are used in bridgeless mode.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f20eda0ee0b3b7494ccb9bb5b4f0d1b0>>
+ * @generated SignedSource<<b13a093e1b52bbc5cf6d6d0871797e94>>
  */
 
 /**
@@ -1469,6 +1469,24 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::useLISAlgorithmInDifferentiator() {
+  auto flagValue = useLISAlgorithmInDifferentiator_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(80, "useLISAlgorithmInDifferentiator");
+
+    flagValue = currentProvider_->useLISAlgorithmInDifferentiator();
+    useLISAlgorithmInDifferentiator_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
   auto flagValue = useNativeViewConfigsInBridgelessMode_.load();
 
@@ -1478,7 +1496,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(80, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(81, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -1496,7 +1514,7 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useNestedScrollViewAndroid");
+    markFlagAsAccessed(82, "useNestedScrollViewAndroid");
 
     flagValue = currentProvider_->useNestedScrollViewAndroid();
     useNestedScrollViewAndroid_ = flagValue;
@@ -1514,7 +1532,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "useSharedAnimatedBackend");
+    markFlagAsAccessed(83, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1532,7 +1550,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(84, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1550,7 +1568,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "useTurboModuleInterop");
+    markFlagAsAccessed(85, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1568,7 +1586,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "useTurboModules");
+    markFlagAsAccessed(86, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;
@@ -1586,7 +1604,7 @@ bool ReactNativeFeatureFlagsAccessor::useUnorderedMapInDifferentiator() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "useUnorderedMapInDifferentiator");
+    markFlagAsAccessed(87, "useUnorderedMapInDifferentiator");
 
     flagValue = currentProvider_->useUnorderedMapInDifferentiator();
     useUnorderedMapInDifferentiator_ = flagValue;
@@ -1604,7 +1622,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(87, "viewCullingOutsetRatio");
+    markFlagAsAccessed(88, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1622,7 +1640,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(88, "viewTransitionEnabled");
+    markFlagAsAccessed(89, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1640,7 +1658,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(89, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(90, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<06dba77b9b76d06d5c338ed8a97e33f5>>
+ * @generated SignedSource<<29e7a9ef1807aaecaf5440e024a5a2f2>>
  */
 
 /**
@@ -112,6 +112,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool updateRuntimeShadowNodeReferencesOnCommitThread();
   bool useAlwaysAvailableJSErrorHandling();
   bool useFabricInterop();
+  bool useLISAlgorithmInDifferentiator();
   bool useNativeViewConfigsInBridgelessMode();
   bool useNestedScrollViewAndroid();
   bool useSharedAnimatedBackend();
@@ -133,7 +134,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 90> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 91> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -215,6 +216,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> updateRuntimeShadowNodeReferencesOnCommitThread_;
   std::atomic<std::optional<bool>> useAlwaysAvailableJSErrorHandling_;
   std::atomic<std::optional<bool>> useFabricInterop_;
+  std::atomic<std::optional<bool>> useLISAlgorithmInDifferentiator_;
   std::atomic<std::optional<bool>> useNativeViewConfigsInBridgelessMode_;
   std::atomic<std::optional<bool>> useNestedScrollViewAndroid_;
   std::atomic<std::optional<bool>> useSharedAnimatedBackend_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0934d867533630904fc69e30e7a929b3>>
+ * @generated SignedSource<<2cf1c7be6b0086da159550454273ce2d>>
  */
 
 /**
@@ -345,6 +345,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
 
   bool useFabricInterop() override {
     return true;
+  }
+
+  bool useLISAlgorithmInDifferentiator() override {
+    return false;
   }
 
   bool useNativeViewConfigsInBridgelessMode() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<25d1f9cb509dbd8274e3a00237d2ea62>>
+ * @generated SignedSource<<20a808bb8708d8088f3d7aae8d58b6b2>>
  */
 
 /**
@@ -763,6 +763,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::useFabricInterop();
+  }
+
+  bool useLISAlgorithmInDifferentiator() override {
+    auto value = values_["useLISAlgorithmInDifferentiator"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::useLISAlgorithmInDifferentiator();
   }
 
   bool useNativeViewConfigsInBridgelessMode() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<feb5aa86f9441652498d10e244717836>>
+ * @generated SignedSource<<8c52d3da48fbc27e8e23493f81a93d55>>
  */
 
 /**
@@ -105,6 +105,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool updateRuntimeShadowNodeReferencesOnCommitThread() = 0;
   virtual bool useAlwaysAvailableJSErrorHandling() = 0;
   virtual bool useFabricInterop() = 0;
+  virtual bool useLISAlgorithmInDifferentiator() = 0;
   virtual bool useNativeViewConfigsInBridgelessMode() = 0;
   virtual bool useNestedScrollViewAndroid() = 0;
   virtual bool useSharedAnimatedBackend() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0b3534a570416860aa1ffc7e1d808090>>
+ * @generated SignedSource<<51f57b07e238ca9c13f4c7ec363eb9a0>>
  */
 
 /**
@@ -442,6 +442,11 @@ bool NativeReactNativeFeatureFlags::useAlwaysAvailableJSErrorHandling(
 bool NativeReactNativeFeatureFlags::useFabricInterop(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useFabricInterop();
+}
+
+bool NativeReactNativeFeatureFlags::useLISAlgorithmInDifferentiator(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::useLISAlgorithmInDifferentiator();
 }
 
 bool NativeReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0aeea7c4fa2a8aa4180c83bbd0746250>>
+ * @generated SignedSource<<8368d761c6a95fcdbf804681a2bf65d3>>
  */
 
 /**
@@ -195,6 +195,8 @@ class NativeReactNativeFeatureFlags
   bool useAlwaysAvailableJSErrorHandling(jsi::Runtime& runtime);
 
   bool useFabricInterop(jsi::Runtime& runtime);
+
+  bool useLISAlgorithmInDifferentiator(jsi::Runtime& runtime);
 
   bool useNativeViewConfigsInBridgelessMode(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include "internal/CullingContext.h"
 #include "internal/DiffMap.h"
+#include "internal/LongestIncreasingSubsequence.h"
 #include "internal/ShadowViewNodePair.h"
 #include "internal/sliceChildShadowNodeViewPairs.h"
 
@@ -1048,13 +1049,275 @@ static void calculateShadowViewMutations(
           oldCullingContext,
           newCullingContextCopy);
     }
+  } else if (ReactNativeFeatureFlags::useLISAlgorithmInDifferentiator()) {
+    // LIS-based Stage 4: find the Longest Increasing Subsequence of
+    // new-list positions among old children to minimize REMOVE/INSERT
+    // mutations. Items in the LIS maintain their relative order and
+    // don't need REMOVE+INSERT — only items outside the LIS are moved.
+    auto remainingOldCount = oldChildPairs.size() - lastIndexAfterFirstStage;
+    auto remainingNewCount = newChildPairs.size() - lastIndexAfterFirstStage;
+
+    // Build newRemainingPairs (required by updateMatchedPairSubtrees for
+    // flattening logic) and tag→index map for O(1) lookups in Step 1.
+    auto newRemainingPairs =
+        DiffMap<Tag, ShadowViewNodePair*>(remainingNewCount);
+    auto newTagToIndex = DiffMap<Tag, size_t>(remainingNewCount);
+    for (size_t i = lastIndexAfterFirstStage; i < newChildPairs.size(); i++) {
+      auto& newChildPair = *newChildPairs[i];
+      newRemainingPairs.insert({newChildPair.shadowView.tag, &newChildPair});
+      newTagToIndex.insert({newChildPair.shadowView.tag, i});
+    }
+
+    // Step 1: Map old children to their positions in the new list.
+    std::vector<size_t> oldToNewPos(remainingOldCount);
+    std::vector<bool> oldExistsInNew(remainingOldCount, false);
+
+    for (size_t i = 0; i < remainingOldCount; i++) {
+      auto oldIdx = lastIndexAfterFirstStage + i;
+      Tag oldTag = oldChildPairs[oldIdx]->shadowView.tag;
+      auto it = newTagToIndex.find(oldTag);
+      if (it != newTagToIndex.end()) {
+        oldToNewPos[i] = it->second;
+        oldExistsInNew[i] = true;
+      }
+    }
+
+    // Step 2: Compute LIS of new-list positions.
+    auto inLIS = longestIncreasingSubsequence(oldToNewPos, oldExistsInNew);
+
+    auto deletionCandidatePairs = std::vector<const ShadowViewNodePair*>{};
+    deletionCandidatePairs.reserve(remainingOldCount);
+
+    // New-child-indexed flag: true = LIS match that stays in place.
+    auto isLISMatch = std::vector<bool>(remainingNewCount, false);
+
+    // Step 4: Process old children.
+    // CRITICAL: check newRemainingPairs at runtime (not the pre-computed
+    // oldExistsInNew). The flattener erases entries from newRemainingPairs
+    // as it consumes them during flatten/unflatten — using the pre-computed
+    // snapshot would cause double-processing of flattened nodes.
+    react_native_assert(inLIS.size() == remainingOldCount);
+    for (size_t i = 0; i < remainingOldCount; i++) {
+      auto oldIdx = lastIndexAfterFirstStage + i;
+      auto& oldChildPair = *oldChildPairs[oldIdx];
+      Tag oldTag = oldChildPair.shadowView.tag;
+
+      auto newIt = newRemainingPairs.find(oldTag);
+      if (newIt == newRemainingPairs.end()) {
+        // Not in new list or consumed by flattening -> REMOVE.
+        if (!oldChildPair.isConcreteView) {
+          continue;
+        }
+
+        DEBUG_LOGS({
+          LOG(ERROR) << "Differ LIS Branch: Removing deleted tag: "
+                     << oldChildPair << " with parent: [" << parentTag << "]";
+        });
+
+        // Edge case: complex (un)flattening — node exists in other tree.
+        if (oldChildPair.inOtherTree() &&
+            oldChildPair.otherTreePair->isConcreteView) {
+          const ShadowView& otherTreeView =
+              oldChildPair.otherTreePair->shadowView;
+          mutationContainer.removeMutations.push_back(
+              ShadowViewMutation::RemoveMutation(
+                  parentTag,
+                  otherTreeView,
+                  static_cast<int>(oldChildPair.mountIndex)));
+          continue;
+        }
+
+        mutationContainer.removeMutations.push_back(
+            ShadowViewMutation::RemoveMutation(
+                parentTag,
+                oldChildPair.shadowView,
+                static_cast<int>(oldChildPair.mountIndex)));
+        deletionCandidatePairs.push_back(&oldChildPair);
+
+      } else if (inLIS[i]) {
+        // In LIS -> stays in place, just UPDATE + subtree recursion.
+        auto& newChildPair = *newIt->second;
+
+        DEBUG_LOGS({
+          LOG(ERROR) << "Differ LIS Branch: Matched in-order (LIS) at old "
+                     << oldIdx << ": " << oldChildPair << " with parent: ["
+                     << parentTag << "]";
+        });
+
+        // For LIS matches with concrete-ness changes, we must use
+        // (true, false) to avoid generating INSERT in updateMatchedPair.
+        // INSERT mutations must be in new-child order (Step 5), not
+        // old-child order (Step 4). Generating INSERT here would put it
+        // out of order relative to Step 5's INSERTs.
+        bool concreteChanged =
+            oldChildPair.isConcreteView != newChildPair.isConcreteView;
+
+        updateMatchedPair(
+            mutationContainer,
+            true,
+            !concreteChanged,
+            parentTag,
+            oldChildPair,
+            newChildPair);
+
+        updateMatchedPairSubtrees(
+            scope,
+            mutationContainer,
+            newRemainingPairs,
+            oldChildPairs,
+            parentTag,
+            oldChildPair,
+            newChildPair,
+            oldCullingContext,
+            newCullingContext);
+
+        if (!concreteChanged) {
+          // Check if this LIS match was consumed by flattening.
+          // updateMatchedPairSubtrees may erase entries from
+          // newRemainingPairs during flatten/unflatten transitions.
+          // If consumed, the node was reparented elsewhere and needs
+          // REMOVE from this parent.
+          if (newRemainingPairs.find(oldTag) != newRemainingPairs.end()) {
+            isLISMatch[oldToNewPos[i] - lastIndexAfterFirstStage] = true;
+          } else if (oldChildPair.isConcreteView) {
+            if (oldChildPair.inOtherTree() &&
+                oldChildPair.otherTreePair->isConcreteView) {
+              mutationContainer.removeMutations.push_back(
+                  ShadowViewMutation::RemoveMutation(
+                      parentTag,
+                      oldChildPair.otherTreePair->shadowView,
+                      static_cast<int>(oldChildPair.mountIndex)));
+            } else {
+              mutationContainer.removeMutations.push_back(
+                  ShadowViewMutation::RemoveMutation(
+                      parentTag,
+                      oldChildPair.shadowView,
+                      static_cast<int>(oldChildPair.mountIndex)));
+              deletionCandidatePairs.push_back(&oldChildPair);
+            }
+          }
+        }
+        // concreteChanged: not in isLISMatch, Step 5 handles INSERT.
+
+      } else {
+        // In new list but NOT in LIS -> REMOVE from old position.
+        // Will be re-inserted at new position in Step 5.
+        auto& newChildPair = *newIt->second;
+
+        DEBUG_LOGS({
+          LOG(ERROR)
+              << "Differ LIS Branch: Matched out-of-order (not in LIS) at old "
+              << oldIdx << ": " << oldChildPair << " with parent: ["
+              << parentTag << "]";
+        });
+
+        updateMatchedPair(
+            mutationContainer,
+            true,
+            false,
+            parentTag,
+            oldChildPair,
+            newChildPair);
+
+        updateMatchedPairSubtrees(
+            scope,
+            mutationContainer,
+            newRemainingPairs,
+            oldChildPairs,
+            parentTag,
+            oldChildPair,
+            newChildPair,
+            oldCullingContext,
+            newCullingContext);
+      }
+    }
+
+    // Step 5: Process new children — INSERT + CREATE.
+    // Generate INSERT for every non-LIS-matched concrete new child.
+    // Only generate CREATE for genuinely new children (not in other tree
+    // from flattening).
+    for (size_t i = lastIndexAfterFirstStage; i < newChildPairs.size(); i++) {
+      auto& newChildPair = *newChildPairs[i];
+
+      if (!newChildPair.isConcreteView) {
+        continue;
+      }
+
+      // LIS matches stay in place — no INSERT needed.
+      if (isLISMatch[i - lastIndexAfterFirstStage]) {
+        continue;
+      }
+
+      DEBUG_LOGS({
+        LOG(ERROR) << "Differ LIS Branch: Inserting tag: " << newChildPair
+                   << " with parent: [" << parentTag << "]"
+                   << (newChildPair.inOtherTree() ? " (in other tree)" : "");
+      });
+
+      mutationContainer.insertMutations.push_back(
+          ShadowViewMutation::InsertMutation(
+              parentTag,
+              newChildPair.shadowView,
+              static_cast<int>(newChildPair.mountIndex)));
+
+      // Only CREATE genuinely new children (not matched by flattening).
+      if (!newChildPair.inOtherTree()) {
+        mutationContainer.createMutations.push_back(
+            ShadowViewMutation::CreateMutation(newChildPair.shadowView));
+
+        auto newCullingContextCopy =
+            newCullingContext.adjustCullingContextIfNeeded(newChildPair);
+
+        ViewNodePairScope innerScope{};
+        calculateShadowViewMutations(
+            innerScope,
+            mutationContainer.downwardMutations,
+            newChildPair.shadowView.tag,
+            {},
+            sliceChildShadowNodeViewPairsFromViewNodePair(
+                newChildPair, innerScope, false, newCullingContextCopy),
+            oldCullingContext,
+            newCullingContextCopy);
+      }
+    }
+
+    // Step 6: Generate DELETE for deletion candidates.
+    for (const auto* deletionCandidatePtr : deletionCandidatePairs) {
+      const auto& oldChildPair = *deletionCandidatePtr;
+
+      DEBUG_LOGS({
+        LOG(ERROR) << "Differ LIS Branch: Deleting removed tag: "
+                   << oldChildPair << " with parent: [" << parentTag << "]";
+      });
+
+      if (!oldChildPair.inOtherTree() && oldChildPair.isConcreteView) {
+        mutationContainer.deleteMutations.push_back(
+            ShadowViewMutation::DeleteMutation(oldChildPair.shadowView));
+        auto oldCullingContextCopy =
+            oldCullingContext.adjustCullingContextIfNeeded(oldChildPair);
+
+        ViewNodePairScope innerScope{};
+        auto grandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
+            oldChildPair, innerScope, false, oldCullingContextCopy);
+        calculateShadowViewMutations(
+            innerScope,
+            mutationContainer.destructiveDownwardMutations,
+            oldChildPair.shadowView.tag,
+            std::move(grandChildPairs),
+            {},
+            oldCullingContextCopy,
+            newCullingContext);
+      }
+    }
   } else {
+    // Existing greedy Stage 4 algorithm.
     // Collect map of tags in the new list
-    auto remainingCount = newChildPairs.size() - index;
+    auto remainingCount = newChildPairs.size() - lastIndexAfterFirstStage;
     auto newRemainingPairs = DiffMap<Tag, ShadowViewNodePair*>(remainingCount);
     auto newInsertedPairs = DiffMap<Tag, ShadowViewNodePair*>(remainingCount);
     auto deletionCandidatePairs = DiffMap<Tag, const ShadowViewNodePair*>{};
-    for (; index < newChildPairs.size(); index++) {
+    for (index = lastIndexAfterFirstStage; index < newChildPairs.size();
+         index++) {
       auto& newChildPair = *newChildPairs[index];
       newRemainingPairs.insert({newChildPair.shadowView.tag, &newChildPair});
     }

--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/LongestIncreasingSubsequence.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/LongestIncreasingSubsequence.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/debug/react_native_assert.h>
+#include <algorithm>
+#include <vector>
+
+namespace facebook::react {
+
+/**
+ * Computes the Longest Increasing Subsequence (LIS) of the given
+ * sequence of values using O(n log n) patience sorting.
+ *
+ * Returns a vector<bool> of the same size as `values`, where
+ * result[i] == true means values[i] is part of the LIS.
+ *
+ * Only elements where include[i] == true are considered;
+ * elements with include[i] == false are ignored and will always
+ * be false in the result.
+ */
+inline std::vector<bool> longestIncreasingSubsequence(
+    const std::vector<size_t> &values,
+    const std::vector<bool> &include)
+{
+  react_native_assert(values.size() == include.size());
+
+  size_t n = values.size();
+  std::vector<bool> inLIS(n, false);
+
+  if (n == 0) {
+    return inLIS;
+  }
+
+  // Collect indices of included elements.
+  std::vector<size_t> indices;
+  indices.reserve(n);
+  for (size_t i = 0; i < n; i++) {
+    if (include[i]) {
+      indices.push_back(i);
+    }
+  }
+
+  if (indices.empty()) {
+    return inLIS;
+  }
+
+  // tails[i] = smallest tail value of all increasing subsequences
+  // of length i+1.
+  std::vector<size_t> tails;
+  // tailIndices[i] = index into `indices` whose value is tails[i].
+  std::vector<size_t> tailIndices;
+  // predecessor[k] = index into `indices` of the predecessor of
+  // indices[k] in the LIS, or -1 if none.
+  std::vector<int> predecessor(indices.size(), -1);
+
+  tails.reserve(indices.size());
+  tailIndices.reserve(indices.size());
+
+  for (size_t k = 0; k < indices.size(); k++) {
+    size_t val = values[indices[k]];
+
+    // Binary search for the first element in tails >= val.
+    auto it = std::lower_bound(tails.begin(), tails.end(), val);
+    auto pos = static_cast<size_t>(it - tails.begin());
+
+    if (it == tails.end()) {
+      tails.push_back(val);
+      tailIndices.push_back(k);
+    } else {
+      *it = val;
+      tailIndices[pos] = k;
+    }
+
+    if (pos > 0) {
+      predecessor[k] = static_cast<int>(tailIndices[pos - 1]);
+    }
+  }
+
+  // Reconstruct LIS by tracing predecessors from the last element.
+  int current = static_cast<int>(tailIndices.back());
+  while (current >= 0) {
+    inLIS[indices[static_cast<size_t>(current)]] = true;
+    current = predecessor[static_cast<size_t>(current)];
+  }
+
+  return inLIS;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/LongestIncreasingSubsequenceTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/LongestIncreasingSubsequenceTest.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "internal/LongestIncreasingSubsequence.h"
+
+namespace facebook::react {
+
+TEST(LongestIncreasingSubsequenceTest, emptyInput) {
+  auto result = longestIncreasingSubsequence({}, {});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LongestIncreasingSubsequenceTest, singleElement) {
+  auto result = longestIncreasingSubsequence({5}, {true});
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_TRUE(result[0]);
+}
+
+TEST(LongestIncreasingSubsequenceTest, alreadySorted) {
+  // [0, 1, 2, 3, 4] — entire sequence is the LIS.
+  std::vector<size_t> values = {0, 1, 2, 3, 4};
+  std::vector<bool> include = {true, true, true, true, true};
+  auto result = longestIncreasingSubsequence(values, include);
+
+  ASSERT_EQ(result.size(), 5u);
+  for (size_t i = 0; i < 5; i++) {
+    EXPECT_TRUE(result[i]) << "index " << i << " should be in LIS";
+  }
+}
+
+TEST(LongestIncreasingSubsequenceTest, reverseSorted) {
+  // [4, 3, 2, 1, 0] — LIS length is 1.
+  std::vector<size_t> values = {4, 3, 2, 1, 0};
+  std::vector<bool> include = {true, true, true, true, true};
+  auto result = longestIncreasingSubsequence(values, include);
+
+  ASSERT_EQ(result.size(), 5u);
+  int count = 0;
+  for (size_t i = 0; i < 5; i++) {
+    if (result[i]) {
+      count++;
+    }
+  }
+  EXPECT_EQ(count, 1);
+}
+
+TEST(LongestIncreasingSubsequenceTest, moveLastToFront) {
+  // Old: [A, B, C, D, E] mapped to new positions [1, 2, 3, 4, 0]
+  // LIS should be [1, 2, 3, 4] (indices 0-3), leaving index 4 out.
+  std::vector<size_t> values = {1, 2, 3, 4, 0};
+  std::vector<bool> include = {true, true, true, true, true};
+  auto result = longestIncreasingSubsequence(values, include);
+
+  ASSERT_EQ(result.size(), 5u);
+  EXPECT_TRUE(result[0]); // value 1
+  EXPECT_TRUE(result[1]); // value 2
+  EXPECT_TRUE(result[2]); // value 3
+  EXPECT_TRUE(result[3]); // value 4
+  EXPECT_FALSE(result[4]); // value 0
+}
+
+TEST(LongestIncreasingSubsequenceTest, moveFirstToLast) {
+  // Old: [A, B, C, D, E] mapped to new positions [4, 0, 1, 2, 3]
+  // LIS should be [0, 1, 2, 3] (indices 1-4), leaving index 0 out.
+  std::vector<size_t> values = {4, 0, 1, 2, 3};
+  std::vector<bool> include = {true, true, true, true, true};
+  auto result = longestIncreasingSubsequence(values, include);
+
+  ASSERT_EQ(result.size(), 5u);
+  EXPECT_FALSE(result[0]); // value 4
+  EXPECT_TRUE(result[1]); // value 0
+  EXPECT_TRUE(result[2]); // value 1
+  EXPECT_TRUE(result[3]); // value 2
+  EXPECT_TRUE(result[4]); // value 3
+}
+
+TEST(LongestIncreasingSubsequenceTest, withExcludedElements) {
+  // values = [1, _, 3, _, 0] where _ are excluded (deleted from new list)
+  std::vector<size_t> values = {1, 999, 3, 999, 0};
+  std::vector<bool> include = {true, false, true, false, true};
+  auto result = longestIncreasingSubsequence(values, include);
+
+  ASSERT_EQ(result.size(), 5u);
+  EXPECT_FALSE(result[1]); // excluded
+  EXPECT_FALSE(result[3]); // excluded
+
+  // Among included: [1, 3, 0]. LIS is [1, 3] (length 2).
+  EXPECT_TRUE(result[0]); // value 1
+  EXPECT_TRUE(result[2]); // value 3
+  EXPECT_FALSE(result[4]); // value 0
+}
+
+TEST(LongestIncreasingSubsequenceTest, allExcluded) {
+  std::vector<size_t> values = {3, 1, 2};
+  std::vector<bool> include = {false, false, false};
+  auto result = longestIncreasingSubsequence(values, include);
+
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_FALSE(result[0]);
+  EXPECT_FALSE(result[1]);
+  EXPECT_FALSE(result[2]);
+}
+
+TEST(LongestIncreasingSubsequenceTest, interleaved) {
+  // [3, 1, 4, 1, 5, 9, 2, 6]
+  // One valid LIS: [1, 4, 5, 9] or [1, 2, 6] etc. Length should be 4.
+  std::vector<size_t> values = {3, 1, 4, 1, 5, 9, 2, 6};
+  std::vector<bool> include(8, true);
+  auto result = longestIncreasingSubsequence(values, include);
+
+  ASSERT_EQ(result.size(), 8u);
+  int count = 0;
+  size_t prev = 0;
+  bool first = true;
+  for (size_t i = 0; i < 8; i++) {
+    if (result[i]) {
+      count++;
+      if (!first) {
+        EXPECT_GT(values[i], prev) << "LIS must be strictly increasing";
+      }
+      prev = values[i];
+      first = false;
+    }
+  }
+  EXPECT_EQ(count, 4);
+}
+
+TEST(LongestIncreasingSubsequenceTest, swapTwoElements) {
+  // Old: [A, B, C, D] → New: [A, C, B, D] → positions [0, 2, 1, 3]
+  // LIS: [0, 1, 3] or [0, 2, 3] — length 3, one element out.
+  std::vector<size_t> values = {0, 2, 1, 3};
+  std::vector<bool> include = {true, true, true, true};
+  auto result = longestIncreasingSubsequence(values, include);
+
+  ASSERT_EQ(result.size(), 4u);
+  int count = 0;
+  for (size_t i = 0; i < 4; i++) {
+    if (result[i]) {
+      count++;
+    }
+  }
+  EXPECT_EQ(count, 3);
+  // First and last should always be in LIS.
+  EXPECT_TRUE(result[0]); // value 0
+  EXPECT_TRUE(result[3]); // value 3
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
@@ -13,9 +13,14 @@
 #include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/components/view/ViewComponentDescriptor.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/element/ComponentBuilder.h>
+#include <react/renderer/element/Element.h>
+#include <react/renderer/element/testUtils.h>
 #include <react/renderer/mounting/Differentiator.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
 #include <react/renderer/mounting/stubs/stubs.h>
 #include <react/test_utils/Entropy.h>
 #include <react/test_utils/shadowTreeGeneration.h>
@@ -346,7 +351,35 @@ static void testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
 
 using namespace facebook::react;
 
-TEST(
+namespace {
+
+class LISFeatureFlagsOverride
+    : public facebook::react::ReactNativeFeatureFlagsDefaults {
+ public:
+  bool useLISAlgorithmInDifferentiator() override {
+    return true;
+  }
+};
+
+} // namespace
+
+// Parametrized lifecycle tests: each test runs with both the greedy
+// algorithm (false) and the LIS algorithm (true).
+class ShadowTreeLifecycleTest : public ::testing::TestWithParam<bool> {
+ protected:
+  void SetUp() override {
+    if (GetParam()) {
+      facebook::react::ReactNativeFeatureFlags::override(
+          std::make_unique<LISFeatureFlagsOverride>());
+    }
+  }
+
+  void TearDown() override {
+    facebook::react::ReactNativeFeatureFlags::dangerouslyReset();
+  }
+};
+
+TEST_P(
     ShadowTreeLifecycleTest,
     stableBiggerTreeFewerIterationsOptimizedMovesFlattener) {
   testShadowNodeTreeLifeCycle(
@@ -356,7 +389,7 @@ TEST(
       /* stages */ 32);
 }
 
-TEST(
+TEST_P(
     ShadowTreeLifecycleTest,
     stableBiggerTreeFewerIterationsOptimizedMovesFlattener2) {
   testShadowNodeTreeLifeCycle(
@@ -366,7 +399,7 @@ TEST(
       /* stages */ 32);
 }
 
-TEST(
+TEST_P(
     ShadowTreeLifecycleTest,
     stableSmallerTreeMoreIterationsOptimizedMovesFlattener) {
   testShadowNodeTreeLifeCycle(
@@ -376,7 +409,7 @@ TEST(
       /* stages */ 32);
 }
 
-TEST(
+TEST_P(
     ShadowTreeLifecycleTest,
     unstableSmallerTreeFewerIterationsExtensiveFlatteningUnflattening) {
   testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
@@ -386,7 +419,7 @@ TEST(
       /* stages */ 32);
 }
 
-TEST(
+TEST_P(
     ShadowTreeLifecycleTest,
     unstableBiggerTreeFewerIterationsExtensiveFlatteningUnflattening) {
   testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
@@ -396,7 +429,7 @@ TEST(
       /* stages */ 32);
 }
 
-TEST(
+TEST_P(
     ShadowTreeLifecycleTest,
     unstableSmallerTreeMoreIterationsExtensiveFlatteningUnflattening) {
   testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
@@ -407,20 +440,18 @@ TEST(
 }
 
 // failing test case found 4-25-2021
-// TODO: T213669056
-// TEST(
-//     ShadowTreeLifecycleTest,
-//     unstableSmallerTreeMoreIterationsExtensiveFlatteningUnflattening_1167342011)
-//     {
-//   testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
-//       /* seed */ 1167342011,
-//       /* size */ 32,
-//       /* repeats */ 512,
-//       /* stages */ 32);
-// }
+TEST_P(
+    ShadowTreeLifecycleTest,
+    unstableSmallerTreeMoreIterationsExtensiveFlatteningUnflattening_1167342011) {
+  testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
+      /* seed */ 1167342011,
+      /* size */ 32,
+      /* repeats */ 512,
+      /* stages */ 32);
+}
 
 // You may uncomment this - locally only! - to generate failing seeds.
-// TEST(
+// TEST_P(
 //     ShadowTreeLifecycleTest,
 //     unstableSmallerTreeMoreIterationsExtensiveFlatteningUnflatteningManyRandom)
 //     {
@@ -435,3 +466,268 @@ TEST(
 //         /* stages */ 32);
 //   }
 // }
+
+// Demonstrates that the LIS algorithm produces fewer mutations than the
+// greedy algorithm for a simple child reorder: [A,B,C,D,E] → [B,C,D,E,A].
+// The greedy two-pointer walk encounters A vs B mismatch and generates
+// excessive REMOVE+INSERT pairs. The LIS algorithm identifies that B,C,D,E
+// are already in increasing order and only moves A.
+TEST_P(ShadowTreeLifecycleTest, moveFirstChildToLast) {
+  auto builder = simpleComponentBuilder();
+
+  auto makeProps = [](const std::string& id) {
+    auto props = std::make_shared<ViewShadowNodeProps>();
+    props->nativeId = id;
+    return props;
+  };
+
+  // clang-format off
+  auto rootElement =
+      Element<RootShadowNode>()
+        .tag(1)
+        .children({
+          Element<ViewShadowNode>().tag(2).props(makeProps("A")),
+          Element<ViewShadowNode>().tag(3).props(makeProps("B")),
+          Element<ViewShadowNode>().tag(4).props(makeProps("C")),
+          Element<ViewShadowNode>().tag(5).props(makeProps("D")),
+          Element<ViewShadowNode>().tag(6).props(makeProps("E")),
+        });
+  // clang-format on
+
+  auto rootNode = builder.build(rootElement);
+
+  // Clone root with children reordered to [B, C, D, E, A].
+  auto children = rootNode->getChildren();
+  auto reorderedChildren =
+      std::make_shared<std::vector<std::shared_ptr<const ShadowNode>>>();
+  for (size_t i = 1; i < children.size(); i++) {
+    reorderedChildren->push_back(children[i]);
+  }
+  reorderedChildren->push_back(children[0]);
+
+  auto reorderedRootNode = std::static_pointer_cast<const RootShadowNode>(
+      rootNode->ShadowNode::clone(
+          ShadowNodeFragment{
+              .props = ShadowNodeFragment::propsPlaceholder(),
+              .children = reorderedChildren}));
+
+  auto expected =
+      buildStubViewTreeWithoutUsingDifferentiator(*reorderedRootNode);
+  auto mutations = calculateShadowViewMutations(*rootNode, *reorderedRootNode);
+
+  auto isMoveOp = [](const ShadowViewMutation& m) {
+    return m.type == ShadowViewMutation::Remove ||
+        m.type == ShadowViewMutation::Insert;
+  };
+
+  if (ReactNativeFeatureFlags::useLISAlgorithmInDifferentiator()) {
+    // LIS: 1 REMOVE + 1 INSERT = 2 move ops.
+    EXPECT_EQ(std::count_if(mutations.begin(), mutations.end(), isMoveOp), 2);
+  } else {
+    // Greedy: 4 REMOVE + 4 INSERT = 8 move ops.
+    EXPECT_EQ(std::count_if(mutations.begin(), mutations.end(), isMoveOp), 8);
+  }
+
+  auto viewTree = buildStubViewTreeWithoutUsingDifferentiator(*rootNode);
+  viewTree.mutate(mutations);
+  EXPECT_EQ(viewTree, expected);
+}
+
+// Exercises the LIS path where concreteChanged=true AND flattening
+// consumption occur simultaneously. Z(tag=7) is reordered to break head/tail
+// matching, forcing A, W, and C into the LIS path. W(tag=3) loses testId
+// (concrete→non-concrete, concreteChanged=true) while remaining in the LIS.
+// updateMatchedPairSubtrees triggers the flattener which promotes B(tag=6).
+// The if(!concreteChanged) block that normally checks consumption is bypassed,
+// so this test verifies the combination still produces correct mutations.
+TEST_P(ShadowTreeLifecycleTest, concreteChangedWithFlattening) {
+  auto builder = simpleComponentBuilder();
+
+  auto concreteProps = [](const std::string& id) {
+    auto props = std::make_shared<ViewShadowNodeProps>();
+    props->testId = id;
+    return props;
+  };
+
+  // clang-format off
+  // Old: Root -> [Z, A, W(concrete, child B), C]
+  // Old flattened: [Z(7), A(2), W(3), C(4)]
+  auto rootElement =
+      Element<RootShadowNode>()
+        .tag(1)
+        .children({
+          Element<ViewShadowNode>().tag(7).props(concreteProps("Z")),
+          Element<ViewShadowNode>().tag(2).props(concreteProps("A")),
+          Element<ViewShadowNode>().tag(3).props(concreteProps("W"))
+            .children({
+              Element<ViewShadowNode>().tag(6).props(concreteProps("B")),
+            }),
+          Element<ViewShadowNode>().tag(4).props(concreteProps("C")),
+        });
+  // clang-format on
+
+  auto rootNode = builder.build(rootElement);
+  auto children = rootNode->getChildren();
+  // children: [Z(7), A(2), W(3), C(4)]
+
+  // W loses testId → non-concrete (flattened). B(tag=6) promoted.
+  auto flatW = children[2]->clone(
+      ShadowNodeFragment{.props = std::make_shared<ViewShadowNodeProps>()});
+
+  // New: Root -> [A, W(flattened), C, Z] — Z moved to end.
+  // New flattened: [A(2), W(3,non-concrete), B(6), C(4), Z(7)]
+  // Z's move breaks head matching; A, W, C enter LIS path.
+  // Among old remaining [Z,A,W,C] mapped to new positions,
+  // LIS includes A,W,C (increasing order), W has concreteChanged=true.
+  auto newChildren =
+      std::make_shared<std::vector<std::shared_ptr<const ShadowNode>>>();
+  newChildren->push_back(children[1]); // A
+  newChildren->push_back(flatW); // W (flattened)
+  newChildren->push_back(children[3]); // C
+  newChildren->push_back(children[0]); // Z (moved to end)
+
+  auto newRootNode = std::static_pointer_cast<const RootShadowNode>(
+      rootNode->ShadowNode::clone(
+          ShadowNodeFragment{
+              .props = ShadowNodeFragment::propsPlaceholder(),
+              .children = newChildren}));
+
+  auto expected = buildStubViewTreeWithoutUsingDifferentiator(*newRootNode);
+  auto mutations = calculateShadowViewMutations(*rootNode, *newRootNode);
+  auto viewTree = buildStubViewTreeWithoutUsingDifferentiator(*rootNode);
+  viewTree.mutate(mutations);
+  EXPECT_EQ(viewTree, expected);
+}
+
+// Reverse: W(tag=3) gains testId (non-concrete→concrete, concreteChanged=true)
+// while in the LIS path. B(tag=6) was promoted by flattening and now gets
+// absorbed back into W via unflattening. Z reorder breaks head matching.
+TEST_P(ShadowTreeLifecycleTest, concreteChangedWithUnflatteningInLIS) {
+  auto builder = simpleComponentBuilder();
+
+  auto concreteProps = [](const std::string& id) {
+    auto props = std::make_shared<ViewShadowNodeProps>();
+    props->testId = id;
+    return props;
+  };
+
+  // clang-format off
+  // Old: Root -> [Z, A, W(NON-concrete, child B(concrete)), C]
+  // Old flattened: [Z(7), A(2), W(3,non-concrete), B(6), C(4)]
+  auto rootElement =
+      Element<RootShadowNode>()
+        .tag(1)
+        .children({
+          Element<ViewShadowNode>().tag(7).props(concreteProps("Z")),
+          Element<ViewShadowNode>().tag(2).props(concreteProps("A")),
+          Element<ViewShadowNode>().tag(3)
+            .children({
+              Element<ViewShadowNode>().tag(6).props(concreteProps("B")),
+            }),
+          Element<ViewShadowNode>().tag(4).props(concreteProps("C")),
+        });
+  // clang-format on
+
+  auto rootNode = builder.build(rootElement);
+  auto children = rootNode->getChildren();
+
+  // W gains testId → concrete (unflattened). B absorbed back into W.
+  auto concreteW =
+      children[2]->clone(ShadowNodeFragment{.props = concreteProps("W")});
+
+  // New: Root -> [A, W(concrete), C, Z] — Z moved to end.
+  // New flattened: [A(2), W(3), C(4), Z(7)]
+  auto newChildren =
+      std::make_shared<std::vector<std::shared_ptr<const ShadowNode>>>();
+  newChildren->push_back(children[1]); // A
+  newChildren->push_back(concreteW); // W (concrete)
+  newChildren->push_back(children[3]); // C
+  newChildren->push_back(children[0]); // Z (moved to end)
+
+  auto newRootNode = std::static_pointer_cast<const RootShadowNode>(
+      rootNode->ShadowNode::clone(
+          ShadowNodeFragment{
+              .props = ShadowNodeFragment::propsPlaceholder(),
+              .children = newChildren}));
+
+  auto expected = buildStubViewTreeWithoutUsingDifferentiator(*newRootNode);
+  auto mutations = calculateShadowViewMutations(*rootNode, *newRootNode);
+  auto viewTree = buildStubViewTreeWithoutUsingDifferentiator(*rootNode);
+  viewTree.mutate(mutations);
+  EXPECT_EQ(viewTree, expected);
+}
+
+// Tests that the LIS algorithm produces correct mutations when child
+// reordering coincides with a view's flattening transition. When W(tag=3)
+// becomes flattened (loses testId), its child B(tag=6) is promoted to the
+// parent level in the flattened view. The LIS pre-computation maps old
+// children to new positions, but the flattener may consume entries from
+// newRemainingPairs during flatten/unflatten processing. This test verifies
+// the runtime newRemainingPairs check correctly handles this interaction.
+TEST_P(ShadowTreeLifecycleTest, reorderWithFlatteningTransition) {
+  auto builder = simpleComponentBuilder();
+
+  auto concreteProps = [](const std::string& id) {
+    auto props = std::make_shared<ViewShadowNodeProps>();
+    props->testId = id;
+    return props;
+  };
+
+  // clang-format off
+  // Old tree: Root -> [A, W(concrete with testId, child B), C, D]
+  auto rootElement =
+      Element<RootShadowNode>()
+        .tag(1)
+        .children({
+          Element<ViewShadowNode>().tag(2).props(concreteProps("A")),
+          Element<ViewShadowNode>().tag(3).props(concreteProps("W"))
+            .children({
+              Element<ViewShadowNode>().tag(6).props(concreteProps("B")),
+            }),
+          Element<ViewShadowNode>().tag(4).props(concreteProps("C")),
+          Element<ViewShadowNode>().tag(5).props(concreteProps("D")),
+        });
+  // clang-format on
+
+  auto rootNode = builder.build(rootElement);
+  auto children = rootNode->getChildren();
+  // children: [A(2), W(3), C(4), D(5)]
+
+  // Clone W without testId to make it non-concrete (flattened).
+  // B(tag=6) will be promoted to the parent level.
+  auto flatW = children[1]->clone(
+      ShadowNodeFragment{.props = std::make_shared<ViewShadowNodeProps>()});
+
+  // New tree: Root -> [C, D, A, W(flattened)]
+  // Reorder [A,W,C,D] -> [C,D,A,W(flattened)]
+  auto reorderedChildren =
+      std::make_shared<std::vector<std::shared_ptr<const ShadowNode>>>();
+  reorderedChildren->push_back(children[2]); // C
+  reorderedChildren->push_back(children[3]); // D
+  reorderedChildren->push_back(children[0]); // A
+  reorderedChildren->push_back(flatW); // W (flattened)
+
+  auto newRootNode = std::static_pointer_cast<const RootShadowNode>(
+      rootNode->ShadowNode::clone(
+          ShadowNodeFragment{
+              .props = ShadowNodeFragment::propsPlaceholder(),
+              .children = reorderedChildren}));
+
+  auto expected = buildStubViewTreeWithoutUsingDifferentiator(*newRootNode);
+  auto mutations = calculateShadowViewMutations(*rootNode, *newRootNode);
+  auto viewTree = buildStubViewTreeWithoutUsingDifferentiator(*rootNode);
+  viewTree.mutate(mutations);
+  EXPECT_EQ(viewTree, expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Greedy,
+    ShadowTreeLifecycleTest,
+    ::testing::Values(false),
+    [](const auto&) { return "Greedy"; });
+
+INSTANTIATE_TEST_SUITE_P(
+    LIS,
+    ShadowTreeLifecycleTest,
+    ::testing::Values(true),
+    [](const auto&) { return "LIS"; });

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -901,6 +901,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    useLISAlgorithmInDifferentiator: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2026-03-12',
+        description:
+          'Use Longest Increasing Subsequence algorithm in the Differentiator to minimize REMOVE/INSERT mutations during child list reconciliation.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     useNativeViewConfigsInBridgelessMode: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5966ef11ee71a38059decda1c529fd6f>>
+ * @generated SignedSource<<e92d2298350e61bc901fe52a7e651657>>
  * @flow strict
  * @noformat
  */
@@ -128,6 +128,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   updateRuntimeShadowNodeReferencesOnCommitThread: Getter<boolean>,
   useAlwaysAvailableJSErrorHandling: Getter<boolean>,
   useFabricInterop: Getter<boolean>,
+  useLISAlgorithmInDifferentiator: Getter<boolean>,
   useNativeViewConfigsInBridgelessMode: Getter<boolean>,
   useNestedScrollViewAndroid: Getter<boolean>,
   useSharedAnimatedBackend: Getter<boolean>,
@@ -529,6 +530,10 @@ export const useAlwaysAvailableJSErrorHandling: Getter<boolean> = createNativeFl
  * Should this application enable the Fabric Interop Layer for Android? If yes, the application will behave so that it can accept non-Fabric components and render them on Fabric. This toggle is controlling extra logic such as custom event dispatching that are needed for the Fabric Interop Layer to work correctly.
  */
 export const useFabricInterop: Getter<boolean> = createNativeFlagGetter('useFabricInterop', true);
+/**
+ * Use Longest Increasing Subsequence algorithm in the Differentiator to minimize REMOVE/INSERT mutations during child list reconciliation.
+ */
+export const useLISAlgorithmInDifferentiator: Getter<boolean> = createNativeFlagGetter('useLISAlgorithmInDifferentiator', false);
 /**
  * When enabled, the native view configs are used in bridgeless mode.
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<85ddaee522fc3be8546aef21cf236e9a>>
+ * @generated SignedSource<<971e04eed130adab56e3306a6a26ff1c>>
  * @flow strict
  * @noformat
  */
@@ -105,6 +105,7 @@ export interface Spec extends TurboModule {
   +updateRuntimeShadowNodeReferencesOnCommitThread?: () => boolean;
   +useAlwaysAvailableJSErrorHandling?: () => boolean;
   +useFabricInterop?: () => boolean;
+  +useLISAlgorithmInDifferentiator?: () => boolean;
   +useNativeViewConfigsInBridgelessMode?: () => boolean;
   +useNestedScrollViewAndroid?: () => boolean;
   +useSharedAnimatedBackend?: () => boolean;

--- a/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
+++ b/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @fantom_flags enableFabricCommitBranching:*
+ * @fantom_flags enableFabricCommitBranching:* useLISAlgorithmInDifferentiator:*
  * @flow strict-local
  * @format
  */
@@ -14,6 +14,7 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {HostInstance} from 'react-native';
 
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
+import * as ReactNativeFeatureFlags from '../../../featureflags/ReactNativeFeatureFlags';
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {View} from 'react-native';
@@ -87,6 +88,80 @@ describe('ViewFlattening', () => {
   });
 
   /**
+   * Test worst-case reordering: moving the first child to the end.
+   *
+   *    P -> [A,B,C,D,E]  ==>  P -> [B,C,D,E,A]
+   *
+   * The greedy two-pointer encounters A vs B mismatch at the first
+   * position and generates excessive REMOVE+INSERT pairs:
+   * 4 removes + 4 inserts = 8 mutations.
+   *
+   * The LIS algorithm identifies [B,C,D,E] as the longest increasing
+   * subsequence — those children stay in place, and only A needs to
+   * move: 1 remove + 1 insert = 2 mutations.
+   */
+  test('reordering: move first child to last (worst case for greedy)', () => {
+    const root = Fantom.createRoot();
+
+    Fantom.runTask(() => {
+      root.render(
+        <View nativeID="P">
+          <View key="A" nativeID="A" />
+          <View key="B" nativeID="B" />
+          <View key="C" nativeID="C" />
+          <View key="D" nativeID="D" />
+          <View key="E" nativeID="E" />
+        </View>,
+      );
+    });
+
+    root.takeMountingManagerLogs();
+
+    Fantom.runTask(() => {
+      root.render(
+        <View nativeID="P">
+          <View key="B" nativeID="B" />
+          <View key="C" nativeID="C" />
+          <View key="D" nativeID="D" />
+          <View key="E" nativeID="E" />
+          <View key="A" nativeID="A" />
+        </View>,
+      );
+    });
+
+    expect(root.getRenderedOutput().toJSX()).toEqual(
+      <rn-view nativeID="P">
+        <rn-view key="0" nativeID="B" />
+        <rn-view key="1" nativeID="C" />
+        <rn-view key="2" nativeID="D" />
+        <rn-view key="3" nativeID="E" />
+        <rn-view key="4" nativeID="A" />
+      </rn-view>,
+    );
+
+    const logs = root.takeMountingManagerLogs();
+    if (ReactNativeFeatureFlags.useLISAlgorithmInDifferentiator()) {
+      // LIS = [B,C,D,E], only A moves: 1 remove + 1 insert = 2 mutations
+      expect(logs).toEqual([
+        'Remove {type: "View", parentNativeID: "P", index: 0, nativeID: "A"}',
+        'Insert {type: "View", parentNativeID: "P", index: 4, nativeID: "A"}',
+      ]);
+    } else {
+      // Greedy: 4 removes + 4 inserts = 8 mutations
+      expect(logs).toEqual([
+        'Remove {type: "View", parentNativeID: "P", index: 4, nativeID: "E"}',
+        'Remove {type: "View", parentNativeID: "P", index: 3, nativeID: "D"}',
+        'Remove {type: "View", parentNativeID: "P", index: 2, nativeID: "C"}',
+        'Remove {type: "View", parentNativeID: "P", index: 1, nativeID: "B"}',
+        'Insert {type: "View", parentNativeID: "P", index: 0, nativeID: "B"}',
+        'Insert {type: "View", parentNativeID: "P", index: 1, nativeID: "C"}',
+        'Insert {type: "View", parentNativeID: "P", index: 2, nativeID: "D"}',
+        'Insert {type: "View", parentNativeID: "P", index: 3, nativeID: "E"}',
+      ]);
+    }
+  });
+
+  /**
    * Test reparenting mutation instruction generation.
    * We cannot practically handle all possible use-cases here.
    */
@@ -146,13 +221,23 @@ describe('ViewFlattening', () => {
       </rn-view>,
     );
 
-    expect(root.takeMountingManagerLogs()).toEqual([
-      'Update {type: "View", nativeID: "A"}',
-      'Remove {type: "View", parentNativeID: "G", index: 0, nativeID: "A"}',
-      'Create {type: "View", nativeID: "H"}',
-      'Insert {type: "View", parentNativeID: "G", index: 0, nativeID: "H"}',
-      'Insert {type: "View", parentNativeID: "H", index: 0, nativeID: "A"}',
-    ]);
+    if (ReactNativeFeatureFlags.useLISAlgorithmInDifferentiator()) {
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Update {type: "View", nativeID: "A"}',
+        'Remove {type: "View", parentNativeID: "G", index: 0, nativeID: "A"}',
+        'Create {type: "View", nativeID: "H"}',
+        'Insert {type: "View", parentNativeID: "H", index: 0, nativeID: "A"}',
+        'Insert {type: "View", parentNativeID: "G", index: 0, nativeID: "H"}',
+      ]);
+    } else {
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Update {type: "View", nativeID: "A"}',
+        'Remove {type: "View", parentNativeID: "G", index: 0, nativeID: "A"}',
+        'Create {type: "View", nativeID: "H"}',
+        'Insert {type: "View", parentNativeID: "G", index: 0, nativeID: "H"}',
+        'Insert {type: "View", parentNativeID: "H", index: 0, nativeID: "A"}',
+      ]);
+    }
 
     // The view is reparented 1 level down with a different sibling
     // Root -> G* -> H* -> I* -> J -> [B*, A*] [nodes with * are _not_ flattened]
@@ -182,14 +267,25 @@ describe('ViewFlattening', () => {
       </rn-view>,
     );
 
-    expect(root.takeMountingManagerLogs()).toEqual([
-      'Remove {type: "View", parentNativeID: "H", index: 0, nativeID: "A"}',
-      'Create {type: "View", nativeID: "I"}',
-      'Create {type: "View", nativeID: "B"}',
-      'Insert {type: "View", parentNativeID: "H", index: 0, nativeID: "I"}',
-      'Insert {type: "View", parentNativeID: "I", index: 0, nativeID: "B"}',
-      'Insert {type: "View", parentNativeID: "I", index: 1, nativeID: "A"}',
-    ]);
+    if (ReactNativeFeatureFlags.useLISAlgorithmInDifferentiator()) {
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Remove {type: "View", parentNativeID: "H", index: 0, nativeID: "A"}',
+        'Create {type: "View", nativeID: "I"}',
+        'Create {type: "View", nativeID: "B"}',
+        'Insert {type: "View", parentNativeID: "I", index: 0, nativeID: "B"}',
+        'Insert {type: "View", parentNativeID: "I", index: 1, nativeID: "A"}',
+        'Insert {type: "View", parentNativeID: "H", index: 0, nativeID: "I"}',
+      ]);
+    } else {
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Remove {type: "View", parentNativeID: "H", index: 0, nativeID: "A"}',
+        'Create {type: "View", nativeID: "I"}',
+        'Create {type: "View", nativeID: "B"}',
+        'Insert {type: "View", parentNativeID: "H", index: 0, nativeID: "I"}',
+        'Insert {type: "View", parentNativeID: "I", index: 0, nativeID: "B"}',
+        'Insert {type: "View", parentNativeID: "I", index: 1, nativeID: "A"}',
+      ]);
+    }
 
     // The view is reparented 1 level further down with its order with the sibling
     // swapped
@@ -222,14 +318,25 @@ describe('ViewFlattening', () => {
       </rn-view>,
     );
 
-    expect(root.takeMountingManagerLogs()).toEqual([
-      'Remove {type: "View", parentNativeID: "I", index: 1, nativeID: "A"}',
-      'Remove {type: "View", parentNativeID: "I", index: 0, nativeID: "B"}',
-      'Create {type: "View", nativeID: "J"}',
-      'Insert {type: "View", parentNativeID: "I", index: 0, nativeID: "J"}',
-      'Insert {type: "View", parentNativeID: "J", index: 0, nativeID: "A"}',
-      'Insert {type: "View", parentNativeID: "J", index: 1, nativeID: "B"}',
-    ]);
+    if (ReactNativeFeatureFlags.useLISAlgorithmInDifferentiator()) {
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Remove {type: "View", parentNativeID: "I", index: 1, nativeID: "A"}',
+        'Remove {type: "View", parentNativeID: "I", index: 0, nativeID: "B"}',
+        'Create {type: "View", nativeID: "J"}',
+        'Insert {type: "View", parentNativeID: "J", index: 0, nativeID: "A"}',
+        'Insert {type: "View", parentNativeID: "J", index: 1, nativeID: "B"}',
+        'Insert {type: "View", parentNativeID: "I", index: 0, nativeID: "J"}',
+      ]);
+    } else {
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Remove {type: "View", parentNativeID: "I", index: 1, nativeID: "A"}',
+        'Remove {type: "View", parentNativeID: "I", index: 0, nativeID: "B"}',
+        'Create {type: "View", nativeID: "J"}',
+        'Insert {type: "View", parentNativeID: "I", index: 0, nativeID: "J"}',
+        'Insert {type: "View", parentNativeID: "J", index: 0, nativeID: "A"}',
+        'Insert {type: "View", parentNativeID: "J", index: 1, nativeID: "B"}',
+      ]);
+    }
   });
 
   test('parent-child switching from unflattened-flattened to flattened-unflattened', () => {
@@ -340,15 +447,28 @@ describe('ViewFlattening', () => {
         </View>,
       );
     });
-    expect(root.takeMountingManagerLogs()).toEqual([
-      'Update {type: "View", nativeID: "child"}',
-      'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
-      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
-      'Delete {type: "View", nativeID: (N/A)}',
-      'Create {type: "View", nativeID: (N/A)}',
-      'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
-      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
-    ]);
+
+    if (ReactNativeFeatureFlags.useLISAlgorithmInDifferentiator()) {
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Update {type: "View", nativeID: "child"}',
+        'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+        'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+        'Delete {type: "View", nativeID: (N/A)}',
+        'Create {type: "View", nativeID: (N/A)}',
+        'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+        'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+      ]);
+    } else {
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Update {type: "View", nativeID: "child"}',
+        'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+        'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+        'Delete {type: "View", nativeID: (N/A)}',
+        'Create {type: "View", nativeID: (N/A)}',
+        'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+        'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+      ]);
+    }
   });
 
   test('#51378: view with rgba(255,255,255,127/256) background color is not flattened', () => {


### PR DESCRIPTION
Summary:

The current Differentiator Stage 4 uses a greedy two-pointer algorithm to
reconcile reordered children. When children are shuffled, it produces excessive
REMOVE+INSERT pairs because it doesn't find the minimal edit.

This adds an alternative code path that uses Longest Increasing Subsequence
(LIS) to identify which children can stay in place vs which need to be moved.
Items in the LIS maintain their relative order — only items outside the LIS
need REMOVE+INSERT.

Example: moving last element to front [A,B,C,D,E] → [E,A,B,C,D]:
- Greedy: 4 REMOVEs + 5 INSERTs = 9 mutations
- LIS: LIS=[A,B,C,D], only E moves = 1 REMOVE + 1 INSERT = 2 mutations

The LIS algorithm is O(n log n) time, O(n) space. Since average child count
is <10, the position mapping uses linear scan instead of hash tables.

Guarded by `useLISAlgorithmInDifferentiator` feature flag (default off).

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D96334873
