### PR TITLE
Add instrumentation tests for FabricMountingManager view lifecycle (#56294)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -687,6 +687,10 @@ tasks.withType<KotlinCompile>().configureEach {
   exclude("com/facebook/annotationprocessors/**")
   exclude("com/facebook/react/processing/**")
   exclude("com/facebook/react/module/processing/**")
+  // These are instrumentation tests that require a device/emulator and native test
+  // libraries not available in the OSS Gradle build (Buck-only).
+  exclude("com/facebook/react/fabric/FabricMountingManagerInstrumentationTest.kt")
+  exclude("com/facebook/react/fabric/FabricMountingManagerTestHelper.kt")
 }
 
 dependencies {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -52,6 +52,15 @@ void FabricMountingManager::onSurfaceStop(SurfaceId surfaceId) {
   allocatedViewRegistry_.erase(surfaceId);
 }
 
+bool FabricMountingManager::isViewAllocated(SurfaceId surfaceId, Tag tag) {
+  std::lock_guard lock(allocatedViewsMutex_);
+  auto it = allocatedViewRegistry_.find(surfaceId);
+  if (it == allocatedViewRegistry_.end()) {
+    return false;
+  }
+  return it->second.count(tag) > 0;
+}
+
 namespace {
 
 #ifdef REACT_NATIVE_DEBUG

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -40,6 +40,20 @@ class FabricMountingManager final {
    */
   void drainPreallocateViewsQueue();
 
+  /*
+   * Preallocates a view on the Java side and registers the tag in
+   * allocatedViewRegistry_ so that executeMount skips the redundant Create
+   * mount item for this tag.
+   */
+  void preallocateShadowView(const ShadowView &shadowView);
+
+  /*
+   * Returns true if the given tag is registered in allocatedViewRegistry_
+   * for the given surface. A registered tag means executeMount will skip
+   * the Create mount item (the view was already preallocated).
+   */
+  bool isViewAllocated(SurfaceId surfaceId, Tag tag);
+
   void executeMount(const MountingTransaction &transaction);
 
   void dispatchCommand(const ShadowView &shadowView, const std::string &commandName, const folly::dynamic &args);
@@ -75,12 +89,6 @@ class FabricMountingManager final {
 
   std::unordered_map<SurfaceId, std::unordered_set<Tag>> allocatedViewRegistry_{};
   std::recursive_mutex allocatedViewsMutex_;
-
-  /*
-   * Calls FabricUIManager.preallocateView() on the Java side if view needs to
-   * be preallocated.
-   */
-  void preallocateShadowView(const ShadowView &shadowView);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/test_helper/FabricMountingManagerTestHelper.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/test_helper/FabricMountingManagerTestHelper.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "FabricMountingManagerTestHelper.h"
+
+#include <react/renderer/components/view/ViewComponentDescriptor.h>
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/ComponentDescriptor.h>
+#include <react/renderer/mounting/ShadowView.h>
+
+namespace facebook::react {
+
+FabricMountingManagerTestHelper::FabricMountingManagerTestHelper(
+    jni::alias_ref<JFabricUIManager::javaobject> jFabricUIManager)
+    : javaUIManager_(jni::make_global(jFabricUIManager)) {
+  mountingManager_ = std::make_shared<FabricMountingManager>(javaUIManager_);
+
+  auto params = ComponentDescriptorParameters{
+      .eventDispatcher = EventDispatcher::Shared{},
+      .contextContainer = std::make_shared<ContextContainer>(),
+      .flavor = nullptr};
+  viewComponentDescriptor_ = std::make_unique<ViewComponentDescriptor>(params);
+}
+
+void FabricMountingManagerTestHelper::initHybrid(
+    jni::alias_ref<jhybridobject> jobj,
+    jni::alias_ref<JFabricUIManager::javaobject> jFabricUIManager) {
+  setCxxInstance(jobj, jFabricUIManager);
+}
+
+void FabricMountingManagerTestHelper::startSurface(jint surfaceId) {
+  mountingManager_->onSurfaceStart(surfaceId);
+}
+
+void FabricMountingManagerTestHelper::stopSurface(jint surfaceId) {
+  mountingManager_->onSurfaceStop(surfaceId);
+}
+
+void FabricMountingManagerTestHelper::preallocateView(
+    jint surfaceId,
+    jint tag) {
+  ShadowView sv{};
+  sv.componentName = "View";
+  sv.surfaceId = surfaceId;
+  sv.tag = tag;
+  sv.props = std::make_shared<const ViewProps>();
+  sv.layoutMetrics.frame.size = {.width = 100, .height = 100};
+  mountingManager_->preallocateShadowView(sv);
+}
+
+void FabricMountingManagerTestHelper::destroyUnmountedView(
+    jint surfaceId,
+    jint tag) {
+  auto family = viewComponentDescriptor_->createFamily(
+      {.tag = tag, .surfaceId = surfaceId, .instanceHandle = nullptr});
+  mountingManager_->destroyUnmountedShadowNode(*family);
+}
+
+bool FabricMountingManagerTestHelper::isTagAllocated(jint surfaceId, jint tag) {
+  return mountingManager_->isViewAllocated(surfaceId, tag);
+}
+
+void FabricMountingManagerTestHelper::registerNatives() {
+  registerHybrid({
+      makeNativeMethod(
+          "initHybrid", FabricMountingManagerTestHelper::initHybrid),
+      makeNativeMethod(
+          "startSurface", FabricMountingManagerTestHelper::startSurface),
+      makeNativeMethod(
+          "stopSurface", FabricMountingManagerTestHelper::stopSurface),
+      makeNativeMethod(
+          "preallocateView", FabricMountingManagerTestHelper::preallocateView),
+      makeNativeMethod(
+          "destroyUnmountedView",
+          FabricMountingManagerTestHelper::destroyUnmountedView),
+      makeNativeMethod(
+          "isTagAllocated", FabricMountingManagerTestHelper::isTagAllocated),
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/test_helper/FabricMountingManagerTestHelper.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/test_helper/FabricMountingManagerTestHelper.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <react/renderer/components/view/ViewComponentDescriptor.h>
+
+#include <react/fabric/FabricMountingManager.h>
+
+namespace facebook::react {
+
+/**
+ * JNI test helper that wraps a real FabricMountingManager
+ */
+class FabricMountingManagerTestHelper : public jni::HybridClass<FabricMountingManagerTestHelper> {
+ public:
+  static constexpr auto kJavaDescriptor = "Lcom/facebook/react/fabric/FabricMountingManagerTestHelper;";
+
+  void startSurface(jint surfaceId);
+  void stopSurface(jint surfaceId);
+  void preallocateView(jint surfaceId, jint tag);
+  void destroyUnmountedView(jint surfaceId, jint tag);
+  bool isTagAllocated(jint surfaceId, jint tag);
+
+  static void registerNatives();
+
+ private:
+  friend HybridBase;
+
+  explicit FabricMountingManagerTestHelper(jni::alias_ref<JFabricUIManager::javaobject> jFabricUIManager);
+
+  static void initHybrid(
+      jni::alias_ref<jhybridobject> jobj,
+      jni::alias_ref<JFabricUIManager::javaobject> jFabricUIManager);
+
+  jni::global_ref<JFabricUIManager::javaobject> javaUIManager_;
+  std::shared_ptr<FabricMountingManager> mountingManager_;
+  std::unique_ptr<ViewComponentDescriptor> viewComponentDescriptor_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/test_helper/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/test_helper/OnLoad.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fbjni/fbjni.h>
+
+#include "FabricMountingManagerTestHelper.h"
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*unused*/) {
+  return facebook::jni::initialize(vm, [] {
+    facebook::react::FabricMountingManagerTestHelper::registerNatives();
+  });
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricMountingManagerInstrumentationTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricMountingManagerInstrumentationTest.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.fabric
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.facebook.react.ReactRootView
+import com.facebook.react.bridge.JSExceptionHandler
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.fabric.mounting.MountingManager
+import com.facebook.react.fabric.mounting.MountingManager.MountItemExecutor
+import com.facebook.react.fabric.mounting.mountitems.IntBufferBatchMountItem
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.uimanager.ViewManagerRegistry
+import com.facebook.react.uimanager.events.BatchEventDispatchedListener
+import com.facebook.react.views.view.ReactViewManager
+import com.facebook.soloader.SoLoader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+/**
+ * Instrumentation tests for [MountingManager] that run on a real Android device/emulator.
+ *
+ * These tests construct [IntBufferBatchMountItem] objects manually (the same format that C++
+ * executeMount serializes mutations into) and execute them against a [MountingManager]. This
+ * validates that the Java-side mount item dispatcher correctly handles the Create→Insert and
+ * Preallocate→Delete→Create→Insert sequences.
+ */
+@RunWith(AndroidJUnit4::class)
+class FabricMountingManagerInstrumentationTest {
+  private lateinit var mountingManager: MountingManager
+  private lateinit var themedReactContext: ThemedReactContext
+  private val surfaceId = 1
+
+  companion object {
+    @BeforeClass
+    @JvmStatic
+    fun setupClass() {
+      SoLoader.init(InstrumentationRegistry.getInstrumentation().targetContext, false)
+    }
+  }
+
+  @Before
+  fun setUp() {
+    ReactNativeFeatureFlagsForTests.setUp()
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val reactAppContext = mock(ReactApplicationContext::class.java)
+    themedReactContext = ThemedReactContext(reactAppContext, context, null, surfaceId)
+    mountingManager =
+        MountingManager(
+            ViewManagerRegistry(listOf<ViewManager<*, *>>(ReactViewManager())),
+            MountItemExecutor {},
+        )
+  }
+
+  @After
+  fun tearDown() {
+    ReactNativeFeatureFlags.dangerouslyReset()
+  }
+
+  private fun startSurface() {
+    val rootView = ReactRootView(themedReactContext)
+    mountingManager.startSurface(surfaceId, themedReactContext, rootView)
+  }
+
+  private fun createAndInsertMountItem(
+      reactTag: Int,
+      parentTag: Int,
+      index: Int,
+      componentName: String = "RCTView",
+  ): IntBufferBatchMountItem {
+    val intBuffer =
+        intArrayOf(
+            IntBufferBatchMountItem.INSTRUCTION_CREATE,
+            reactTag,
+            1,
+            IntBufferBatchMountItem.INSTRUCTION_INSERT,
+            reactTag,
+            parentTag,
+            index,
+        )
+    val objBuffer = arrayOf<Any?>(componentName, JavaOnlyMap.of(), null, null)
+    return IntBufferBatchMountItem(surfaceId, intBuffer, objBuffer, 1)
+  }
+
+  /** Basic test: CREATE + INSERT via IntBufferBatchMountItem produces a mounted view. */
+  @Test
+  fun executeMount_createAndInsert_producesView() {
+    startSurface()
+
+    val mountItem = createAndInsertMountItem(42, surfaceId, 0)
+    mountItem.execute(mountingManager)
+
+    val smm = mountingManager.getSurfaceManagerEnforced(surfaceId, "test")
+    assertThat(smm.getViewExists(42)).isTrue()
+    assertThat(smm.getView(42)).isNotNull()
+  }
+
+  /**
+   * Simulates the scenario fixed by D98729251 via IntBufferBatchMountItem:
+   * 1. Preallocate a view (simulates C++ preallocateShadowView calling Java preallocateView)
+   * 2. Delete it (simulates C++ destroyUnmountedShadowNode calling Java destroyUnmountedView)
+   * 3. CREATE + INSERT via batch mount item (simulates C++ executeMount after the fix erases from
+   *    allocatedViewRegistry_, so CREATE is included in the batch)
+   */
+  @Test
+  fun executeMount_createAfterPreallocateAndDelete_succeeds() {
+    startSurface()
+    val smm = mountingManager.getSurfaceManagerEnforced(surfaceId, "test")
+
+    smm.preallocateView("RCTView", 42, JavaOnlyMap.of(), null, true)
+    assertThat(smm.getViewExists(42)).isTrue()
+
+    smm.deleteView(42)
+    assertThat(smm.getViewExists(42)).isFalse()
+
+    val mountItem = createAndInsertMountItem(42, surfaceId, 0)
+    mountItem.execute(mountingManager)
+
+    assertThat(smm.getViewExists(42)).isTrue()
+    assertThat(smm.getView(42)).isNotNull()
+  }
+
+  /**
+   * Multiple tags go through preallocate → delete → recreate cycle. Simulates a concurrent render
+   * being superseded.
+   */
+  @Test
+  fun executeMount_multipleTagsRecycledAfterConcurrentRenderCancellation() {
+    startSurface()
+    val smm = mountingManager.getSurfaceManagerEnforced(surfaceId, "test")
+
+    for (tag in intArrayOf(42, 43, 44)) {
+      smm.preallocateView("RCTView", tag, JavaOnlyMap.of(), null, true)
+    }
+
+    for (tag in intArrayOf(42, 43, 44)) {
+      smm.deleteView(tag)
+      assertThat(smm.getViewExists(tag)).isFalse()
+    }
+
+    for ((index, tag) in intArrayOf(42, 43, 44).withIndex()) {
+      val mountItem = createAndInsertMountItem(tag, surfaceId, index)
+      mountItem.execute(mountingManager)
+      assertThat(smm.getViewExists(tag)).isTrue()
+      assertThat(smm.getView(tag)).isNotNull()
+    }
+  }
+
+  /**
+   * REMOVE + DELETE + CREATE + INSERT for the same tag in a single batch. Simulates full lifecycle
+   * during tree reconciliation.
+   */
+  @Test
+  fun executeMount_removeDeleteCreateInsert_sameTagInOneBatch() {
+    startSurface()
+    val smm = mountingManager.getSurfaceManagerEnforced(surfaceId, "test")
+
+    val initialMount = createAndInsertMountItem(42, surfaceId, 0)
+    initialMount.execute(mountingManager)
+    assertThat(smm.getView(42)).isNotNull()
+
+    val intBuffer =
+        intArrayOf(
+            IntBufferBatchMountItem.INSTRUCTION_REMOVE,
+            42,
+            surfaceId,
+            0,
+            IntBufferBatchMountItem.INSTRUCTION_DELETE,
+            42,
+            IntBufferBatchMountItem.INSTRUCTION_CREATE,
+            42,
+            1,
+            IntBufferBatchMountItem.INSTRUCTION_INSERT,
+            42,
+            surfaceId,
+            0,
+        )
+    val objBuffer = arrayOf<Any?>("RCTView", JavaOnlyMap.of(), null, null)
+    val batchMount = IntBufferBatchMountItem(surfaceId, intBuffer, objBuffer, 2)
+    batchMount.execute(mountingManager)
+
+    assertThat(smm.getViewExists(42)).isTrue()
+    assertThat(smm.getView(42)).isNotNull()
+  }
+
+  // ---- Native code tests via FabricMountingManagerTestHelper ----
+
+  private fun createTestHelper(): FabricMountingManagerTestHelper {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val reactAppContext = mock(ReactApplicationContext::class.java)
+    `when`(reactAppContext.applicationContext).thenReturn(context)
+    `when`(reactAppContext.exceptionHandler).thenReturn(JSExceptionHandler {})
+    val viewManagerRegistry = ViewManagerRegistry(listOf<ViewManager<*, *>>(ReactViewManager()))
+    val fabricUIManager =
+        FabricUIManager(reactAppContext, viewManagerRegistry, BatchEventDispatchedListener {})
+    return FabricMountingManagerTestHelper.create(fabricUIManager)
+  }
+
+  /**
+   * Exercises the real C++ FabricMountingManager::onSurfaceStart and verifies the surfaceId tag is
+   * registered in allocatedViewRegistry_.
+   */
+  @Test
+  fun native_startSurface_registersSurfaceTag() {
+    val helper = createTestHelper()
+    helper.startSurface(surfaceId)
+    assertThat(helper.isTagAllocated(surfaceId, surfaceId)).isTrue()
+  }
+
+  /**
+   * Exercises real C++ preallocateShadowView — verifies the tag is added to allocatedViewRegistry_.
+   */
+  @Test
+  fun native_preallocateView_addsToRegistry() {
+    val helper = createTestHelper()
+    helper.startSurface(surfaceId)
+    helper.preallocateView(surfaceId, 42)
+    assertThat(helper.isTagAllocated(surfaceId, 42)).isTrue()
+  }
+
+  /**
+   * Verifies that stopSurface clears the allocatedViewRegistry_ for the surface, even if views were
+   * preallocated.
+   */
+  @Test
+  fun native_stopSurface_clearsRegistry() {
+    val helper = createTestHelper()
+    helper.startSurface(surfaceId)
+    helper.preallocateView(surfaceId, 42)
+    assertThat(helper.isTagAllocated(surfaceId, 42)).isTrue()
+
+    helper.stopSurface(surfaceId)
+    assertThat(helper.isTagAllocated(surfaceId, 42)).isFalse()
+  }
+
+  @Test
+  fun native_destroyUnmountedView_removesFromAllocatedRegistry() {
+    val helper = createTestHelper()
+    helper.startSurface(surfaceId)
+    helper.preallocateView(surfaceId, 42)
+    assertThat(helper.isTagAllocated(surfaceId, 42)).isTrue()
+    helper.destroyUnmountedView(surfaceId, 42)
+    assertThat(helper.isTagAllocated(surfaceId, 42)).isFalse()
+  }
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricMountingManagerTestHelper.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricMountingManagerTestHelper.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.fabric
+
+import com.facebook.jni.HybridClassBase
+import com.facebook.soloader.SoLoader
+
+/**
+ * JNI test helper that wraps a real C++ [FabricMountingManager] to exercise native code paths
+ * around preallocateShadowView, destroyUnmountedShadowNode, and the allocatedViewRegistry_
+ * lifecycle.
+ */
+class FabricMountingManagerTestHelper private constructor(fabricUIManager: FabricUIManager) :
+    HybridClassBase() {
+
+  init {
+    initHybrid(fabricUIManager)
+  }
+
+  private external fun initHybrid(fabricUIManager: FabricUIManager)
+
+  external fun startSurface(surfaceId: Int)
+
+  external fun stopSurface(surfaceId: Int)
+
+  external fun preallocateView(surfaceId: Int, tag: Int)
+
+  external fun destroyUnmountedView(surfaceId: Int, tag: Int)
+
+  external fun isTagAllocated(surfaceId: Int, tag: Int): Boolean
+
+  companion object {
+    init {
+      SoLoader.loadLibrary("fabricjni")
+      SoLoader.loadLibrary("fabricjni_test_helper")
+    }
+
+    @JvmStatic
+    fun create(fabricUIManager: FabricUIManager): FabricMountingManagerTestHelper {
+      return FabricMountingManagerTestHelper(fabricUIManager)
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/SurfaceMountingManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/SurfaceMountingManagerTest.kt
@@ -115,4 +115,81 @@ class SurfaceMountingManagerTest {
     smm.createView("RCTView", 42, JavaOnlyMap.of(), null, null, true)
     assertThat(smm.getView(42)).isSameAs(viewBefore)
   }
+
+  /** Calling deleteView twice should not crash — second call logs a soft exception. */
+  @Test
+  fun deleteView_isIdempotent() {
+    val smm = startSurface()
+    smm.preallocateView("RCTView", 42, JavaOnlyMap.of(), null, true)
+    smm.deleteView(42)
+    smm.deleteView(42)
+    assertThat(smm.getViewExists(42)).isFalse()
+  }
+
+  /** createView works for a tag that was never preallocated (normal non-preallocated path). */
+  @Test
+  fun createView_afterDeleteWithoutPreallocate() {
+    val smm = startSurface()
+
+    smm.createView("RCTView", 42, JavaOnlyMap.of(), null, null, true)
+    assertThat(smm.getViewExists(42)).isTrue()
+
+    smm.deleteView(42)
+    assertThat(smm.getViewExists(42)).isFalse()
+
+    smm.createView("RCTView", 42, JavaOnlyMap.of(), null, null, true)
+    assertThat(smm.getViewExists(42)).isTrue()
+  }
+
+  /**
+   * Validates the fix works with multiple concurrent tag recycling — the real-world scenario with
+   * concurrent renders where several preallocated views are destroyed.
+   */
+  @Test
+  fun preallocateAndDeleteMultipleTags_thenRecreate() {
+    val smm = startSurface()
+
+    smm.preallocateView("RCTView", 42, JavaOnlyMap.of(), null, true)
+    smm.preallocateView("RCTView", 43, JavaOnlyMap.of(), null, true)
+    smm.preallocateView("RCTView", 44, JavaOnlyMap.of(), null, true)
+
+    smm.deleteView(42)
+    smm.deleteView(43)
+    smm.deleteView(44)
+
+    for (tag in intArrayOf(42, 43, 44)) {
+      assertThat(smm.getViewExists(tag)).isFalse()
+      smm.createView("RCTView", tag, JavaOnlyMap.of(), null, null, true)
+      assertThat(smm.getViewExists(tag)).isTrue()
+      smm.addViewAt(surfaceId, tag, 0)
+      assertThat(smm.getView(tag)).isNotNull()
+    }
+  }
+
+  /** Calling preallocateView twice with the same tag is a no-op (same view returned). */
+  @Test
+  fun preallocateView_isIdempotent() {
+    val smm = startSurface()
+
+    smm.preallocateView("RCTView", 42, JavaOnlyMap.of(), null, true)
+    val viewBefore = smm.getView(42)
+
+    smm.preallocateView("RCTView", 42, JavaOnlyMap.of(), null, true)
+    assertThat(smm.getView(42)).isSameAs(viewBefore)
+  }
+
+  /** preallocateView recreates a view after it was preallocated and then deleted. */
+  @Test
+  fun deleteView_thenPreallocateView_recreatesView() {
+    val smm = startSurface()
+
+    smm.preallocateView("RCTView", 42, JavaOnlyMap.of(), null, true)
+    assertThat(smm.getViewExists(42)).isTrue()
+
+    smm.deleteView(42)
+    assertThat(smm.getViewExists(42)).isFalse()
+
+    smm.preallocateView("RCTView", 42, JavaOnlyMap.of(), null, true)
+    assertThat(smm.getViewExists(42)).isTrue()
+  }
 }

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -2316,6 +2316,7 @@ class facebook::react::ExecutorDelegate {
 class facebook::react::FabricMountingManager {
   public FabricMountingManager(const facebook::react::FabricMountingManager&) = delete;
   public FabricMountingManager(jni::global_ref<JFabricUIManager::javaobject>& javaUIManager);
+  public bool isViewAllocated(facebook::react::SurfaceId surfaceId, facebook::react::Tag tag);
   public void destroyUnmountedShadowNode(const facebook::react::ShadowNodeFamily& family);
   public void dispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args);
   public void drainPreallocateViewsQueue();
@@ -2325,6 +2326,7 @@ class facebook::react::FabricMountingManager {
   public void onAnimationStarted();
   public void onSurfaceStart(facebook::react::SurfaceId surfaceId);
   public void onSurfaceStop(facebook::react::SurfaceId surfaceId);
+  public void preallocateShadowView(const facebook::react::ShadowView& shadowView);
   public void scheduleReactRevisionMerge(facebook::react::SurfaceId surfaceId);
   public void sendAccessibilityEvent(const facebook::react::ShadowView& shadowView, const std::string& eventType);
   public void setIsJSResponder(const facebook::react::ShadowView& shadowView, bool isJSResponder, bool blockNativeResponder);
@@ -3869,6 +3871,11 @@ class facebook::react::NativeToastAndroidSpecJSI : public facebook::react::JavaT
 
 class facebook::react::NativeVibrationSpecJSI : public facebook::react::JavaTurboModule {
   public NativeVibrationSpecJSI(const facebook::react::JavaTurboModule::InitParams& params);
+}
+
+class facebook::react::NativeViewTransition : public facebook::react::NativeViewTransitionCxxSpec<facebook::react::NativeViewTransition> {
+  public NativeViewTransition(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public std::optional<facebook::jsi::Object> getViewTransitionInstance(facebook::jsi::Runtime& rt, const std::string& name, const std::string& pseudo);
 }
 
 class facebook::react::NativeWebSocketModuleSpecJSI : public facebook::react::JavaTurboModule {
@@ -5657,6 +5664,7 @@ enum facebook::react::BlendMode {
   Multiply,
   Normal,
   Overlay,
+  PlusLighter,
   Saturation,
   Screen,
   SoftLight,
@@ -8921,6 +8929,12 @@ class facebook::react::NativeVibrationCxxSpec : public facebook::react::TurboMod
 }
 
 template <typename T>
+class facebook::react::NativeViewTransitionCxxSpec : public facebook::react::TurboModule {
+  protected NativeViewTransitionCxxSpec(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public static constexpr std::string_view kModuleName;
+}
+
+template <typename T>
 class facebook::react::NativeWebSocketModuleCxxSpec : public facebook::react::TurboModule {
   protected NativeWebSocketModuleCxxSpec(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
   public static constexpr std::string_view kModuleName;
@@ -10673,6 +10687,7 @@ class facebook::react::jsinspector_modern::RuntimeAgent {
   public const facebook::react::jsinspector_modern::ExecutionContextDescription& getExecutionContextDescription() const;
   public facebook::react::jsinspector_modern::RuntimeAgent::ExportedState getExportedState();
   public void notifyBindingCalled(const std::string& bindingName, const std::string& payload);
+  public void notifyFastRefreshComplete();
   public ~RuntimeAgent();
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -2314,6 +2314,7 @@ class facebook::react::ExecutorDelegate {
 class facebook::react::FabricMountingManager {
   public FabricMountingManager(const facebook::react::FabricMountingManager&) = delete;
   public FabricMountingManager(jni::global_ref<JFabricUIManager::javaobject>& javaUIManager);
+  public bool isViewAllocated(facebook::react::SurfaceId surfaceId, facebook::react::Tag tag);
   public void destroyUnmountedShadowNode(const facebook::react::ShadowNodeFamily& family);
   public void dispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args);
   public void drainPreallocateViewsQueue();
@@ -2323,6 +2324,7 @@ class facebook::react::FabricMountingManager {
   public void onAnimationStarted();
   public void onSurfaceStart(facebook::react::SurfaceId surfaceId);
   public void onSurfaceStop(facebook::react::SurfaceId surfaceId);
+  public void preallocateShadowView(const facebook::react::ShadowView& shadowView);
   public void scheduleReactRevisionMerge(facebook::react::SurfaceId surfaceId);
   public void sendAccessibilityEvent(const facebook::react::ShadowView& shadowView, const std::string& eventType);
   public void setIsJSResponder(const facebook::react::ShadowView& shadowView, bool isJSResponder, bool blockNativeResponder);
@@ -3866,6 +3868,11 @@ class facebook::react::NativeToastAndroidSpecJSI : public facebook::react::JavaT
 
 class facebook::react::NativeVibrationSpecJSI : public facebook::react::JavaTurboModule {
   public NativeVibrationSpecJSI(const facebook::react::JavaTurboModule::InitParams& params);
+}
+
+class facebook::react::NativeViewTransition : public facebook::react::NativeViewTransitionCxxSpec<facebook::react::NativeViewTransition> {
+  public NativeViewTransition(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public std::optional<facebook::jsi::Object> getViewTransitionInstance(facebook::jsi::Runtime& rt, const std::string& name, const std::string& pseudo);
 }
 
 class facebook::react::NativeWebSocketModuleSpecJSI : public facebook::react::JavaTurboModule {
@@ -5648,6 +5655,7 @@ enum facebook::react::BlendMode {
   Multiply,
   Normal,
   Overlay,
+  PlusLighter,
   Saturation,
   Screen,
   SoftLight,
@@ -8912,6 +8920,12 @@ class facebook::react::NativeVibrationCxxSpec : public facebook::react::TurboMod
 }
 
 template <typename T>
+class facebook::react::NativeViewTransitionCxxSpec : public facebook::react::TurboModule {
+  protected NativeViewTransitionCxxSpec(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public static constexpr std::string_view kModuleName;
+}
+
+template <typename T>
 class facebook::react::NativeWebSocketModuleCxxSpec : public facebook::react::TurboModule {
   protected NativeWebSocketModuleCxxSpec(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
   public static constexpr std::string_view kModuleName;
@@ -10529,6 +10543,7 @@ class facebook::react::jsinspector_modern::RuntimeAgent {
   public const facebook::react::jsinspector_modern::ExecutionContextDescription& getExecutionContextDescription() const;
   public facebook::react::jsinspector_modern::RuntimeAgent::ExportedState getExportedState();
   public void notifyBindingCalled(const std::string& bindingName, const std::string& payload);
+  public void notifyFastRefreshComplete();
   public ~RuntimeAgent();
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -6469,6 +6469,11 @@ class facebook::react::NativeVibrationSpecJSI : public facebook::react::ObjCTurb
   public NativeVibrationSpecJSI(const facebook::react::ObjCTurboModule::InitParams& params);
 }
 
+class facebook::react::NativeViewTransition : public facebook::react::NativeViewTransitionCxxSpec<facebook::react::NativeViewTransition> {
+  public NativeViewTransition(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public std::optional<facebook::jsi::Object> getViewTransitionInstance(facebook::jsi::Runtime& rt, const std::string& name, const std::string& pseudo);
+}
+
 class facebook::react::NativeWebSocketModuleSpecJSI : public facebook::react::ObjCTurboModule {
   public NativeWebSocketModuleSpecJSI(const facebook::react::ObjCTurboModule::InitParams& params);
 }
@@ -8262,6 +8267,7 @@ enum facebook::react::BlendMode {
   Multiply,
   Normal,
   Overlay,
+  PlusLighter,
   Saturation,
   Screen,
   SoftLight,
@@ -11296,6 +11302,12 @@ class facebook::react::NativeVibrationCxxSpec : public facebook::react::TurboMod
 }
 
 template <typename T>
+class facebook::react::NativeViewTransitionCxxSpec : public facebook::react::TurboModule {
+  protected NativeViewTransitionCxxSpec(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public static constexpr std::string_view kModuleName;
+}
+
+template <typename T>
 class facebook::react::NativeWebSocketModuleCxxSpec : public facebook::react::TurboModule {
   protected NativeWebSocketModuleCxxSpec(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
   public static constexpr std::string_view kModuleName;
@@ -12964,6 +12976,7 @@ class facebook::react::jsinspector_modern::RuntimeAgent {
   public const facebook::react::jsinspector_modern::ExecutionContextDescription& getExecutionContextDescription() const;
   public facebook::react::jsinspector_modern::RuntimeAgent::ExportedState getExportedState();
   public void notifyBindingCalled(const std::string& bindingName, const std::string& payload);
+  public void notifyFastRefreshComplete();
   public ~RuntimeAgent();
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -6466,6 +6466,11 @@ class facebook::react::NativeVibrationSpecJSI : public facebook::react::ObjCTurb
   public NativeVibrationSpecJSI(const facebook::react::ObjCTurboModule::InitParams& params);
 }
 
+class facebook::react::NativeViewTransition : public facebook::react::NativeViewTransitionCxxSpec<facebook::react::NativeViewTransition> {
+  public NativeViewTransition(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public std::optional<facebook::jsi::Object> getViewTransitionInstance(facebook::jsi::Runtime& rt, const std::string& name, const std::string& pseudo);
+}
+
 class facebook::react::NativeWebSocketModuleSpecJSI : public facebook::react::ObjCTurboModule {
   public NativeWebSocketModuleSpecJSI(const facebook::react::ObjCTurboModule::InitParams& params);
 }
@@ -8253,6 +8258,7 @@ enum facebook::react::BlendMode {
   Multiply,
   Normal,
   Overlay,
+  PlusLighter,
   Saturation,
   Screen,
   SoftLight,
@@ -11287,6 +11293,12 @@ class facebook::react::NativeVibrationCxxSpec : public facebook::react::TurboMod
 }
 
 template <typename T>
+class facebook::react::NativeViewTransitionCxxSpec : public facebook::react::TurboModule {
+  protected NativeViewTransitionCxxSpec(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public static constexpr std::string_view kModuleName;
+}
+
+template <typename T>
 class facebook::react::NativeWebSocketModuleCxxSpec : public facebook::react::TurboModule {
   protected NativeWebSocketModuleCxxSpec(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
   public static constexpr std::string_view kModuleName;
@@ -12830,6 +12842,7 @@ class facebook::react::jsinspector_modern::RuntimeAgent {
   public const facebook::react::jsinspector_modern::ExecutionContextDescription& getExecutionContextDescription() const;
   public facebook::react::jsinspector_modern::RuntimeAgent::ExportedState getExportedState();
   public void notifyBindingCalled(const std::string& bindingName, const std::string& payload);
+  public void notifyFastRefreshComplete();
   public ~RuntimeAgent();
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -2519,6 +2519,11 @@ class facebook::react::NativeToJsBridge {
   public void* getJavaScriptContext();
 }
 
+class facebook::react::NativeViewTransition : public NativeViewTransitionCxxSpec<facebook::react::NativeViewTransition> {
+  public NativeViewTransition(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public std::optional<facebook::jsi::Object> getViewTransitionInstance(facebook::jsi::Runtime& rt, const std::string& name, const std::string& pseudo);
+}
+
 class facebook::react::NetworkReporter {
   public bool isDebuggingEnabled() const;
   public static facebook::react::NetworkReporter& getInstance();
@@ -4053,6 +4058,7 @@ enum facebook::react::BlendMode {
   Multiply,
   Normal,
   Overlay,
+  PlusLighter,
   Saturation,
   Screen,
   SoftLight,
@@ -7744,6 +7750,7 @@ class facebook::react::jsinspector_modern::RuntimeAgent {
   public const facebook::react::jsinspector_modern::ExecutionContextDescription& getExecutionContextDescription() const;
   public facebook::react::jsinspector_modern::RuntimeAgent::ExportedState getExportedState();
   public void notifyBindingCalled(const std::string& bindingName, const std::string& payload);
+  public void notifyFastRefreshComplete();
   public ~RuntimeAgent();
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -2516,6 +2516,11 @@ class facebook::react::NativeToJsBridge {
   public void* getJavaScriptContext();
 }
 
+class facebook::react::NativeViewTransition : public NativeViewTransitionCxxSpec<facebook::react::NativeViewTransition> {
+  public NativeViewTransition(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
+  public std::optional<facebook::jsi::Object> getViewTransitionInstance(facebook::jsi::Runtime& rt, const std::string& name, const std::string& pseudo);
+}
+
 class facebook::react::NetworkReporter {
   public bool isDebuggingEnabled() const;
   public static facebook::react::NetworkReporter& getInstance();
@@ -4044,6 +4049,7 @@ enum facebook::react::BlendMode {
   Multiply,
   Normal,
   Overlay,
+  PlusLighter,
   Saturation,
   Screen,
   SoftLight,
@@ -7735,6 +7741,7 @@ class facebook::react::jsinspector_modern::RuntimeAgent {
   public const facebook::react::jsinspector_modern::ExecutionContextDescription& getExecutionContextDescription() const;
   public facebook::react::jsinspector_modern::RuntimeAgent::ExportedState getExportedState();
   public void notifyBindingCalled(const std::string& bindingName, const std::string& payload);
+  public void notifyFastRefreshComplete();
   public ~RuntimeAgent();
 }
 

--- a/scripts/cxx-api/config.yml
+++ b/scripts/cxx-api/config.yml
@@ -4,6 +4,7 @@ exclude_patterns:
   - "*/ReactCommon/react/featureflags/*"
   - "*/test_utils/*"
   - "*/test/*"
+  - "*/test_helper/*"
   - "*/stubs/*"
 
 exclude_symbols:


### PR DESCRIPTION
Summary:

Add Android instrumentation tests that validate the Java-side and C++ registry
behavior around view preallocation, destruction, and recreation — the core
scenario fixed by D98729251.

Two layers of tests:

1. **Java-side tests** (IntBufferBatchMountItem): Construct mount item int/obj
   buffers manually and execute against MountingManager. Validates CREATE→INSERT
   and Preallocate→Delete→CREATE→INSERT sequences through the Java mount system.

2. **Native registry tests** (FabricMountingManagerTestHelper): JNI hybrid class
   that creates a real C++ FabricMountingManager and exercises the
   allocatedViewRegistry_ lifecycle. Validates that after preallocate + destroy,
   the tag is removed from the registry (the D98729251 fix), so executeMount
   would correctly emit a CREATE instruction.

The native test helper is built as a separate library (libfabricjni_test_helper.so)
under jni/react/fabric/test/, with friend access to FabricMountingManager internals.

Changelog: [Internal]

Reviewed By: Abbondanzo

Differential Revision: D98935855


