### PR TITLE
Fix NoHungarianNotation: Rename mHybridData to hybridData in BindingsInstallerHolder

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/FpsView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/FpsView.kt
@@ -23,7 +23,7 @@ import java.util.Locale
  *
  * NB: Requires API 16 for use of FpsDebugFrameCallback.
  */
-internal class FpsView(reactContext: ReactContext?) : FrameLayout(reactContext!!) {
+internal class FpsView(reactContext: ReactContext) : FrameLayout(reactContext) {
   private val textView: TextView
   private val frameCallback: FpsDebugFrameCallback
   private val fpsMonitorRunnable: FPSMonitorRunnable
@@ -31,7 +31,7 @@ internal class FpsView(reactContext: ReactContext?) : FrameLayout(reactContext!!
   init {
     inflate(reactContext, R.layout.fps_view, this)
     textView = findViewById<View>(R.id.fps_text) as TextView
-    frameCallback = FpsDebugFrameCallback(reactContext!!)
+    frameCallback = FpsDebugFrameCallback(reactContext)
     fpsMonitorRunnable = FPSMonitorRunnable()
     setCurrentFPS(0.0, 0.0, 0, 0, frameCallback.isRunningOnFabric)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.kt
@@ -9,8 +9,10 @@ package com.facebook.react.devsupport
 
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
 /** JNI wrapper for `jsinspector_modern::InspectorFlags`. */
+@SoLoaderLibrary("react_devsupportjni")
 @DoNotStrip
 internal object InspectorFlags {
   init {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
@@ -395,9 +395,9 @@ public class WebSocketModule(context: ReactApplicationContext) :
 
         val defaultOrigin =
             if (requestURI.port != -1) {
-              String.format("%s://%s:%s", scheme, requestURI.host, requestURI.port)
+              "$scheme://${requestURI.host}:${requestURI.port}"
             } else {
-              String.format("%s://%s", scheme, requestURI.host)
+              "$scheme://${requestURI.host}"
             }
 
         return defaultOrigin

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BindingsInstallerHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BindingsInstallerHolder.kt
@@ -12,4 +12,4 @@ import com.facebook.proguard.annotations.DoNotStrip
 
 /** A Java holder for a C++ BindingsInstallerHolder. */
 @DoNotStrip
-public class BindingsInstallerHolder(@field:DoNotStrip private val mHybridData: HybridData)
+public class BindingsInstallerHolder(@field:DoNotStrip private val hybridData: HybridData)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.uimanager
 
+import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
@@ -30,6 +31,7 @@ import kotlin.math.sin
  *
  * @see <a href="https://www.w3.org/TR/filter-effects-1/">CSS Filter Effects Module Level 1</a>
  */
+@SuppressLint("UseRequiresApi")
 @TargetApi(31)
 internal object FilterHelper {
 
@@ -104,7 +106,7 @@ internal object FilterHelper {
     }
 
     for (i in 0 until filters.size()) {
-      val filter = filters.getMap(i)!!.entryIterator.next()
+      val filter = checkNotNull(filters.getMap(i)).entryIterator.next()
       val filterName = filter.key
       if (filterName == "blur" || filterName == "dropShadow") {
         return false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIConstantsProviderBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIConstantsProviderBinding.kt
@@ -11,8 +11,10 @@ import com.facebook.proguard.annotations.DoNotStripAny
 import com.facebook.react.bridge.NativeMap
 import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 import kotlin.jvm.JvmStatic
 
+@SoLoaderLibrary("uimanagerjni")
 @DoNotStripAny
 internal object UIConstantsProviderBinding {
   init {


### PR DESCRIPTION
Summary:
Fixed NoHungarianNotation lint warning in BindingsInstallerHolder.kt.

Renamed private field `mHybridData` to `hybridData` to follow Kotlin naming conventions. Hungarian notation (m prefix) should be avoided in Kotlin as it does not play well with Java interoperability.

changelog: [internal] internal

Differential Revision: D96784887


