### PR TITLE
Add reporter hook to `loadBundleFromServer` (#56155)

### DIFF
--- a/packages/react-native/Libraries/Core/Devtools/loadBundleFromServer.js
+++ b/packages/react-native/Libraries/Core/Devtools/loadBundleFromServer.js
@@ -15,6 +15,11 @@ import getDevServer from './getDevServer';
 
 declare var global: {
   globalEvalWithSourceUrl?: (string, string) => unknown,
+  __BUNDLE_LOADER_REPORTER__?: {
+    onStart: (url: string | URL) => void,
+    onSuccess: (url: string | URL) => void,
+    onError: (url: string | URL, error: Error) => void,
+  },
   ...
 };
 
@@ -153,6 +158,7 @@ export default function loadBundleFromServer(
   }
   DevLoadingView.showMessage('Downloading...', 'load');
   ++pendingRequests;
+  global.__BUNDLE_LOADER_REPORTER__?.onStart(requestUrl);
 
   loadPromise = asyncRequest(requestUrl)
     .then<void>(({body, headers}) => {
@@ -183,9 +189,11 @@ export default function loadBundleFromServer(
         // eslint-disable-next-line no-eval
         eval(body);
       }
+      global.__BUNDLE_LOADER_REPORTER__?.onSuccess(requestUrl);
     })
     .catch<void>(e => {
       cachedPromisesByUrl.delete(requestUrl);
+      global.__BUNDLE_LOADER_REPORTER__?.onError(requestUrl, e);
       throw e;
     })
     .finally(() => {


### PR DESCRIPTION
Summary:

Add a `global.__BUNDLE_LOADER_REPORTER__` optional hook to `loadBundleFromServer.js`, following the same pattern as `global.__NETWORK_REPORTER__` in `RCTNetworking`. This provides an OSS-safe abstraction for reporting dev-mode bundle load timing and failure events.

The OSS side calls `onStart`/`onSuccess`/`onError` through optional chaining, making it a complete no-op when no reporter is installed.

Changelog:
[General][Added] Call methods on `global.__BUNDLE_LOADER_REPORTER__`, if given, during dev-mode bundler loads from Metro

Reviewed By: huntie

Differential Revision: D97115145


