### PR TITLE
Add `__pycache__` to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,9 @@ fix_*.patch
 # [Experimental] Generated TS type definitions
 /packages/**/types_generated/
 
+# Python
+__pycache__/
+
 # Doxygen XML output used for C++ API tracking
 /packages/react-native/**/api/xml
 /packages/react-native/**/api/codegen


### PR DESCRIPTION
Summary:
The `__pycache__` is generated when I run the script locally. This should be added to `.gitignore`.

Changelog:
[Internal]

Differential Revision: D97119516


