### PR TITLE
Do not synchronize on java.lang.Boolean.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -178,6 +178,7 @@ public class ReactInstanceManager {
   // Identifies whether the instance manager destroy function is in process,
   // while true any spawned create thread should wait for proper clean up before initializing
   private volatile Boolean mHasStartedDestroying = false;
+  private final Object mHasStartedDestroyingLock = new Object();
   private final MemoryPressureRouter mMemoryPressureRouter;
   private final @Nullable JSExceptionHandler mJSExceptionHandler;
   private final @Nullable UIManagerProvider mUIManagerProvider;
@@ -792,8 +793,8 @@ public class ReactInstanceManager {
     ResourceDrawableIdHelper.getInstance().clear();
 
     mHasStartedDestroying = false;
-    synchronized (mHasStartedDestroying) {
-      mHasStartedDestroying.notifyAll();
+    synchronized (mHasStartedDestroyingLock) {
+      mHasStartedDestroyingLock.notifyAll();
     }
     synchronized (mPackages) {
       mViewManagerNames = null;
@@ -1149,10 +1150,10 @@ public class ReactInstanceManager {
             null,
             () -> {
               ReactMarker.logMarker(REACT_CONTEXT_THREAD_END);
-              synchronized (ReactInstanceManager.this.mHasStartedDestroying) {
+              synchronized (ReactInstanceManager.this.mHasStartedDestroyingLock) {
                 while (ReactInstanceManager.this.mHasStartedDestroying) {
                   try {
-                    ReactInstanceManager.this.mHasStartedDestroying.wait();
+                    ReactInstanceManager.this.mHasStartedDestroyingLock.wait();
                   } catch (InterruptedException e) {
                     // Interrupted while waiting for destruction to complete, just retry
                     continue;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:  Do not synchronize on java.lang.Boolean.

Once JEP 401 is implemented synchronization on
value classes (which box classes are) will throw IdentityException.
In general synchronization on 1) mutable field 2) box class is
inefficient (instances are shared) at best and a bug at worst case
as synchronization is done holding different monitors (it might be
fine, but is hard to reason about).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID] [FIXED] Use explicit `ReactInstanceManager.mHasStartedDestroyingLock` instead of using `ReactInstanceManager.mHasStartedDestroying`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan: GHA

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
