### PR TITLE
Use lazy TurboModule lookup for Clipboard in LogBoxInspector (#56199)

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
@@ -8,7 +8,6 @@
  * @format
  */
 
-import Clipboard from '../../Components/Clipboard/Clipboard';
 import Keyboard from '../../Components/Keyboard/Keyboard';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
@@ -98,6 +97,9 @@ export default function LogBoxInspector(props: Props): React.Node {
       }
     }
 
+    // Lazy-require to avoid crashing in environments where the native
+    // Clipboard module is unavailable (e.g. Fantom integration tests).
+    const Clipboard = require('../../Components/Clipboard/Clipboard').default;
     Clipboard.setString(parts.join('\n'));
   }
 


### PR DESCRIPTION
Summary:

D95277489 added a Copy button to LogBoxInspector that imports
`Clipboard`, which calls `TurboModuleRegistry.getEnforcing('Clipboard')`
at module load time. In environments where the native Clipboard module
is not available (e.g., Fantom integration tests), this throws and
crashes the entire test file (`LogBox-itest.fb.js`).

Replace the static `Clipboard` import with a lazy
`TurboModuleRegistry.get()` call at invocation time, which returns
`null` when the module is unavailable instead of throwing.

Changelog: [Fixed][LogBox] - Fix crash when Clipboard module is unavailable

Reviewed By: NickGerleman

Differential Revision: D97008263
