### PR TITLE
Update to use modern casting syntax in codegen fixtures

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/ArrayPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/ArrayPropsNativeComponent.js
@@ -45,6 +45,6 @@ type NativeProps = Readonly<{
   arrayOfMixed?: ReadonlyArray<UnsafeMixed>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'ArrayPropsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/BooleanPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/BooleanPropNativeComponent.js
@@ -22,6 +22,6 @@ type NativeProps = Readonly<{
   disabledNullable?: WithDefault<boolean, null>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'BooleanPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/ColorPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/ColorPropNativeComponent.js
@@ -21,6 +21,6 @@ type NativeProps = Readonly<{
   tintColor?: ColorValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'ColorPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/DimensionPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/DimensionPropNativeComponent.js
@@ -21,6 +21,6 @@ type NativeProps = Readonly<{
   marginBack?: DimensionValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'DimensionPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/EdgeInsetsPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/EdgeInsetsPropNativeComponent.js
@@ -21,6 +21,6 @@ type NativeProps = Readonly<{
   // contentInset?: EdgeInsetsValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'EdgeInsetsPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/EnumPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/EnumPropNativeComponent.js
@@ -22,6 +22,6 @@ type NativeProps = Readonly<{
   intervals?: WithDefault<0 | 15 | 30 | 60, 0>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'EnumPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
@@ -38,6 +38,6 @@ type NativeProps = Readonly<{
   onChange?: ?BubblingEventHandler<OnChangeEvent>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'EventNestedObjectPropsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/EventPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/EventPropsNativeComponent.js
@@ -59,6 +59,6 @@ type NativeProps = Readonly<{
   >,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'EventPropsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/FloatPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/FloatPropsNativeComponent.js
@@ -30,6 +30,6 @@ type NativeProps = Readonly<{
   blurRadiusNullable?: WithDefault<Float, null>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'FloatPropsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/ImagePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/ImagePropNativeComponent.js
@@ -21,6 +21,6 @@ type NativeProps = Readonly<{
   thumbImage?: ImageSource,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'ImagePropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/IntegerPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/IntegerPropNativeComponent.js
@@ -26,6 +26,6 @@ type NativeProps = Readonly<{
   progress3?: WithDefault<Int32, 10>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'IntegerPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
@@ -27,10 +27,10 @@ type NativeProps = Readonly<{
   onChange?: ?BubblingEventHandler<Readonly<{value: boolean}>>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'InterfaceOnlyNativeComponentView',
   {
     interfaceOnly: true,
     paperComponentName: 'RCTInterfaceOnlyComponent',
   },
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/MixedPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/MixedPropNativeComponent.js
@@ -21,6 +21,6 @@ type NativeProps = Readonly<{
   mixedProp?: UnsafeMixed,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'MixedPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/MultiNativePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/MultiNativePropNativeComponent.js
@@ -26,6 +26,6 @@ type NativeProps = Readonly<{
   point?: PointValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'MultiNativePropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
@@ -19,6 +19,6 @@ type NativeProps = Readonly<{
   // No Props or events
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'NoPropsNoEventsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/ObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/ObjectPropsNativeComponent.js
@@ -45,6 +45,6 @@ type NativeProps = Readonly<{
   }>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'ObjectPropsNativeComponent',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/PointPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/PointPropNativeComponent.js
@@ -21,6 +21,6 @@ type NativeProps = Readonly<{
   startPoint?: PointValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'PointPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/StringPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/components/StringPropNativeComponent.js
@@ -22,6 +22,6 @@ type NativeProps = Readonly<{
   defaultValue?: string,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'StringPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeArrayTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeArrayTurboModule.js
@@ -21,6 +21,6 @@ export interface Spec extends TurboModule {
   +getArrayWithAlias: (a: AnotherArray, b: Array<ArrayType>) => AnotherArray;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeBooleanTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeBooleanTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getBooleanWithAlias: (arg: Boolean) => AnotherBoolean;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeCallbackTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeCallbackTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getValueWithCallbackWithAlias: (c: CB) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeEnumTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeEnumTurboModule.js
@@ -64,6 +64,6 @@ export interface Spec extends TurboModule {
   ) => StateTypeWithEnums;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'NativeEnumTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeNullableTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeNullableTurboModule.js
@@ -21,6 +21,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: () => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeNumberTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeNumberTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getNumberWithAlias: (arg: Number) => AnotherNumber;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeObjectTurboModule.js
@@ -59,6 +59,6 @@ export interface Spec extends TurboModule {
   };
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
@@ -33,6 +33,6 @@ export interface Spec extends TurboModule {
   };
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativePartialAnnotationTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativePartialAnnotationTurboModule.js
@@ -31,6 +31,6 @@ export interface Spec extends TurboModule {
   ) => SomeObj;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'NativePartialAnnotationTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativePromiseTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativePromiseTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromiseWithAlias: (arg: String) => AnotherPromise;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModule.js
@@ -40,6 +40,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: boolean) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModuleArrays.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModuleArrays.js
@@ -45,6 +45,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: Array<boolean>) => Promise<Array<string>>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModuleArrays',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModuleNullable.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModuleNullable.js
@@ -40,6 +40,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: ?boolean) => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModuleNullable',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModuleNullableAndOptional.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModuleNullableAndOptional.js
@@ -40,6 +40,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise?: (error?: ?boolean) => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModuleNullableAndOptional',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModuleOptional.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModuleOptional.js
@@ -40,6 +40,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise?: (error?: boolean) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModuleOptional',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeStringTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeStringTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getStringWithAlias: (arg: String) => AnotherString;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.getEnforcing<Spec>(
   'SampleTurboModule',
-): Spec);
+) as Spec;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/ArrayPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/ArrayPropsNativeComponent.js
@@ -42,6 +42,6 @@ type NativeProps = Readonly<{
   arrayOfMixed?: ReadonlyArray<CodegenTypes.UnsafeMixed>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'ArrayPropsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/BooleanPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/BooleanPropNativeComponent.js
@@ -20,6 +20,6 @@ type NativeProps = Readonly<{
   disabledNullable?: CodegenTypes.WithDefault<boolean, null>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'BooleanPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/ColorPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/ColorPropNativeComponent.js
@@ -19,6 +19,6 @@ type NativeProps = Readonly<{
   tintColor?: ColorValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'ColorPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/DimensionPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/DimensionPropNativeComponent.js
@@ -19,6 +19,6 @@ type NativeProps = Readonly<{
   marginBack?: DimensionValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'DimensionPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/EdgeInsetsPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/EdgeInsetsPropNativeComponent.js
@@ -20,6 +20,6 @@ type NativeProps = Readonly<{
   // contentInset?: EdgeInsetsValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'EdgeInsetsPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/EnumPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/EnumPropNativeComponent.js
@@ -23,6 +23,6 @@ type NativeProps = Readonly<{
   intervals?: CodegenTypes.WithDefault<0 | 15 | 30 | 60, 0>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'EnumPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
@@ -32,6 +32,6 @@ type NativeProps = Readonly<{
   onChange?: ?CodegenTypes.BubblingEventHandler<OnChangeEvent>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'EventNestedObjectPropsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/EventPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/EventPropsNativeComponent.js
@@ -54,6 +54,6 @@ type NativeProps = Readonly<{
   >,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'EventPropsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/FloatPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/FloatPropsNativeComponent.js
@@ -25,6 +25,6 @@ type NativeProps = Readonly<{
   blurRadiusNullable?: CodegenTypes.WithDefault<CodegenTypes.Float, null>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'FloatPropsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/ImagePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/ImagePropNativeComponent.js
@@ -19,6 +19,6 @@ type NativeProps = Readonly<{
   thumbImage?: ImageSource,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'ImagePropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/IntegerPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/IntegerPropNativeComponent.js
@@ -21,6 +21,6 @@ type NativeProps = Readonly<{
   progress3?: CodegenTypes.WithDefault<CodegenTypes.Int32, 10>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'IntegerPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
@@ -22,10 +22,10 @@ type NativeProps = Readonly<{
   onChange?: ?CodegenTypes.BubblingEventHandler<Readonly<{value: boolean}>>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'InterfaceOnlyNativeComponentView',
   {
     interfaceOnly: true,
     paperComponentName: 'RCTInterfaceOnlyComponent',
   },
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/MixedPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/MixedPropNativeComponent.js
@@ -19,6 +19,6 @@ type NativeProps = Readonly<{
   mixedProp?: CodegenTypes.UnsafeMixed,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'MixedPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/MultiNativePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/MultiNativePropNativeComponent.js
@@ -28,6 +28,6 @@ type NativeProps = Readonly<{
   point?: PointValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'MultiNativePropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
@@ -18,6 +18,6 @@ type NativeProps = Readonly<{
   // No Props or events
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'NoPropsNoEventsNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/ObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/ObjectPropsNativeComponent.js
@@ -43,6 +43,6 @@ type NativeProps = Readonly<{
   }>,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'ObjectPropsNativeComponent',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/PointPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/PointPropNativeComponent.js
@@ -19,6 +19,6 @@ type NativeProps = Readonly<{
   startPoint?: PointValue,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'PointPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/StringPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/namespaced/__test_fixtures__/components/StringPropNativeComponent.js
@@ -20,6 +20,6 @@ type NativeProps = Readonly<{
   defaultValue?: string,
 }>;
 
-export default (codegenNativeComponent<NativeProps>(
+export default codegenNativeComponent<NativeProps>(
   'StringPropNativeComponentView',
-): HostComponent<NativeProps>);
+) as HostComponent<NativeProps>;

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -698,9 +698,9 @@ describe('buildSchema', () => {
         ...ViewProps,
       |}>;
 
-      export default (codegenNativeComponent<ModuleProps>(
+      export default codegenNativeComponent<ModuleProps>(
         'Module',
-      ): HostComponent<ModuleProps>);
+      ) as HostComponent<ModuleProps>;
     `;
 
     it('returns a module with good properties', () => {
@@ -808,9 +808,9 @@ describe('buildSchema', () => {
         +getArray: (a: Array<any>) => Array<string>;
       }
 
-      export default (TurboModuleRegistry.getEnforcing<Spec>(
+      export default TurboModuleRegistry.getEnforcing<Spec>(
         'SampleTurboModule',
-      ): Spec);
+      ) as Spec;
     `;
 
     it('returns a module with good properties', () => {
@@ -1101,9 +1101,9 @@ describe('buildModuleSchema', () => {
       +getArray: (a: Array<any>) => Array<string>;
     }
 
-    export default (TurboModuleRegistry.getEnforcing<Spec>(
+    export default TurboModuleRegistry.getEnforcing<Spec>(
       'SampleTurboModule',
-    ): Spec);
+    ) as Spec;
   `;
 
   describe('throwIfModuleInterfaceNotFound', () => {
@@ -1201,9 +1201,9 @@ describe('buildModuleSchema', () => {
           +getArray: (a: Array<any>) => Array<string>;
         }
 
-        export default (TurboModuleRegistry.getEnforcing<Spec>(
+        export default TurboModuleRegistry.getEnforcing<Spec>(
           'SampleTurboModule',
-        ): Spec);
+        ) as Spec;
       `;
       const ast = flowParser.getAst(contents);
       const types = flowParser.getTypes(ast);

--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/failures.js
@@ -43,9 +43,9 @@ export const Commands = codegenNativeCommands<{
   supportedCommands: ['hotspotUpdate'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const COMMANDS_DEFINED_MULTIPLE_TIMES = `
@@ -84,9 +84,9 @@ export const Commands2 = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['hotspotUpdate'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const COMMANDS_DEFINED_WITHOUT_REF = `
@@ -122,9 +122,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['hotspotUpdate'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const COMMANDS_DEFINED_WITH_NULLABLE_REF = `
@@ -160,9 +160,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['hotspotUpdate'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const COMMANDS_DEFINED_WITH_MISMATCHED_METHOD_NAMES = `
@@ -203,9 +203,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['scrollTo'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const COMMANDS_DEFINED_WITHOUT_METHOD_NAMES = `
@@ -244,9 +244,9 @@ export type ModuleProps = $ReadOnly<{|
 
 export const Commands = codegenNativeCommands<NativeCommands>();
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const NULLABLE_WITH_DEFAULT = `
@@ -273,9 +273,9 @@ export type ModuleProps = $ReadOnly<{|
   nullable_with_default: ?WithDefault<Float, 1.0>,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const NON_OPTIONAL_KEY_WITH_DEFAULT_VALUE = `
@@ -302,9 +302,9 @@ export type ModuleProps = $ReadOnly<{|
   required_key_with_default: WithDefault<Float, 1.0>,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROPS_CONFLICT_NAMES = `
@@ -332,9 +332,9 @@ export type ModuleProps = $ReadOnly<{|
   isEnabled: boolean,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROPS_CONFLICT_WITH_SPREAD_PROPS = `
@@ -366,9 +366,9 @@ export type ModuleProps = $ReadOnly<{|
   isEnabled: boolean,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROPS_SPREAD_CONFLICTS_WITH_PROPS = `
@@ -400,9 +400,9 @@ export type ModuleProps = $ReadOnly<{|
   ...PropsInFile,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROP_NUMBER_TYPE = `
@@ -429,9 +429,9 @@ export type ModuleProps = $ReadOnly<{|
   someProp: number
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROP_MIXED_ENUM = `
@@ -458,9 +458,9 @@ export type ModuleProps = $ReadOnly<{|
   someProp?: WithDefault<'foo' | 1, 1>
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROP_ENUM_BOOLEAN = `
@@ -487,9 +487,9 @@ export type ModuleProps = $ReadOnly<{|
   someProp?: WithDefault<false | true, false>
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROP_ARRAY_MIXED_ENUM = `
@@ -516,9 +516,9 @@ export type ModuleProps = $ReadOnly<{|
   someProp?: WithDefault<$ReadOnlyArray<'foo' | 1>, 1>
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROP_ARRAY_ENUM_BOOLEAN = `
@@ -545,9 +545,9 @@ export type ModuleProps = $ReadOnly<{|
   someProp?: WithDefault<$ReadOnlyArray<false | true>, false>
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROP_ARRAY_ENUM_INT = `
@@ -574,9 +574,9 @@ export type ModuleProps = $ReadOnly<{|
   someProp?: WithDefault<$ReadOnlyArray<0 | 1>, 0>
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
@@ -171,10 +171,10 @@ type ModuleProps = $ReadOnly<{|
   onBubblingEventDefinedInlineNull: BubblingEventHandler<null>,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>('Module', {
+export default codegenNativeComponent<ModuleProps>('Module', {
   interfaceOnly: true,
   paperComponentName: 'RCTModule',
-}): HostComponent<ModuleProps>);
+}) as HostComponent<ModuleProps>;
 `;
 
 const ONE_OF_EACH_PROP_EVENT_DEFAULT_AND_OPTIONS_NO_CAST = `
@@ -240,9 +240,9 @@ type ModuleProps = $ReadOnly<{|
   ...ViewProps,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>('Module', {
+export default codegenNativeComponent<ModuleProps>('Module', {
   deprecatedViewConfigName: 'DeprecateModuleName',
-}): HostComponent<ModuleProps>);
+}) as HostComponent<ModuleProps>;
 `;
 
 const ALL_PROP_TYPES_NO_EVENTS = `
@@ -374,9 +374,9 @@ type ModuleProps = $ReadOnly<{|
   mixed_optional_key?: UnsafeMixed,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps, Options>(
+export default codegenNativeComponent<ModuleProps, Options>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const ARRAY_PROP_TYPES_NO_EVENTS = `
@@ -539,9 +539,9 @@ type ModuleProps = $ReadOnly<{|
   >,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const OBJECT_PROP_TYPES_NO_EVENTS = `
@@ -637,9 +637,9 @@ type ModuleProps = $ReadOnly<{|
   object_optional_both?: ?$ReadOnly<{|prop: $ReadOnly<{nestedProp: string}>|}>,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROPS_ALIASED_LOCALLY = `
@@ -682,9 +682,9 @@ export type ModuleProps = $ReadOnly<{|
   localArr: $ReadOnlyArray<PropsInFile>
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const EVENTS_DEFINED_INLINE_WITH_ALL_TYPES = `
@@ -791,9 +791,9 @@ type ModuleProps = $ReadOnly<{|
     >,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const EVENTS_DEFINED_AS_NULL_INLINE = `
@@ -840,9 +840,9 @@ type ModuleProps = $ReadOnly<{|
   >,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROPS_AND_EVENTS_TYPES_EXPORTED = `
@@ -883,9 +883,9 @@ export type ModuleProps = $ReadOnly<{|
   onDirectEventDefinedInlineWithPaperName: DirectEventHandler<EventInFile, 'paperDirectEventDefinedInlineWithPaperName'>,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const PROPS_AS_EXTERNAL_TYPES = `
@@ -913,9 +913,9 @@ export type ModuleProps = $ReadOnly<{|
   array: AnotherArray,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const COMMANDS_DEFINED_WITH_ALL_TYPES = `
@@ -971,9 +971,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['handleRootTag', 'hotspotUpdate', 'scrollTo', 'arrayArgs'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): NativeType);
+) as NativeType;
 `;
 
 const COMMANDS_WITH_EXTERNAL_TYPES = `
@@ -1032,9 +1032,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['scrollTo', 'addOverlays'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): NativeType);
+) as NativeType;
 `;
 
 const COMMANDS_EVENTS_TYPES_EXPORTED = `
@@ -1091,9 +1091,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['scrollTo']
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): NativeType);
+) as NativeType;
 `;
 
 const NAMESPACED_EVENT_DEFINITION = `
@@ -1250,10 +1250,10 @@ type ModuleProps = $ReadOnly<{|
   onBubblingEventDefinedInlineNull: CodegenTypes.BubblingEventHandler<null>,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>('Module', {
+export default codegenNativeComponent<ModuleProps>('Module', {
   interfaceOnly: true,
   paperComponentName: 'RCTModule',
-}): HostComponent<ModuleProps>);
+}) as HostComponent<ModuleProps>;
 `;
 
 const NAMESPACED_ONE_OF_EACH_PROP_EVENT_DEFAULT_AND_OPTIONS_NO_CAST = `
@@ -1420,9 +1420,9 @@ type ModuleProps = $ReadOnly<{|
   mixed_optional_key?: CodegenTypes.UnsafeMixed,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps, Options>(
+export default codegenNativeComponent<ModuleProps, Options>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const NAMESPACED_ARRAY_PROP_TYPES_NO_EVENTS = `
@@ -1584,9 +1584,9 @@ type ModuleProps = $ReadOnly<{|
   >,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const NAMESPACED_OBJECT_PROP_TYPES_NO_EVENTS = `
@@ -1681,9 +1681,9 @@ type ModuleProps = $ReadOnly<{|
   object_optional_both?: ?$ReadOnly<{|prop: $ReadOnly<{nestedProp: string}>|}>,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const NAMESPACED_EVENTS_DEFINED_INLINE_WITH_ALL_TYPES = `
@@ -1782,9 +1782,9 @@ type ModuleProps = $ReadOnly<{|
     >,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const NAMESPACED_EVENTS_DEFINED_AS_NULL_INLINE = `
@@ -1830,9 +1830,9 @@ type ModuleProps = $ReadOnly<{|
   >,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const NAMESPACED_PROPS_AND_EVENTS_TYPES_EXPORTED = `
@@ -1869,9 +1869,9 @@ export type ModuleProps = $ReadOnly<{|
   onDirectEventDefinedInlineWithPaperName: CodegenTypes.DirectEventHandler<EventInFile, 'paperDirectEventDefinedInlineWithPaperName'>,
 |}>;
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): HostComponent<ModuleProps>);
+) as HostComponent<ModuleProps>;
 `;
 
 const NAMESPACED_COMMANDS_DEFINED_WITH_ALL_TYPES = `
@@ -1926,9 +1926,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['handleRootTag', 'hotspotUpdate', 'scrollTo', 'arrayArgs'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): NativeType);
+) as NativeType;
 `;
 
 const NAMESPACED_COMMANDS_WITH_EXTERNAL_TYPES = `
@@ -1986,9 +1986,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['scrollTo', 'addOverlays'],
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): NativeType);
+) as NativeType;
 `;
 
 const NAMESPACED_COMMANDS_EVENTS_TYPES_EXPORTED = `
@@ -2041,9 +2041,9 @@ export const Commands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['scrollTo']
 });
 
-export default (codegenNativeComponent<ModuleProps>(
+export default codegenNativeComponent<ModuleProps>(
   'Module',
-): NativeType);
+) as NativeType;
 `;
 
 module.exports = {


### PR DESCRIPTION
Summary:
According to my understanding, the codegen already outputs the modern casting syntax. Only these fixtures are stuck on the old syntax. This diff fixes them all.

Changelog: [Internal]

Differential Revision: D98537137
