### PR TITLE
[iOS] Fix ScrollView stale keyboard inset after dismiss

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -274,6 +274,17 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
       @"Unexpected implementation of UIViewAnimationCurve");
   return curve << 16;
 }
+
+static inline UIEdgeInsets RCTEffectiveContentInset(UIScrollView *scrollView)
+{
+  if (@available(iOS 11.0, *)) {
+    if (!UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, scrollView.adjustedContentInset)) {
+      return scrollView.adjustedContentInset;
+    }
+  }
+
+  return scrollView.contentInset;
+}
 #endif
 
 - (RCTGenericDelegateSplitter<id<UIScrollViewDelegate>> *)scrollViewDelegateSplitter
@@ -923,29 +934,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
 - (void)scrollTo:(double)x y:(double)y animated:(BOOL)animated
 {
-  CGPoint offset = CGPointMake(x, y);
-  CGRect maxRect = CGRectMake(
-      fmin(-_scrollView.contentInset.left, 0),
-      fmin(-_scrollView.contentInset.top, 0),
-      fmax(
-          _scrollView.contentSize.width - _scrollView.bounds.size.width + _scrollView.contentInset.right +
-              fmax(_scrollView.contentInset.left, 0),
-          0.01),
-      fmax(
-          _scrollView.contentSize.height - _scrollView.bounds.size.height + _scrollView.contentInset.bottom +
-              fmax(_scrollView.contentInset.top, 0),
-          0.01)); // Make width and height greater than 0
-
-  const auto &props = static_cast<const ScrollViewProps &>(*_props);
-  if (!CGRectContainsPoint(maxRect, offset) && !props.scrollToOverflowEnabled) {
-    CGFloat localX = fmax(offset.x, CGRectGetMinX(maxRect));
-    localX = fmin(localX, CGRectGetMaxX(maxRect));
-    CGFloat localY = fmax(offset.y, CGRectGetMinY(maxRect));
-    localY = fmin(localY, CGRectGetMaxY(maxRect));
-    offset = CGPointMake(localX, localY);
-  }
-
-  [self scrollToOffset:offset animated:animated];
+  [self scrollToOffset:CGPointMake(x, y) animated:animated];
 }
 
 - (void)scrollToEnd:(BOOL)animated
@@ -1015,6 +1004,27 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   if (_layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
     // Adjusting offset.x in right to left layout direction.
     offset.x = self.contentSize.width - _scrollView.frame.size.width - offset.x;
+  }
+
+  UIEdgeInsets contentInset = RCTEffectiveContentInset(_scrollView);
+  CGRect maxRect = CGRectMake(
+      fmin(-contentInset.left, 0),
+      fmin(-contentInset.top, 0),
+      fmax(
+          _scrollView.contentSize.width - _scrollView.bounds.size.width + contentInset.right + fmax(contentInset.left, 0),
+          0.01),
+      fmax(
+          _scrollView.contentSize.height - _scrollView.bounds.size.height + contentInset.bottom +
+              fmax(contentInset.top, 0),
+          0.01)); // Make width and height greater than 0
+
+  const auto &props = static_cast<const ScrollViewProps &>(*_props);
+  if (!CGRectContainsPoint(maxRect, offset) && !props.scrollToOverflowEnabled) {
+    CGFloat localX = fmax(offset.x, CGRectGetMinX(maxRect));
+    localX = fmin(localX, CGRectGetMaxX(maxRect));
+    CGFloat localY = fmax(offset.y, CGRectGetMinY(maxRect));
+    localY = fmin(localY, CGRectGetMaxY(maxRect));
+    offset = CGPointMake(localX, localY);
   }
 
   if (CGPointEqualToPoint(_scrollView.contentOffset, offset)) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -278,9 +278,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 static inline UIEdgeInsets RCTEffectiveContentInset(UIScrollView *scrollView)
 {
   if (@available(iOS 11.0, *)) {
-    if (!UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, scrollView.adjustedContentInset)) {
-      return scrollView.adjustedContentInset;
-    }
+    return scrollView.adjustedContentInset;
   }
 
   return scrollView.contentInset;

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -281,6 +281,17 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   return curve << 16;
 }
 
