### PR TITLE
Measure node instance during applyViewTransitionName

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -940,11 +940,6 @@ jsi::Value UIManagerBinding::get(
           result.setProperty(runtime, "width", domRect.width);
           result.setProperty(runtime, "height", domRect.height);
 
-          auto* viewTransitionDelegate = uiManager->getViewTransitionDelegate();
-          if (viewTransitionDelegate != nullptr) {
-            viewTransitionDelegate->captureLayoutMetricsFromRoot(*shadowNode);
-          }
-
           return result;
         });
   }

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerViewTransitionDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerViewTransitionDelegate.h
@@ -27,8 +27,6 @@ class UIManagerViewTransitionDelegate {
 
   virtual void restoreViewTransitionName(const ShadowNode &shadowNode) {}
 
-  virtual void captureLayoutMetricsFromRoot(const ShadowNode &shadowNode) {}
-
   virtual void startViewTransition(
       std::function<void()> mutationCallback,
       std::function<void()> onReadyCallback,

--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.cpp
@@ -25,14 +25,10 @@ void ViewTransitionModule::applyViewTransitionName(
   auto tag = shadowNode.getTag();
   auto surfaceId = shadowNode.getSurfaceId();
 
-  // Look up the captured layout metrics for this shadowNode
-  auto metricsIt = capturedLayoutMetricsFromRoot_.find(tag);
-  if (metricsIt == capturedLayoutMetricsFromRoot_.end()) {
-    // No measurement captured yet, nothing to do
+  auto layoutMetrics = captureLayoutMetricsFromRoot(shadowNode);
+  if (layoutMetrics == EmptyLayoutMetrics) {
     return;
   }
-
-  const auto& layoutMetrics = metricsIt->second;
 
   // Convert LayoutMetrics to AnimationKeyFrameViewLayoutMetrics
   AnimationKeyFrameViewLayoutMetrics keyframeMetrics{
@@ -54,8 +50,6 @@ void ViewTransitionModule::applyViewTransitionName(
         .layoutMetrics = keyframeMetrics, .tag = tag, .surfaceId = surfaceId};
     newLayout_[name] = newView;
   }
-
-  capturedLayoutMetricsFromRoot_.erase(tag);
 }
 
 void ViewTransitionModule::cancelViewTransitionName(
@@ -73,10 +67,10 @@ void ViewTransitionModule::restoreViewTransitionName(
   cancelledNameRegistry_.erase(shadowNode.getTag());
 }
 
-void ViewTransitionModule::captureLayoutMetricsFromRoot(
+LayoutMetrics ViewTransitionModule::captureLayoutMetricsFromRoot(
     const ShadowNode& shadowNode) {
   if (uiManager_ == nullptr) {
-    return;
+    return EmptyLayoutMetrics;
   }
 
   // Get the current revision (root node) for this surface
@@ -85,22 +79,18 @@ void ViewTransitionModule::captureLayoutMetricsFromRoot(
           shadowNode.getSurfaceId());
 
   if (currentRevision == nullptr) {
-    return;
+    return EmptyLayoutMetrics;
   }
 
   // Cast root to LayoutableShadowNode
   auto layoutableRoot =
       dynamic_cast<const LayoutableShadowNode*>(currentRevision.get());
   if (layoutableRoot == nullptr) {
-    return;
+    return EmptyLayoutMetrics;
   }
 
-  // Compute layout metrics from root
-  auto layoutMetrics = LayoutableShadowNode::computeLayoutMetricsFromRoot(
+  return LayoutableShadowNode::computeLayoutMetricsFromRoot(
       shadowNode.getFamily(), *layoutableRoot, {});
-
-  // Store the layout metrics keyed by tag
-  capturedLayoutMetricsFromRoot_[shadowNode.getTag()] = layoutMetrics;
 }
 
 void ViewTransitionModule::startViewTransition(
@@ -110,7 +100,7 @@ void ViewTransitionModule::startViewTransition(
   // Mark transition as started
   transitionStarted_ = true;
 
-  // Call mutation callback (including commitRoot, measureInstance,
+  // Call mutation callback (including commitRoot, measureInstance
   // applyViewTransitionName for old & new)
   if (mutationCallback) {
     mutationCallback();

--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.h
@@ -36,8 +36,6 @@ class ViewTransitionModule : public UIManagerViewTransitionDelegate {
   // restore cancellation
   void restoreViewTransitionName(const ShadowNode &shadowNode) override;
 
-  void captureLayoutMetricsFromRoot(const ShadowNode &shadowNode) override;
-
   void startViewTransition(
       std::function<void()> mutationCallback,
       std::function<void()> onReadyCallback,
@@ -65,9 +63,6 @@ class ViewTransitionModule : public UIManagerViewTransitionDelegate {
   // registry of layout of old/new views
   std::unordered_map<std::string, AnimationKeyFrameView> oldLayout_{};
   std::unordered_map<std::string, AnimationKeyFrameView> newLayout_{};
-  // temporary registry of measured layout metrics keyed by tag
-  std::unordered_map<Tag, LayoutMetrics> capturedLayoutMetricsFromRoot_{};
-
   // tag -> names registry, populated during applyViewTransitionName
   // Note that tag and name are not 1:1 mapping
   // - In some nested composition 2 names are mappped to the same tag
@@ -76,6 +71,8 @@ class ViewTransitionModule : public UIManagerViewTransitionDelegate {
 
   // used for cancel/restore viewTransitionName
   std::unordered_map<Tag, std::unordered_set<std::string>> cancelledNameRegistry_{};
+
+  LayoutMetrics captureLayoutMetricsFromRoot(const ShadowNode &shadowNode);
 
   UIManager *uiManager_{nullptr};
 


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Changed] - Measure node instance during applyViewTransitionName

measureInstance config function in react reconciler is not specifically for notifying runtime to measure old/new instance. this change generally will not affect current behavior because `applyViewTransitionName` is invoked right after `measureInstance` on the same instance.

Reviewed By: christophpurrer

Differential Revision: D97192977


