### PR TITLE
Remove dead code `useAndroidRippleForView`

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -12,12 +12,13 @@ import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {GestureResponderEvent} from '../../Types/CoreEventTypes';
 
 import processColor from '../../StyleSheet/processColor';
-import Platform from '../../Utilities/Platform';
 import View from '../View/View';
 import {Commands} from '../View/ViewNativeComponent';
 import invariant from 'invariant';
 import * as React from 'react';
 import {useMemo} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 type NativeBackgroundProp = Readonly<{
   type: 'RippleAndroid',


### PR DESCRIPTION

## Summary:

Metro inline plugin won't work when es import is used for `Platform`, to remove dead-code I use `require()`

similar example:
 
https://github.com/facebook/react-native/blob/37a18419b195d3f2c2340212266b259835a44c8d/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js#L22

```diff
-import Platform from '../../Utilities/Platform';
+const Platform = require('../../Utilities/Platform').default;
```




**Before:**

<img width="1904" height="911" alt="Screenshot 2026-04-07 at 16 13 01" src="https://github.com/user-attachments/assets/ea0b1151-0c56-4fde-a8b4-44126daab666" />

**After:**

<img width="1887" height="890" alt="Screenshot 2026-04-07 at 16 12 19" src="https://github.com/user-attachments/assets/741b3aaf-9184-47b5-b864-3dcc1cb38e1c" />



## Changelog:


[IOS] [CHANGED] - Remove`useAndroidRippleForView` dead-code from iOS builds


## Test Plan:

```
1. build the app 
2. finial bundle should include `return null` as body of `useAndroidRippleForView` hook
```
