### PR TITLE
Exclude TinyMap and packAnimatedProps from the public C++ API

### DIFF
--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -306,17 +306,6 @@ struct pre_merge_jni_library {
   public int(*onload_func)(JNIEnv *, jclass);
 }
 
-template <typename KeyT, typename ValueT>
-class TinyMap {
-  public TinyMap::Iterator begin();
-  public TinyMap::Iterator end();
-  public TinyMap::Iterator find(KeyT key);
-  public using Iterator = TinyMap::Pair*;
-  public using Pair = std::pair<KeyT, ValueT>;
-  public void erase(TinyMap::Iterator iterator);
-  public void insert(TinyMap::Pair pair);
-}
-
 union jvalue {
   public jboolean z;
   public jbyte b;
@@ -11402,9 +11391,6 @@ struct facebook::react::dom::RNMeasureRect {
   public double x;
   public double y;
 }
-
-
-folly::dynamic facebook::react::animationbackend::packAnimatedProps(const facebook::react::AnimatedProps& animatedProps);
 
 
 static constexpr facebook::react::Tag facebook::react::animated::undefinedAnimatedNodeIdentifier;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -306,17 +306,6 @@ struct pre_merge_jni_library {
   public int(*onload_func)(JNIEnv *, jclass);
 }
 
-template <typename KeyT, typename ValueT>
-class TinyMap {
-  public TinyMap::Iterator begin();
-  public TinyMap::Iterator end();
-  public TinyMap::Iterator find(KeyT key);
-  public using Iterator = TinyMap::Pair*;
-  public using Pair = std::pair<KeyT, ValueT>;
-  public void erase(TinyMap::Iterator iterator);
-  public void insert(TinyMap::Pair pair);
-}
-
 union jvalue {
   public jboolean z;
   public jbyte b;
@@ -11258,9 +11247,6 @@ struct facebook::react::dom::RNMeasureRect {
   public double x;
   public double y;
 }
-
-
-folly::dynamic facebook::react::animationbackend::packAnimatedProps(const facebook::react::AnimatedProps& animatedProps);
 
 
 static constexpr facebook::react::Tag facebook::react::animated::undefinedAnimatedNodeIdentifier;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -3637,17 +3637,6 @@ struct YGValue {
   public float value;
 }
 
-template <typename KeyT, typename ValueT>
-class TinyMap {
-  public TinyMap::Iterator begin();
-  public TinyMap::Iterator end();
-  public TinyMap::Iterator find(KeyT key);
-  public using Iterator = TinyMap::Pair*;
-  public using Pair = std::pair<KeyT, ValueT>;
-  public void erase(TinyMap::Iterator iterator);
-  public void insert(TinyMap::Pair pair);
-}
-
 template <typename T>
 struct RCTRequired {
   public RCTRequired& operator=(RCTRequired&&) = default;
@@ -13684,9 +13673,6 @@ struct facebook::react::dom::RNMeasureRect {
 
 facebook::jsi::Value facebook::react::TurboModuleConvertUtils::convertObjCObjectToJSIValue(facebook::jsi::Runtime& runtime, id value);
 id facebook::react::TurboModuleConvertUtils::convertJSIValueToObjCObject(facebook::jsi::Runtime& runtime, const facebook::jsi::Value& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker, BOOL useNSNull = NO);
-
-
-folly::dynamic facebook::react::animationbackend::packAnimatedProps(const facebook::react::AnimatedProps& animatedProps);
 
 
 static const facebook::react::Color facebook::react::HostPlatformColor::UndefinedColor;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -3637,17 +3637,6 @@ struct YGValue {
   public float value;
 }
 
-template <typename KeyT, typename ValueT>
-class TinyMap {
-  public TinyMap::Iterator begin();
-  public TinyMap::Iterator end();
-  public TinyMap::Iterator find(KeyT key);
-  public using Iterator = TinyMap::Pair*;
-  public using Pair = std::pair<KeyT, ValueT>;
-  public void erase(TinyMap::Iterator iterator);
-  public void insert(TinyMap::Pair pair);
-}
-
 template <typename T>
 struct RCTRequired {
   public RCTRequired& operator=(RCTRequired&&) = default;
@@ -13550,9 +13539,6 @@ struct facebook::react::dom::RNMeasureRect {
 
 facebook::jsi::Value facebook::react::TurboModuleConvertUtils::convertObjCObjectToJSIValue(facebook::jsi::Runtime& runtime, id value);
 id facebook::react::TurboModuleConvertUtils::convertJSIValueToObjCObject(facebook::jsi::Runtime& runtime, const facebook::jsi::Value& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker, BOOL useNSNull = NO);
-
-
-folly::dynamic facebook::react::animationbackend::packAnimatedProps(const facebook::react::AnimatedProps& animatedProps);
 
 
 static const facebook::react::Color facebook::react::HostPlatformColor::UndefinedColor;

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -16,17 +16,6 @@ struct YGValue {
   public float value;
 }
 
-template <typename KeyT, typename ValueT>
-class TinyMap {
-  public TinyMap::Iterator begin();
-  public TinyMap::Iterator end();
-  public TinyMap::Iterator find(KeyT key);
-  public using Iterator = TinyMap::Pair*;
-  public using Pair = std::pair<KeyT, ValueT>;
-  public void erase(TinyMap::Iterator iterator);
-  public void insert(TinyMap::Pair pair);
-}
-
 
 bool facebook::xplat::jsArgAsBool(const folly::dynamic& args, size_t n);
 double facebook::xplat::jsArgAsDouble(const folly::dynamic& args, size_t n);
@@ -8460,9 +8449,6 @@ struct facebook::react::dom::RNMeasureRect {
   public double x;
   public double y;
 }
-
-
-folly::dynamic facebook::react::animationbackend::packAnimatedProps(const facebook::react::AnimatedProps& animatedProps);
 
 
 static constexpr facebook::react::Tag facebook::react::animated::undefinedAnimatedNodeIdentifier;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -16,17 +16,6 @@ struct YGValue {
   public float value;
 }
 
-template <typename KeyT, typename ValueT>
-class TinyMap {
-  public TinyMap::Iterator begin();
-  public TinyMap::Iterator end();
-  public TinyMap::Iterator find(KeyT key);
-  public using Iterator = TinyMap::Pair*;
-  public using Pair = std::pair<KeyT, ValueT>;
-  public void erase(TinyMap::Iterator iterator);
-  public void insert(TinyMap::Pair pair);
-}
-
 
 bool facebook::xplat::jsArgAsBool(const folly::dynamic& args, size_t n);
 double facebook::xplat::jsArgAsDouble(const folly::dynamic& args, size_t n);
@@ -8451,9 +8440,6 @@ struct facebook::react::dom::RNMeasureRect {
   public double x;
   public double y;
 }
-
-
-folly::dynamic facebook::react::animationbackend::packAnimatedProps(const facebook::react::AnimatedProps& animatedProps);
 
 
 static constexpr facebook::react::Tag facebook::react::animated::undefinedAnimatedNodeIdentifier;

--- a/scripts/cxx-api/config.yml
+++ b/scripts/cxx-api/config.yml
@@ -11,6 +11,8 @@ exclude_symbols:
   - "NativeReactNativeFeatureFlags"
   - "UnstableLegacy"
   - "Experimental"
+  - "TinyMap"
+  - "packAnimatedProps"
 
 platforms:
   ReactCommon:


### PR DESCRIPTION
Summary:
The TinyMap is a helper class under internal directory, not referenced anywhere in the snapshot, and considered unsafe (from the comment). It is not part of any module, so it is better to remove that from the snapshot.

The `packAnimatedProps` method is used in `AnimationBackend` for translation from `AnimatedProps` to `folly::dynamic` and should not be used outside of React Native. 

Changelog:
[Internal]

Differential Revision: D98907855


