### PR TITLE
Fix CVE-2021-3807: Upgrade transitive dependency ansi-regex from 4.1.1 to 5.0.1 (#56359)

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "react-is": "19.2.3",
     "on-headers": "1.1.0",
     "compression": "1.8.1",
-    "@microsoft/api-extractor/minimatch": "3.1.4"
+    "@microsoft/api-extractor/minimatch": "3.1.4",
+    "**/ansi-regex": "5.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,20 +2670,10 @@ ansi-fragments@^0.2.1:
     slice-ansi "^2.0.0"
     strip-ansi "^5.0.0"
 
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@5.0.1, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^3.2.0:
   version "3.2.1"


### PR DESCRIPTION
Summary:

Fix CVE-2021-3807: Upgrade transitive dependency ansi-regex from 4.1.1 to 5.0.1

## Summary
Upgrading the transitive dependency `ansi-regex` from 4.1.1 to 5.0.1 to fix CVE-2021-3807 (ReDoS vulnerability).

**Dependency chain:** react-native/tester -> react-native-community/cli-platform-android -> logkitty -> ansi-fragments -> strip-ansi -> ansi-regex@4.1.1

The fix was applied via yarn resolution,. 

Changelog: 
[General][Security] -Upgrade transitive dependency ansi-regex from 4.1.1 to 5.0.1

Reviewed By: cortinico

Differential Revision: D99867505


