### PR TITLE
fix: guard against duplicate Fusebox DevTools dispatcher initialization

### DIFF
--- a/packages/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js
@@ -105,9 +105,11 @@ class FuseboxReactDevToolsDispatcher {
   }
 }
 
-Object.defineProperty(global, '__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__', {
-  value: FuseboxReactDevToolsDispatcher,
-  configurable: false,
-  enumerable: false,
-  writable: false,
-});
+if (global.__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__ == null) {
+  Object.defineProperty(global, '__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__', {
+    value: FuseboxReactDevToolsDispatcher,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When using Expo dev client, switching the app from background to foreground can cause TypeError: property is not writable in setUpFuseboxReactDevToolsDispatcher.js .

This issue only affects development builds - production builds are not affected because:

1. setUpFuseboxReactDevToolsDispatcher.js is only loaded in __DEV__ mode
2. Metro HMR is not available in production builds
The issue occurs because Metro HMR may invalidate module cache during foreground transitions, causing setUpDefaultReactNativeEnvironment to be re-executed and its initialized guard to be reset. This leads to Object.defineProperty on __FUSEBOX_REACT_DEVTOOLS_DISPATCHER__ running twice with configurable: false and writable: false , which throws an error.

Root cause:

1. App goes to background → Metro HMR WebSocket disconnects
2. App returns to foreground → WebSocket reconnects
3. Metro sends "update" message to sync state (even if no code changed)
4. HMR client re-evaluates modules via eval()
5. setUpDefaultReactNativeEnvironment.js is re-evaluated, initialized flag is reset
6. setUpFuseboxReactDevToolsDispatcher.js runs again
7. Object.defineProperty fails because property already exists with configurable: false
The fix makes the property definition idempotent by checking if it already exists before defining it.

error log
```
ERROR  ExceptionsManager should be set up after React DevTools to avoid console.error arguments mutation 
Code: construct.js
  2 | var setPrototypeOf = require("./setPrototypeOf.js");
  3 | function _construct(t, e, r) {
> 4 |   if (isNativeReflectConstruct()) return Reflect.construct.apply(null, arguments);
    |                                                                 ^
  5 |   var o = [null];
  6 |   o.push.apply(o, e);
  7 |   var p = new (t.bind.apply(t, o))();
Call Stack
  construct (xxx/<native>)
  apply (xxx/<native>)
  _construct (xxx/node_modules/@babel/runtime/helpers/construct.js:4:65)
  Wrapper (xxx/node_modules/@babel/runtime/helpers/wrapNativeSuper.js:15:14)
  construct (xxx/<native>)
  _callSuper (xxx/node_modules/@babel/runtime/helpers/callSuper.js:5:108)
  NamelessError (xxx/node_modules/@expo/metro-runtime/src/metroServerLogs.native.ts:102:20)
  captureCurrentStack (xxx/node_modules/@expo/metro-runtime/src/metroServerLogs.native.ts:106:27)
  HMRClient.log (xxx/node_modules/@expo/metro-runtime/src/metroServerLogs.native.ts:39:79)
  console.level (xxx/node_modules/react-native/Libraries/Core/setUpDeveloperTools.js:41:24)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Core/setUpReactDevTools.js:26:18)
  setUpDefaltReactNativeEnvironment (node_modules/expo/node_modules/react-native/src/private/setup/setUpDefaultReactNativeEnvironment.js:28:12)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Core/InitializeCore.js:31:78)
  <global> (node_modules/expo/node_modules/react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore.js:11)
  <anonymous> (node_modules/expo/node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js:13872:12)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js:16837:4)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Renderer/shims/ReactFabric.js:22:24)
  renderElement (node_modules/expo/node_modules/react-native/Libraries/ReactNative/RendererImplementation.js:37:12)
  renderApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/renderApplication.js:102:25)
  runnables.appKey (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:89:22)
  runApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:178:20)
 ERROR  [TypeError: property is not writable] 
Code: setUpFuseboxReactDevToolsDispatcher.js
  106 | }
  107 |
> 108 | Object.defineProperty(global, '__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__', {
      |                      ^
  109 |   value: FuseboxReactDevToolsDispatcher,
  110 |   configurable: false,
  111 |   enumerable: false,
Call Stack
  defineProperty (xxx/<native>)
  <global> (node_modules/expo/node_modules/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js:108:22)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Core/setUpReactDevTools.js:34:10)
  setUpDefaltReactNativeEnvironment (node_modules/expo/node_modules/react-native/src/private/setup/setUpDefaultReactNativeEnvironment.js:28:12)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Core/InitializeCore.js:31:78)
  <global> (node_modules/expo/node_modules/react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore.js:11)
  <anonymous> (node_modules/expo/node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js:13872:12)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js:16837:4)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Renderer/shims/ReactFabric.js:22:24)
  renderElement (node_modules/expo/node_modules/react-native/Libraries/ReactNative/RendererImplementation.js:37:12)
  renderApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/renderApplication.js:102:25)
  runnables.appKey (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:89:22)
  runApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:178:20)
 ERROR  [TypeError: Cannot read property 'default' of undefined] 
Code: RendererImplementation.js
  35 | }): void {
  36 |   if (useFabric) {
> 37 |     require('../Renderer/shims/ReactFabric').default.render(
     |                                             ^
  38 |       element,
  39 |       rootTag,
  40 |       null,
Call Stack
  renderElement (node_modules/expo/node_modules/react-native/Libraries/ReactNative/RendererImplementation.js:37:45)
  renderApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/renderApplication.js:102:25)
  runnables.appKey (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:89:22)
  runApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:178:20)
 ERROR  [TypeError: property is not writable] 
Code: setUpFuseboxReactDevToolsDispatcher.js
  106 | }
  107 |
> 108 | Object.defineProperty(global, '__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__', {
      |                      ^
  109 |   value: FuseboxReactDevToolsDispatcher,
  110 |   configurable: false,
  111 |   enumerable: false,
Call Stack
  defineProperty (xxx/<native>)
  <global> (node_modules/expo/node_modules/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js:108:22)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Core/setUpReactDevTools.js:34:10)
  setUpDefaltReactNativeEnvironment (node_modules/expo/node_modules/react-native/src/private/setup/setUpDefaultReactNativeEnvironment.js:28:12)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Core/InitializeCore.js:31:78)
  <global> (node_modules/expo/node_modules/react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore.js:11)
  <anonymous> (node_modules/expo/node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js:13872:12)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js:16837:4)
  <global> (node_modules/expo/node_modules/react-native/Libraries/Renderer/shims/ReactFabric.js:22:24)
  renderElement (node_modules/expo/node_modules/react-native/Libraries/ReactNative/RendererImplementation.js:37:12)
  renderApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/renderApplication.js:102:25)
  runnables.appKey (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:89:22)
  runApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:178:20)
 ERROR  [TypeError: Cannot read property 'default' of undefined] 
Code: RendererImplementation.js
  35 | }): void {
  36 |   if (useFabric) {
> 37 |     require('../Renderer/shims/ReactFabric').default.render(
     |                                             ^
  38 |       element,
  39 |       rootTag,
  40 |       null,
Call Stack
  renderElement (node_modules/expo/node_modules/react-native/Libraries/ReactNative/RendererImplementation.js:37:45)
  renderApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/renderApplication.js:102:25)
  runnables.appKey (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:89:22)
  runApplication (node_modules/expo/node_modules/react-native/Libraries/ReactNative/AppRegistryImpl.js:178:20)
```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Guard against duplicate Fusebox DevTools dispatcher initialization during HMR reconnection

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Applied the fix as a patch to the affected app. After patching, the error no longer occurs during background/foreground transitions.
