### PR TITLE
Fix SIGSEGV in animation backend callback by capturing weak_ptr

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -552,9 +552,13 @@ void NativeAnimatedNodesManager::startRenderCallbackIfNeeded(bool isAsync) {
 
   if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
     if (auto animationBackend = animationBackend_.lock()) {
-      animationBackendCallbackId_ =
-          animationBackend->start([this](AnimationTimestamp timestamp) {
-            return pullAnimationMutations(timestamp);
+      auto weak = weak_from_this();
+      animationBackendCallbackId_ = animationBackend->start(
+          [weak](AnimationTimestamp timestamp) -> AnimationMutations {
+            if (auto self = weak.lock()) {
+              return self->pullAnimationMutations(timestamp);
+            }
+            return {};
           });
     }
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -51,7 +51,7 @@ using AnimationEndCallback = AsyncCallback<EndResult>;
 template <>
 struct Bridging<EndResult> : NativeAnimatedTurboModuleEndResultBridging<EndResult> {};
 
-class NativeAnimatedNodesManager {
+class NativeAnimatedNodesManager : public std::enable_shared_from_this<NativeAnimatedNodesManager> {
  public:
   using DirectManipulationCallback = std::function<void(Tag, const folly::dynamic &)>;
   using FabricCommitCallback = std::function<void(std::unordered_map<Tag, folly::dynamic> &)>;


### PR DESCRIPTION
Summary:
The NativeAnimatedNodesManager crashes with SIGSEGV (for example in mid 2e1610331cf5e285e285a2af191fe6f3, but there are also others with similar stacks). When the
manager is destroyed on the JS thread while the Choreographer thread is still
firing animation frames, `pullAnimationMutations` runs on a freed object, because we captured it as a raw `this` pointer. To fix this I added a `weak_from_this` call there, to ensure the manager is still around.

One thing about this issue is that it looks like it should also happen for c++ Animated without the Animation Backend, as right after this call we have:
```
  if (startOnRenderCallback_) {
    startOnRenderCallback_([this]() { onRender(); }, isAsync);
    stopRenderCallbackIfNeeded(false);
  }
}
```
which also captures `this`.

On android it is not a problem though, as Android doesn't use `startOnRenderCallback_` (it only relies on `driveCxxAnimations` which is safe). On iOS it seems to be safe due to D91236980, as it adds locking a pointer to the `_nativeAnimatedNodesManagerProvider` (which owns `nativeAnimatedNodesManager`) before calling the scheduled callback.

Differential Revision: D97101348


