### PR TITLE
Fix nullability in ObjC TurboModule setEventEmitterCallback (#56226)

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
@@ -34,6 +34,8 @@ exports[`GenerateModuleObjCpp can generate a header file NativeModule specs 1`] 
 #import <vector>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol NativeArrayTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
 - (NSArray<NSString *> *)getArray:(NSArray *)a;
@@ -47,7 +49,7 @@ exports[`GenerateModuleObjCpp can generate a header file NativeModule specs 1`] 
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -73,7 +75,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -99,7 +101,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -165,7 +167,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -196,7 +198,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -222,7 +224,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -413,7 +415,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -567,7 +569,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -643,7 +645,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -673,7 +675,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -776,7 +778,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -880,7 +882,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -983,7 +985,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1086,7 +1088,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1189,7 +1191,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1215,7 +1217,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1548,6 +1550,7 @@ inline JS::NativeSampleTurboModuleOptional::Constants::Builder::Builder(Constant
   return i.unsafeRawValue();
 }) {}
 
+NS_ASSUME_NONNULL_END
 #endif // RNCodegenModuleFixtures_H
 "
 `;
@@ -1601,7 +1604,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1627,7 +1630,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1653,7 +1656,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1719,7 +1722,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1750,7 +1753,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1776,7 +1779,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1967,7 +1970,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2121,7 +2124,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2197,7 +2200,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2227,7 +2230,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2330,7 +2333,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2434,7 +2437,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2537,7 +2540,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2640,7 +2643,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2743,7 +2746,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -2769,7 +2772,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -3123,11 +3126,13 @@ exports[`GenerateModuleObjCpp can generate an implementation file NativeModule s
 
 #import \\"RNCodegenModuleFixtures.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeArrayTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3165,7 +3170,7 @@ namespace facebook::react {
 @implementation NativeBooleanTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3196,7 +3201,7 @@ namespace facebook::react {
 @implementation NativeCallbackTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3227,7 +3232,7 @@ namespace facebook::react {
 @implementation NativeEnumTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3297,7 +3302,7 @@ namespace facebook::react {
 @implementation NativeNullableTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3356,7 +3361,7 @@ namespace facebook::react {
 @implementation NativeNumberTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3387,7 +3392,7 @@ namespace facebook::react {
 @implementation NativeObjectTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3450,7 +3455,7 @@ namespace facebook::react {
 @implementation NativeOptionalObjectTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3474,7 +3479,7 @@ namespace facebook::react {
 @implementation NativePartialAnnotationTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3537,7 +3542,7 @@ namespace facebook::react {
 @implementation NativePromiseTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3568,7 +3573,7 @@ namespace facebook::react {
 @implementation NativeSampleTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3687,7 +3692,7 @@ namespace facebook::react {
 @implementation NativeSampleTurboModuleArraysSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3795,7 +3800,7 @@ namespace facebook::react {
 @implementation NativeSampleTurboModuleNullableSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -3914,7 +3919,7 @@ namespace facebook::react {
 @implementation NativeSampleTurboModuleNullableAndOptionalSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -4033,7 +4038,7 @@ namespace facebook::react {
 @implementation NativeSampleTurboModuleOptionalSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -4152,7 +4157,7 @@ namespace facebook::react {
 @implementation NativeStringTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -4179,5 +4184,7 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 "
 `;

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/index.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/index.js
@@ -43,7 +43,7 @@ ${protocolMethods}
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 ${eventEmitters}
 @end
@@ -105,11 +105,11 @@ const HeaderFileTemplate = ({
 #import <vector>
 
 ` +
-    (assumeNonnull ? '\nNS_ASSUME_NONNULL_BEGIN\n' : '') +
+    '\nNS_ASSUME_NONNULL_BEGIN\n' +
     moduleDeclarations +
     '\n' +
     structInlineMethods +
-    (assumeNonnull ? '\nNS_ASSUME_NONNULL_END\n' : '\n') +
+    '\nNS_ASSUME_NONNULL_END\n' +
     `#endif // ${headerFileNameWithNoExt}_H` +
     '\n'
   );
@@ -136,7 +136,11 @@ const SourceFileTemplate = ({
 
 #import "${headerFileName}"
 
+NS_ASSUME_NONNULL_BEGIN
+
 ${moduleImplementations}
+
+NS_ASSUME_NONNULL_END
 `;
 
 module.exports = {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/source/serializeModule.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/source/serializeModule.js
@@ -39,7 +39,7 @@ ${eventEmitters
   .map(eventEmitter => EventEmitterImplementationTemplate(eventEmitter))
   .join('\n')}
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleHObjCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleHObjCpp-test.js.snap
@@ -35,6 +35,8 @@ Map {
 #import <vector>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol NativeSampleTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
 
@@ -45,7 +47,7 @@ Map {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -60,6 +62,7 @@ namespace facebook::react {
   };
 } // namespace facebook::react
 
+NS_ASSUME_NONNULL_END
 #endif // SampleWithUppercaseName_H
 ",
 }
@@ -99,6 +102,8 @@ Map {
 #import <optional>
 #import <vector>
 
+
+NS_ASSUME_NONNULL_BEGIN
 namespace JS {
   namespace NativeSampleTurboModule {
     struct SpecDifficultAE {
@@ -221,7 +226,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -335,6 +340,7 @@ inline facebook::react::LazyVector<JS::NativeSampleTurboModule::SpecGetArraysOpt
   id const p = _v[@\\"arrayOfObjects\\"];
   return RCTBridgingToVec(p, ^JS::NativeSampleTurboModule::SpecGetArraysOptionsArrayOfObjectsElement(id itemValue_0) { return JS::NativeSampleTurboModule::SpecGetArraysOptionsArrayOfObjectsElement(itemValue_0); });
 }
+NS_ASSUME_NONNULL_END
 #endif // complex_objects_H
 ",
 }
@@ -375,7 +381,10 @@ Map {
 #import <vector>
 
 
+NS_ASSUME_NONNULL_BEGIN
 
+
+NS_ASSUME_NONNULL_END
 #endif // cxx_only_native_modules_H
 ",
 }
@@ -416,6 +425,8 @@ Map {
 #import <vector>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol NativeSampleTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
 
@@ -426,7 +437,7 @@ Map {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -441,6 +452,7 @@ namespace facebook::react {
   };
 } // namespace facebook::react
 
+NS_ASSUME_NONNULL_END
 #endif // empty_native_modules_H
 ",
 }
@@ -481,6 +493,8 @@ Map {
 #import <vector>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol NativeSampleTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
 - (void)voidFunc;
@@ -491,7 +505,7 @@ Map {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 - (void)emitOnEvent1;
 - (void)emitOnEvent2:(NSString *_Nonnull)value;
@@ -511,6 +525,7 @@ namespace facebook::react {
   };
 } // namespace facebook::react
 
+NS_ASSUME_NONNULL_END
 #endif // event_emitter_module_H
 ",
 }
@@ -550,6 +565,8 @@ Map {
 #import <optional>
 #import <vector>
 
+
+NS_ASSUME_NONNULL_BEGIN
 namespace JS {
   namespace AliasTurboModule {
     struct OptionsOffset {
@@ -627,7 +644,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -696,6 +713,7 @@ inline std::optional<bool> JS::AliasTurboModule::Options::allowExternalStorage()
   id const p = _v[@\\"allowExternalStorage\\"];
   return RCTBridgingToOptionalBool(p);
 }
+NS_ASSUME_NONNULL_END
 #endif // native_modules_with_type_aliases_H
 ",
 }
@@ -735,6 +753,8 @@ Map {
 #import <optional>
 #import <vector>
 
+
+NS_ASSUME_NONNULL_BEGIN
 namespace JS {
   namespace NativeCameraRollManager {
     struct GetPhotosParams {
@@ -775,7 +795,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -850,7 +870,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -964,6 +984,7 @@ inline id<NSObject> _Nullable JS::NativeExceptionsManager::ExceptionData::extraD
   id const p = _v[@\\"extraData\\"];
   return p;
 }
+NS_ASSUME_NONNULL_END
 #endif // real_module_example_H
 ",
 }
@@ -1003,6 +1024,8 @@ Map {
 #import <optional>
 #import <vector>
 
+
+NS_ASSUME_NONNULL_BEGIN
 namespace JS {
   namespace NativeSampleTurboModule {
     struct Constants {
@@ -1067,7 +1090,7 @@ namespace JS {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1094,6 +1117,7 @@ inline JS::NativeSampleTurboModule::Constants::Builder::Builder(const Input i) :
 inline JS::NativeSampleTurboModule::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
+NS_ASSUME_NONNULL_END
 #endif // simple_native_modules_H
 ",
 }
@@ -1134,6 +1158,8 @@ Map {
 #import <vector>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol NativeSampleTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
 - (NSString *)getStringLiteral:(NSString *)literalParam;
@@ -1144,7 +1170,7 @@ Map {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 - (void)emitLiteralEvent:(NSString *_Nonnull)value;
 @end
@@ -1159,6 +1185,7 @@ namespace facebook::react {
   };
 } // namespace facebook::react
 
+NS_ASSUME_NONNULL_END
 #endif // string_literals_H
 ",
 }
@@ -1199,6 +1226,8 @@ Map {
 #import <vector>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol NativeSampleTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
 - (void)voidFunc;
@@ -1209,7 +1238,7 @@ Map {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1234,7 +1263,7 @@ namespace facebook::react {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1250,6 +1279,7 @@ namespace facebook::react {
 } // namespace facebook::react
 
 
+NS_ASSUME_NONNULL_END
 #endif // two_modules_different_files_H
 ",
 }
@@ -1290,6 +1320,8 @@ Map {
 #import <vector>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol NativeSampleTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
 - (NSDictionary *)getUnion:(double)chooseInt
@@ -1304,7 +1336,7 @@ Map {
 @protected
 facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 
 @end
@@ -1319,6 +1351,7 @@ namespace facebook::react {
   };
 } // namespace facebook::react
 
+NS_ASSUME_NONNULL_END
 #endif // union_module_H
 ",
 }

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleMm-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleMm-test.js.snap
@@ -17,11 +17,13 @@ Map {
 
 #import \\"SampleWithUppercaseName.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeSampleTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -36,6 +38,8 @@ namespace facebook::react {
       
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -57,11 +61,13 @@ Map {
 
 #import \\"complex_objects.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeSampleTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -158,6 +164,8 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -179,7 +187,11 @@ Map {
 
 #import \\"cxx_only_native_modules.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
 
+
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -201,11 +213,13 @@ Map {
 
 #import \\"empty_native_modules.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeSampleTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -220,6 +234,8 @@ namespace facebook::react {
       
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -240,6 +256,8 @@ Map {
  */
 
 #import \\"event_emitter_module.h\\"
+
+NS_ASSUME_NONNULL_BEGIN
 
 
 @implementation NativeSampleTurboModuleSpecBase
@@ -268,7 +286,7 @@ Map {
   _eventEmitterCallback(\\"onEvent6\\", value);
 }
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -297,6 +315,8 @@ namespace facebook::react {
         });
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -318,11 +338,13 @@ Map {
 
 #import \\"native_modules_with_type_aliases.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation AliasTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -365,6 +387,8 @@ namespace facebook::react {
         setMethodArgConversionSelector(@\\"cropImage\\", 0, @\\"JS_AliasTurboModule_Options:\\");
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -386,11 +410,13 @@ Map {
 
 #import \\"real_module_example.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeCameraRollManagerSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -433,7 +459,7 @@ namespace facebook::react {
 @implementation NativeExceptionsManagerSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -492,6 +518,8 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -513,11 +541,13 @@ Map {
 
 #import \\"simple_native_modules.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeSampleTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -628,6 +658,8 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -649,6 +681,8 @@ Map {
 
 #import \\"string_literals.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeSampleTurboModuleSpecBase
 - (void)emitLiteralEvent:(NSString *_Nonnull)value
@@ -656,7 +690,7 @@ Map {
   _eventEmitterCallback(\\"literalEvent\\", value);
 }
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -680,6 +714,8 @@ namespace facebook::react {
         });
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -701,11 +737,13 @@ Map {
 
 #import \\"two_modules_different_files.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeSampleTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -729,7 +767,7 @@ namespace facebook::react {
 @implementation NativeSampleTurboModule2SpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -749,6 +787,8 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;
@@ -770,11 +810,13 @@ Map {
 
 #import \\"union_module.h\\"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @implementation NativeSampleTurboModuleSpecBase
 
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }
@@ -794,6 +836,8 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END
 ",
 }
 `;

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
@@ -113,7 +113,7 @@ inline JS::NativeSampleTurboModule::Constants::Builder::Builder(Constants i)
  @protected
   facebook::react::EventEmitterCallback _eventEmitterCallback;
 }
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper;
 
 - (void)emitOnPress;
 - (void)emitOnClick:(NSString *_Nonnull)value;

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
@@ -25,7 +25,7 @@
   _eventEmitterCallback("onSubmit", value);
 }
 
-- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
 {
   _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
 }


### PR DESCRIPTION
Summary:

Changelog: [Internal]

Must be `NonNull` otherwise this code crashes

```
- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *_Nonnull)eventEmitterCallbackWrapper
{
  _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
}
```

Differential Revision: D98263404


