### PR TITLE
Fix activity context leak in LogBoxDialogSurfaceDelegate (#56232)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
@@ -45,7 +45,7 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
   }
 
   override fun show() {
-    if (isShowing() || !isContentViewReady()) {
+    if (isShowing()) {
       return
     }
     val context = devSupportManager.currentActivity
@@ -56,6 +56,14 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
       )
       return
     }
+
+    if (!isContentViewReady()) {
+      createContentView("LogBox")
+    }
+    if (!isContentViewReady()) {
+      return
+    }
+
     dialog = LogBoxDialog(context, reactRootView)
     dialog?.let { dialog ->
       dialog.setCancelable(false)
@@ -69,6 +77,7 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
     }
     (reactRootView?.parent as ViewGroup?)?.removeView(reactRootView)
     dialog = null
+    destroyContentView()
   }
 
   override fun isShowing(): Boolean = dialog?.isShowing ?: false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImplDevHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImplDevHelper.kt
@@ -70,7 +70,14 @@ internal class ReactHostImplDevHelper(private val delegate: ReactHostImpl) :
   }
 
   override fun destroyRootView(rootView: View) {
-    // Not implemented, only referenced by BridgeDevSupportManager
+    val surface = (rootView as? ReactSurfaceView)?.surface ?: return
+    // stop() synchronously removes the surface from ReactHostImpl.attachedSurfaces via
+    // detachSurface(), then asynchronously tears down the React component tree.
+    // detach() severs the surface's back-reference to the host.
+    // clear() removes child views from the ReactSurfaceView.
+    surface.stop()
+    surface.detach()
+    surface.clear()
   }
 
   override fun reload(reason: String) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
@@ -36,7 +36,7 @@ import kotlin.math.max
  * rendering a React component.
  */
 @OptIn(FrameworkAPI::class, UnstableReactNativeAPI::class)
-public class ReactSurfaceView(context: Context?, private val surface: ReactSurfaceImpl) :
+public class ReactSurfaceView(context: Context?, internal val surface: ReactSurfaceImpl) :
     ReactRootView(context) {
   private val jsTouchDispatcher: JSTouchDispatcher = JSTouchDispatcher(this)
   private var jsPointerDispatcher: JSPointerDispatcher? = null


### PR DESCRIPTION
Summary:

## Problem

LeakCanary detected a memory leak in React Native Android apps using LogBox in bridgeless mode where a destroyed Activity is retained through the LogBox surface delegate chain:

```
GC Root: Global variable in native code
│
├─ LogBoxModule instance
│    ↓ LogBoxModule.surfaceDelegate
├─ LogBoxDialogSurfaceDelegate instance
│    ↓ LogBoxDialogSurfaceDelegate.reactRootView
├─ ReactSurfaceView instance
│    View.mContext references a destroyed activity
│    ↓ View.mContext
╰→ Activity instance (mDestroyed = true)
```

## Root Cause

The leak has two contributing factors:

1. **`hide()` doesn't clean up the root view** — `LogBoxDialogSurfaceDelegate.hide()` dismisses the dialog but keeps `reactRootView` alive, retaining a reference to the destroyed Activity via `View.mContext`.
2. **`destroyRootView()` is a no-op in bridgeless mode** — `ReactHostImplDevHelper.destroyRootView()` did nothing, so the ReactSurface was never detached from `ReactHostImpl.attachedSurfaces`.

Factor 2 made Factor 1 unfixable: calling `destroyContentView()` in `hide()` would null `reactRootView`, but the surface remained registered as attached. On the next `show()` call, `createRootView("LogBox")` would return null (because `isSurfaceWithModuleNameAttached("LogBox")` was still true), breaking LogBox reopen entirely.

## Fix

### 1. Implement `destroyRootView()` in `ReactHostImplDevHelper`

The bridgeless `destroyRootView()` was a no-op. The fix casts the root view to `ReactSurfaceView` to access the underlying `ReactSurfaceImpl`, then properly tears it down:

- `surface.stop()` — synchronously removes from `attachedSurfaces`
- `surface.detach()` — nulls host back-reference
- `surface.clear()` — removes child views

To enable this, `ReactSurfaceView.surface` visibility is changed from `private` to `internal` (both classes are in the same `com.facebook.react.runtime` package).

### 2. Add `destroyContentView()` to `hide()` in `LogBoxDialogSurfaceDelegate`

Now that `destroyRootView()` properly detaches the surface, `hide()` safely destroys the content view, breaking the reference chain that retained the destroyed Activity.

### 3. Make `show()` self-sufficient

`show()` now recreates the content view when it's missing (e.g., after `hide()` destroyed it), instead of returning early.

## Why this is safe

1. **LogBox reopen works.** After `hide()` detaches the surface, `createRootView("LogBox")` succeeds because `isSurfaceWithModuleNameAttached("LogBox")` returns false.
2. **`destroyContentView()` is idempotent.** Null-checks `reactRootView` before cleanup.
3. **`destroyRootView()` is safe for non-ReactSurfaceView.** The `as?` cast returns null for bridge-mode `ReactRootView` instances — bridge mode already has its own implementation.
4. **Dev-only impact.** LogBox is excluded from release builds.
5. **`internal` visibility is appropriate.** Both `ReactSurfaceView` and `ReactHostImplDevHelper` are in the same package.

Changelog: [Android][Fixed] - Fixed activity context memory leak in LogBoxDialogSurfaceDelegate when using bridgeless mode

Reviewed By: javache

Differential Revision: D97825193
