### PR TITLE
Register VirtualView component

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.h
@@ -40,6 +40,7 @@ Class<RCTComponentViewProtocol> RCTSwitchCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTTextInputCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTUnimplementedNativeViewCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTViewCls(void) __attribute__((used));
+Class<RCTComponentViewProtocol> VirtualViewCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTImageCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTModalHostViewCls(void) __attribute__((used));
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.mm
@@ -29,6 +29,7 @@ Class<RCTComponentViewProtocol> RCTFabricComponentsProvider(const char *name) {
     {"TextInput", RCTTextInputCls},
     {"UnimplementedNativeView", RCTUnimplementedNativeViewCls},
     {"View", RCTViewCls},
+    {"VirtualView", VirtualViewCls},
     {"Image", RCTImageCls},
     {"ModalHostView", RCTModalHostViewCls},
   };

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.kt
@@ -63,6 +63,7 @@ import com.facebook.react.views.text.SelectableTextViewManager
 import com.facebook.react.views.textinput.ReactTextInputManager
 import com.facebook.react.views.unimplementedview.ReactUnimplementedViewManager
 import com.facebook.react.views.view.ReactViewManager
+import com.facebook.react.views.virtual.view.ReactVirtualViewManager
 
 /**
  * Package defining basic modules and view managers.
@@ -155,6 +156,7 @@ constructor(private val config: MainPackageConfig? = null) :
           else ReactTextViewManager(),
           SelectableTextViewManager(),
           ReactViewManager(),
+          ReactVirtualViewManager(),
           ReactUnimplementedViewManager(),
       )
 
@@ -199,6 +201,8 @@ constructor(private val config: MainPackageConfig? = null) :
           SelectableTextViewManager.REACT_CLASS to
               ModuleSpec.viewManagerSpec { SelectableTextViewManager() },
           ReactViewManager.REACT_CLASS to ModuleSpec.viewManagerSpec { ReactViewManager() },
+          ReactVirtualViewManager.REACT_CLASS to
+              ModuleSpec.viewManagerSpec { ReactVirtualViewManager() },
           ReactUnimplementedViewManager.REACT_CLASS to
               ModuleSpec.viewManagerSpec { ReactUnimplementedViewManager() },
       )

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -148,7 +148,7 @@ Pod::Spec.new do |s|
     end
 
     ss.subspec "virtualview" do |sss|
-      sss.source_files         = "react/renderer/components/virtualview/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/virtualview/**/*.{m,mm,cpp,h}", "react/renderer/components/virtualview/**/*.h")
       sss.exclude_files        = "react/renderer/components/virtualview/tests"
       sss.header_dir           = "react/renderer/components/virtualview"
     end


### PR DESCRIPTION
Summary:
Changelog: [GENERAL][FIXED] Link VirtualView component

I saw D98039999 and I wanted to check how the new components are working in OSS, and currently they don't. VirtualView component isn't correctly linked in OSS. This diff addresses that.

Note that VirtualView in OSS requires `babel-plugin-transform-flow-enums` which is not part of the default template.

Differential Revision: D98887952


