### PR TITLE
Add performance marker for Fast Refresh update (#56176)

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -212,6 +212,7 @@ Error: ${e.message}`;
     });
 
     let pendingUpdatesCount = 0;
+    let lastMarkerChangeId: string | null = null;
     client.on('update-start', ({isInitialUpdate}) => {
       pendingUpdatesCount++;
       currentCompileErrorMessage = null;
@@ -229,10 +230,23 @@ Error: ${e.message}`;
       }
     });
 
-    client.on('update-done', () => {
+    client.on('update-done', body => {
       pendingUpdatesCount--;
       if (pendingUpdatesCount === 0) {
         DevLoadingView.hide();
+        const changeId = body?.changeId;
+        if (changeId != null && changeId !== lastMarkerChangeId) {
+          lastMarkerChangeId = changeId;
+          performance.mark('Fast Refresh - Update done', {
+            detail: {
+              devtools: {
+                dataType: 'marker',
+                color: 'primary',
+                tooltipText: 'Fast Refresh \u269b',
+              },
+            },
+          });
+        }
       }
     });
 


### PR DESCRIPTION
Summary:

NOTE: Resubmission of D84624705.

Adds a prominent vertical "Fast Refresh ⚛︎" marker entry in the performance timeline when a Fast Refresh update is complete.

Changelog: [Internal]

Reviewed By: GijsWeterings

Differential Revision: D97486551
