### PR TITLE
Preserve Expo-generated modulemap in replace-rncore-version.js

### DIFF
--- a/packages/react-native/scripts/replace-rncore-version.js
+++ b/packages/react-native/scripts/replace-rncore-version.js
@@ -145,15 +145,20 @@ function replaceRNCoreConfiguration(
       }
     }
 
-    // Restore Expo-generated modulemap after directory replacement
-    if (savedModulemap != null) {
-      const restoredPath = path.join(finalLocation, useFrameworksModulemapName);
-      fs.writeFileSync(restoredPath, savedModulemap);
-      console.log('Restored', useFrameworksModulemapName);
-    }
   } finally {
     // Clean up temp directory
     fs.rmSync(tmpDir, {force: true, recursive: true});
+
+    // Restore Expo-generated modulemap after directory replacement.
+    // Runs in finally so it is not skipped if mv/cp partially fails.
+    if (savedModulemap != null) {
+      const restoredPath = path.join(
+        finalLocation,
+        useFrameworksModulemapName,
+      );
+      fs.writeFileSync(restoredPath, savedModulemap);
+      console.log('Restored', useFrameworksModulemapName);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

When using Expo with `use_frameworks!` in the Podfile, Expo generates a `React-use-frameworks.modulemap` file inside `React-Core-prebuilt`. When `replaceRNCoreConfiguration` runs (e.g., when switching between Debug and Release builds), this file can be lost, causing subsequent builds to fail with modulemap-related errors.

The current code removes only directories inside `React-Core-prebuilt` (preserving top-level files), but `React-use-frameworks.modulemap` may reside inside one of those subdirectories depending on the Expo version. This PR explicitly saves and restores the modulemap around the directory replacement to make the intent clear and guard against this case.

The restore is placed inside the `finally` block so it runs even if `mv`/`cp` partially fails during the directory move.

## Changelog:

[IOS] [Fixed] - Preserve Expo-generated `React-use-frameworks.modulemap` across `replace-rncore-version.js` runs

## Test Plan

- Set up an Expo project with `use_frameworks!` in Podfile
- Run `pod install` for a Debug build
- Switch to a Release build to trigger `replace-rncore-version.js`
- Verify `React-use-frameworks.modulemap` is present in `React-Core-prebuilt/` after the replacement
- Confirm the build succeeds without modulemap-related errors