### PR TITLE
feat: add viewport size to LayoutContext class

### DIFF
--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -214,7 +214,8 @@ using namespace facebook::react;
   if (!isnan(viewportOffset.x) && !isnan(viewportOffset.y)) {
     layoutContext.viewportOffset = RCTPointFromCGPoint(viewportOffset);
   }
-
+  layoutContext.viewportSize = layoutConstraints.maximumSize;
+  
   _surfaceHandler->constraintLayout(layoutConstraints, layoutContext);
 }
 
@@ -236,6 +237,8 @@ using namespace facebook::react;
   layoutConstraints.minimumSize = RCTSizeFromCGSize(minimumSize);
   layoutConstraints.maximumSize = RCTSizeFromCGSize(maximumSize);
 
+  layoutContext.viewportSize = layoutConstraints.maximumSize;
+  
   return RCTCGSizeFromSize(_surfaceHandler->measure(layoutConstraints, layoutContext));
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.cpp
@@ -60,6 +60,7 @@ void SurfaceHandlerBinding::setLayoutConstraints(
   context.swapLeftAndRightInRTL = (doLeftAndRightSwapInRTL != 0u);
   context.pointScaleFactor = pixelDensity;
   context.viewportOffset = {.x = offsetX, .y = offsetY};
+  context.viewportSize = {.width = maxWidth, .height = maxHeight};
   context.fontSizeMultiplier = fontScale;
 
   surfaceHandler_.constraintLayout(constraints, context);

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutContext.h
@@ -59,6 +59,11 @@ struct LayoutContext {
    * If React Native takes up entire screen, it will be {0, 0}.
    */
   Point viewportOffset{};
+
+  /*
+   * Viewport size is size of the React Native's root view.
+   */
+  Size viewportSize{};
 };
 
 inline bool operator==(const LayoutContext &lhs, const LayoutContext &rhs)
@@ -68,13 +73,15 @@ inline bool operator==(const LayoutContext &lhs, const LayoutContext &rhs)
              lhs.affectedNodes,
              lhs.swapLeftAndRightInRTL,
              lhs.fontSizeMultiplier,
-             lhs.viewportOffset) ==
+             lhs.viewportOffset,
+             lhs.viewportSize) ==
       std::tie(
              rhs.pointScaleFactor,
              rhs.affectedNodes,
              rhs.swapLeftAndRightInRTL,
              rhs.fontSizeMultiplier,
-             rhs.viewportOffset);
+             rhs.viewportOffset,
+             rhs.viewportSize);
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
## Summary:

Add viewport size to `LayoutContext` and wire it through Android and iOS layout setup so viewport dimensions are available during layout. 

This was extracted from the larger `calc()` work in PR https://github.com/facebook/react-native/pull/56162.

## Changelog:

[GENERAL] [ADDED] - Add viewport size to LayoutContext

## Test Plan:
 - This change is limited to internal layout plumbing in React Native core and does not alter external behavior on its own.
 - Validation for the actual `calc()` use cases will be covered in the follow-up work that consumes this plumbing.