### PR TITLE
Fix declarative blur not working

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1777,14 +1777,14 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     return;
   }
 
+  // Do not resignFirstRespodner if we lost focus, let whoever took focus
+  // becomeFirstResponder thereby resigning for us. If we resign here,
+  // first responder will be assigned to some ancestor view and they
+  // can temporarily call onFocus/onBlur
   if (context.nextFocusedView == self) {
-    if (_eventEmitter) {
-      _eventEmitter->onFocus();
-    }
-  } else {
-    if (_eventEmitter) {
-      _eventEmitter->onBlur();
-    }
+    [self becomeFirstResponder];
+  } else if (context.previouslyFocusedView == self && context.nextFocusedView == nil) {
+    [self resignFirstResponder];
   }
 
   [super didUpdateFocusInContext:context withAnimationCoordinator:coordinator];


### PR DESCRIPTION
Summary:
Calling blur() on a ref works now. Failed before bc we did not become first responder when we were focused, so resign first responder would fail and no onBlur() event would be generated.

Changelog: [Internal]

Reviewed By: jorge-cab

Differential Revision: D98006567


