### PR TITLE
Fix RefreshControl jest mock to forward props

### DIFF
--- a/packages/jest-preset/jest/RefreshControlMock.js
+++ b/packages/jest-preset/jest/RefreshControlMock.js
@@ -10,20 +10,20 @@
 
 'use strict';
 
+import type {RefreshControlProps} from 'react-native/Libraries/Components/RefreshControl/RefreshControl';
 import type {HostComponent} from 'react-native/src/private/types/HostComponent';
 
 import * as React from 'react';
 import requireNativeComponent from 'react-native/Libraries/ReactNative/requireNativeComponent';
 
-const RCTRefreshControl: HostComponent<{}> = requireNativeComponent<{}>(
-  'RCTRefreshControl',
-);
+const RCTRefreshControl: HostComponent<RefreshControlProps> =
+  requireNativeComponent<RefreshControlProps>('RCTRefreshControl');
 
-export default class RefreshControlMock extends React.Component<{...}> {
+export default class RefreshControlMock extends React.Component<RefreshControlProps> {
   static latestRef: ?RefreshControlMock;
 
   render(): React.Node {
-    return <RCTRefreshControl />;
+    return <RCTRefreshControl {...this.props} />;
   }
 
   componentDidMount() {

--- a/packages/jest-preset/jest/mocks/RefreshControl.js
+++ b/packages/jest-preset/jest/mocks/RefreshControl.js
@@ -14,15 +14,14 @@ import type {HostComponent} from 'react-native/src/private/types/HostComponent';
 import * as React from 'react';
 import requireNativeComponent from 'react-native/Libraries/ReactNative/requireNativeComponent';
 
-const RCTRefreshControl: HostComponent<{}> = requireNativeComponent<{}>(
-  'RCTRefreshControl',
-);
+const RCTRefreshControl: HostComponent<RefreshControlProps> =
+  requireNativeComponent<RefreshControlProps>('RCTRefreshControl');
 
 export default class RefreshControlMock extends React.Component<RefreshControlProps> {
   static latestRef: ?RefreshControlMock;
 
   render(): React.Node {
-    return <RCTRefreshControl />;
+    return <RCTRefreshControl {...this.props} />;
   }
 
   componentDidMount() {


### PR DESCRIPTION
## Summary:

The `RefreshControl` jest mock renders `<RCTRefreshControl />` without forwarding any props. This is inconsistent with the `ScrollView` mock, which spreads `{...this.props}` to its native component.

This has two consequences:

1. **The rendered RefreshControl is invisible to RNTL host queries.** Props like `testID` and `accessibilityLabel` are not forwarded to the native component, so `getByTestId`, `getByLabelText`, etc. cannot find it. The only way to locate it is `UNSAFE_getByType`.

2. **Props transformed internally by wrapper components are inaccessible.** When a component wraps `RefreshControl` and transforms props before passing them down (e.g. wrapping `onRefresh` with throttle/debounce), the rendered native component should receive the transformed props. But since the mock discards all props, there is no way to access the transformed values without `UNSAFE_getByType`. The [RNTL-recommended pattern](https://github.com/callstack/react-native-testing-library/issues/809#issuecomment-984823700) of `list.props.refreshControl.props.onRefresh()` only gives the original untransformed props from the React element descriptor.

The fix spreads `this.props` onto `RCTRefreshControl` in both mock files, matching how the ScrollView mock already works. The `HostComponent` generic is also updated from `{}` to `RefreshControlProps` for proper typing.

## Changelog:

[GENERAL] [FIXED] - Forward props in RefreshControl jest mock to make testID, onRefresh, and other props visible to testing library queries

## Test Plan:

Before this change, rendering a `RefreshControl` with `testID="my-control"` produces:

```
<RCTRefreshControl />
```

After this change:

```
<RCTRefreshControl testID="my-control" onRefresh={[Function]} refreshing={false} ... />
```

This enables standard RNTL queries:

```js
screen.getByTestId('my-control').props.onRefresh();
```

Instead of requiring:

```js
screen.UNSAFE_getByType(RefreshControl).props.onRefresh();
```