### PR TITLE
fix(jni) ensure correct export of react/uimanager headers in prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -100,6 +100,8 @@ val preparePrefab by
                       Pair("../ReactCommon/hermes/inspector-modern/", "hermes/inspector-modern/"),
                       // fabricjni
                       Pair("src/main/jni/react/fabric", "react/fabric/"),
+                      // uimanagerjni
+                      Pair("src/main/jni/react/uimanager", "react/uimanager/"),
                       // glog
                       Pair(File(buildDir, "third-party-ndk/glog/exported/").absolutePath, ""),
                       // jsiinpsector


### PR DESCRIPTION
## Summary:

When testing React Native nightlies, we got the following error from `react-android-0.86.0-nightly-20260325-d1809f0aa-SNAPSHOT-release`:

```
StateWrapperImpl.h:14:10: fatal error: 'react/uimanager/StateWrapper.h' file not found
```

The reason is that build.gradle.kts exports src/main/jni/react/fabric → react/fabric/ in the prefab headers, which includes StateWrapperImpl.h. That header does #include <react/uimanager/StateWrapper.h>, but src/main/jni/react/uimanager is not in the prefab export list — so the header is missing from the AAR.

This was introduced in #55288 where they modified StateWrapperImpl.h to inherit from StateWrapper and added the #include on StateWrapper.h.

This has caused Expo's nightlies to break due to the missing header file in the prefabs:

- Internally (when RN builds itself): Works fine because all JNI source dirs are on the include path
- Externally (when consumers use the published AAR): StateWrapperImpl.h is included in the prefab, it references <react/uimanager/StateWrapper.h>, but that header doesn't exist in the prefab package

## Fix

This commit fixes the above problem by including `src/main/jni/react/uimanager` in the prefab.

## Test Plan:

I have tested and verified this by running this in the root of the repo:

```
./gradlew :packages:react-native:ReactAndroid:preparePrefab
ls packages/react-native/ReactAndroid/build/prefab-headers/reactnative/react/uimanager/
```

Before the fix the uimanager folder was not found, with the fix it exists and contains the following files: ComponentNameResolverBinding.h  StateWrapper.h  UIConstantsProviderBinding.h

## Changelog:

[ANDROID] [FIXED] - Fixed missing StateWrapper.h header in prefabs

## Potential Issues

There might be an issue with exporting these files in addition to the missing StateWrapper.h - but it seems like this is an issue with other folders in the jni / prefab - everything in a folder is exported when included for prefab.

