### PR TITLE
Fix XMLHttpRequest.setRequestHeader to append duplicate headers per spec

### DIFF
--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -509,7 +509,9 @@ class XMLHttpRequest extends EventTarget {
     if (this.readyState !== this.OPENED) {
       throw new Error('Request has not been opened');
     }
-    this._headers[header.toLowerCase()] = String(value);
+    const key = header.toLowerCase();
+    const existing = this._headers[key];
+    this._headers[key] = existing ? existing + ', ' + String(value) : String(value);
   }
 
   /**

--- a/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -294,6 +294,32 @@ describe('XMLHttpRequest', function () {
     expect(GlobalPerformanceLogger.stopTimespan).not.toHaveBeenCalled();
   });
 
+  it('should append values when setRequestHeader is called with the same header', function () {
+    xhr.open('GET', 'blabla');
+    xhr.setRequestHeader('X-Custom', 'value1');
+    xhr.setRequestHeader('X-Custom', 'value2');
+
+    // $FlowFixMe[prop-missing]
+    expect(xhr._headers['x-custom']).toBe('value1, value2');
+  });
+
+  it('should lowercase header names in setRequestHeader', function () {
+    xhr.open('GET', 'blabla');
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.setRequestHeader('content-type', 'text/plain');
+
+    // $FlowFixMe[prop-missing]
+    expect(xhr._headers['content-type']).toBe(
+      'application/json, text/plain',
+    );
+  });
+
+  it('should throw when setRequestHeader is called before open', function () {
+    expect(() => {
+      xhr.setRequestHeader('foo', 'bar');
+    }).toThrow('Request has not been opened');
+  });
+
   it('should sort and lowercase response headers', function () {
     // Derived from XHR Web Platform Test: https://github.com/web-platform-tests/wpt/blob/master/xhr/getallresponseheaders.htm
     xhr.open('GET', 'blabla');


### PR DESCRIPTION
## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`XMLHttpRequest.setRequestHeader()` overwrites the previous value when called multiple times with the same header name. Per the [XHR Living Standard §4.5.2](https://xhr.spec.whatwg.org/#the-setrequestheader()-method), duplicate headers should be appended with `, `.

Real-world example: [Sentry JS SDK assumes append behavior](https://github.com/getsentry/sentry-javascript/blob/10.38.0/packages/browser/src/tracing/request.ts#L440-L445)
when setting the `baggage` header, which causes previously set baggage values to be silently dropped on React Native.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Fix XMLHttpRequest.setRequestHeader to append duplicate headers per spec

> **Note:** This is technically a breaking change for code that relied on the previous overwrite behavior (e.g., calling `setRequestHeader` twice to replace a value). However, that behavior was non-compliant with the XHR spec, so such code should use a single call with the desired final value instead.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

**Unit tests** — 3 tests added in `XMLHttpRequest-test.js`:
- Appends values when same header is set twice
- Merges case-insensitively
- Throws when called before `open()`

Run the snippet below in both browser DevTools and RN debugger console to compare:

```js
const xhr = new XMLHttpRequest();
xhr.open('GET', 'https://httpbin.org/headers');
xhr.setRequestHeader('X-Test', 'value1');
xhr.setRequestHeader('X-Test', 'value2');
xhr.onload = () => {
  const headers = JSON.parse(xhr.responseText).headers;
  console.log('X-Test:', headers['X-Test']);
  // Before: "value2"
  // After:  "value1, value2"
};
xhr.send();
```