### PR TITLE
feat(Pressable): add support for PlatformColor and alpha

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.d.ts
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.d.ts
@@ -30,6 +30,7 @@ export interface PressableAndroidRippleConfig {
   borderless?: null | boolean | undefined;
   radius?: null | number | undefined;
   foreground?: null | boolean | undefined;
+  alpha?: null | number | undefined;
 }
 
 export interface PressableProps

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
@@ -9,6 +9,8 @@
  */
 
 import {expectRendersMatchingSnapshot} from '../../../Utilities/ReactNativeTestTools';
+import Platform from '../../../Utilities/Platform';
+import {PlatformColor} from '../../../StyleSheet/PlatformColorValueTypes';
 import View from '../../View/View';
 import Pressable from '../Pressable';
 import * as React from 'react';
@@ -83,6 +85,68 @@ describe('<Pressable disabled={true} accessibilityState={{disabled: false}} />',
       'Pressable',
       () => (
         <Pressable disabled={true} accessibilityState={{disabled: false}}>
+          <View />
+        </Pressable>
+      ),
+      () => {
+        jest.dontMock('../Pressable');
+      },
+    );
+  });
+});
+
+describe('<Pressable android_ripple /> on Android', () => {
+  let originalOS: string;
+
+  beforeEach(() => {
+    originalOS = Platform.OS;
+    /* $FlowFixMe[incompatible-type] */
+    Platform.OS = 'android';
+  });
+
+  afterEach(() => {
+    /* $FlowFixMe[incompatible-type] */
+    Platform.OS = originalOS;
+  });
+
+  it('should set nativeBackgroundAndroid with numeric color and alpha', async () => {
+    await expectRendersMatchingSnapshot(
+      'Pressable',
+      () => (
+        <Pressable android_ripple={{color: '#FF0000', alpha: 0.5}}>
+          <View />
+        </Pressable>
+      ),
+      () => {
+        jest.dontMock('../Pressable');
+      },
+    );
+  });
+
+  it('should set nativeBackgroundAndroid with PlatformColor and alpha', async () => {
+    await expectRendersMatchingSnapshot(
+      'Pressable',
+      () => (
+        <Pressable
+          android_ripple={{color: PlatformColor('?attr/colorAccent'), alpha: 0.3}}>
+          <View />
+        </Pressable>
+      ),
+      () => {
+        jest.dontMock('../Pressable');
+      },
+    );
+  });
+
+  it('should not crash with an unresolvable PlatformColor', async () => {
+    await expectRendersMatchingSnapshot(
+      'Pressable',
+      () => (
+        <Pressable
+          android_ripple={{
+            color: PlatformColor('?attr/doesNotExist'),
+            alpha: 0.5,
+          }}>
           <View />
         </Pressable>
       ),

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
@@ -72,6 +72,292 @@ exports[`<Pressable /> should render as expected: should deep render when not mo
 </View>
 `;
 
+exports[`<Pressable android_ripple /> on Android should not crash with an unresolvable PlatformColor: should deep render when mocked (please verify output manually) 1`] = `
+<View
+  accessibilityState={
+    Object {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    Object {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "alpha": 0.5,
+      "borderless": false,
+      "color": Object {
+        "semantic": Array [
+          "?attr/doesNotExist",
+        ],
+      },
+      "rippleRadius": undefined,
+      "type": "RippleAndroid",
+    }
+  }
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View />
+</View>
+`;
+
+exports[`<Pressable android_ripple /> on Android should not crash with an unresolvable PlatformColor: should deep render when not mocked (please verify output manually) 1`] = `
+<View
+  accessibilityState={
+    Object {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    Object {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "alpha": 0.5,
+      "borderless": false,
+      "color": Object {
+        "semantic": Array [
+          "?attr/doesNotExist",
+        ],
+      },
+      "rippleRadius": undefined,
+      "type": "RippleAndroid",
+    }
+  }
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View />
+</View>
+`;
+
+exports[`<Pressable android_ripple /> on Android should set nativeBackgroundAndroid with PlatformColor and alpha: should deep render when mocked (please verify output manually) 1`] = `
+<View
+  accessibilityState={
+    Object {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    Object {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "alpha": 0.3,
+      "borderless": false,
+      "color": Object {
+        "semantic": Array [
+          "?attr/colorAccent",
+        ],
+      },
+      "rippleRadius": undefined,
+      "type": "RippleAndroid",
+    }
+  }
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View />
+</View>
+`;
+
+exports[`<Pressable android_ripple /> on Android should set nativeBackgroundAndroid with PlatformColor and alpha: should deep render when not mocked (please verify output manually) 1`] = `
+<View
+  accessibilityState={
+    Object {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    Object {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "alpha": 0.3,
+      "borderless": false,
+      "color": Object {
+        "semantic": Array [
+          "?attr/colorAccent",
+        ],
+      },
+      "rippleRadius": undefined,
+      "type": "RippleAndroid",
+    }
+  }
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View />
+</View>
+`;
+
+exports[`<Pressable android_ripple /> on Android should set nativeBackgroundAndroid with numeric color and alpha: should deep render when mocked (please verify output manually) 1`] = `
+<View
+  accessibilityState={
+    Object {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    Object {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "alpha": 0.5,
+      "borderless": false,
+      "color": -65536,
+      "rippleRadius": undefined,
+      "type": "RippleAndroid",
+    }
+  }
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View />
+</View>
+`;
+
+exports[`<Pressable android_ripple /> on Android should set nativeBackgroundAndroid with numeric color and alpha: should deep render when not mocked (please verify output manually) 1`] = `
+<View
+  accessibilityState={
+    Object {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    Object {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "alpha": 0.5,
+      "borderless": false,
+      "color": -65536,
+      "rippleRadius": undefined,
+      "type": "RippleAndroid",
+    }
+  }
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View />
+</View>
+`;
+
 exports[`<Pressable disabled={true} /> should be disabled when disabled is true: should deep render when mocked (please verify output manually) 1`] = `
 <View
   accessibilityState={

--- a/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -9,21 +9,22 @@
  */
 
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
+import type {ProcessedColorValue} from '../../StyleSheet/processColor';
 import type {GestureResponderEvent} from '../../Types/CoreEventTypes';
 
 import processColor from '../../StyleSheet/processColor';
 import Platform from '../../Utilities/Platform';
 import View from '../View/View';
 import {Commands} from '../View/ViewNativeComponent';
-import invariant from 'invariant';
 import * as React from 'react';
 import {useMemo} from 'react';
 
 type NativeBackgroundProp = Readonly<{
   type: 'RippleAndroid',
-  color: ?number,
+  color: ?ProcessedColorValue,
   borderless: boolean,
   rippleRadius: ?number,
+  alpha: ?number,
 }>;
 
 export type PressableAndroidRippleConfig = {
@@ -31,6 +32,7 @@ export type PressableAndroidRippleConfig = {
   borderless?: boolean,
   radius?: number,
   foreground?: boolean,
+  alpha?: number,
 };
 
 /**
@@ -48,7 +50,7 @@ export default function useAndroidRippleForView(
     | Readonly<{nativeBackgroundAndroid: NativeBackgroundProp}>
     | Readonly<{nativeForegroundAndroid: NativeBackgroundProp}>,
 }> {
-  const {color, borderless, radius, foreground} = rippleConfig ?? {};
+  const {color, borderless, radius, foreground, alpha} = rippleConfig ?? {};
 
   return useMemo(() => {
     if (
@@ -56,16 +58,13 @@ export default function useAndroidRippleForView(
       (color != null || borderless != null || radius != null)
     ) {
       const processedColor = processColor(color);
-      invariant(
-        processedColor == null || typeof processedColor === 'number',
-        'Unexpected color given for Ripple color',
-      );
 
       const nativeRippleValue = {
         type: 'RippleAndroid',
         color: processedColor,
         borderless: borderless === true,
         rippleRadius: radius,
+        alpha: alpha ?? null,
       };
 
       return {
@@ -105,5 +104,5 @@ export default function useAndroidRippleForView(
       };
     }
     return null;
-  }, [borderless, color, foreground, radius, viewRef]);
+  }, [alpha, borderless, color, foreground, radius, viewRef]);
 }

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -9,6 +9,8 @@
  */
 
 import type {GestureResponderEvent} from '../../Types/CoreEventTypes';
+import type {ColorValue} from '../../StyleSheet/StyleSheet';
+import type {ProcessedColorValue} from '../../StyleSheet/processColor';
 import type {TouchableWithoutFeedbackProps} from './TouchableWithoutFeedback';
 
 import View from '../../Components/View/View';
@@ -20,7 +22,6 @@ import {findHostInstance_DEPRECATED} from '../../ReactNative/RendererProxy';
 import processColor from '../../StyleSheet/processColor';
 import Platform from '../../Utilities/Platform';
 import {Commands} from '../View/ViewNativeComponent';
-import invariant from 'invariant';
 import * as React from 'react';
 import {cloneElement} from 'react';
 
@@ -177,23 +178,18 @@ class TouchableNativeFeedback extends React.Component<
    * @param rippleRadius The radius of ripple effect
    */
   static Ripple: (
-    color: string,
+    color: ColorValue,
     borderless: boolean,
     rippleRadius?: ?number,
   ) => Readonly<{
     borderless: boolean,
-    color: ?number,
+    color: ?ProcessedColorValue,
     rippleRadius: ?number,
     type: 'RippleAndroid',
-  }> = (color: string, borderless: boolean, rippleRadius?: ?number) => {
+  }> = (color: ColorValue, borderless: boolean, rippleRadius?: ?number) => {
     const processedColor = processColor(color);
-    invariant(
-      processedColor == null || typeof processedColor === 'number',
-      'Unexpected color given for Ripple color',
-    );
     return {
       type: 'RippleAndroid',
-      // $FlowFixMe[incompatible-type]
       color: processedColor,
       borderless,
       rippleRadius,

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -267,6 +267,7 @@ type AndroidDrawableRipple = Readonly<{
   color?: ?number,
   borderless?: ?boolean,
   rippleRadius?: ?number,
+  alpha?: ?number,
 }>;
 
 type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.kt
@@ -15,10 +15,16 @@ import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.RippleDrawable
 import android.util.TypedValue
+import com.facebook.common.logging.FLog
+import com.facebook.react.bridge.ColorPropConverter
+import com.facebook.react.bridge.JSApplicationCausedNativeException
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import com.facebook.react.common.ReactConstants
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.ViewProps
+import kotlin.math.roundToInt
 
 /**
  * Utility class that helps with converting android drawable description used in JS to an actual
@@ -73,11 +79,19 @@ public object ReactDrawableHelper {
       context: Context,
       drawableDescriptionDict: ReadableMap,
   ): RippleDrawable {
-    val color = getColor(context, drawableDescriptionDict)
-    val mask = getMask(drawableDescriptionDict)
-    val colorStateList = ColorStateList(arrayOf(intArrayOf()), intArrayOf(color))
+    val resolvedColor = getColor(context, drawableDescriptionDict)
+    var color = resolvedColor ?: getFallbackColor(context)
 
-    return RippleDrawable(colorStateList, null, mask)
+    if (resolvedColor != null &&
+        drawableDescriptionDict.hasKey("alpha") &&
+        !drawableDescriptionDict.isNull("alpha")) {
+      val alphaFactor = drawableDescriptionDict.getDouble("alpha").coerceIn(0.0, 1.0)
+      val newAlpha = (Color.alpha(color) * alphaFactor).roundToInt()
+      color = Color.argb(newAlpha, Color.red(color), Color.green(color), Color.blue(color))
+    }
+
+    val mask = getMask(drawableDescriptionDict)
+    return RippleDrawable(ColorStateList(arrayOf(intArrayOf()), intArrayOf(color)), null, mask)
   }
 
   private fun setRadius(drawableDescriptionDict: ReadableMap, drawable: Drawable?): Drawable? {
@@ -88,26 +102,35 @@ public object ReactDrawableHelper {
     return drawable
   }
 
-  private fun getColor(context: Context, drawableDescriptionDict: ReadableMap): Int =
-      if (
-          drawableDescriptionDict.hasKey(ViewProps.COLOR) &&
-              !drawableDescriptionDict.isNull(ViewProps.COLOR)
-      ) {
-        drawableDescriptionDict.getInt(ViewProps.COLOR)
+  /**
+   * Returns the resolved ripple color, or null if none was provided or the
+   * PlatformColor resource couldn't be found.
+   */
+  private fun getColor(context: Context, drawableDescriptionDict: ReadableMap): Int? {
+    val rawColor: Any? =
+        if (drawableDescriptionDict.hasKey(ViewProps.COLOR) &&
+            !drawableDescriptionDict.isNull(ViewProps.COLOR)) {
+          when (drawableDescriptionDict.getType(ViewProps.COLOR)) {
+            ReadableType.Number -> drawableDescriptionDict.getDouble(ViewProps.COLOR)
+            ReadableType.Map -> drawableDescriptionDict.getMap(ViewProps.COLOR)
+            else -> null
+          }
+        } else null
+    return try {
+      ColorPropConverter.getColor(rawColor, context)
+    } catch (e: JSApplicationCausedNativeException) {
+      FLog.w(ReactConstants.TAG, e, "android_ripple: color resource not found, using colorControlHighlight")
+      null
+    }
+  }
+
+  private fun getFallbackColor(context: Context): Int =
+      if (context.theme.resolveAttribute(
+          android.R.attr.colorControlHighlight, resolveOutValue, true)) {
+        context.resources.getColor(resolveOutValue.resourceId, context.theme)
       } else {
-        if (
-            context.theme.resolveAttribute(
-                android.R.attr.colorControlHighlight,
-                resolveOutValue,
-                true,
-            )
-        ) {
-          context.resources.getColor(resolveOutValue.resourceId, context.theme)
-        } else {
-          throw JSApplicationIllegalArgumentException(
-              "Attribute colorControlHighlight couldn't be resolved into a drawable"
-          )
-        }
+        throw JSApplicationIllegalArgumentException(
+            "Attribute colorControlHighlight couldn't be resolved into a drawable")
       }
 
   private fun getMask(drawableDescriptionDict: ReadableMap): Drawable? {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -12,6 +12,7 @@ package com.facebook.react.views.view
 import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.BlendMode
 import android.graphics.Canvas
 import android.graphics.Paint
@@ -25,6 +26,7 @@ import android.view.ViewStructure
 import android.view.accessibility.AccessibilityManager
 import com.facebook.common.logging.FLog
 import com.facebook.react.R
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReactNoCrashSoftException
 import com.facebook.react.bridge.ReactSoftExceptionLogger
 import com.facebook.react.bridge.ReactSoftExceptionLogger.logSoftException
@@ -83,6 +85,25 @@ public open class ReactViewGroup public constructor(context: Context?) :
     ReactOverflowViewWithInset {
 
   public override val overflowInset: Rect = Rect()
+
+  internal var nativeBackgroundMap: ReadableMap? = null
+  internal var nativeForegroundMap: ReadableMap? = null
+
+  internal fun applyNativeBackground(map: ReadableMap?) {
+    nativeBackgroundMap = map
+    setFeedbackUnderlay(this, map?.let { ReactDrawableHelper.createDrawableFromJSDescription(context, it) })
+  }
+
+  internal fun applyNativeForeground(map: ReadableMap?) {
+    nativeForegroundMap = map
+    foreground = map?.let { ReactDrawableHelper.createDrawableFromJSDescription(context, it) }
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    applyNativeBackground(nativeBackgroundMap)
+    applyNativeForeground(nativeForegroundMap)
+  }
 
   /**
    * This listener will be set for child views when `removeClippedSubview` property is enabled. When
@@ -179,6 +200,9 @@ public open class ReactViewGroup public constructor(context: Context?) :
     backfaceOpacity = 1f
     backfaceVisible = true
     childrenRemovedWhileTransitioning = null
+
+    nativeBackgroundMap = null
+    nativeForegroundMap = null
   }
 
   internal open fun recycleView() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -305,17 +305,12 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
 
   @ReactProp(name = "nativeBackgroundAndroid")
   public open fun setNativeBackground(view: ReactViewGroup, background: ReadableMap?) {
-    val bg = background?.let {
-      ReactDrawableHelper.createDrawableFromJSDescription(view.context, it)
-    }
-    BackgroundStyleApplicator.setFeedbackUnderlay(view, bg)
+    view.applyNativeBackground(background)
   }
 
   @ReactProp(name = "nativeForegroundAndroid")
   public open fun setNativeForeground(view: ReactViewGroup, foreground: ReadableMap?) {
-    view.foreground = foreground?.let {
-      ReactDrawableHelper.createDrawableFromJSDescription(view.context, it)
-    }
+    view.applyNativeForeground(foreground)
   }
 
   @ReactProp(name = ViewProps.NEEDS_OFFSCREEN_ALPHA_COMPOSITING)

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -421,8 +421,22 @@ inline static void updateNativeDrawableProp(
       nativeDrawableResult["rippleRadius"] =
           nativeDrawableValue.ripple.rippleRadius.value();
     }
-    if (nativeDrawableValue.ripple.color.has_value()) {
-      nativeDrawableResult["color"] = nativeDrawableValue.ripple.color.value();
+    if (nativeDrawableValue.ripple.color.has_value() || nativeDrawableValue.ripple.colorResourcePaths.has_value()) {
+      if (nativeDrawableValue.ripple.colorResourcePaths.has_value()) {
+        folly::dynamic resourcePaths = folly::dynamic::array();
+        for (const auto& path : nativeDrawableValue.ripple.colorResourcePaths.value()) {
+          resourcePaths.push_back(path);
+        }
+        folly::dynamic platformColorMap = folly::dynamic::object();
+        platformColorMap["resource_paths"] = resourcePaths;
+        nativeDrawableResult["color"] = platformColorMap;
+      } else {
+        nativeDrawableResult["color"] =
+            toAndroidRepr(nativeDrawableValue.ripple.color.value());
+      }
+      if (nativeDrawableValue.ripple.alpha.has_value()) {
+        nativeDrawableResult["alpha"] = nativeDrawableValue.ripple.alpha.value();
+      }
     }
     nativeDrawableResult["borderless"] = nativeDrawableValue.ripple.borderless;
   } else {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
@@ -10,6 +10,7 @@
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
 #include <unordered_map>
 
@@ -22,14 +23,16 @@ struct NativeDrawable {
   };
 
   struct Ripple {
-    std::optional<int32_t> color{};
+    std::optional<SharedColor> color{};
+    std::optional<std::vector<std::string>> colorResourcePaths{};
     std::optional<Float> rippleRadius{};
     bool borderless{false};
+    std::optional<Float> alpha{};
 
     bool operator==(const Ripple &rhs) const
     {
-      return std::tie(this->color, this->borderless, this->rippleRadius) ==
-          std::tie(rhs.color, rhs.borderless, rhs.rippleRadius);
+      return std::tie(this->color, this->colorResourcePaths, this->borderless, this->rippleRadius, this->alpha) ==
+          std::tie(rhs.color, rhs.colorResourcePaths, rhs.borderless, rhs.rippleRadius, rhs.alpha);
     }
   };
 
@@ -60,7 +63,7 @@ struct NativeDrawable {
 };
 
 static inline void
-fromRawValue(const PropsParserContext & /*context*/, const RawValue &rawValue, NativeDrawable &result)
+fromRawValue(const PropsParserContext &context, const RawValue &rawValue, NativeDrawable &result)
 {
   auto map = (std::unordered_map<std::string, RawValue>)rawValue;
 
@@ -81,14 +84,43 @@ fromRawValue(const PropsParserContext & /*context*/, const RawValue &rawValue, N
     auto color = map.find("color");
     auto borderless = map.find("borderless");
     auto rippleRadius = map.find("rippleRadius");
+    auto alpha = map.find("alpha");
+
+    std::optional<SharedColor> parsedColor{};
+    std::optional<std::vector<std::string>> parsedColorResourcePaths{};
+    if (color != map.end()) {
+      if (color->second.hasType<std::unordered_map<std::string, std::vector<std::string>>>()) {
+        auto colorMap = (std::unordered_map<std::string, std::vector<std::string>>)color->second;
+        auto pathsIt = colorMap.find("resource_paths");
+        if (pathsIt != colorMap.end()) {
+          parsedColorResourcePaths = pathsIt->second;
+        }
+      } else {
+        SharedColor resolved;
+        fromRawValue(context, color->second, resolved);
+        if (resolved) {
+          parsedColor = resolved;
+        }
+      }
+    }
+
+    std::optional<Float> parsedAlpha{};
+    if (alpha != map.end() && alpha->second.hasType<Float>()) {
+      parsedAlpha = (Float)alpha->second;
+    }
 
     result = NativeDrawable{
         std::string{},
         NativeDrawable::Ripple{
-            color != map.end() && color->second.hasType<int32_t>() ? (int32_t)color->second : std::optional<int32_t>{},
-            rippleRadius != map.end() && rippleRadius->second.hasType<Float>() ? (Float)rippleRadius->second
-                                                                               : std::optional<Float>{},
-            borderless != map.end() && borderless->second.hasType<bool>() ? (bool)borderless->second : false,
+            parsedColor,
+            parsedColorResourcePaths,
+            rippleRadius != map.end() && rippleRadius->second.hasType<Float>()
+                ? (Float)rippleRadius->second
+                : std::optional<Float>{},
+            borderless != map.end() && borderless->second.hasType<bool>()
+                ? (bool)borderless->second
+                : false,
+            parsedAlpha,
         },
         NativeDrawable::Kind::Ripple,
     };

--- a/packages/react-native/ReactNativeApi.d.ts
+++ b/packages/react-native/ReactNativeApi.d.ts
@@ -3807,6 +3807,7 @@ declare type PressableAndroidRippleConfig = {
   color?: ColorValue
   foreground?: boolean
   radius?: number
+  alpha?: number
 }
 declare type PressableBaseProps = {
   readonly android_disableSound?: boolean

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -17,6 +17,7 @@ import {
   Animated,
   Image,
   Platform,
+  PlatformColor,
   Pressable,
   StyleSheet,
   Text,
@@ -508,6 +509,57 @@ const examples = [
             </Pressable>
             <Text>use foreground</Text>
           </View>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Pressable with PlatformColor ripple and alpha',
+    description:
+      'android_ripple accepts PlatformColor and a separate alpha (0–1) parameter' as string,
+    platform: 'android',
+    render: function (): React.Node {
+      const buttonStyle = {textAlign: 'center', margin: 10};
+      return (
+        <View>
+          <Pressable
+            android_ripple={{
+              color: PlatformColor('?attr/colorAccent'),
+              borderless: false,
+            }}
+            style={{padding: 10, margin: 4, backgroundColor: '#eee'}}>
+            <Text style={buttonStyle}>
+              PlatformColor('?attr/colorAccent'), no alpha
+            </Text>
+          </Pressable>
+          <Pressable
+            android_ripple={{
+              color: PlatformColor('?attr/colorAccent'),
+              alpha: 0.3,
+              borderless: false,
+            }}
+            style={{padding: 10, margin: 4, backgroundColor: '#eee'}}>
+            <Text style={buttonStyle}>
+              PlatformColor('?attr/colorAccent'), alpha=0.3
+            </Text>
+          </Pressable>
+          <Pressable
+            android_ripple={{
+              color: '#FF0000',
+              borderless: false,
+            }}
+            style={{padding: 10, margin: 4, backgroundColor: '#eee'}}>
+            <Text style={buttonStyle}>Red (#FF0000), no alpha</Text>
+          </Pressable>
+          <Pressable
+            android_ripple={{
+              color: '#FF0000',
+              alpha: 0.5,
+              borderless: false,
+            }}
+            style={{padding: 10, margin: 4, backgroundColor: '#eee'}}>
+            <Text style={buttonStyle}>Red (#FF0000), alpha=0.5</Text>
+          </Pressable>
         </View>
       );
     },


### PR DESCRIPTION
## Summary:

`android_ripple` on `Pressable` (and `TouchableNativeFeedback.Ripple()`) only
accepted numeric (pre-processed ARGB int) colors. Passing a `PlatformColor`
would throw an invariant in JS, making theme-aware ripple colors impossible.

This PR removes those guards and wires up the full color pipeline:

1. **JS** (`useAndroidRippleForView.js`, `TouchableNativeFeedback.js`):
   removed the `invariant` that rejected non-numeric processed colors.
   `TouchableNativeFeedback.Ripple()` now accepts `ColorValue` instead of                                                                    
   `string`.
2. **C++** (`NativeDrawable.h`, `HostPlatformViewProps.cpp`): `color`                                                                        
   changed from `int32_t` to `SharedColor` + a separate `colorResourcePaths`                                                                 
   field for `PlatformColor` resource paths. The `fromRawValue` pipeline now
   resolves both plain colors and `PlatformColor` objects.                                                                                   
3. **Kotlin** (`ReactDrawableHelper.kt`): `getColor()` now handles both                                                                      
   numeric and `PlatformColor` map values via `ColorPropConverter.getColor()`,
   catching `JSApplicationCausedNativeException` to fall back gracefully                                                                     
   instead of crashing.                                                                                                                      
4. **Theme change support** (`ReactViewGroup.kt`): the raw drawable
   description maps are retained on the view, and `onConfigurationChanged`                                                                   
   re-applies them so ripple colors update automatically on light/dark mode
   switch.                                                                                                                                   

A new `alpha: number` (0–1) field is also added so users can apply opacity to                                                                
a `PlatformColor` whose value is fully opaque and can't have alpha embedded at
the JS level. It is applied by multiplying into the resolved color's alpha
channel.                                                                                                                                     

Unresolvable `PlatformColor` resources are handled gracefully: on New Arch,                                                                  
C++ omits the `color` key so Kotlin falls back to `colorControlHighlight`; on
Old Arch, `ReactDrawableHelper` catches the `JSApplicationCausedNativeException`                                                             
and falls back to `colorControlHighlight` instead of crashing.
                                                                                                                   
## Changelog:   

[ANDROID] [ADDED] - `android_ripple` now accepts `PlatformColor` for                                                                         
theme-aware ripple colors, and a new `alpha` (0–1) parameter for controlling
ripple opacity independently of the color value.                                                                                             
              
## Test Plan:

**Automated:**
- Existing Pressable snapshot tests pass unchanged.
- Updated snapshot for `PlatformColor + alpha` to use `?attr/colorAccent`                                                                    
  (matching the RNTester example).
- Added snapshot test `should not crash with an unresolvable PlatformColor`                                                                  
  verifying the component renders at the JS level without throwing.
                                                                                                                                             
**Manual (RNTester → Pressable → "Pressable with PlatformColor ripple and alpha"):**
1. `PlatformColor('?attr/colorAccent'), no alpha` → full-opacity accent ripple                                                               
2. `PlatformColor('?attr/colorAccent'), alpha=0.3` → 30% opacity accent ripple                                                               
3. `#FF0000, no alpha` → full red ripple (regression check)
4. `#FF0000, alpha=0.5` → 50% opacity red ripple                                                                                             
5. Toggle system light/dark mode → ripple color updates automatically                                                                        
6. Pass an intentionally invalid attribute (e.g. `?attr/doesNotExist`) → no
   crash, ripple falls back to default `colorControlHighlight` grey
     
[Screen_recording_20260410_091000.webm](https://github.com/user-attachments/assets/5607d267-8cf1-4bbe-bad1-a80aac82d027)

> [!NOTE]
This is required in [React Native Paper](https://github.com/callstack/react-native-paper) to be able to fully support the Material Design specs but also useful as a general purpose feature for providing more flexibility when customizing ripple color.
