### PR TITLE
Fix iOS RNTester CI: update prebuilt pods alongside hermes-engine

### DIFF
--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -75,7 +75,7 @@ runs:
         cd packages/rn-tester
 
         bundle install
-        bundle exec pod update hermes-engine --no-repo-update
+        bundle exec pod update hermes-engine React-Core-prebuilt ReactNativeDependencies --no-repo-update
     - name: Build RNTester
       shell: bash
       run: |


### PR DESCRIPTION
Summary:
The test-ios-rntester CI action only runs pod update hermes-engine, but React-Core-prebuilt and ReactNativeDependencies also derive their version from package.json. When a version bump lands on the stable branch before bump-podfile-lock.yml
  regenerates the Podfile.lock, CocoaPods fails with a version mismatch error.

Fix: add React-Core-prebuilt and ReactNativeDependencies to the pod update command in .github/actions/test-ios-rntester/action.yml.

This is safe to run unconditionally — when versions haven't changed, pod update for those pods is a no-op.

Changelog: [Internal]
---

Differential Revision: D98799372


