### PR TITLE
enable check_is_status in fbsource flow roots

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -48,6 +48,8 @@ experimental.pattern_matching=true
 casting_syntax=both
 component_syntax=true
 
+check_is_status=true
+
 emoji=true
 
 exact_by_default=true


### PR DESCRIPTION
Summary:
This was enabled in www in D97051123

Changelog: [internal]

Reviewed By: SamChou19815

Differential Revision: D97379650


