### PR TITLE
Revert RCTAnimatedModuleProvider change from D94244698 (#56100)

### DIFF
--- a/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.mm
+++ b/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.mm
@@ -70,10 +70,7 @@
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {
-  if (facebook::react::ReactNativeFeatureFlags::cxxNativeAnimatedEnabled() &&
-      // initialization is moved to DefaultTurboModules when using shared animated backend
-      // TODO: T257053961 deprecate RCTAnimatedModuleProvider.
-      !facebook::react::ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+  if (facebook::react::ReactNativeFeatureFlags::cxxNativeAnimatedEnabled()) {
     if (name == facebook::react::AnimatedModule::kModuleName) {
       __weak RCTAnimatedModuleProvider *weakSelf = self;
       auto provider = std::make_shared<facebook::react::NativeAnimatedNodesManagerProvider>(


### PR DESCRIPTION
Summary:

## Changelog:

[iOS] [Fixed] - Revert RCTAnimatedModuleProvider change from D94244698

D94244698 added a guard in RCTAnimatedModuleProvider that returns nullptr
when useSharedAnimatedBackend() is true, expecting DefaultTurboModules to
handle AnimatedModule creation instead.

However, on iOS the TurboModule resolution chain in RCTReactNativeFactory
delegates to the app-provided getTurboModule:jsInvoker: and returns whatever
the delegate returns — even nullptr — without falling through to
DefaultTurboModules.

This causes `Invariant Violation: Native animated module is not available`
on any surface using Animated.View (e.g. Marketplace PDP) when
react_fabric.enable_shared_animated_backend_ios is enabled.

Revert the RCTAnimatedModuleProvider change from D94244698 so it always
provides AnimatedModule when cxxNativeAnimatedEnabled is true, regardless
of useSharedAnimatedBackend. The shared backend path in DefaultTurboModules
still exists as fallback for non-iOS platforms.

Reviewed By: christophpurrer

Differential Revision: D96611917
