### PR TITLE
Fix FlatList initialScrollIndex behavior when short list fits viewport

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -627,7 +627,9 @@ class VirtualizedList extends StateSafePureComponent<
     } else {
       // If we have a pending scroll update, we should not adjust the render window as it
       // might override the correct window.
-      if (pendingScrollUpdateCount > 0) {
+      // We only block the update if the content is large enough to scroll, otherwise
+      // we might never receive a scroll event to clear the pending update.
+      if (pendingScrollUpdateCount > 0 && contentLength > visibleLength) {
         return cellsAroundViewport.last >= getItemCount(data)
           ? VirtualizedList._constrainToItemCount(cellsAroundViewport, props)
           : cellsAroundViewport;

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -4865,12 +4865,21 @@ exports[`renders new items when data is updated with non-zero initialScrollIndex
       />
     </View>
     <View
-      style={
-        Object {
-          "height": 20,
-        }
-      }
-    />
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={2}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={3}
+      />
+    </View>
   </View>
 </RCTScrollView>
 `;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR fixes a bug in `VirtualizedList` (and thus `FlatList`) where setting `initialScrollIndex` to a non-zero value prevents items before it from rendering if the entire list fits within the viewport.

The issue was that `VirtualizedList` blocks render window updates when there is a `pendingScrollUpdateCount > 0`. However, when the content fits the screen, a scroll event is never triggered to clear that pending update, leaving preceding items unrendered. This fix ensures that updates are only blocked if the content is large enough to scroll (`contentLength > visibleLength`).

Fixes #56237

## Changelog:

[ANDROID] [FIXED] - Fix FlatList initialScrollIndex behavior when short list fits viewport

## Test Plan:

1. Use the provided reproducer: https://snack.expo.dev/@andyhoover/flatlist-initialscrollindex-bug-2026
2. Verify that on Android, items before the `initialScrollIndex` (e.g., Index 0, 1) are now correctly rendered when the list is short.
3. Verified with existing unit tests: `yarn jest packages/virtualized-lists/Lists/VirtualizedList-test.js` (Snapshots updated).