+static inline UIEdgeInsets RCTEffectiveContentInset(UIScrollView *scrollView)
+{
+  if (@available(iOS 11.0, *)) {
+    if (!UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, scrollView.adjustedContentInset)) {
+      return scrollView.adjustedContentInset;
+    }
+  }
+
+  return scrollView.contentInset;
+}
+
 - (void)_keyboardWillChangeFrame:(NSNotification *)notification
 {
   if (![self automaticallyAdjustKeyboardInsets]) {
@@ -570,27 +581,28 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
     offset.x = _scrollView.contentSize.width - _scrollView.frame.size.width - offset.x;
   }
 
+  UIEdgeInsets contentInset = RCTEffectiveContentInset(_scrollView);
+  CGRect maxRect = CGRectMake(
+      fmin(-contentInset.left, 0),
+      fmin(-contentInset.top, 0),
+      fmax(
+          _scrollView.contentSize.width - _scrollView.bounds.size.width + contentInset.right + fmax(contentInset.left, 0),
+          0.01),
+      fmax(
+          _scrollView.contentSize.height - _scrollView.bounds.size.height + contentInset.bottom +
+              fmax(contentInset.top, 0),
+          0.01)); // Make width and height greater than 0
+  if (!CGRectContainsPoint(maxRect, offset) && !self.scrollToOverflowEnabled) {
+    CGFloat x = fmax(offset.x, CGRectGetMinX(maxRect));
+    x = fmin(x, CGRectGetMaxX(maxRect));
+    CGFloat y = fmax(offset.y, CGRectGetMinY(maxRect));
+    y = fmin(y, CGRectGetMaxY(maxRect));
+    offset = CGPointMake(x, y);
+  }
+
   if (!CGPointEqualToPoint(_scrollView.contentOffset, offset)) {
-    CGRect maxRect = CGRectMake(
-        fmin(-_scrollView.contentInset.left, 0),
-        fmin(-_scrollView.contentInset.top, 0),
-        fmax(
-            _scrollView.contentSize.width - _scrollView.bounds.size.width + _scrollView.contentInset.right +
-                fmax(_scrollView.contentInset.left, 0),
-            0.01),
-        fmax(
-            _scrollView.contentSize.height - _scrollView.bounds.size.height + _scrollView.contentInset.bottom +
-                fmax(_scrollView.contentInset.top, 0),
-            0.01)); // Make width and height greater than 0
     // Ensure at least one scroll event will fire
     _allowNextScrollNoMatterWhat = YES;
-    if (!CGRectContainsPoint(maxRect, offset) && !self.scrollToOverflowEnabled) {
-      CGFloat x = fmax(offset.x, CGRectGetMinX(maxRect));
-      x = fmin(x, CGRectGetMaxX(maxRect));
-      CGFloat y = fmax(offset.y, CGRectGetMinY(maxRect));
-      y = fmin(y, CGRectGetMaxY(maxRect));
-      offset = CGPointMake(x, y);
-    }
     [_scrollView setContentOffset:offset animated:animated];
   }
 }

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -284,9 +284,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 static inline UIEdgeInsets RCTEffectiveContentInset(UIScrollView *scrollView)
 {
   if (@available(iOS 11.0, *)) {
-    if (!UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, scrollView.adjustedContentInset)) {
-      return scrollView.adjustedContentInset;
-    }
+    return scrollView.adjustedContentInset;
   }
 
   return scrollView.contentInset;

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewKeyboardInsetsIOSExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewKeyboardInsetsIOSExample.js
@@ -123,6 +123,37 @@ component ScrollViewKeyboardInsetsExample() {
   );
 }
 
