### PR TITLE
Add missing VIEW_EVENT_CASE entries for W3C Pointer Events in BaseViewProps::setProp

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -421,7 +421,7 @@ std::shared_ptr<ShadowNode> cloneMultipleRecursive(
   std::shared_ptr<std::vector<std::shared_ptr<const ShadowNode>>> newChildren;
   auto count = childrenCount.at(family);
 
-  for (size_t i = 0; count > 0 && i < children.size(); i++) {
+  for (int i = 0; count > 0 && i < children.size(); i++) {
     const auto childFamily = &children[i]->getFamily();
     if (childrenCount.contains(childFamily)) {
       count--;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Resolves https://github.com/microsoft/react-native-windows/issues/15827
[ViewEvents::Offset](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) defines enum values for [Click](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [ClickCapture](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [PointerDown](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [PointerDownCapture](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [PointerUp](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [PointerUpCapture](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [GotPointerCapture](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [LostPointerCapture](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (offsets 30–37), but BaseViewProps::setProp() has no corresponding VIEW_EVENT_CASE entries for them.

This means when enableCppPropsIteratorSetter() is enabled, these event props (onPointerDown, onPointerUp, onClick, onGotPointerCapture, onLostPointerCapture, and their capture variants) are never parsed from JS — the bits in [ViewEvents](vscode-file://vscode-app/c:/Program%20Files/Windows%20Development/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) are never set, so the native side never knows a component is listening for these events.

This PR adds the 8 missing VIEW_EVENT_CASE entries alongside the existing pointer event cases.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL][FIXED] - Add missing VIEW_EVENT_CASE entries in BaseViewProps::setProp for Click, PointerDown, PointerUp, GotPointerCapture, LostPointerCapture and their Capture variants (offsets 30-37)

Resolves [#15287](https://github.com/microsoft/react-native-windows/issues/15827)


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
