### PR TITLE
Fix SIGSEGV crash in EventTarget::getTag() when instanceHandle is null

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/EventTarget.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventTarget.cpp
@@ -30,7 +30,9 @@ void EventTarget::retain(jsi::Runtime& runtime) {
   }
 
   if (retainCount_ == 0) {
-    strongInstanceHandle_ = instanceHandle_->getInstanceHandle(runtime);
+    if (instanceHandle_ != nullptr) {
+      strongInstanceHandle_ = instanceHandle_->getInstanceHandle(runtime);
+    }
   }
   retainCount_ += 1;
 
@@ -72,6 +74,9 @@ SurfaceId EventTarget::getSurfaceId() const {
 }
 
 Tag EventTarget::getTag() const {
+  if (instanceHandle_ == nullptr) {
+    return -1;
+  }
   return instanceHandle_->getTag();
 }
 


### PR DESCRIPTION
Summary:
Changelog:
[General][Fixed] - Fix crash in EventTarget when instanceHandle is null

This fixes a null pointer dereference crash in EventTarget::getTag() that occurs when instanceHandle_ is null. The crash was observed in UIManagerBinding::dispatchEventToJS() when dispatching events to JS.

The EventTarget can be constructed with a null instanceHandle (as evidenced by test code and production usage), but getTag() and retain() were dereferencing it without checking for null first.

This change adds defensive null checks in:
1. EventTarget::getTag() - returns -1 (invalid tag) if instanceHandle_ is null
2. EventTarget::retain() - skips getting instance handle if instanceHandle_ is null

This follows the existing pattern used in ShadowNodeFamily::getInstanceHandle() which already handles the null instanceHandle_ case.

Reviewed By: javache

Differential Revision: D96473264


