### PR TITLE
Add null check for ViewState in SurfaceMountingManager::updateProps

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
@@ -608,7 +608,14 @@ internal constructor(
       return
     }
 
-    val viewState = getViewState(reactTag)
+    val viewState = getNullableViewState(reactTag)
+    if (viewState == null) {
+      ReactSoftExceptionLogger.logSoftException(
+          ReactSoftExceptionLogger.Categories.SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE,
+          ReactNoCrashSoftException("Unable to find viewState for tag $reactTag for updateProps"),
+      )
+      return
+    }
 
     if (
         ReactNativeFeatureFlags.overrideBySynchronousMountPropsAtMountingAndroid() &&
@@ -624,7 +631,7 @@ internal constructor(
       viewState.currentProps = ReactStylesDiffMap(props)
     }
 
-    val view: View = checkNotNull(viewState.view) { "Unable to find view for tag [$reactTag]" }
+    val view: View = viewState.view ?: return
     checkNotNull(viewState.viewManager).updateProperties(view, viewState.currentProps)
   }
 


### PR DESCRIPTION
Summary:
I saw that in D95793355 a null check was added for the view state in updateLayout. A similar issue can happen (and has been happening with Reanimated) with the updateProps method, so this diff makes it consistent with the other codepaths.

## Changelog:
[General] [Changed] - use getNullableViewState in SurfaceMountingManager::updateProps and log a soft exception instead

Differential Revision: D97087668


