### PR TITLE
fix(android): fix `bad_optional_access` when `zIndex` changes to undefined with props 2.0

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -623,11 +623,7 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
   }
 
   if (zIndex != oldProps->zIndex) {
-    if (zIndex.has_value()) {
-      result["zIndex"] = zIndex.value();
-    } else {
-      result["zIndex"] = folly::dynamic(nullptr);
-    }
+    result["zIndex"] = zIndex.has_value() ? zIndex.value() :  folly::dynamic(nullptr);
   }
 
   if (boxShadow != oldProps->boxShadow) {


### PR DESCRIPTION
## Summary:

When Android props 2.0 diffs a `View` where `zIndex` changes from a value to `undefined`, `HostPlatformViewProps::getDiffProps` calls `zIndex.value()` and throws `bad_optional_access`:


https://github.com/user-attachments/assets/89752243-ff48-42c7-a584-b47a091b4a4d



This change emits `folly::dynamic(nullptr)` when `zIndex` is cleared instead.

## Changelog:

[ANDROID] [FIXED] - Fixed a crash when clearing `zIndex` with props 2.0 enabled

## Test Plan:

Use the repro in `packages/rn-tester/js/examples/Playground/RNTesterPlayground.js`:

```js
function Playground() {
  const [toggle, setToggle] = React.useState(false);

  return (
    <View style={styles.container}>
      <Button title="Toggle" onPress={() => setToggle(t => !t)} />
      <View
        style={{
          backgroundColor: toggle ? 'blue' : 'red',
          height: 100,
          width: 100,
          position: 'absolute',
          zIndex: toggle ? undefined : 1,
        }}
      />
    </View>
  );
}
```

1. Enable Android props 2.0:

```
  override fun enableAccumulatedUpdatesInRawPropsAndroid(): Boolean = true
  override fun enableExclusivePropsUpdateAndroid(): Boolean = true
  override fun enablePropsUpdateReconciliationAndroid(): Boolean = true
```

2. run RNTester Playground on Android, and press `Toggle` to switch `zIndex` between `1` and `undefined`.

This is with the issue fixed:



https://github.com/user-attachments/assets/11253c23-b235-4e70-89a3-0d7bd07937f5



