### PR TITLE
Fix null pointer crash in Scheduler::animationTick by adding null check for uiManager_ (#56128) (#56128)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -295,6 +295,9 @@ SchedulerDelegate* Scheduler::getDelegate() const {
 #pragma mark - UIManagerAnimationDelegate
 
 void Scheduler::animationTick() const {
+  if (!uiManager_) {
+    return;
+  }
   uiManager_->animationTick();
 }
 


### PR DESCRIPTION
Summary: Changelog: [Android] [Fixed] - Fix crash in Scheduler::animationTick when uiManager_ is null.

Test Plan:
CI

Fixes a null pointer dereference crash in `Scheduler::animationTick()` that occurs during shutdown race conditions.

### Root Cause Analysis

**The Symptom**: `uiManager_` is null when `Scheduler::animationTick()` is called, causing a crash at offset 0x50 from null when accessing members of `UIManager`.

**The Root Cause**: During shutdown, when `uninstallFabricUIManager()` is called, the Choreographer's animation frame callback (`doFrame`) can still arrive. While `FabricUIManagerBinding::driveCxxAnimations()` checks for null scheduler (added in D92986523), the internal `Scheduler::animationTick()` method didn't check if `uiManager_` is valid before dereferencing it:

```cpp
void Scheduler::animationTick() const {
  uiManager_->animationTick();  // No null check - crashes if uiManager_ is null
}
```

**The Fix**: Added a null check for `uiManager_` before accessing it, following the same defensive pattern used in `driveCxxAnimations()` and other methods in the codebase:

```cpp
void Scheduler::animationTick() const {
  if (!uiManager_) {
    return;
  }
  uiManager_->animationTick();
}
```

**Why This Fix Works**: It prevents the null pointer dereference by checking `uiManager_` validity before use. During shutdown, if the scheduler is accessed after `uiManager_` becomes invalid, the method will safely return instead of crashing.

### Related Diffs
- D92986523: Similar fix for null scheduler check in `driveCxxAnimations()`

Logview link: [b3d4c4d8f7e6dd50b09fb7df9a1ad66a](https://www.internalfb.com/logview/system_vros_crashes/b3d4c4d8f7e6dd50b09fb7df9a1ad66a)

CI

Differential Revision: D93363797

Pulled By: shubhamksavita


