### PR TITLE
Allow RCTScrollViewComponentView to be subclass-able (#56319)

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Returns an actual UIScrollView that this component uses under the hood.
  */
-@property (nonatomic, strong, readonly) UIScrollView *scrollView;
+@property (nonatomic, strong, readwrite) UIScrollView *scrollView;
 
 /** Focus area of newly-activated text input relative to the window to compare against UIKeyboardFrameBegin/End */
 @property (nonatomic, assign) CGRect firstResponderFocus;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -1987,8 +1987,8 @@ interface RCTScrollView : public RCTView <UIScrollViewDelegate, RCTScrollablePro
 interface RCTScrollViewComponentView {
   protected  __pad0__;
   public @property (assign) CGRect firstResponderFocus;
+  public @property (strong) UIScrollView* scrollView;
   public @property (strong, readonly) RCTGenericDelegateSplitter<id<UIScrollViewDelegate>>* scrollViewDelegateSplitter;
-  public @property (strong, readonly) UIScrollView* scrollView;
   public @property (strong, readonly) UIView* containerView;
   public @property (weak) UIView* firstResponderViewOutsideScrollView;
   public virtual static _Nullable RCTScrollViewComponentView* findScrollViewComponentViewForView:(UIView* view);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -1987,8 +1987,8 @@ interface RCTScrollView : public RCTView <UIScrollViewDelegate, RCTScrollablePro
 interface RCTScrollViewComponentView {
   protected  __pad0__;
   public @property (assign) CGRect firstResponderFocus;
+  public @property (strong) UIScrollView* scrollView;
   public @property (strong, readonly) RCTGenericDelegateSplitter<id<UIScrollViewDelegate>>* scrollViewDelegateSplitter;
-  public @property (strong, readonly) UIScrollView* scrollView;
   public @property (strong, readonly) UIView* containerView;
   public @property (weak) UIView* firstResponderViewOutsideScrollView;
   public virtual static _Nullable RCTScrollViewComponentView* findScrollViewComponentViewForView:(UIView* view);


### PR DESCRIPTION
Summary:

While RCTScrollViewComponentView is overridable, its NOT a UIScrollView. It has a private property this is the scroll view and if you want to override UIScrollView behavior you have to change this.

Changelog: [Internal]

Reviewed By: sbuggay

Differential Revision: D99462381
