### PR TITLE
Fix JNI registration bug: HermesSamplingProfiler.disable() calls enable()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/HermesSamplingProfiler.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/HermesSamplingProfiler.cpp
@@ -34,7 +34,7 @@ void HermesSamplingProfiler::dumpSampledTraceToFile(
 void HermesSamplingProfiler::registerNatives() {
   javaClassLocal()->registerNatives({
       makeNativeMethod("enable", HermesSamplingProfiler::enable),
-      makeNativeMethod("disable", HermesSamplingProfiler::enable),
+      makeNativeMethod("disable", HermesSamplingProfiler::disable),
       makeNativeMethod(
           "dumpSampledTraceToFile",
           HermesSamplingProfiler::dumpSampledTraceToFile),


### PR DESCRIPTION
## Summary:

`HermesSamplingProfiler::registerNatives()` maps the JNI `"disable"` method to `HermesSamplingProfiler::enable` instead of `HermesSamplingProfiler::disable` (copy-paste bug). This means calling `HermesSamplingProfiler.disable()` from Java actually calls `enable()` again, which corrupts the sampling thread state.

This causes a SIGABRT crash on Android when any profiling tool (e.g. Sentry) calls `disable()` to stop profiling:
```
Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid (hermes-sampling)
Abort message: 'invalid pthread_t passed to pthread_kill'
```

The fix is a one-character change: `::enable` → `::disable`.

Related issue: https://github.com/facebook/react-native/issues/56120

## Changelog:

[ANDROID] [FIXED] - Fix HermesSamplingProfiler.disable() JNI registration calling enable() instead of disable()

## Test Plan:

This is a copy-paste bug fix visible by code inspection. The correct `disable()` C++ implementation already exists (line 20-24, calls `hermesAPI->disableSamplingProfiler()`) — it was just never invoked due to the incorrect JNI registration.

Verified in production at Expensify: with this fix applied via patch-package, the SIGABRT crash no longer occurs when Sentry Hermes profiling is enabled.