### PR TITLE
[ios][precompiled] fix duplicate symbols with React.XCFramework

### DIFF
--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUI.podspec
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUI.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{h,m,swift}"
+  s.source_files           = podspec_sources("*.{h,m,swift}", "")
   s.public_header_files    = "*.h"
   s.module_name            = "RCTSwiftUI"
   s.header_dir             = "RCTSwiftUI"


### PR DESCRIPTION
## Summary:

When building React.XCFramework we build and link all source files in the XCFramework directly. To avoid Cocoapods to include the same files, we use a Ruby utility function called `podspec_sources` that will emit onlh header files when using (consuming) the build React.XFramework.

When running RN-Tester after building it using the following pod install command line we have effectively linked with the prebuilt XCFrameworks instead of building from source:

`# RCT_USE_RN_DEP=1  RCT_USE_PREBUILT_RNCORE=1 RCT_DEPS_VERSION=nightly RCT_TESTONLY_RNCORE_VERSION=nightly  bundle exec pod install`

The log in XCode will show an issue with duplciate symbols:

```
oobjc[2551]: Class _TtC10RCTSwiftUI23RCTSwiftUIContainerView is implemented in both xxxx/Library/Develope
r/CoreSimulator/Devices/72157AA1-8D26-424E-8C2E-62D701E70B4A/data/Containers/Bundle/Application/3C711879-443E-48F1-B422-740E7AE82A74/RNTester.app/Frameworks/React.framework/React (0x108d3fb90) and
xxx/Library/Developer/CoreSimulator/Devices/72157AA1-8D26-424E-8C2E-62D701E70B4A/data/Containers/Bundle/Application/3C711879-443E-48F1-B422-740E7AE82A74/RNTester.app/RNTester.debug.dylib
(0x1039ef780). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.
objc[2551]: Class _TtC10RCTSwiftUI18ContainerViewModel is implemented in both xxx/Library/Developer/CoreSimulator/Devices/72157AA1-8D26-424E-8C2E-62D701E70B4A/data/Containers/Bundle/Applicatio
n/3C711879-443E-48F1-B422-740E7AE82A74/RNTester.app/Frameworks/React.framework/React (0x108d43b98) and
xxx/Library/Developer/CoreSimulator/Devices/72157AA1-8D26-424E-8C2E-62D701E70B4A/data/Containers/Bundle/Application/3C711879-443E-48F1-B422-740E7AE82A74/RNTester.app/RNTester.debug.dylib
(0x1039f0288). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.
```

This is because the RCTSwiftUI.podspec is missing using the `podspec_sources` function when setting up its source files:

```
s.source_files = "*.{h,m,swift}"
```

This will cause Xcode to both link with the XCFramework and compile the sources for this podspec once more - causing an app with duplicate symbols.

After applying this fix, the same test as above shows no duplicate symbols.

## Changelog:

[IOS] [FIXED] - Fixed duplicate symbol error when using React.XCFramework

## Test Plan:

Run RN-Tester using the following pod install command line, causing us to link with the prebuilt XCFrameworks instead of building from source:

`# RCT_USE_RN_DEP=1  RCT_USE_PREBUILT_RNCORE=1 RCT_DEPS_VERSION=nightly RCT_TESTONLY_RNCORE_VERSION=nightly  bundle exec pod install`

Build/run the app, observe that the duplicate symbol message is gone.