### PR TITLE
Add React-Core-prebuilt and ReactNativeDependencies to pod update command (#56297)

### DIFF
--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -75,6 +75,7 @@ runs:
         cd packages/rn-tester
 
         bundle install
+        bundle exec pod install --no-repo-update
         bundle exec pod update hermes-engine --no-repo-update
     - name: Build RNTester
       shell: bash


### PR DESCRIPTION
Summary:

React-Core-prebuilt and ReactNativeDependencies are new prebuilt pods that may not exist in the checked-in Podfile.lock. When CI runs `pod update hermes-engine`, CocoaPods resolves all pods in the Podfile, but `pod update` cannot handle pods that aren't already installed in the sandbox — it fails with "Pods React-Core-prebuilt, ReactNativeDependencies are not installed and cannot be updated".

This error is seen in CI jobs when updating to a new RC tag in a release branch; https://github.com/facebook/react-native/actions/runs/23755047813/job/69243975080

The fix splits the CocoaPods step into two commands:
1. `pod install` — installs all pods from the Podfile, including any new prebuilt pods not yet in the Podfile.lock
2. `pod update hermes-engine` — unlocks and updates hermes-engine to the nightly version (needed because `pod install` respects the locked version in Podfile.lock)

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D98989657
