### PR TITLE
Increase trace screenshot scale factor to 1x

### DIFF
--- a/packages/react-native/React/DevSupport/RCTFrameTimingsObserver.mm
+++ b/packages/react-native/React/DevSupport/RCTFrameTimingsObserver.mm
@@ -22,7 +22,7 @@
 
 using namespace facebook::react;
 
-static constexpr CGFloat kScreenshotScaleFactor = 0.75;
+static constexpr CGFloat kScreenshotScaleFactor = 1.0;
 static constexpr CGFloat kScreenshotJPEGQuality = 0.8;
 
 namespace {


### PR DESCRIPTION
Summary:
Following D97131485, brings iOS screenshot recording to parity with Android.

NOTE: Dynamic frame sampling (D97131485) becomes more load bearing after this change, as a 1x scale increases processing overhead significantly. Let's continue dogfooding.

Changelog: [Internal]

Differential Revision: D97131484


