### PR TITLE
Add missing stream state properties to Flow defs

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -3610,14 +3610,22 @@ declare class stream$Readable extends stream$Stream {
   static toWeb(streamReadable: stream$Readable): ReadableStream;
 
   constructor(options?: readableStreamOptions): void;
+  closed: boolean;
   destroy(error?: Error): this;
+  destroyed: boolean;
+  errored: ?Error;
   isPaused(): boolean;
   pause(): this;
   pipe<T extends stream$Writable>(dest: T, options?: {end?: boolean, ...}): T;
   read(size?: number): ?(string | Buffer);
   readable: boolean;
+  readableAborted: boolean;
+  readableDidRead: boolean;
+  readableEnded: boolean;
+  readableFlowing: boolean | null;
   readableHighWaterMark: number;
   readableLength: number;
+  readableObjectMode: boolean;
   resume(): this;
   setEncoding(encoding: string): this;
   unpipe(dest?: stream$Writable): this;
@@ -3662,8 +3670,10 @@ declare class stream$Writable extends stream$Stream {
   static toWeb(streamWritable: stream$Writable): WritableStream;
 
   constructor(options?: writableStreamOptions): void;
+  closed: boolean;
   cork(): void;
   destroy(error?: Error): this;
+  destroyed: boolean;
   end(callback?: () => void): this;
   end(chunk?: string | Buffer | Uint8Array, callback?: () => void): this;
   end(
@@ -3671,11 +3681,17 @@ declare class stream$Writable extends stream$Stream {
     encoding?: string,
     callback?: () => void,
   ): this;
+  errored: ?Error;
   setDefaultEncoding(encoding: string): this;
   uncork(): void;
   writable: boolean;
+  writableAborted: boolean;
+  writableEnded: boolean;
+  writableFinished: boolean;
   writableHighWaterMark: number;
   writableLength: number;
+  writableNeedDrain: boolean;
+  writableObjectMode: boolean;
   write(
     chunk: string | Buffer | Uint8Array,
     callback?: (error?: Error) => void,


### PR DESCRIPTION
Summary:
Add standard Node.js stream properties to the Flow type definitions for `stream$Readable` and `stream$Writable` that were previously missing:

- `stream$Readable`: 
  - [`closed: boolean`](https://nodejs.org/api/stream.html#readableclosed)
  - [`destroyed: boolean`](https://nodejs.org/api/stream.html#readabledestroyed)
  - [`errored: ?Error`](https://nodejs.org/api/stream.html#readableerrored)
  - [`readableEnded: boolean`](https://nodejs.org/api/stream.html#readablereadableended)
  - [`readableAborted: boolean`](https://nodejs.org/api/stream.html#readablereadableaborted)
  - [`readableDidRead: boolean`](https://nodejs.org/api/stream.html#readablereadabledidread)
  - [`readableFlowing: ?boolean`](https://nodejs.org/api/stream.html#readablereadableflowing)
  - [`readableObjectMode: boolean`](https://nodejs.org/api/stream.html#readablereadableobjectmode)
- `stream$Writable`: 
  - [`closed: boolean`](https://nodejs.org/api/stream.html#writableclosed)
  - [`destroyed: boolean`](https://nodejs.org/api/stream.html#writabledestroyed)
  - [`errored: ?Error`](https://nodejs.org/api/stream.html#writableerrored)
  - [`writableEnded: boolean`](https://nodejs.org/api/stream.html#writablewritableended)
  - [`writableAborted: boolean`](https://nodejs.org/api/stream.html#writablewritableaborted)
  - [`writableFinished: boolean`](https://nodejs.org/api/stream.html#writablewritablefinished)
  - [`writableNeedDrain: boolean`](https://nodejs.org/api/stream.html#writablewritableneeddrain)
  - [`writableObjectMode: boolean`](https://nodejs.org/api/stream.html#writablewritableobjectmode)


Docs: https://nodejs.org/api/stream.html

These properties exist on all Node.js streams and are needed by Metro to detect when HTTP response streams have been closed by a client disconnect.

Changelog: [Internal]

Differential Revision: D98176491


