### PR TITLE
Fix MissingSoLoaderLibrary: Add @SoLoaderLibrary to InspectorFlags

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.kt
@@ -9,8 +9,10 @@ package com.facebook.react.devsupport
 
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
 /** JNI wrapper for `jsinspector_modern::InspectorFlags`. */
+@SoLoaderLibrary("react_devsupportjni")
 @DoNotStrip
 internal object InspectorFlags {
   init {


### PR DESCRIPTION
Summary:
Fixed MissingSoLoaderLibrary lint warning in InspectorFlags.kt.

Added SoLoaderLibrary("react_devsupportjni") annotation to the class which calls SoLoader.loadLibrary("react_devsupportjni") but was missing the annotation needed for build tools to sanity check JNI merging. Also added the soloader annotation Buck dependency.

changelog: [internal] internal

Differential Revision: D96784589


