### PR TITLE
Apply doxygen input filters only when needed

### DIFF
--- a/scripts/cxx-api/config.yml
+++ b/scripts/cxx-api/config.yml
@@ -10,6 +10,7 @@ ReactCommon:
     - "*/platform/macos/*"
     - "*/platform/ios/*"
     - "*/platform/android/*"
+  input_filter: false
   definitions:
   variants:
     debug:
@@ -33,6 +34,7 @@ ReactAndroid:
     - "*/platform/windows/*"
     - "*/platform/macos/*"
     - "*/platform/ios/*"
+  input_filter: false
   definitions:
     RN_SERIALIZABLE_STATE: 1
     ANDROID: 1
@@ -66,6 +68,7 @@ ReactApple:
     - "*+Internal.h"
     - "*/scripts/*"
     - "*/templates/*"
+  input_filter: true
   definitions:
     __cplusplus: 1
   variants:

--- a/scripts/cxx-api/parser/__main__.py
+++ b/scripts/cxx-api/parser/__main__.py
@@ -139,7 +139,7 @@ def build_snapshots(
                 output_dir=output_dir,
                 codegen_platform=config.codegen_platform,
                 verbose=verbose,
-                input_filter=input_filter,
+                input_filter=input_filter if config.input_filter else None,
             )
     else:
         snapshot = build_snapshot_for_view(

--- a/scripts/cxx-api/parser/config.py
+++ b/scripts/cxx-api/parser/config.py
@@ -37,6 +37,7 @@ class ApiViewSnapshotConfig:
     exclude_patterns: list[str]
     definitions: dict[str, str | int]
     codegen_platform: str | None = None
+    input_filter: bool = False
 
 
 def parse_config(
@@ -65,6 +66,7 @@ def parse_config(
         codegen_config = view_config.get("codegen") or {}
         codegen_platform = codegen_config.get("platform")
         exclude_patterns = view_config.get("exclude_patterns") or []
+        input_filter = view_config.get("input_filter", False)
         base_definitions = view_config.get("definitions") or {}
 
         raw_variants = view_config.get("variants") or {}
@@ -84,6 +86,7 @@ def parse_config(
                     exclude_patterns=exclude_patterns,
                     definitions=base_definitions,
                     codegen_platform=codegen_platform,
+                    input_filter=input_filter,
                 )
             )
         else:
@@ -97,6 +100,7 @@ def parse_config(
                         exclude_patterns=exclude_patterns,
                         definitions=merged_definitions,
                         codegen_platform=codegen_platform,
+                        input_filter=input_filter,
                     )
                 )
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Makes doxygen input filers opt-in via the config file. Those are only needed for objective c files, so there's no need to run them for ReactCommon or ReactAndroid.

Differential Revision: D97489420


