### PR TITLE
[General] [Fixed] - Fix missing format specifier in renderApplication invariant

### DIFF
--- a/packages/react-native/Libraries/ReactNative/renderApplication.js
+++ b/packages/react-native/Libraries/ReactNative/renderApplication.js
@@ -44,7 +44,7 @@ export default function renderApplication<Props extends Object>(
   displayMode?: ?DisplayModeType,
   useOffscreen?: boolean,
 ) {
-  invariant(rootTag, 'Expect to have a valid rootTag, instead got ', rootTag);
+  invariant(rootTag, 'Expect to have a valid rootTag, instead got %s', rootTag);
 
   const performanceLogger = scopedPerformanceLogger ?? GlobalPerformanceLogger;
 


### PR DESCRIPTION
## Summary

The `invariant` call in `renderApplication` passes `rootTag` as a substitution argument, but the format string has no `%s` placeholder. When the invariant fails, the error message reads:

```
Expect to have a valid rootTag, instead got
```

instead of:

```
Expect to have a valid rootTag, instead got null
```

The value is silently dropped, making the error less useful for debugging.

## Changelog:

[General] [Fixed] - Fix missing format specifier in renderApplication invariant

## Test Plan

- Verified with `invariant` directly: without `%s` the third argument is ignored, with `%s` it is substituted into the message.
- Prettier and ESLint checks pass.