### PR TITLE
Replace FIXME comment with explanation for JS safety in MutationObserver

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
@@ -116,8 +116,9 @@ void NativeMutationObserver::onMutations(std::vector<MutationRecord>& records) {
     pendingRecords_.emplace_back(
         NativeMutationRecord{
             record.mutationObserverId,
-            // FIXME(T157129303) Instead of assuming we can call into JS from
-            // here, we should use an API that explicitly indicates it.
+            // It's safe to call into JS here because we only check mutations
+            // synchronously when committing from React (so we're in a JS
+            // task already).
             getPublicInstanceFromShadowNode(*record.targetShadowNode),
             getPublicInstancesFromShadowNodes(record.addedShadowNodes),
             getPublicInstancesFromShadowNodes(record.removedShadowNodes)});


### PR DESCRIPTION
Summary:
Replace the FIXME(T157129303) comment in NativeMutationObserver with a
clarifying comment explaining why it is safe to call into JS at that
point: we only check mutations synchronously when committing from React,
so we are already in a JS task.

Changelog: [Internal]

Differential Revision: D98714071


