### PR TITLE
Inline onTransitionAnimationEnd and fix iterator invalidation in ViewTransitionModule

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.cpp
@@ -131,9 +131,13 @@ void ViewTransitionModule::startViewTransition(
 }
 
 void ViewTransitionModule::startViewTransitionEnd() {
-  for (const auto& it : nameRegistry_) {
-    onTransitionAnimationEnd(it.second, it.first, 0);
+  for (const auto& [tag, names] : nameRegistry_) {
+    for (const auto& name : names) {
+      oldLayout_.erase(name);
+      newLayout_.erase(name);
+    }
   }
+  nameRegistry_.clear();
 
   transitionStarted_ = false;
 }
@@ -168,23 +172,6 @@ ViewTransitionModule::getViewTransitionInstance(
   }
 
   return std::nullopt;
-}
-
-void ViewTransitionModule::onTransitionAnimationEnd(
-    const std::unordered_set<std::string>& names,
-    Tag newTag,
-    Tag oldTag) {
-  for (const auto& name : names) {
-    oldLayout_.erase(name);
-    newLayout_.erase(name);
-  }
-
-  if (newTag != 0) {
-    nameRegistry_.erase(newTag);
-  }
-  if (oldTag != 0) {
-    nameRegistry_.erase(oldTag);
-  }
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.h
@@ -62,8 +62,6 @@ class ViewTransitionModule : public UIManagerViewTransitionDelegate {
   };
 
  private:
-  void onTransitionAnimationEnd(const std::unordered_set<std::string> &names, Tag newTag, Tag oldTag);
-
   // registry of layout of old/new views
   std::unordered_map<std::string, AnimationKeyFrameView> oldLayout_{};
   std::unordered_map<std::string, AnimationKeyFrameView> newLayout_{};


### PR DESCRIPTION
Summary:
`startViewTransitionEnd` was removing entries from `nameRegistry_` while iterating over it via `onTransitionAnimationEnd`, which is undefined behavior.

This diff improves the fix by:
  - Inlining `onTransitionAnimationEnd` (private, single call site)
  - Clearing `nameRegistry_` after the loop instead of erasing during iteration, removing the need for a copy

## Changelog:

[Internal] [Fixed] - Inline onTransitionAnimationEnd and fix iterator invalidation in ViewTransitionModule

Reviewed By: christophpurrer

Differential Revision: D96085815


