### PR TITLE
Exclude RCTBridge RCTGetModuleClasses() when LEGACY_ARCH is COMPILED OUT (#56101)

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -35,11 +35,15 @@ static NSMutableArray<Class> *RCTModuleClasses;
 static dispatch_queue_t RCTModuleClassesSyncQueue;
 NSArray<Class> *RCTGetModuleClasses(void)
 {
+#ifndef RCT_REMOVE_LEGACY_ARCH
   __block NSArray<Class> *result;
   dispatch_sync(RCTModuleClassesSyncQueue, ^{
     result = [RCTModuleClasses copy];
   });
   return result;
+#else
+  return @[];
+#endif
 }
 
 NSSet<NSString *> *getCoreModuleClasses(void);


### PR DESCRIPTION
Summary:

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D96615034
