### PR TITLE
Fix auto-sized parent not accounting for child min-width in canSkipFlex path

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -1149,7 +1149,14 @@ static void justifyMainAxis(
       // dimensionWithMargin.
       flexLine.layout.mainDim +=
           child->style().computeMarginForAxis(mainAxis, availableInnerWidth) +
-          childLayout.computedFlexBasis.unwrap();
+          boundAxisWithinMinAndMax(
+              child,
+              direction,
+              mainAxis,
+              childLayout.computedFlexBasis,
+              mainAxisOwnerSize,
+              ownerWidth)
+              .unwrap();
       flexLine.layout.crossDim = availableInnerCrossDim;
     } else {
       // The main dimension is the sum of all the elements dimension plus


### PR DESCRIPTION
Summary:
When a flex container with auto main-axis is measured with a with a known cross dimensions, the `canSkipFlex` optimization in `justifyMainAxis` uses `computedFlexBasis` directly. This doesn't account for the `min` & `max` width constraints, causing the parent to undersize.


I have added a `.html` test page here to mirror the C++ test I added to confirm that flexbox does respect the min-width constraint. [minwidth-test.html](https://github.com/user-attachments/files/25695677/minwidth-test.html)

Changelog: [Internal]

X-link: https://github.com/facebook/yoga/pull/1905

Reviewed By: sammy-SC, adityasharat

Differential Revision: D95177338

Pulled By: NickGerleman


