### PR TITLE
Fix HermesSamplingProfiler JNI 'disable' method mapping to ::enable i…

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/HermesSamplingProfiler.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/HermesSamplingProfiler.cpp
@@ -34,7 +34,7 @@ void HermesSamplingProfiler::dumpSampledTraceToFile(
 void HermesSamplingProfiler::registerNatives() {
   javaClassLocal()->registerNatives({
       makeNativeMethod("enable", HermesSamplingProfiler::enable),
-      makeNativeMethod("disable", HermesSamplingProfiler::enable),
+      makeNativeMethod("disable", HermesSamplingProfiler::disable),
       makeNativeMethod(
           "dumpSampledTraceToFile",
           HermesSamplingProfiler::dumpSampledTraceToFile),


### PR DESCRIPTION
…nstead of ::disable

## Summary:

The registerNatives() function incorrectly maps the JNI 'disable' method to HermesSamplingProfiler::enable instead of HermesSamplingProfiler::disable, which can corrupt the sampling profiler state when calling HermesSamplingProfiler.disable() from Java.

This is a one-line fix: change HermesSamplingProfiler::enable to HermesSamplingProfiler::disable.

Fixes #56126

## Changelog:

[INTERNAL] -

## Test Plan:

CI