### PR TITLE
Do not include test files in `gradle-plugin` bundle

### DIFF
--- a/packages/gradle-plugin/package.json
+++ b/packages/gradle-plugin/package.json
@@ -31,6 +31,7 @@
     "gradlew.bat",
     "README.md",
     "react-native-gradle-plugin",
+    "!react-native-gradle-plugin/src/test",
     "settings-plugin",
     "shared",
     "shared-testutil"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While analysing dependency trees of several React Native libraries I have spotted that `@react-native/gradle-plugin` package bundle includes test files.

This PR adds the exclude rule in package.json `files` array which prevents from adding test files to the dist.

## Changelog:

[INTERNAL] [CHANGED] - Do not include test files in `@react-native/gradle-plugin` package bundle

## Test Plan:

```
npm pack --dry-run
```

### Before

<img width="1026" height="302" alt="Screenshot 2026-03-23 at 13 46 43" src="https://github.com/user-attachments/assets/22e0458f-b4ee-4ffe-8c5c-21204be1f983" />

### After

<img width="1026" height="302" alt="Screenshot 2026-03-23 at 13 46 59" src="https://github.com/user-attachments/assets/9c558a5b-3720-424b-9f6f-bb79048454bb" />
