### PR TITLE
Fix Android onTextLayout reporting extra lines when width is fractional

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -637,7 +637,7 @@ internal object TextLayoutManager {
 
     val layoutWidth =
         when (widthYogaMeasureMode) {
-          YogaMeasureMode.EXACTLY -> floor(width).toInt()
+          YogaMeasureMode.EXACTLY -> ceil(width).toInt()
           YogaMeasureMode.AT_MOST -> min(desiredWidth, floor(width).toInt())
           else -> desiredWidth
         }


### PR DESCRIPTION

Hi, I found a bug while investigating `onTextLayout` behavior on Android and would love any feedback on the approach.

---

`onTextLayout` incorrectly reports a single visual line as multiple lines on Android when `<Text>` is placed next to a `flexGrow: 1` sibling.

```jsx
<View style={{ flexDirection: 'row' }}>
  <View style={{ flexGrow: 1 }} />
  <Text onTextLayout={e => console.log(e.nativeEvent.lines)}>
    Welcome!
  </Text>
</View>

// Before: lines → [{text: "Welcome"}, {text: "!"}]  ← 2 lines (incorrect)
// After:  lines → [{text: "Welcome!"}]               ← 1 line  (correct)
```

---

### What I Found

After digging into the code, I believe the root cause is in `TextLayoutManager.kt`. When `onTextLayout` is present, `measureLines()` is called (via JNI from `FabricUIManager`) and creates a **separate** `StaticLayout` purely for measurement — independent of the one `TextView` uses for rendering.

In the pre-Android 15 path, `EXACTLY` mode computes the `StaticLayout` width using `floor(width)`:

```kotlin
// TextLayoutManager.kt line 633 (before fix)
YogaMeasureMode.EXACTLY -> floor(width).toInt()
```

When `width` (the Yoga-allocated pixel value) has a fractional part — which is common on non-integer density devices like Pixel 4 (density=2.75) or Galaxy series (density=3.5) — `floor()` produces a `StaticLayout` that is **1px narrower** than what `TextView` actually renders with.

This causes the two `StaticLayout`s to disagree on line breaks:

```
Yoga allocated width = 240.6px

  measureLines StaticLayout  →  floor(240.6) = 240px  →  "Welcome" / "!"  (2 lines)
  TextView rendering         →  getMeasuredWidth() = 241px  →  "Welcome!"  (1 line)

onTextLayout fires from the measureLines StaticLayout
→ reports 2 lines even though the text visually renders as 1 line
```

The `flexGrow: 1` sibling seems to amplify this because Yoga's flex distribution applies `Math.round()` when allocating pixel widths, which more frequently produces fractional remainders that trigger this rounding discrepancy.

---

### Proposed Fix

Changing `floor` to `ceil` for `EXACTLY` mode in the pre-Android 15 path:

```kotlin
// TextLayoutManager.kt (after fix)
YogaMeasureMode.EXACTLY -> ceil(width).toInt()
```

I believe this aligns the `measureLines` `StaticLayout` width with the actual rendered width. Please let me know if there's a better approach or if I'm missing something.

---

### iOS Comparison

While investigating, I noticed that the iOS equivalent (`RCTTextLayoutManager.mm`) has always used `ceil()`:

```objc
// RCTTextLayoutManager.mm line 391
size = (CGSize){
    ceil(size.width  * layoutContext.pointScaleFactor) / layoutContext.pointScaleFactor,
    ceil(size.height * layoutContext.pointScaleFactor) / layoutContext.pointScaleFactor
};
```

iOS also uses `CGFloat` throughout the layout pipeline without integer pixel conversion, so this class of rounding issue doesn't occur there. This change seemed to bring Android's behavior in line with iOS.


### Changelog:

[ANDROID] [FIXED] - Fix `onTextLayout` reporting incorrect line splits for single-line text in flex layouts

### Test Plan:

**Setup:** On Android, render a `<Text>` with `onTextLayout` next to a `flexGrow: 1` sibling in a row, and log (or display) the `lines` payload.

```jsx
<View style={{ flexDirection: 'row' }}>
  <View style={{ flexGrow: 1 }} />
  <Text onTextLayout={e => console.log(e.nativeEvent.lines)}>
    Welcome!
  </Text>
</View>
```

Steps:

1. Run on an Android device or emulator (prefer a non-integer density device such as Pixel 4 at 2.75x or a Galaxy-class device at 3.5x, where Yoga often yields fractional pixel widths).
2. Wait for the layout to settle and onTextLayout to fire.
3. Inspect lines.length and each line.text (e.g. via Logcat).

Before fix: The string visually fits on one line, but onTextLayout reports two lines with text split like "Welcome" and "!".

After fix: lines matches what is rendered: one line whose text is the full "Welcome!".

### Related issues for context:

- https://github.com/facebook/react-native/issues/54552