### PR TITLE
RN: Default `reportErrorsAsExceptions` w/o Global Property (#56197)

### DIFF
--- a/packages/polyfills/console.js
+++ b/packages/polyfills/console.js
@@ -611,13 +611,12 @@ if (global.nativeLoggingHook) {
   // Delete the copy there after the c++ pipeline is rolled out everywhere.
   if (global.RN$useAlwaysAvailableJSErrorHandling === true) {
     let originalConsoleError = console.error;
-    console.reportErrorsAsExceptions = true;
     function stringifySafe(arg) {
       return inspect(arg, {depth: 10}).replace(/\n\s*/g, ' ');
     }
     console.error = function (...args) {
       originalConsoleError.apply(this, args);
-      if (!console.reportErrorsAsExceptions) {
+      if (console.reportErrorsAsExceptions === false) {
         return;
       }
       if (global.RN$inExceptionHandler?.()) {

--- a/packages/react-native/Libraries/Core/ExceptionsManager.js
+++ b/packages/react-native/Libraries/Core/ExceptionsManager.js
@@ -137,7 +137,7 @@ function reportException(
 declare var console: {
   error: (...data: ReadonlyArray<unknown>) => void,
   _errorOriginal: (...data: ReadonlyArray<unknown>) => void,
-  reportErrorsAsExceptions: boolean,
+  reportErrorsAsExceptions?: boolean,
   ...
 };
 
@@ -182,7 +182,7 @@ function handleException(e: unknown, isFatal: boolean) {
 function reactConsoleErrorHandler(...args) {
   // bubble up to any original handlers
   console._errorOriginal(...args);
-  if (!console.reportErrorsAsExceptions) {
+  if (console.reportErrorsAsExceptions === false) {
     return;
   }
   if (inExceptionHandler || global.RN$inExceptionHandler?.()) {
@@ -272,18 +272,12 @@ function reactConsoleErrorHandler(...args) {
  * setting `console.reportErrorsAsExceptions = false;` in your app.
  */
 function installConsoleErrorReporter() {
-  // Enable reportErrorsAsExceptions
   if (console._errorOriginal) {
     return; // already installed
   }
   // Flow doesn't like it when you set arbitrary values on a global object
   console._errorOriginal = console.error.bind(console);
   console.error = reactConsoleErrorHandler;
-  if (console.reportErrorsAsExceptions === undefined) {
-    // Individual apps can disable this
-    // Flow doesn't like it when you set arbitrary values on a global object
-    console.reportErrorsAsExceptions = true;
-  }
 }
 
 const ExceptionsManager = {


### PR DESCRIPTION
Summary:

Refactors `ExceptionsManager` so that `reportErrorsAsExceptions` defaults to `true` without setting the `console.reportErrorsAsExceptions` global property.

This reduces the amount of non-idiomatic code that needs to be maintained, and it also makes it clearer that the default of `reportErrorsAsExceptions` is `true`. (It already is, but now it's more obvious by reading the conditional.)

This is *technically* a change in behavior of a public interface, but it's very subtle and — for most if not all codebases — should not result in any change in behavior.

Changelog:
[General][Changed] - Setting `reportErrorsAsExceptions` to anything other than `false` no longer does anything. (Previously, setting it to a falsey value would be similar to setting it to `false`.)

Differential Revision: D97788692


