### PR TITLE
Fix CVE-2026-25896: Upgrade deep transitive dependency fast-xml-parser from 4.5.0 to 4.5.4 (#56163)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4588,9 +4588,9 @@ fast-uri@^3.0.1:
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
 fast-xml-parser@^4.4.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz#2882b7d01a6825dfdf909638f2de0256351def37"
-  integrity sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz#64e52ddf1308001893bd225d5b1768840511c797"
+  integrity sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
Summary:

Fix CVE-2026-25896: Upgrade deep transitive dependency fast-xml-parser from 4.5.0 to 4.5.4

## Summary
Upgrading the deep transitive dependency `fast-xml-parser` from 4.5.0 to 4.5.4 in `xplat/js/react-native-github` to fix:
- CVE-2026-25896 (Incorrect Regular Expression)

Dependency chain (3 levels deep):
  react-native/tester -> react-native-community/cli-platform-android -> react-native-community/cli-config-android -> fast-xml-parser@^4.4.1

The semver range `^4.4.1` naturally allows 4.5.4, so the version was nudged via temporary resolution and sticks after removal. No permanent resolution needed.

Changelog:
[General][Security] - Bumped fast-xml-parser from 4.5.0 to 4.5.4 to fix CVE-2026-25896

Reviewed By: huntie

Differential Revision: D96997931
