### PR TITLE
Handle member array types in the snapshot (#56206)

### DIFF
--- a/scripts/cxx-api/parser/member/variable_member.py
+++ b/scripts/cxx-api/parser/member/variable_member.py
@@ -111,6 +111,8 @@ class VariableMember(Member):
                 result += f"{qualified_type} (*{name})({formatted_args})"
         else:
             result += f"{format_parsed_type(self._parsed_type)} {name}"
+            if self.argstring:
+                result += self.argstring
 
         if STORE_INITIALIZERS_IN_SNAPSHOT and self.value is not None:
             if self.is_brace_initializer:

--- a/scripts/cxx-api/tests/snapshots/should_handle_array_variable/snapshot.api
+++ b/scripts/cxx-api/tests/snapshots/should_handle_array_variable/snapshot.api
@@ -1,0 +1,1 @@
+const char test::ViewComponentName[];

--- a/scripts/cxx-api/tests/snapshots/should_handle_array_variable/test.h
+++ b/scripts/cxx-api/tests/snapshots/should_handle_array_variable/test.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace test {
+
+const char ViewComponentName[] = "View";
+
+} // namespace test


### PR DESCRIPTION
Summary:

Changelog: [Internal]

Correctly handles array types in member definitions in the API snapshot.

Reviewed By: cipolleschi

Differential Revision: D97923375
