### PR TITLE
Fix Android accessibility descendant race in ReactViewGroup

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
@@ -11,6 +11,7 @@ import androidx.annotation.StringDef
 import com.facebook.common.logging.FLog
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.CLIPPING_PROHIBITED_VIEW
+import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.RVG_ADD_CHILDREN_FOR_ACCESSIBILITY
 import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.RVG_IS_VIEW_CLIPPED
 import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.RVG_ON_VIEW_REMOVED
 import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.SOFT_ASSERTIONS
@@ -21,6 +22,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 internal object ReactSoftExceptionLogger {
   @Retention(AnnotationRetention.SOURCE)
   @StringDef(
+      RVG_ADD_CHILDREN_FOR_ACCESSIBILITY,
       RVG_IS_VIEW_CLIPPED,
       RVG_ON_VIEW_REMOVED,
       CLIPPING_PROHIBITED_VIEW,
@@ -31,6 +33,8 @@ internal object ReactSoftExceptionLogger {
 
   /** Constants that listeners can utilize for custom category-based behavior. */
   object Categories {
+    const val RVG_ADD_CHILDREN_FOR_ACCESSIBILITY: String =
+        "ReactViewGroup.addChildrenForAccessibility"
     const val RVG_IS_VIEW_CLIPPED: String = "ReactViewGroup.isViewClipped"
     const val RVG_ON_VIEW_REMOVED: String = "ReactViewGroup.onViewRemoved"
     const val CLIPPING_PROHIBITED_VIEW: String = "ReactClippingProhibitedView"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -1021,7 +1021,12 @@ public open class ReactViewGroup public constructor(context: Context?) :
       super.addChildrenForAccessibility(outChildren)
     } catch (error: IllegalArgumentException) {
       // Android 16 can race while building accessibility child lists during fast re-parenting.
-      if (error.message?.contains("descendant of this view") != true) {
+      if (error.message?.contains("descendant of this view") == true) {
+        logSoftException(
+            ReactSoftExceptionLogger.Categories.RVG_ADD_CHILDREN_FOR_ACCESSIBILITY,
+            error,
+        )
+      } else {
         throw error
       }
     }


### PR DESCRIPTION
## Summary
Guard `ReactViewGroup.addChildrenForAccessibility` against transient non-descendant races during accessibility traversal on Android.

This replaces direct `super.addChildrenForAccessibility(...)` calls with a small wrapper that:
- catches `IllegalArgumentException`
- only swallows the specific "descendant of this view" case
- rethrows all other `IllegalArgumentException`s

## Why
There are recurring crashes with stack traces ending in:
`ViewGroup.offsetRectBetweenParentAndChild` -> `offsetDescendantRectToMyCoords` -> `addChildrenForAccessibility` -> `IllegalArgumentException: parameter must be a descendant of this view`.

This can happen when accessibility is traversing children while views are being re-parented/removed.

Related reports:
- https://github.com/facebook/react-native/issues/32649
- https://github.com/facebook/react-native/issues/38925
- https://github.com/facebook/react-native/issues/7377
- https://github.com/kirillzyusko/react-native-keyboard-controller/issues/961
- https://github.com/kirillzyusko/react-native-keyboard-controller/pull/962
- https://github.com/dotnet/maui/issues/32927

There is also precedent in RN for handling this class of non-descendant race defensively:
- https://github.com/facebook/react-native/pull/55273

## Scope
This is intentionally minimal and localized to accessibility child collection in `ReactViewGroup`. Behavior is unchanged in the non-racy path.

## Changelog:
[Android] [Fixed] - Guard `ReactViewGroup.addChildrenForAccessibility` against transient non-descendant accessibility traversal crashes.

## Test Plan:
Validated in a downstream RN Android app on Android 16 with repeated sheet/modal open-close stress and active accessibility hierarchy traversal; crash reproduces before patch and no longer reproduces with this guard.
