### PR TITLE
Add pushAnimationMutations to the AnimationBackend

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -515,7 +515,10 @@ void NativeAnimatedNodesManager::handleAnimatedEvent(
     // frames.
     if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
       if (auto animationBackend = animationBackend_.lock()) {
-        animationBackend->trigger();
+        animationBackend->pushAnimationMutations(
+            [this](AnimationTimestamp timestamp) -> AnimationMutations {
+              return pullAnimationMutations(timestamp);
+            });
       }
     } else {
       onRender();

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -51,31 +51,27 @@ AnimationBackend::AnimationBackend(
   react_native_assert(uiManager_.expired() == false);
 }
 
-void AnimationBackend::onAnimationFrame(AnimationTimestamp timestamp) {
-  std::vector<CallbackWithId> callbacksCopy;
-  std::unordered_map<SurfaceId, SurfaceUpdates> surfaceUpdates;
-  std::set<SurfaceId> asyncFlushSurfaces;
+void AnimationBackend::unpackMutations(
+    AnimationMutations& mutations,
+    std::unordered_map<SurfaceId, SurfaceUpdates>& surfaceUpdates,
+    std::set<SurfaceId>& asyncFlushSurfaces) {
+  for (auto& mutation : mutations.batch) {
+    const auto family = mutation.family;
+    react_native_assert(family != nullptr);
 
-  {
-    std::lock_guard lock(mutex_);
-    callbacksCopy = callbacks;
+    auto& [families, updates, hasLayoutUpdates] =
+        surfaceUpdates[family->getSurfaceId()];
+    hasLayoutUpdates |= mutation.hasLayoutUpdates;
+    families.insert(family);
+    updates[mutation.tag] = std::move(mutation.props);
   }
 
-  for (auto& callbackWithId : callbacksCopy) {
-    auto mutations = callbackWithId.callback(timestamp);
-    asyncFlushSurfaces.merge(mutations.asyncFlushSurfaces);
-    for (auto& mutation : mutations.batch) {
-      const auto family = mutation.family;
-      react_native_assert(family != nullptr);
+  asyncFlushSurfaces.merge(mutations.asyncFlushSurfaces);
+}
 
-      auto& [families, updates, hasLayoutUpdates] =
-          surfaceUpdates[family->getSurfaceId()];
-      hasLayoutUpdates |= mutation.hasLayoutUpdates;
-      families.insert(family);
-      updates[mutation.tag] = std::move(mutation.props);
-    }
-  }
-
+void AnimationBackend::applySurfaceUpdates(
+    std::unordered_map<SurfaceId, SurfaceUpdates>& surfaceUpdates,
+    const std::set<SurfaceId>& asyncFlushSurfaces) {
   animatedPropsRegistry_->update(surfaceUpdates);
 
   for (auto& [surfaceId, updates] : surfaceUpdates) {
@@ -87,6 +83,30 @@ void AnimationBackend::onAnimationFrame(AnimationTimestamp timestamp) {
   }
 
   requestAsyncFlushForSurfaces(asyncFlushSurfaces);
+}
+
+void AnimationBackend::applyMutations(AnimationMutations mutations) {
+  std::unordered_map<SurfaceId, SurfaceUpdates> surfaceUpdates;
+  std::set<SurfaceId> asyncFlushSurfaces;
+  unpackMutations(mutations, surfaceUpdates, asyncFlushSurfaces);
+  applySurfaceUpdates(surfaceUpdates, asyncFlushSurfaces);
+}
+
+void AnimationBackend::onAnimationFrame(AnimationTimestamp timestamp) {
+  std::vector<CallbackWithId> callbacksCopy;
+
+  {
+    std::lock_guard lock(mutex_);
+    callbacksCopy = callbacks;
+  }
+
+  std::unordered_map<SurfaceId, SurfaceUpdates> surfaceUpdates;
+  std::set<SurfaceId> asyncFlushSurfaces;
+  for (auto& callbackWithId : callbacksCopy) {
+    auto mutations = callbackWithId.callback(timestamp);
+    unpackMutations(mutations, surfaceUpdates, asyncFlushSurfaces);
+  }
+  applySurfaceUpdates(surfaceUpdates, asyncFlushSurfaces);
 }
 
 CallbackId AnimationBackend::start(const Callback& callback) {
@@ -121,6 +141,12 @@ void AnimationBackend::stop(CallbackId callbackId) {
 
 void AnimationBackend::trigger() {
   onAnimationFrame(std::chrono::steady_clock::now().time_since_epoch());
+}
+
+void AnimationBackend::pushAnimationMutations(const Callback& callback) {
+  auto timestamp = animationChoreographer_->now();
+  auto mutations = callback(timestamp);
+  applyMutations(std::move(mutations));
 }
 
 void AnimationBackend::commitUpdates(

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -59,10 +59,19 @@ class AnimationBackend : public UIManagerAnimationBackend {
 
   void onAnimationFrame(AnimationTimestamp timestamp) override;
   void trigger() override;
+  void pushAnimationMutations(const Callback &callback) override;
   CallbackId start(const Callback &callback) override;
   void stop(CallbackId callbackId) override;
 
  private:
+  void unpackMutations(
+      AnimationMutations &mutations,
+      std::unordered_map<SurfaceId, SurfaceUpdates> &surfaceUpdates,
+      std::set<SurfaceId> &asyncFlushSurfaces);
+  void applySurfaceUpdates(
+      std::unordered_map<SurfaceId, SurfaceUpdates> &surfaceUpdates,
+      const std::set<SurfaceId> &asyncFlushSurfaces);
+  void applyMutations(AnimationMutations mutations);
   std::vector<CallbackWithId> callbacks;
   std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
   std::shared_ptr<AnimationChoreographer> animationChoreographer_;

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationChoreographer.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationChoreographer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <react/renderer/uimanager/UIManagerAnimationBackend.h>
+#include <react/timing/primitives.h>
 
 namespace facebook::react {
 
@@ -21,6 +22,10 @@ class AnimationChoreographer {
 
   virtual void resume() = 0;
   virtual void pause() = 0;
+  virtual AnimationTimestamp now() const
+  {
+    return HighResTimeStamp::now().toChronoSteadyClockTimePoint().time_since_epoch();
+  }
   void setAnimationBackend(std::weak_ptr<UIManagerAnimationBackend> animationBackend)
   {
     animationBackend_ = animationBackend;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
@@ -31,6 +31,7 @@ class UIManagerAnimationBackend {
   virtual void stop(CallbackId callbackId) = 0;
   virtual void clearRegistry(SurfaceId surfaceId) = 0;
   virtual void trigger() = 0;
+  virtual void pushAnimationMutations(const Callback &callback) = 0;
   virtual void registerJSInvoker(std::shared_ptr<CallInvoker> jsInvoker) = 0;
 };
 

--- a/private/react-native-fantom/tester/src/TesterAnimationChoreographer.h
+++ b/private/react-native-fantom/tester/src/TesterAnimationChoreographer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include <react/renderer/animationbackend/AnimationChoreographer.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/runtime/ReactInstanceConfig.h>
@@ -19,8 +21,22 @@ class TesterAnimationChoreographer : public AnimationChoreographer {
   void pause() override;
   void runUITick(AnimationTimestamp timestamp);
 
+  AnimationTimestamp now() const override
+  {
+    if (clockProvider_) {
+      return clockProvider_();
+    }
+    return AnimationChoreographer::now();
+  }
+
+  void setClockProvider(std::function<AnimationTimestamp()> clockProvider)
+  {
+    clockProvider_ = std::move(clockProvider);
+  }
+
  private:
   bool isPaused_{false};
+  std::function<AnimationTimestamp()> clockProvider_;
 };
 
 } // namespace facebook::react

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1546,6 +1546,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
   public virtual void stop(facebook::react::CallbackId callbackId) override;
   public virtual void trigger() override;
@@ -1562,6 +1563,7 @@ class facebook::react::AnimationBackendCommitHook : public facebook::react::UIMa
 }
 
 class facebook::react::AnimationChoreographer {
+  public virtual facebook::react::AnimationTimestamp now() const;
   public virtual void pause() = 0;
   public virtual void resume() = 0;
   public virtual ~AnimationChoreographer() = default;
@@ -2814,7 +2816,7 @@ class facebook::react::JReactHostInspectorTarget : public jni::HybridClass<faceb
   public static void registerNatives();
   public virtual facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() override;
   public virtual facebook::react::jsinspector_modern::HostTargetTracingDelegate* getTracingDelegate() override;
-  public virtual void captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&, const std::function<void(std::optional<std::string> base64Data)>& callback) override;
+  public virtual std::optional<std::string> captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&) override;
   public virtual void onReload(const facebook::react::jsinspector_modern::HostTargetDelegate::PageReloadRequest& request) override;
   public virtual void onSetPausedInDebuggerMessage(const facebook::react::jsinspector_modern::HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest& request) override;
   public void loadNetworkResource(const facebook::react::jsinspector_modern::LoadNetworkResourceRequest& params, facebook::react::jsinspector_modern::ScopedExecutor<facebook::react::jsinspector_modern::NetworkRequestListener> executor) override;
@@ -5211,6 +5213,7 @@ class facebook::react::UIManagerAnimationBackend {
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;
   public virtual void stop(facebook::react::CallbackId callbackId) = 0;
   public virtual void trigger() = 0;
@@ -10379,7 +10382,7 @@ class facebook::react::jsinspector_modern::HostTargetDelegate : public facebook:
   public facebook::react::jsinspector_modern::HostTargetDelegate& operator=(facebook::react::jsinspector_modern::HostTargetDelegate&&) = delete;
   public virtual facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() = 0;
   public virtual facebook::react::jsinspector_modern::HostTargetTracingDelegate* getTracingDelegate();
-  public virtual void captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&, const std::function<void(std::optional<std::string> base64Data)>& callback);
+  public virtual std::optional<std::string> captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&);
   public virtual void loadNetworkResource(const facebook::react::jsinspector_modern::LoadNetworkResourceRequest&, facebook::react::jsinspector_modern::ScopedExecutor<facebook::react::jsinspector_modern::NetworkRequestListener>) override;
   public virtual void onReload(const facebook::react::jsinspector_modern::HostTargetDelegate::PageReloadRequest& request) = 0;
   public virtual void onSetPausedInDebuggerMessage(const facebook::react::jsinspector_modern::HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest& request) = 0;
@@ -12930,6 +12933,8 @@ class facebook::yoga::StyleSizeLength {
 class facebook::yoga::StyleValueHandle {
   public constexpr bool isAuto() const;
   public constexpr bool isDefined() const;
+  public constexpr bool isPercent() const;
+  public constexpr bool isPoint() const;
   public constexpr bool isUndefined() const;
   public static constexpr facebook::yoga::StyleValueHandle ofAuto();
 }
@@ -12938,6 +12943,7 @@ class facebook::yoga::StyleValuePool {
   public facebook::yoga::FloatOptional getNumber(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleLength getLength(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleSizeLength getSize(facebook::yoga::StyleValueHandle handle) const;
+  public float getStoredValue(facebook::yoga::StyleValueHandle handle) const;
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::FloatOptional number);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleLength length);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleSizeLength sizeValue);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1545,6 +1545,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
   public virtual void stop(facebook::react::CallbackId callbackId) override;
   public virtual void trigger() override;
@@ -1561,6 +1562,7 @@ class facebook::react::AnimationBackendCommitHook : public facebook::react::UIMa
 }
 
 class facebook::react::AnimationChoreographer {
+  public virtual facebook::react::AnimationTimestamp now() const;
   public virtual void pause() = 0;
   public virtual void resume() = 0;
   public virtual ~AnimationChoreographer() = default;
@@ -2811,7 +2813,7 @@ class facebook::react::JReactHostInspectorTarget : public jni::HybridClass<faceb
   public static void registerNatives();
   public virtual facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() override;
   public virtual facebook::react::jsinspector_modern::HostTargetTracingDelegate* getTracingDelegate() override;
-  public virtual void captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&, const std::function<void(std::optional<std::string> base64Data)>& callback) override;
+  public virtual std::optional<std::string> captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&) override;
   public virtual void onReload(const facebook::react::jsinspector_modern::HostTargetDelegate::PageReloadRequest& request) override;
   public virtual void onSetPausedInDebuggerMessage(const facebook::react::jsinspector_modern::HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest& request) override;
   public void loadNetworkResource(const facebook::react::jsinspector_modern::LoadNetworkResourceRequest& params, facebook::react::jsinspector_modern::ScopedExecutor<facebook::react::jsinspector_modern::NetworkRequestListener> executor) override;
@@ -5202,6 +5204,7 @@ class facebook::react::UIManagerAnimationBackend {
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;
   public virtual void stop(facebook::react::CallbackId callbackId) = 0;
   public virtual void trigger() = 0;
@@ -10235,7 +10238,7 @@ class facebook::react::jsinspector_modern::HostTargetDelegate : public facebook:
   public facebook::react::jsinspector_modern::HostTargetDelegate& operator=(facebook::react::jsinspector_modern::HostTargetDelegate&&) = delete;
   public virtual facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() = 0;
   public virtual facebook::react::jsinspector_modern::HostTargetTracingDelegate* getTracingDelegate();
-  public virtual void captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&, const std::function<void(std::optional<std::string> base64Data)>& callback);
+  public virtual std::optional<std::string> captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&);
   public virtual void loadNetworkResource(const facebook::react::jsinspector_modern::LoadNetworkResourceRequest&, facebook::react::jsinspector_modern::ScopedExecutor<facebook::react::jsinspector_modern::NetworkRequestListener>) override;
   public virtual void onReload(const facebook::react::jsinspector_modern::HostTargetDelegate::PageReloadRequest& request) = 0;
   public virtual void onSetPausedInDebuggerMessage(const facebook::react::jsinspector_modern::HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest& request) = 0;
@@ -12786,6 +12789,8 @@ class facebook::yoga::StyleSizeLength {
 class facebook::yoga::StyleValueHandle {
   public constexpr bool isAuto() const;
   public constexpr bool isDefined() const;
+  public constexpr bool isPercent() const;
+  public constexpr bool isPoint() const;
   public constexpr bool isUndefined() const;
   public static constexpr facebook::yoga::StyleValueHandle ofAuto();
 }
@@ -12794,6 +12799,7 @@ class facebook::yoga::StyleValuePool {
   public facebook::yoga::FloatOptional getNumber(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleLength getLength(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleSizeLength getSize(facebook::yoga::StyleValueHandle handle) const;
+  public float getStoredValue(facebook::yoga::StyleValueHandle handle) const;
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::FloatOptional number);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleLength length);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleSizeLength sizeValue);

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -4491,6 +4491,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
   public virtual void stop(facebook::react::CallbackId callbackId) override;
   public virtual void trigger() override;
@@ -4507,6 +4508,7 @@ class facebook::react::AnimationBackendCommitHook : public facebook::react::UIMa
 }
 
 class facebook::react::AnimationChoreographer {
+  public virtual facebook::react::AnimationTimestamp now() const;
   public virtual void pause() = 0;
   public virtual void resume() = 0;
   public virtual ~AnimationChoreographer() = default;
@@ -7781,6 +7783,7 @@ class facebook::react::UIManagerAnimationBackend {
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;
   public virtual void stop(facebook::react::CallbackId callbackId) = 0;
   public virtual void trigger() = 0;
@@ -12667,7 +12670,7 @@ class facebook::react::jsinspector_modern::HostTargetDelegate : public facebook:
   public facebook::react::jsinspector_modern::HostTargetDelegate& operator=(facebook::react::jsinspector_modern::HostTargetDelegate&&) = delete;
   public virtual facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() = 0;
   public virtual facebook::react::jsinspector_modern::HostTargetTracingDelegate* getTracingDelegate();
-  public virtual void captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&, const std::function<void(std::optional<std::string> base64Data)>& callback);
+  public virtual std::optional<std::string> captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&);
   public virtual void loadNetworkResource(const facebook::react::jsinspector_modern::LoadNetworkResourceRequest&, facebook::react::jsinspector_modern::ScopedExecutor<facebook::react::jsinspector_modern::NetworkRequestListener>) override;
   public virtual void onReload(const facebook::react::jsinspector_modern::HostTargetDelegate::PageReloadRequest& request) = 0;
   public virtual void onSetPausedInDebuggerMessage(const facebook::react::jsinspector_modern::HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest& request) = 0;
@@ -15138,6 +15141,8 @@ class facebook::yoga::StyleSizeLength {
 class facebook::yoga::StyleValueHandle {
   public constexpr bool isAuto() const;
   public constexpr bool isDefined() const;
+  public constexpr bool isPercent() const;
+  public constexpr bool isPoint() const;
   public constexpr bool isUndefined() const;
   public static constexpr facebook::yoga::StyleValueHandle ofAuto();
 }
@@ -15146,6 +15151,7 @@ class facebook::yoga::StyleValuePool {
   public facebook::yoga::FloatOptional getNumber(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleLength getLength(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleSizeLength getSize(facebook::yoga::StyleValueHandle handle) const;
+  public float getStoredValue(facebook::yoga::StyleValueHandle handle) const;
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::FloatOptional number);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleLength length);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleSizeLength sizeValue);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -4490,6 +4490,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
   public virtual void stop(facebook::react::CallbackId callbackId) override;
   public virtual void trigger() override;
@@ -4506,6 +4507,7 @@ class facebook::react::AnimationBackendCommitHook : public facebook::react::UIMa
 }
 
 class facebook::react::AnimationChoreographer {
+  public virtual facebook::react::AnimationTimestamp now() const;
   public virtual void pause() = 0;
   public virtual void resume() = 0;
   public virtual ~AnimationChoreographer() = default;
@@ -7772,6 +7774,7 @@ class facebook::react::UIManagerAnimationBackend {
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;
   public virtual void stop(facebook::react::CallbackId callbackId) = 0;
   public virtual void trigger() = 0;
@@ -12533,7 +12536,7 @@ class facebook::react::jsinspector_modern::HostTargetDelegate : public facebook:
   public facebook::react::jsinspector_modern::HostTargetDelegate& operator=(facebook::react::jsinspector_modern::HostTargetDelegate&&) = delete;
   public virtual facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() = 0;
   public virtual facebook::react::jsinspector_modern::HostTargetTracingDelegate* getTracingDelegate();
-  public virtual void captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&, const std::function<void(std::optional<std::string> base64Data)>& callback);
+  public virtual std::optional<std::string> captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&);
   public virtual void loadNetworkResource(const facebook::react::jsinspector_modern::LoadNetworkResourceRequest&, facebook::react::jsinspector_modern::ScopedExecutor<facebook::react::jsinspector_modern::NetworkRequestListener>) override;
   public virtual void onReload(const facebook::react::jsinspector_modern::HostTargetDelegate::PageReloadRequest& request) = 0;
   public virtual void onSetPausedInDebuggerMessage(const facebook::react::jsinspector_modern::HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest& request) = 0;
@@ -15004,6 +15007,8 @@ class facebook::yoga::StyleSizeLength {
 class facebook::yoga::StyleValueHandle {
   public constexpr bool isAuto() const;
   public constexpr bool isDefined() const;
+  public constexpr bool isPercent() const;
+  public constexpr bool isPoint() const;
   public constexpr bool isUndefined() const;
   public static constexpr facebook::yoga::StyleValueHandle ofAuto();
 }
@@ -15012,6 +15017,7 @@ class facebook::yoga::StyleValuePool {
   public facebook::yoga::FloatOptional getNumber(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleLength getLength(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleSizeLength getSize(facebook::yoga::StyleValueHandle handle) const;
+  public float getStoredValue(facebook::yoga::StyleValueHandle handle) const;
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::FloatOptional number);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleLength length);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleSizeLength sizeValue);

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -874,6 +874,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
   public virtual void stop(facebook::react::CallbackId callbackId) override;
   public virtual void trigger() override;
@@ -890,6 +891,7 @@ class facebook::react::AnimationBackendCommitHook : public facebook::react::UIMa
 }
 
 class facebook::react::AnimationChoreographer {
+  public virtual facebook::react::AnimationTimestamp now() const;
   public virtual void pause() = 0;
   public virtual void resume() = 0;
   public virtual ~AnimationChoreographer() = default;
@@ -3678,6 +3680,7 @@ class facebook::react::UIManagerAnimationBackend {
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;
   public virtual void stop(facebook::react::CallbackId callbackId) = 0;
   public virtual void trigger() = 0;
@@ -7494,7 +7497,7 @@ class facebook::react::jsinspector_modern::HostTargetDelegate : public facebook:
   public facebook::react::jsinspector_modern::HostTargetDelegate& operator=(facebook::react::jsinspector_modern::HostTargetDelegate&&) = delete;
   public virtual facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() = 0;
   public virtual facebook::react::jsinspector_modern::HostTargetTracingDelegate* getTracingDelegate();
-  public virtual void captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&, const std::function<void(std::optional<std::string> base64Data)>& callback);
+  public virtual std::optional<std::string> captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&);
   public virtual void loadNetworkResource(const facebook::react::jsinspector_modern::LoadNetworkResourceRequest&, facebook::react::jsinspector_modern::ScopedExecutor<facebook::react::jsinspector_modern::NetworkRequestListener>) override;
   public virtual void onReload(const facebook::react::jsinspector_modern::HostTargetDelegate::PageReloadRequest& request) = 0;
   public virtual void onSetPausedInDebuggerMessage(const facebook::react::jsinspector_modern::HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest& request) = 0;
@@ -9955,6 +9958,8 @@ class facebook::yoga::StyleSizeLength {
 class facebook::yoga::StyleValueHandle {
   public constexpr bool isAuto() const;
   public constexpr bool isDefined() const;
+  public constexpr bool isPercent() const;
+  public constexpr bool isPoint() const;
   public constexpr bool isUndefined() const;
   public static constexpr facebook::yoga::StyleValueHandle ofAuto();
 }
@@ -9963,6 +9968,7 @@ class facebook::yoga::StyleValuePool {
   public facebook::yoga::FloatOptional getNumber(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleLength getLength(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleSizeLength getSize(facebook::yoga::StyleValueHandle handle) const;
+  public float getStoredValue(facebook::yoga::StyleValueHandle handle) const;
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::FloatOptional number);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleLength length);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleSizeLength sizeValue);

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -873,6 +873,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
   public virtual void stop(facebook::react::CallbackId callbackId) override;
   public virtual void trigger() override;
@@ -889,6 +890,7 @@ class facebook::react::AnimationBackendCommitHook : public facebook::react::UIMa
 }
 
 class facebook::react::AnimationChoreographer {
+  public virtual facebook::react::AnimationTimestamp now() const;
   public virtual void pause() = 0;
   public virtual void resume() = 0;
   public virtual ~AnimationChoreographer() = default;
@@ -3669,6 +3671,7 @@ class facebook::react::UIManagerAnimationBackend {
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
+  public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;
   public virtual void stop(facebook::react::CallbackId callbackId) = 0;
   public virtual void trigger() = 0;
@@ -7485,7 +7488,7 @@ class facebook::react::jsinspector_modern::HostTargetDelegate : public facebook:
   public facebook::react::jsinspector_modern::HostTargetDelegate& operator=(facebook::react::jsinspector_modern::HostTargetDelegate&&) = delete;
   public virtual facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() = 0;
   public virtual facebook::react::jsinspector_modern::HostTargetTracingDelegate* getTracingDelegate();
-  public virtual void captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&, const std::function<void(std::optional<std::string> base64Data)>& callback);
+  public virtual std::optional<std::string> captureScreenshot(const facebook::react::jsinspector_modern::HostTargetDelegate::PageCaptureScreenshotRequest&);
   public virtual void loadNetworkResource(const facebook::react::jsinspector_modern::LoadNetworkResourceRequest&, facebook::react::jsinspector_modern::ScopedExecutor<facebook::react::jsinspector_modern::NetworkRequestListener>) override;
   public virtual void onReload(const facebook::react::jsinspector_modern::HostTargetDelegate::PageReloadRequest& request) = 0;
   public virtual void onSetPausedInDebuggerMessage(const facebook::react::jsinspector_modern::HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest& request) = 0;
@@ -9946,6 +9949,8 @@ class facebook::yoga::StyleSizeLength {
 class facebook::yoga::StyleValueHandle {
   public constexpr bool isAuto() const;
   public constexpr bool isDefined() const;
+  public constexpr bool isPercent() const;
+  public constexpr bool isPoint() const;
   public constexpr bool isUndefined() const;
   public static constexpr facebook::yoga::StyleValueHandle ofAuto();
 }
@@ -9954,6 +9959,7 @@ class facebook::yoga::StyleValuePool {
   public facebook::yoga::FloatOptional getNumber(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleLength getLength(facebook::yoga::StyleValueHandle handle) const;
   public facebook::yoga::StyleSizeLength getSize(facebook::yoga::StyleValueHandle handle) const;
+  public float getStoredValue(facebook::yoga::StyleValueHandle handle) const;
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::FloatOptional number);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleLength length);
   public void store(facebook::yoga::StyleValueHandle& handle, facebook::yoga::StyleSizeLength sizeValue);


### PR DESCRIPTION
Summary:
Add `pushAnimationMutations(Callback)` to the AnimationBackend as a targeted alternative to `trigger()`.

The existing `trigger()` method has two problems:

1. **Blast radius**: It calls `onAnimationFrame()` which invokes ALL registered callbacks. When one animation frontend (e.g. Animated) calls `trigger()` in response to an event, every other frontend (e.g. Reanimated) also spins up unnecessarily.

2. **Broken timestamp on iOS**: `trigger()` uses `std::chrono::steady_clock` which on iOS maps to a different kernel clock than what `CADisplayLink` uses for vsync timestamps. These clocks have different baselines and can diverge over time (e.g. after device sleep), causing animations to see time jumps.

`pushAnimationMutations(Callback)` fixes both issues:
- Executes only the provided callback, not all registered ones
- Uses `AnimationChoreographer::now()` which delegates to `HighResTimeStamp`, providing a timestamp from the same clock as the vsync path on each platform

Also refactors `onAnimationFrame` to use `unpackMutations`/`applySurfaceUpdates` helpers, avoiding intermediate vector/set merging when accumulating mutations from multiple callbacks.

## Changelog:
[General][Added] - Add pushAnimationMutations to AnimationBackend for targeted event-driven animation updates

Differential Revision: D100164749
