### PR TITLE
test: fix recieved -> received typos in W3C pointer event tests

### DIFF
--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
@@ -23,7 +23,7 @@ function PointerEventPointerCancelTouchTestCase(
 ) {
   const {harness} = props;
 
-  const testPointerEvent = harness.useAsyncTest('pointercancel event recieved');
+  const testPointerEvent = harness.useAsyncTest('pointercancel event received');
 
   const pointerDownEventRef = useRef<PointerEvent | null>(null);
   const pointerCancelEventRef = useRef<PointerEvent | null>(null);
@@ -40,7 +40,7 @@ function PointerEventPointerCancelTouchTestCase(
 
       testPointerEvent.step(({assert_equals, assert_not_equals}) => {
         const pointerDownEvent = pointerDownEventRef.current;
-        assert_not_equals(pointerDownEvent, null, 'pointerdown was recieved: ');
+        assert_not_equals(pointerDownEvent, null, 'pointerdown was received: ');
         if (pointerDownEvent != null) {
           assert_equals(
             event.nativeEvent.pointerId,
@@ -87,7 +87,7 @@ function PointerEventPointerCancelTouchTestCase(
         assert_not_equals(
           pointerCancelEvent,
           null,
-          'pointercancel was recieved: ',
+          'pointercancel was received: ',
         );
         if (pointerCancelEvent != null) {
           assert_equals(
@@ -118,7 +118,7 @@ function PointerEventPointerCancelTouchTestCase(
         assert_not_equals(
           pointerCancelEvent,
           null,
-          'pointercancel was recieved: ',
+          'pointercancel was received: ',
         );
         if (pointerCancelEvent != null) {
           assert_equals(

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
@@ -78,7 +78,7 @@ function PointerEventPointerOverOutTestCase(
         assert_equals(
           innerOverRef.current,
           innerOutRef.current,
-          'pointerover is recieved before pointerout',
+          'pointerover is received before pointerout',
         );
         switch (innerOverRef.current) {
           case 0: {
@@ -144,7 +144,7 @@ function PointerEventPointerOverOutTestCase(
           assert_equals(
             outerOwnOverRef.current,
             outerOwnOutRef.current,
-            'outer: pointerover is recieved before pointerout',
+            'outer: pointerover is received before pointerout',
           );
           outerOwnOverRef.current++;
         } else {
@@ -167,7 +167,7 @@ function PointerEventPointerOverOutTestCase(
           assert_equals(
             outerOwnOverRef.current,
             outerOwnOutRef.current + 1,
-            'outer: pointerout is recieved after pointerover',
+            'outer: pointerout is received after pointerover',
           );
           if (outerOwnOutRef.current === 1) {
             assert_equals(innerOutRef.current, 2, 'inner should be done now');


### PR DESCRIPTION
Fixes multiple instances where 'received' was misspelled as 'recieved' in W3C pointer event platform tests within rn-tester.