### PR TITLE
xplat/js: Auto-fix `react-prefer-namespace-import` ESLint Rule (#56233)

### DIFF
--- a/packages/rn-tester/js/RNTesterApp.ios.js
+++ b/packages/rn-tester/js/RNTesterApp.ios.js
@@ -15,7 +15,7 @@ import RNTesterModuleContainer from './components/RNTesterModuleContainer';
 import SnapshotViewIOS from './examples/Snapshot/SnapshotViewIOS.ios';
 import RNTesterApp from './RNTesterAppShared';
 import RNTesterList from './utils/RNTesterList';
-import React from 'react';
+import * as React from 'react';
 import {AppRegistry} from 'react-native';
 
 AppRegistry.registerComponent('SetPropertiesExampleApp', () =>

--- a/packages/rn-tester/js/components/ListExampleShared.js
+++ b/packages/rn-tester/js/components/ListExampleShared.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import RNTesterText from './RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {memo} from 'react';
 import {
   ActivityIndicator,

--- a/packages/rn-tester/js/components/RNTesterButton.js
+++ b/packages/rn-tester/js/components/RNTesterButton.js
@@ -12,7 +12,7 @@
 
 import type {GestureResponderEvent} from 'react-native';
 
-import React from 'react';
+import * as React from 'react';
 import {Pressable, StyleSheet, Text} from 'react-native';
 
 type Props = Readonly<{

--- a/packages/rn-tester/js/components/RNTesterText.js
+++ b/packages/rn-tester/js/components/RNTesterText.js
@@ -11,7 +11,8 @@
 import type {TextProps} from 'react-native';
 
 import {RNTesterThemeContext} from './RNTesterTheme';
-import React, {useContext, useMemo} from 'react';
+import * as React from 'react';
+import {useContext, useMemo} from 'react';
 import {Text} from 'react-native';
 
 type Props = Readonly<{

--- a/packages/rn-tester/js/components/RNTesterTitle.js
+++ b/packages/rn-tester/js/components/RNTesterTitle.js
@@ -9,7 +9,7 @@
  */
 
 import {RNTesterThemeContext} from './RNTesterTheme';
-import React from 'react';
+import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
 type Props = Readonly<{

--- a/packages/rn-tester/js/components/TextInlineView.js
+++ b/packages/rn-tester/js/components/TextInlineView.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import RNTesterText from '../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useState} from 'react';
 import {Image, TouchableHighlight, View} from 'react-native';
 

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.js
@@ -15,7 +15,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterPage from '../../components/RNTesterPage';
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {Alert, StyleSheet, TouchableWithoutFeedback, View} from 'react-native';
 
 const importantForAccessibilityValues = [

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -18,7 +18,8 @@ import RNTesterText from '../../components/RNTesterText';
 import checkImageSource from './check.png';
 import mixedCheckboxImageSource from './mixed.png';
 import uncheckImageSource from './uncheck.png';
-import React, {createRef, useEffect, useRef, useState} from 'react';
+import * as React from 'react';
+import {createRef, useEffect, useRef, useState} from 'react';
 import {
   AccessibilityInfo,
   Alert,

--- a/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -11,7 +11,8 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {Node} from 'react';
 
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import * as React from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';
 
 function ToggleAnimatingActivityIndicator() {

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExApp.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExApp.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import AnExSet from './AnExSet';
-import React from 'react';
+import * as React from 'react';
 import {
   Animated,
   LayoutAnimation,

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExBobble.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExBobble.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import React from 'react';
+import * as React from 'react';
 import {Animated, PanResponder, StyleSheet, View} from 'react-native';
 
 const NUM_BOBBLES = 5;

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExChained.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExChained.js
@@ -15,7 +15,7 @@ import type {
   PanResponderGestureState,
 } from 'react-native';
 
-import React from 'react';
+import * as React from 'react';
 import {Animated, PanResponder, StyleSheet, View} from 'react-native';
 
 class AnExChained extends React.Component<Object, any> {

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExScroll.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExScroll.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import React from 'react';
+import * as React from 'react';
 import {
   Animated,
   Image,

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSet.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSet.js
@@ -14,7 +14,8 @@ import AnExBobble from './AnExBobble';
 import AnExChained from './AnExChained';
 import AnExScroll from './AnExScroll';
 import AnExTilt from './AnExTilt';
-import React, {useState} from 'react';
+import * as React from 'react';
+import {useState} from 'react';
 import {
   Animated,
   PanResponder,

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExTilt.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExTilt.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-import React, {useCallback, useEffect} from 'react';
+import * as React from 'react';
+import {useCallback, useEffect} from 'react';
 import {
   Animated,
   PanResponder,

--- a/packages/rn-tester/js/examples/AppState/AppStateExample.js
+++ b/packages/rn-tester/js/examples/AppState/AppStateExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {AppState, Platform} from 'react-native';
 

--- a/packages/rn-tester/js/examples/ContentURLAndroid/ContentURLAndroid.js
+++ b/packages/rn-tester/js/examples/ContentURLAndroid/ContentURLAndroid.js
@@ -15,7 +15,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterPage from '../../components/RNTesterPage';
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useCallback, useState} from 'react';
 import {
   Image,

--- a/packages/rn-tester/js/examples/Crash/CrashExample.js
+++ b/packages/rn-tester/js/examples/Crash/CrashExample.js
@@ -11,7 +11,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {Node} from 'react';
 
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'react-native';
 
 exports.displayName = (undefined: ?string);

--- a/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
+++ b/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
@@ -11,7 +11,8 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React, {useEffect, useState} from 'react';
+import * as React from 'react';
+import {useEffect, useState} from 'react';
 import {Dimensions, useWindowDimensions} from 'react-native';
 
 type Props = {dim: string};

--- a/packages/rn-tester/js/examples/DrawerLayoutAndroid/DrawerLayoutAndroidExample.js
+++ b/packages/rn-tester/js/examples/DrawerLayoutAndroid/DrawerLayoutAndroidExample.js
@@ -14,7 +14,8 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {Node} from 'react';
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
-import React, {useContext, useRef, useState} from 'react';
+import * as React from 'react';
+import {useContext, useRef, useState} from 'react';
 import {
   Button,
   DrawerLayoutAndroid,

--- a/packages/rn-tester/js/examples/FabricInteropLayer/FabricInteropLayer.js
+++ b/packages/rn-tester/js/examples/FabricInteropLayer/FabricInteropLayer.js
@@ -12,7 +12,8 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewProps} from 'react-native';
 
-import React, {useState} from 'react';
+import * as React from 'react';
+import {useState} from 'react';
 import {
   Button,
   StyleSheet,

--- a/packages/rn-tester/js/examples/Filter/FilterExample.js
+++ b/packages/rn-tester/js/examples/Filter/FilterExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import React from 'react';
+import * as React from 'react';
 import {useState} from 'react';
 import {
   Animated,

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -16,7 +16,7 @@ import type {ImageProps, LayoutChangeEvent} from 'react-native';
 import RNTesterButton from '../../components/RNTesterButton';
 import RNTesterText from '../../components/RNTesterText';
 import ImageCapInsetsExample from './ImageCapInsetsExample';
-import React from 'react';
+import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {Image, ImageBackground, StyleSheet, Text, View} from 'react-native';
 

--- a/packages/rn-tester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js
+++ b/packages/rn-tester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js
@@ -11,7 +11,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {PanResponder, ScrollView, StyleSheet, View} from 'react-native';
 
 exports.displayName = 'JSResponderHandlerExample';

--- a/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
+++ b/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
@@ -12,7 +12,8 @@
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
-import React, {useState} from 'react';
+import * as React from 'react';
+import {useState} from 'react';
 import {
   Alert,
   Button,

--- a/packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.android.js
+++ b/packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.android.js
@@ -15,7 +15,8 @@ import type {KeyEvent, NativeSyntheticEvent} from 'react-native';
 
 import RNTesterButton from '../../components/RNTesterButton';
 import RNTesterText from '../../components/RNTesterText';
-import React, {useCallback, useState} from 'react';
+import * as React from 'react';
+import {useCallback, useState} from 'react';
 import {ScrollView, StyleSheet, TextInput, View} from 'react-native';
 
 type KeyEventLog = {

--- a/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {
   LayoutAnimation,
   StyleSheet,

--- a/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
@@ -17,7 +17,7 @@ import type {
 } from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {Image, LayoutAnimation, StyleSheet, View} from 'react-native';
 
 type Props = Readonly<{}>;

--- a/packages/rn-tester/js/examples/Layout/LayoutExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutExample.js
@@ -16,7 +16,7 @@ import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterPage from '../../components/RNTesterPage';
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
 
 type CicleProps = Readonly<{

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -14,7 +14,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {Platform, PlatformColor, StyleSheet, View} from 'react-native';
 
 type Props = Readonly<{

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -12,7 +12,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useState} from 'react';
 import {
   Button,

--- a/packages/rn-tester/js/examples/MixBlendMode/MixBlendModeExample.js
+++ b/packages/rn-tester/js/examples/MixBlendMode/MixBlendModeExample.js
@@ -11,7 +11,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import React from 'react';
+import * as React from 'react';
 import {useState} from 'react';
 import {Image, ImageBackground, StyleSheet, Text, View} from 'react-native';
 

--- a/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
+++ b/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
@@ -16,7 +16,7 @@ import type AnimatedValue from 'react-native/Libraries/Animated/nodes/AnimatedVa
 import RNTesterSettingSwitchRow from '../../components/RNTesterSettingSwitchRow';
 import RNTesterText from '../../components/RNTesterText';
 import useJsStalls from '../../utils/useJsStalls';
-import React from 'react';
+import * as React from 'react';
 import {
   Animated,
   StyleSheet,

--- a/packages/rn-tester/js/examples/OrientationChange/OrientationChangeExample.js
+++ b/packages/rn-tester/js/examples/OrientationChange/OrientationChangeExample.js
@@ -11,7 +11,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {DeviceEventEmitter, View} from 'react-native';
 

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -12,7 +12,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ColorValue} from 'react-native';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {
   Appearance,
   Button,

--- a/packages/rn-tester/js/examples/RTL/RTLExample.js
+++ b/packages/rn-tester/js/examples/RTL/RTLExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTexterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {
   Alert,
   Animated,

--- a/packages/rn-tester/js/examples/RadialGradient/RadialGradientExample.js
+++ b/packages/rn-tester/js/examples/RadialGradient/RadialGradientExample.js
@@ -14,7 +14,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {Platform, PlatformColor, StyleSheet, View} from 'react-native';
 
 type Props = Readonly<{

--- a/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js
+++ b/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js
@@ -11,7 +11,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {
   RefreshControl,
   ScrollView,

--- a/packages/rn-tester/js/examples/SafeAreaView/SafeAreaViewExample.js
+++ b/packages/rn-tester/js/examples/SafeAreaView/SafeAreaViewExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useState} from 'react';
 import {Button, DeviceInfo, Modal, StyleSheet, View} from 'react-native';
 

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -27,7 +27,7 @@ import {
 } from '../../components/ListExampleShared';
 import RNTesterPage from '../../components/RNTesterPage';
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useRef, useState} from 'react';
 import {
   Alert,

--- a/packages/rn-tester/js/examples/Share/ShareExample.js
+++ b/packages/rn-tester/js/examples/Share/ShareExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useState} from 'react';
 import {Button, Share, StyleSheet, View} from 'react-native';
 

--- a/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
+++ b/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {
   Modal,
   StatusBar,

--- a/packages/rn-tester/js/examples/Switch/SwitchExample.js
+++ b/packages/rn-tester/js/examples/Switch/SwitchExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {Platform, Switch, View} from 'react-native';
 
 type OnOffIndicatorProps = Readonly<{on: boolean, testID: string}>;

--- a/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
+++ b/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
@@ -9,7 +9,8 @@
  */
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
-import React, {useContext} from 'react';
+import * as React from 'react';
+import {useContext} from 'react';
 import {StyleSheet, TextInput} from 'react-native';
 
 const ExampleTextInput: component(

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -17,7 +17,7 @@ import type {
 
 import ExampleTextInput from './ExampleTextInput';
 import TextInputSharedExamples from './TextInputSharedExamples';
-import React from 'react';
+import * as React from 'react';
 import {useState} from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -19,7 +19,7 @@ import type {KeyboardTypeOptions} from 'react-native';
 import RNTesterText from '../../components/RNTesterText';
 import ExampleTextInput from './ExampleTextInput';
 import TextInputSharedExamples from './TextInputSharedExamples';
-import React from 'react';
+import * as React from 'react';
 import {useRef} from 'react';
 import {
   Alert,

--- a/packages/rn-tester/js/examples/TextInput/TextInputKeyProp.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputKeyProp.js
@@ -12,7 +12,8 @@
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
-import React, {useEffect, useState} from 'react';
+import * as React from 'react';
+import {useEffect, useState} from 'react';
 import {TextInput, View} from 'react-native';
 
 function TextInputKeyProp() {

--- a/packages/rn-tester/js/examples/Timer/TimerExample.js
+++ b/packages/rn-tester/js/examples/Timer/TimerExample.js
@@ -14,7 +14,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterButton from '../../components/RNTesterButton';
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {Alert, Platform, ToastAndroid, View} from 'react-native';
 
 function burnCPU(milliseconds: number) {

--- a/packages/rn-tester/js/examples/ToastAndroid/ToastAndroidExample.js
+++ b/packages/rn-tester/js/examples/ToastAndroid/ToastAndroidExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {Pressable, StyleSheet, ToastAndroid} from 'react-native';
 
 const ToastWithShortDuration = () => {

--- a/packages/rn-tester/js/examples/Touchable/TouchableExample.js
+++ b/packages/rn-tester/js/examples/Touchable/TouchableExample.js
@@ -11,7 +11,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 import {
   Animated,

--- a/packages/rn-tester/js/examples/Urls/UrlExample.js
+++ b/packages/rn-tester/js/examples/Urls/UrlExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
 
 type Props = {

--- a/packages/rn-tester/js/examples/Vibration/VibrationExample.js
+++ b/packages/rn-tester/js/examples/Vibration/VibrationExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {
   Platform,
   StyleSheet,

--- a/packages/rn-tester/js/examples/WebSocket/WebSocketExample.js
+++ b/packages/rn-tester/js/examples/WebSocket/WebSocketExample.js
@@ -11,7 +11,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {
   Image,
   PixelRatio,

--- a/packages/rn-tester/js/examples/XHR/XHRExampleBinaryUpload.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleBinaryUpload.js
@@ -12,7 +12,7 @@
 
 import RNTesterText from '../../components/RNTesterText';
 import RNTOption from '../../components/RNTOption';
-import React from 'react';
+import * as React from 'react';
 import {Alert, StyleSheet, Text, TouchableHighlight, View} from 'react-native';
 
 const BINARY_TYPES = {

--- a/packages/rn-tester/js/examples/XHR/XHRExampleFetch.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleFetch.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
-import React from 'react';
+import * as React from 'react';
 import {
   Button,
   Platform,

--- a/packages/rn-tester/js/examples/XHR/XHRExampleHeaders.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleHeaders.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import RNTesterText from '../../components/RNTesterText';
-import React from 'react';
+import * as React from 'react';
 import {StyleSheet, Text, TouchableHighlight, View} from 'react-native';
 
 class XHRExampleHeaders extends React.Component {


### PR DESCRIPTION
Summary:

Applies the automatic fixes from the new `react-prefer-namespace-import` ESLint rule.

Changelog:
[Internal]

Reviewed By: thegreatercurve

Differential Revision: D98338132
