### PR TITLE
Fix uncontrolled multiline TextInput not resizing when children change

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -204,6 +204,23 @@ class BaseTextInputShadowNode
             layoutContext.fontSizeMultiplier;
     if (meaningfulState) {
       const auto &stateData = BaseShadowNode::getStateData();
+      const auto &props = BaseShadowNode::getConcreteProps();
+
+      // For uncontrolled TextInputs (no value prop), the react tree attributed
+      // string may have diverged from state if children changed since the last
+      // native state update. In that case, prefer the react tree for measurement
+      // since attributedStringBox may contain stale native text.
+      if (props.text.empty()) {
+        const auto &reactTreeAttributedString = getAttributedString(layoutContext);
+        if (!stateData.reactTreeAttributedString.isContentEqual(reactTreeAttributedString)) {
+          auto attributedString = reactTreeAttributedString;
+          if (attributedString.isEmpty()) {
+            attributedString = getPlaceholderAttributedString(layoutContext);
+          }
+          return AttributedStringBox{attributedString};
+        }
+      }
+
       auto attributedStringBox = stateData.attributedStringBox;
       if (attributedStringBox.getMode() == AttributedStringBox::Mode::OpaquePointer ||
           !attributedStringBox.getValue().isEmpty()) {


### PR DESCRIPTION
## Summary:

When a multiline TextInput is uncontrolled (no `value` prop) and uses children for styled text, changing the children does not cause the TextInput to resize. For example, if the children go from multiline content to empty, the input stays at its expanded height.

### Root cause

During a layout pass, `YGNodeCalculateLayout` calls `measureContent()` which uses `attributedStringBoxToMeasure()` to decide what text to measure. For uncontrolled TextInputs with Text children, `attributedStringBox` in state holds the native text from the last `_updateState()` call — but by the time the React tree children have changed (e.g. cleared), `attributedStringBox` still contains the old native text.

`updateStateIfNeeded()` would normally sync the state, but it runs in `layout()` which is called *after* `YGNodeCalculateLayout` has already computed sizes. So Yoga measures with stale text and the height doesn't update.

### Fix

In `attributedStringBoxToMeasure()`, for uncontrolled TextInputs (`props.text` is empty), check if the React tree attributed string has diverged from what's stored in state. If so, use the React tree version for measurement instead of the stale `attributedStringBox`.

The check is guarded by `props.text.empty()` so controlled TextInputs (which are the common case and don't have this issue) skip it entirely with zero overhead.

## Changelog:

[IOS][FIXED] - Fix uncontrolled multiline TextInput not resizing when children change

## Test Plan:

1. Create an uncontrolled multiline TextInput with children:
```tsx
const [text, setText] = useState('');
<TextInput multiline onChangeText={setText}>
  <Text>{text}</Text>
</TextInput>
<Button title="Clear" onPress={() => setText('')} />
```
2. Type enough text to make the input expand to multiple lines
3. Press "Clear" to empty the text
4. **Before fix:** Input stays at its expanded height
5. **After fix:** Input shrinks back to single-line height