### PR TITLE
Add header_mappings_dir to React-Fabric.podspec animated subspec

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -60,6 +60,7 @@ Pod::Spec.new do |s|
     ss.source_files         = podspec_sources("react/renderer/animated/**/*.{m,mm,cpp,h}", "react/renderer/animated/**/*.{h}")
     ss.exclude_files        = "react/renderer/animated/tests"
     ss.header_dir           = "react/renderer/animated"
+    ss.header_mappings_dir  = "react/renderer/animated"
   end
 
   s.subspec "animations" do |ss|


### PR DESCRIPTION
## Summary:

When building React Native (`0.85.0-rc.5`) core from source (`RCT_USE_PREBUILT_RNCORE=0`), the `React-Fabric/animated` CocoaPods subspec flattens the `event_drivers/` subdirectory headers because `header_mappings_dir` is not set.

CocoaPods' `header_dir` without `header_mappings_dir` places all matched headers directly under the specified directory, losing any subdirectory structure. This means `event_drivers/EventAnimationDriver.h` ends up at `react/renderer/animated/EventAnimationDriver.h` instead of `react/renderer/animated/event_drivers/EventAnimationDriver.h`.

The `#include` in `NativeAnimatedNodesManager.h` expects the full path with the `event_drivers/` subdirectory, so the build fails with:

```
'react/renderer/animated/event_drivers/EventAnimationDriver.h' file not found
```

<img width="1512" height="1012" alt="Screenshot 2026-03-19 at 13 54 29" src="https://github.com/user-attachments/assets/49361c39-d48f-494f-ad7a-c9f3e9749a67" />

This doesn't affect prebuilt (`RCT_USE_PREBUILT_RNCORE=1`) builds because the xcframework ships with a VFS overlay that maps headers correctly.

The fix adds `header_mappings_dir` to the `animated` subspec in `React-Fabric.podspec`, which tells CocoaPods to preserve the directory structure relative to `react/renderer/animated`.

## Changelog:

[IOS] [FIXED] - Fix `EventAnimationDriver.h` not found when building React Native from source due to missing `header_mappings_dir` in `React-Fabric/animated` podspec

## Test Plan:

1. Set `RCT_USE_PREBUILT_RNCORE=0` in your Podfile
2. Run `pod install`
3. Build the project — previously fails with `'react/renderer/animated/event_drivers/EventAnimationDriver.h' file not found`
4. With this fix, the build succeeds
