### PR TITLE
fix(text): use glyph ink bounds to prevent italic clipping

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -9,6 +9,7 @@ package com.facebook.react.views.text
 
 import android.content.res.AssetManager
 import android.graphics.Color
+import android.graphics.Rect
 import android.graphics.Typeface
 import android.os.Build
 import android.text.BoringLayout
@@ -1224,7 +1225,33 @@ internal object TextLayoutManager {
       return width
     }
 
-    return layout.width.toFloat()
+    // Grow width by per-line ink overshoot so italic glyphs aren't clipped.
+    val layoutWidth = layout.width.toFloat()
+    val paint = layout.paint
+    val bounds = Rect()
+    var maxLineOvershoot = 0f
+
+    for (lineIndex in 0 until calculatedLineCount) {
+      val lineStart = layout.getLineStart(lineIndex)
+      val lineEnd = layout.getLineEnd(lineIndex)
+      if (lineStart >= lineEnd) continue
+
+      paint.getTextBounds(text, lineStart, lineEnd, bounds)
+      val advanceWidth = layout.getLineWidth(lineIndex)
+
+      val rightOvershoot = bounds.right.toFloat() - advanceWidth
+      val leftOvershoot = -bounds.left.toFloat()
+      val lineOvershoot = maxOf(0f, leftOvershoot) + maxOf(0f, rightOvershoot)
+      if (lineOvershoot > maxLineOvershoot) {
+        maxLineOvershoot = lineOvershoot
+      }
+    }
+
+    return if (maxLineOvershoot > 0f) {
+      ceil(layoutWidth + maxLineOvershoot)
+    } else {
+      layoutWidth
+    }
   }
 
   private fun calculateHeight(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -687,6 +687,12 @@ internal object TextLayoutManager {
       builder.setUseLineSpacingFromFallbacks(true)
     }
 
+    if (Build.VERSION.SDK_INT >= 35) {
+      try {
+        setUseBoundsForWidthMethod?.invoke(builder, true)
+      } catch (_: ReflectiveOperationException) {}
+    }
+
     return builder.build()
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -374,7 +374,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 
   if (!textDidWrap && glyphRange.length > 0) {
     CGRect inkRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
-    CGFloat inkRight = CGRectGetMaxX(inkRect);
+    CGFloat inkRight = CGRectGetMaxX(inkRect) - textContainer.lineFragmentPadding;
     if (inkRight > size.width) {
       size.width = inkRight;
     }

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -372,6 +372,14 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 
   CGSize size = [layoutManager usedRectForTextContainer:textContainer].size;
 
+  if (!textDidWrap && glyphRange.length > 0) {
+    CGRect inkRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
+    CGFloat inkRight = CGRectGetMaxX(inkRect);
+    if (inkRight > size.width) {
+      size.width = inkRight;
+    }
+  }
+
   if (textDidWrap) {
     size.width = textContainer.size.width;
   }

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -9,6 +9,7 @@
 
 #import "RCTAttributedTextUtils.h"
 
+#import <CoreText/CoreText.h>
 #import <React/NSTextStorage+FontScaling.h>
 #import <React/RCTUtils.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
@@ -372,16 +373,51 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 
   CGSize size = [layoutManager usedRectForTextContainer:textContainer].size;
 
-  if (!textDidWrap && glyphRange.length > 0) {
-    CGRect inkRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
-    CGFloat inkRight = CGRectGetMaxX(inkRect) - textContainer.lineFragmentPadding;
-    if (inkRight > size.width) {
-      size.width = inkRight;
-    }
-  }
-
   if (textDidWrap) {
     size.width = textContainer.size.width;
+  }
+
+  // Grow width by per-line ink overshoot so italic glyphs aren't clipped.
+  __block CGFloat maxInkOvershoot = 0;
+  [layoutManager enumerateLineFragmentsForGlyphRange:glyphRange
+                                          usingBlock:^(
+                                              CGRect rect,
+                                              CGRect usedRect,
+                                              NSTextContainer *tc,
+                                              NSRange lineGlyphRange,
+                                              BOOL *stop) {
+                                            NSRange charRange =
+                                                [layoutManager characterRangeForGlyphRange:lineGlyphRange
+                                                                          actualGlyphRange:nil];
+                                            if (charRange.length == 0) {
+                                              return;
+                                            }
+
+                                            NSAttributedString *lineStr =
+                                                [textStorage attributedSubstringFromRange:charRange];
+                                            CTLineRef ctLine =
+                                                CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)lineStr);
+                                            if (ctLine == NULL) {
+                                              return;
+                                            }
+
+                                            CGRect pathBounds =
+                                                CTLineGetBoundsWithOptions(ctLine, kCTLineBoundsUseGlyphPathBounds);
+                                            CGFloat advanceWidth =
+                                                (CGFloat)CTLineGetTypographicBounds(ctLine, NULL, NULL, NULL);
+                                            CFRelease(ctLine);
+
+                                            CGFloat rightOvershoot = CGRectGetMaxX(pathBounds) - advanceWidth;
+                                            CGFloat leftOvershoot = -CGRectGetMinX(pathBounds);
+                                            CGFloat lineOvershoot =
+                                                MAX((CGFloat)0, leftOvershoot) + MAX((CGFloat)0, rightOvershoot);
+                                            if (lineOvershoot > maxInkOvershoot) {
+                                              maxInkOvershoot = lineOvershoot;
+                                            }
+                                          }];
+
+  if (maxInkOvershoot > 0) {
+    size.width += maxInkOvershoot;
   }
 
   if (paragraphAttributes.maximumNumberOfLines != 0) {


### PR DESCRIPTION
## Summary:                                     
                                              
  Fixes #56349 — text rendered with italic / bold-italic fonts whose glyph outlines overshoot their advance width was being horizontally clipped on both iOS and Android.
                                                 
  The root cause is that text measurement on both platforms sizes the text container using glyph **advance widths** instead of **ink bounds**. Many italic typefaces (e.g. Magistral-BoldItalic in the linked repro) have glyphs whose visible outline extends past the advance, so the rightmost character gets cut off — most visibly with `alignSelf: 'flex-start'` and larger font sizes.
                                                                                                                                                                                                                                                           
  **Android** (`TextLayoutManager.kt`) — A reflection helper for `StaticLayout.Builder.setUseBoundsForWidth` was already cached but never invoked. This PR wires it up inside `buildLayout` so that on API 35+ the platform sizes the layout using glyph bounds.                                                                                                                                                                                                                                                  
                                               
  **iOS** (`RCTTextLayoutManager.mm`) — After `usedRectForTextContainer:`, widen the measured size using `boundingRectForGlyphRange:inTextContainer:` when the text fits on a single line. This is a no-op for wrapped text (where the container width is already authoritative) and for empty glyph ranges.                                                                                                                                                                                                     
                                                                                                                                                                                                                                                           
  ### Known follow-ups (not in this PR)                                                                                                                                                                                                                    
                            
  - Pre-API-35 Android still uses advance widths (the platform helper doesn't exist on older versions). Could be addressed with a manual `Paint.getTextBounds` fallback.                                                                                   
  - The Android `BoringLayout` fast path also uses advance widths and could benefit from a similar adjustment.                                                                                                                                             
                                               
  Left out to keep this PR minimal and low-risk; happy to follow up in a separate PR if maintainers prefer.                                                                                                                                                
                                                                                                                                                                                                                                                         
  ## Changelog:                            
                                                                                                                                                                                                                                                           
  [GENERAL] [FIXED] - Fix horizontal clipping of italic / bold-italic text
                                                                                                                                                                                                                                                           
  ## Test Plan:                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                           
  - Reproduced the bug using the Expo Snack from #56349 with Magistral-BoldItalic at large font size and `alignSelf: 'flex-start'`.                                                                                                                      
  - After the patch, the trailing italic glyphs are no longer clipped on iOS.
  - After the patch, the trailing italic glyphs are no longer clipped on Android (API 35+).                                                                                                                                                                
  - Non-italic text measurements are unchanged (no behavior change for fonts whose ink bounds fit within advance widths).