### PR TITLE
fix: pin 6 unpinned action(s),extract 5 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -22,6 +22,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.8
+        uses: cirrus-actions/rebase@b87d48154a87a85666003575337e27b8cd65f691 # 1.8
         env:
           GITHUB_TOKEN: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/bump-podfile-lock.yml
+++ b/.github/workflows/bump-podfile-lock.yml
@@ -23,10 +23,12 @@ jobs:
         uses: ./.github/actions/setup-xcode
       - name: Extract branch name
         run: |
-          TAG="${{ github.ref_name }}";
+          TAG="${REF_NAME}";
           BRANCH_NAME=$(echo "$TAG" | sed -E 's/v([0-9]+\.[0-9]+)\.[0-9]+(-rc\.[0-9]+)?/\1-stable/')
           echo "Branch Name is $BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Checkout release branch
         run: |
           git checkout "$BRANCH_NAME"

--- a/.github/workflows/monitor-new-issues.yml
+++ b/.github/workflows/monitor-new-issues.yml
@@ -22,13 +22,15 @@ jobs:
         uses:  ./.github/actions/yarn-install
       - name: Extract next oncall
         run: |
-          ONCALLS=$(node ./.github/workflow-scripts/extractIssueOncalls.js "${{ secrets.ONCALL_SCHEDULE }}")
+          ONCALLS=$(node ./.github/workflow-scripts/extractIssueOncalls.js "${ONCALL_SCHEDULE}")
           ONCALL1=$(echo $ONCALLS | cut -d ' ' -f 1)
           ONCALL2=$(echo $ONCALLS | cut -d ' ' -f 2)
           echo "oncall1=$ONCALL1" >> $GITHUB_ENV
           echo "oncall2=$ONCALL2" >> $GITHUB_ENV
+        env:
+          ONCALL_SCHEDULE: ${{ secrets.ONCALL_SCHEDULE }}
       - name: Monitor New Issues
-        uses: react-native-community/repo-monitor@v1.0.1
+        uses: react-native-community/repo-monitor@d58266a4f198b830ccaa495b853d251ad3aa8cc8 # v1.0.1
         with:
           task: "monitor-issues"
           git_secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/needs-attention.yml
+++ b/.github/workflows/needs-attention.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Apply Needs Attention Label
-        uses: react-native-community/needs-attention@v2.0.0
+        uses: react-native-community/needs-attention@c6f1c6640a2aba7965c152d7e903fa8b2be06f43 # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           response-required-label: "Needs: Author Feedback"

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -163,7 +163,7 @@ jobs:
           merge-multiple: true
       - name: Setup Keychain
         if: ${{ steps.restore-ios-xcframework.outputs.cache-hit != 'true' && env.REACT_ORG_CODE_SIGNING_P12_CERT != '' }}
-        uses: apple-actions/import-codesign-certs@v3 # https://github.com/marketplace/actions/import-code-signing-certificates
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3 # https://github.com/marketplace/actions/import-code-signing-certificates
         with:
           p12-file-base64: ${{ secrets.REACT_ORG_CODE_SIGNING_P12_CERT }}
           p12-password: ${{ secrets.REACT_ORG_CODE_SIGNING_P12_CERT_PWD }}

--- a/.github/workflows/prebuild-ios-dependencies.yml
+++ b/.github/workflows/prebuild-ios-dependencies.yml
@@ -148,7 +148,7 @@ jobs:
           merge-multiple: true
       - name: Setup Keychain
         if: ${{ steps.restore-xcframework.outputs.cache-hit != 'true' && env.REACT_ORG_CODE_SIGNING_P12_CERT != '' }}
-        uses: apple-actions/import-codesign-certs@v3 # https://github.com/marketplace/actions/import-code-signing-certificates
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3 # https://github.com/marketplace/actions/import-code-signing-certificates
         with:
           p12-file-base64: ${{ secrets.REACT_ORG_CODE_SIGNING_P12_CERT }}
           p12-password: ${{ secrets.REACT_ORG_CODE_SIGNING_P12_CERT_PWD }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -113,7 +113,9 @@ jobs:
           curl -X POST https://api.github.com/repos/react-native-community/rn-diff-purge/dispatches \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer $REACT_NATIVE_BOT_GITHUB_TOKEN" \
-            -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${{ github.ref_name }}\" }}"
+            -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${REF_NAME}\" }}"
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Verify Release is on NPM
         timeout-minutes: 3
         uses: actions/github-script@v8

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Run yarn
         uses: ./.github/actions/yarn-install
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@eab2afb99481ca09a4e91171a8e0aee0e89bfedd # v1
         with:
           ruby-version: 2.6.10
       - name: Download React Native Package
@@ -238,7 +238,7 @@ jobs:
 
           # For stable branches, we want to use the stable branch of the template
           # In all the other cases, we want to use "main"
-          BRANCH=${{ github.ref_name }}
+          BRANCH=${REF_NAME}
           if ! [[ $BRANCH == *-stable* ]]; then
             BRANCH=main
           fi
@@ -261,6 +261,8 @@ jobs:
             -sdk "iphonesimulator" \
             -destination "generic/platform=iOS Simulator" \
             -derivedDataPath "/tmp/RNTestProject"
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
@@ -312,7 +314,7 @@ jobs:
 
           # For stable branches, we want to use the stable branch of the template
           # In all the other cases, we want to use "main"
-          BRANCH=${{ github.ref_name }}
+          BRANCH=${REF_NAME}
           if ! [[ $BRANCH == *-stable* ]]; then
             BRANCH=main
           fi
@@ -327,6 +329,8 @@ jobs:
           CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
           ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
         timeout-minutes: 60


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/autorebase.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/bump-podfile-lock.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/monitor-new-issues.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/monitor-new-issues.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/needs-attention.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/prebuild-ios-core.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/prebuild-ios-dependencies.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/publish-release.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/test-all.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/test-all.yml` | Extracted 2 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/autorebase.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/autorebase.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/needs-attention.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/needs-attention.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/needs-attention.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-005 | medium | `.github/workflows/autorebase.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/needs-attention.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.