### PR TITLE
[GENERAL][FIXED] - Fix WHATWG spec violations in URL and URLSearchParams polyfills

### DIFF
--- a/packages/react-native/Libraries/Blob/URL.js
+++ b/packages/react-native/Libraries/Blob/URL.js
@@ -123,8 +123,8 @@ export class URL {
   }
 
   get hash(): string {
-    const hashMatch = this._url.match(/#([^/]*)/);
-    return hashMatch ? `#${hashMatch[1]}` : '';
+    const hashIndex = this._url.indexOf('#');
+    return hashIndex !== -1 ? this._url.slice(hashIndex) : '';
   }
 
   get host(): string {

--- a/packages/react-native/Libraries/Blob/URLSearchParams.js
+++ b/packages/react-native/Libraries/Blob/URLSearchParams.js
@@ -14,7 +14,11 @@ export class URLSearchParams {
   _searchParams: Map<string, string[]> = new Map();
 
   get size(): number {
-    return this._searchParams.size;
+    let count = 0;
+    for (const values of this._searchParams.values()) {
+      count += values.length;
+    }
+    return count;
   }
 
   constructor(params?: Record<string, string> | string | [string, string][]) {
@@ -33,9 +37,11 @@ export class URLSearchParams {
           if (!pair) {
             return;
           }
-          const [key, value] = pair
-            .split('=')
-            .map(part => decodeURIComponent(part.replace(/\+/g, ' ')));
+          const eqIndex = pair.indexOf('=');
+          const rawKey = eqIndex === -1 ? pair : pair.slice(0, eqIndex);
+          const rawValue = eqIndex === -1 ? '' : pair.slice(eqIndex + 1);
+          const key = decodeURIComponent(rawKey.replace(/\+/g, ' '));
+          const value = decodeURIComponent(rawValue.replace(/\+/g, ' '));
           this.append(key, value);
         });
     } else if (Array.isArray(params)) {

--- a/packages/react-native/Libraries/Blob/__tests__/URL-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/URL-test.js
@@ -110,7 +110,7 @@ describe('URL', function () {
       ['key1', 'value2'],
       ['key2', 'value3'],
     ]);
-    expect(paramsFromArray.size).toBe(2);
+    expect(paramsFromArray.size).toBe(3);
     expect(paramsFromArray.getAll('key1')).toEqual(['value1', 'value2']);
     expect(paramsFromArray.get('key2')).toBe('value3');
 


### PR DESCRIPTION
## Summary

Three spec violations in the `URL` and `URLSearchParams` polyfills (`Libraries/Blob/`):

1. **`URLSearchParams.size`** returned the number of unique keys (`Map.size`) instead of the total number of name-value pairs. Per [WHATWG spec](https://url.spec.whatwg.org/#dom-urlsearchparams-size), `.size` must return the list's total size.

2. **`URLSearchParams` string constructor** split on every `=` character, silently dropping parts of values containing `=` (e.g. base64 tokens, JWTs). Per [WHATWG spec](https://url.spec.whatwg.org/#concept-urlencoded-parser), only the first `=` is the key-value separator.

3. **`URL.hash`** getter used a regex `/#([^/]*)/` that stopped matching at `/`, breaking fragment identifiers like `#/users/123` common in SPA hash-routing. Per [WHATWG spec](https://url.spec.whatwg.org/#dom-url-hash), the hash includes everything from `#` to end of string.

## Changelog:

[General] [Fixed] - Fix WHATWG spec violations in URL and URLSearchParams polyfills

## Test Plan

- Updated existing test: `URLSearchParams` constructed from array with duplicate keys now expects `size` to be `3` (total pairs) instead of `2` (unique keys).
- All existing tests pass: `yarn jest packages/react-native/Libraries/Blob/__tests__/URL-test.js`
- Prettier and ESLint checks pass.
- Verified browser behavior matches the fix:

```js
// Browser console (Chrome/Firefox/Safari):
new URLSearchParams([['a','1'],['a','2'],['b','3']]).size // 3
new URLSearchParams('token=abc=def').get('token')         // 'abc=def'
new URL('https://example.com/#/users/123').hash           // '#/users/123'
```