+component ScrollViewKeyboardInsetsAutomaticContentInsetExample() {
+  return (
+    <ScrollView
+      style={styles.automaticInsetScrollView}
+      contentContainerStyle={styles.automaticInsetContent}
+      automaticallyAdjustKeyboardInsets
+      contentInsetAdjustmentBehavior="automatic"
+      keyboardDismissMode="interactive">
+      <Text style={styles.automaticInsetTitle}>
+        Focus the input near the bottom and dismiss the keyboard.
+      </Text>
+      <Text style={styles.automaticInsetDescription}>
+        The content should return to its original position immediately without
+        leaving extra space at the bottom.
+      </Text>
+      <View style={styles.automaticInsetCard}>
+        <Text>
+          This reproduces the combination of automatic keyboard insets and
+          automatic content inset adjustment that previously left a stale bottom
+          gap until the next manual scroll.
+        </Text>
+      </View>
+      <View style={styles.automaticInsetSpacer} />
+      <TextInput
+        placeholder="Keyboard dismissal repro"
+        style={styles.automaticInsetTextInput}
+      />
+    </ScrollView>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -176,6 +207,42 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontFamily: 'Courier',
   },
+  automaticInsetScrollView: {
+    flex: 1,
+    backgroundColor: '#f2f5f7',
+  },
+  automaticInsetContent: {
+    padding: 16,
+    paddingBottom: 32,
+    gap: 16,
+  },
+  automaticInsetTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  automaticInsetDescription: {
+    fontSize: 15,
+    lineHeight: 21,
+  },
+  automaticInsetCard: {
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#d0d7de',
+  },
+  automaticInsetSpacer: {
+    height: 320,
+  },
+  automaticInsetTextInput: {
+    borderWidth: 1,
+    borderColor: '#999',
+    borderRadius: 10,
+    backgroundColor: '#fff',
+    fontSize: 18,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
 });
 
 exports.title = 'ScrollViewKeyboardInsets';
@@ -186,5 +253,12 @@ exports.examples = [
   {
     title: '<ScrollView> automaticallyAdjustKeyboardInsets Example',
     render: (): React.Node => <ScrollViewKeyboardInsetsExample />,
+  },
+  {
+    title:
+      '<ScrollView> keyboard dismissal with automatic content inset adjustment',
+    render: (): React.Node => (
+      <ScrollViewKeyboardInsetsAutomaticContentInsetExample />
+    ),
   },
 ] as Array<RNTesterModuleExample>;


### PR DESCRIPTION
## Summary:

This fixes an iOS `ScrollView` bug where using `automaticallyAdjustKeyboardInsets` together with `contentInsetAdjustmentBehavior="automatic"` can leave a stale bottom gap after the keyboard is dismissed. The extra space is not cleared until the user scrolls again.

The underlying issue is that the keyboard dismissal path can call `scrollToOffset` with an offset that needs to be clamped against the new inset-adjusted bounds, but the current code checks for an unchanged `contentOffset` before that clamping happens. When `adjustedContentInset` shrinks after the keyboard closes, the numeric offset can compare equal while still being outside the valid range, so `setContentOffset` is skipped and the stale gap remains visible.

This change:

- clamps the target offset before the equality check
- uses the effective inset (`adjustedContentInset` when available) when computing the valid scroll range
- applies the same behavior to both Paper and Fabric iOS scroll view implementations
- adds an RNTester repro for the `automaticallyAdjustKeyboardInsets` + `contentInsetAdjustmentBehavior="automatic"` combination

## Changelog:

[IOS] [FIXED] Fix `ScrollView` leaving stale bottom inset after keyboard dismissal when using `automaticallyAdjustKeyboardInsets` with automatic content inset adjustment

## Test Plan:

1. Reproduced the issue in a minimal Expo app on iOS with:
   - `automaticallyAdjustKeyboardInsets`
   - `contentInsetAdjustmentBehavior="automatic"`
   - a `TextInput` near the bottom of the scroll view
2. Built the app with React Native compiled from source so the native iOS changes were used.
3. Verified on the iOS simulator that:
   - focusing the text input moves content above the keyboard
   - dismissing the keyboard returns the content to the original position
   - no extra bottom gap remains and no manual scroll is required to reset layout
4. Added a dedicated RNTester scenario in `ScrollViewKeyboardInsetsIOSExample.js` that reproduces this exact prop combination for upstream verification.

Build/validation details:

- `npx expo prebuild --platform ios --no-install`
- `npx pod-install ios`
- `xcodebuild -workspace ios/scrollviewautomaticallyadjustkeyboardinsetsbug.xcworkspace -scheme scrollviewautomaticallyadjustkeyboardinsetsbug -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build`

