### PR TITLE
Fix RCTImageLoader to call completion handler when networking is unavailable

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -714,17 +714,19 @@ static RCTImageLoaderCancellationBlock RCTLoadImageURLFromLoader(
                                                        completionHandler
 {
   RCTNetworking *networking = [_moduleRegistry moduleForName:"Networking"];
-  if (RCT_DEBUG && !networking) {
+  if (!networking) {
     RCTLogError(
         @"No suitable image URL loader found for %@. You may need to "
          " import the RCTNetwork library in order to load images.",
         request.URL.absoluteString);
+    completionHandler(RCTErrorWithMessage(@"RCTNetworking module is not available"), nil, nil);
     return NULL;
   }
 
   // Check if networking module can load image
-  if (RCT_DEBUG && ![networking canHandleRequest:request]) {
+  if (![networking canHandleRequest:request]) {
     RCTLogError(@"No suitable image URL loader found for %@", request.URL.absoluteString);
+    completionHandler(RCTErrorWithMessage(@"No suitable URL loader for request"), nil, nil);
     return NULL;
   }
 


### PR DESCRIPTION
Summary:
`RCTImageLoader._loadURLRequest:` returned NULL without calling the completion handler when the `RCTNetworking` module was unavailable. This left `dispatch_group_wait` in `RCTSyncImageManager` blocking for the full 20-second timeout per image.

Additionally, the checks were guarded by `RCT_DEBUG`, meaning they only ran in debug builds. Remove the `RCT_DEBUG` guard so the error path runs in all builds.

Changelog: [Internal]

Differential Revision: D98122553


