### PR TITLE
Add aliases for running cxx-api scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build-types": "node ./scripts/js-api/build-types",
     "clang-format": "clang-format -i --glob=*/**/*.{h,cpp,m,mm}",
     "clean": "node ./scripts/build/clean.js",
+    "cxx-api-build": "python -m scripts.cxx-api.parser",
+    "cxx-api-validate": "python -m scripts.cxx-api.parser --check",
     "flow-check": "flow check",
     "flow": "flow",
     "format-check": "prettier --list-different \"./**/*.{js,md,yml,ts,tsx}\"",


### PR DESCRIPTION
Summary:
Add npm aliases for running python cxx-api snapshot generation script (build and validate):

```sh
python -m scripts.cxx-api.parser // cxx-api-build
python -m scripts.cxx-api.parser --check // cxx-api-validate
```


and also a js1 wrapper for buck equivalent.

Changelog:
[Internal]

Reviewed By: cortinico

Differential Revision: D97132752


