### PR TITLE
Add focusable to view props

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -372,6 +372,8 @@ const validAttributesForNonEventProps = {
 
   direction: true,
 
+  focusable: true,
+
   style: ReactNativeStyleAttributes,
 } as const;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformTouch.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/BaseTouch.h>
+
+namespace facebook::react {
+using HostPlatformTouch = BaseTouch;
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/BaseViewEventEmitter.h>
+
+namespace facebook::react {
+using HostPlatformViewEventEmitter = BaseViewEventEmitter;
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostPlatformViewProps.h"
+
+#include <react/renderer/core/propsConversions.h>
+
+namespace facebook::react {
+
+HostPlatformViewProps::HostPlatformViewProps(
+    const PropsParserContext& context,
+    const HostPlatformViewProps& sourceProps,
+    const RawProps& rawProps)
+    : BaseViewProps(context, sourceProps, rawProps),
+      focusable(convertRawProp(
+          context,
+          rawProps,
+          "focusable",
+          sourceProps.focusable,
+          false)) {}
+
+void HostPlatformViewProps::setProp(
+    const PropsParserContext& context,
+    RawPropsPropNameHash hash,
+    const char* propName,
+    const RawValue& value) {
+  BaseViewProps::setProp(context, hash, propName, value);
+
+  static auto defaults = HostPlatformViewProps{};
+
+  switch (hash) { RAW_SET_PROP_SWITCH_CASE_BASIC(focusable); }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewProps.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/BaseViewProps.h>
+#include <react/renderer/core/PropsParserContext.h>
+
+namespace facebook::react {
+
+class HostPlatformViewProps : public BaseViewProps {
+ public:
+  HostPlatformViewProps() = default;
+  HostPlatformViewProps(
+      const PropsParserContext &context,
+      const HostPlatformViewProps &sourceProps,
+      const RawProps &rawProps);
+
+  void
+  setProp(const PropsParserContext &context, RawPropsPropNameHash hash, const char *propName, const RawValue &value);
+
+  bool focusable{false};
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/ShadowNodeTraits.h>
+
+namespace facebook::react::HostPlatformViewTraitsInitializer {
+
+inline bool formsStackingContext(const ViewProps &props)
+{
+  return false;
+}
+
+inline bool formsView(const ViewProps &props)
+{
+  return false;
+}
+
+inline bool isKeyboardFocusable(const ViewProps & /*props*/)
+{
+  return false;
+}
+
+} // namespace facebook::react::HostPlatformViewTraitsInitializer


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds `focusable` as a prop to iOS so we can re-use it on views for `canBecomeFocused` in AppleTV apps. We do not intend to make this an actual public API change, but it is non-destructive.

Reviewed By: joevilches

Differential Revision: D96752037


