### PR TITLE
feat: support native text selection for selectable Text on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -34,6 +34,9 @@ using namespace facebook::react;
 
 @end
 
+@interface RCTParagraphSelectableTextView : UITextView
+@end
+
 #if !TARGET_OS_TV
 @interface RCTParagraphComponentView () <UIEditMenuInteractionDelegate>
 
@@ -50,6 +53,7 @@ using namespace facebook::react;
   RCTParagraphComponentAccessibilityProvider *_accessibilityProvider;
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
   RCTParagraphTextView *_textView;
+  RCTParagraphSelectableTextView *_selectableTextView;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -111,9 +115,9 @@ using namespace facebook::react;
 
   if (newParagraphProps.isSelectable != oldParagraphProps.isSelectable) {
     if (newParagraphProps.isSelectable) {
-      [self enableContextMenu];
+      [self _enableSelection];
     } else {
-      [self disableContextMenu];
+      [self _disableSelection];
     }
   }
 
@@ -125,6 +129,10 @@ using namespace facebook::react;
   _textView.state = std::static_pointer_cast<const ParagraphShadowNode::ConcreteState>(state);
   [_textView setNeedsDisplay];
   [self setNeedsLayout];
+
+  if (_selectableTextView) {
+    [self updateSelectableTextStorage];
+  }
 }
 
 - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
@@ -136,11 +144,18 @@ using namespace facebook::react;
   _textView.layoutMetrics = _layoutMetrics;
   [_textView setNeedsDisplay];
   [self setNeedsLayout];
+
+  if (_selectableTextView) {
+    [self updateSelectableTextStorage];
+  }
 }
 
 - (void)prepareForRecycle
 {
   [super prepareForRecycle];
+  if (_selectableTextView) {
+    [self _disableSelection];
+  }
   _textView.state = nullptr;
   _accessibilityProvider = nil;
 }
@@ -149,7 +164,79 @@ using namespace facebook::react;
 {
   [super layoutSubviews];
 
+  if (_selectableTextView) {
+    _selectableTextView.frame = self.bounds;
+  } else {
+    _textView.frame = self.bounds;
+  }
+}
+
+#pragma mark - Selection Management
+
+- (void)_enableSelection
+{
+  if (_selectableTextView) {
+    return;
+  }
+
+  _selectableTextView = [[RCTParagraphSelectableTextView alloc] initWithFrame:self.bounds];
+  _selectableTextView.editable = NO;
+  _selectableTextView.selectable = YES;
+  _selectableTextView.scrollEnabled = NO;
+  _selectableTextView.textContainerInset = UIEdgeInsetsZero;
+  _selectableTextView.textContainer.lineFragmentPadding = 0;
+  _selectableTextView.backgroundColor = [UIColor clearColor];
+
+  // Sync text content into the UITextView.
+  [self updateSelectableTextStorage];
+
+  // Swap: remove the default text view, install the selectable one.
+  [_textView removeFromSuperview];
+  self.contentView = _selectableTextView;
+
+  // Also enable the context menu (long press to copy).
+  [self enableContextMenu];
+}
+
+- (void)_disableSelection
+{
+  if (!_selectableTextView) {
+    return;
+  }
+
+  [self disableContextMenu];
+
+  // Swap back: remove the selectable text view, restore the default one.
+  [_selectableTextView removeFromSuperview];
+  _selectableTextView = nil;
+
+  self.contentView = _textView;
   _textView.frame = self.bounds;
+  [_textView setNeedsDisplay];
+}
+
+- (void)updateSelectableTextStorage
+{
+  if (!_selectableTextView || !_textView.state) {
+    return;
+  }
+
+  const auto &stateData = _textView.state->getData();
+  auto textLayoutManager = stateData.layoutManager.lock();
+  if (!textLayoutManager) {
+    return;
+  }
+
+  RCTTextLayoutManager *nativeTextLayoutManager =
+      (RCTTextLayoutManager *)unwrapManagedObject(textLayoutManager->getNativeTextLayoutManager());
+  CGRect frame = RCTCGRectFromRect(_layoutMetrics.getContentFrame());
+
+  NSTextStorage *textStorage = [nativeTextLayoutManager getTextStorageForAttributedString:stateData.attributedString
+                                                                      paragraphAttributes:_paragraphAttributes
+                                                                                     size:frame.size];
+
+  _selectableTextView.attributedText = textStorage;
+  _selectableTextView.frame = frame;
 }
 
 #pragma mark - Accessibility
@@ -425,4 +512,7 @@ Class<RCTComponentViewProtocol> RCTParagraphCls(void)
                               }];
 }
 
+@end
+
+@implementation RCTParagraphSelectableTextView
 @end

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
@@ -59,6 +59,10 @@ using RCTTextLayoutFragmentEnumerationBlock =
                               frame:(CGRect)frame
                          usingBlock:(RCTTextLayoutFragmentEnumerationBlock)block;
 
+- (NSTextStorage *)getTextStorageForAttributedString:(facebook::react::AttributedString)attributedString
+                                 paragraphAttributes:(facebook::react::ParagraphAttributes)paragraphAttributes
+                                                size:(CGSize)size;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -443,4 +443,16 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   return TextMeasurement{.size = {.width = size.width, .height = size.height}, .attachments = attachments};
 }
 
+- (NSTextStorage *)getTextStorageForAttributedString:(AttributedString)attributedString
+                                 paragraphAttributes:(ParagraphAttributes)paragraphAttributes
+                                                size:(CGSize)size
+{
+  NSAttributedString *nsAttributedString = [self _nsAttributedStringFromAttributedString:attributedString];
+  NSTextStorage *textStorage = [self _textStorageAndLayoutManagerWithAttributesString:nsAttributedString
+                                                                  paragraphAttributes:paragraphAttributes
+                                                                                 size:size];
+
+  return textStorage;
+}
+
 @end


### PR DESCRIPTION
Hi, I would have made this an RFC but I figured it's easier to just see this as a PR. If we like, I can gate this behind a React Native Feature Flag too.

This is upstreaming a change we've had in React Native macOS a while (albeit on Paper, the Fabric one just landed recently), actually originally made by the React Native Desktop team at Meta.

- Original Paper PR: https://github.com/microsoft/react-native-macos/pull/1346
- Fabric PR (just landed): https://github.com/microsoft/react-native-macos/pull/2864

## Summary:
React Native on iOS has been missing native selectable text for a while, leading to 3rd parties like Bluesky writing their own native modules to use UITextView. Presumbly the issue is perf, `UITextView` is much heavier than just rendering text. This PR takes an approach to only pay that cost if `selectable` is true. When false, we follow the oiriginal fast path.

When enabled:

- A UITextView (RCTParagraphSelectableTextView) is created and swapped in as the content view, replacing the lightweight RCTParagraphTextView
- Text storage is synced from RCTTextLayoutManager so rendering matches
- The UITextView handles selection natively (long press to select, drag handles, double-tap for word selection)
- The context menu (copy) continues to work alongside selection
- The UITextView is torn down on prepareForRecycle and when the prop toggles back to false

Also exposes `getTextStorageForAttributedString:paragraphAttributes:size:` on RCTTextLayoutManager as a public API, which simply wraps the existing private `_textStorageAndLayoutManagerWithAttributesString:` method.

## Changelog:

[iOS][Added] - Native text selection support for `<Text selectable={true}>`

## Test Plan:

https://github.com/user-attachments/assets/99d1c3bf-9fc0-4c42-9225-373c5dcb002f


