### PR TITLE
fix: formData upload broken in debug builds

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -19,6 +19,7 @@ import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import java.io.IOException
 import java.net.SocketTimeoutException
 import okhttp3.Headers
+import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okio.Buffer
 
@@ -260,6 +261,13 @@ internal object NetworkEventUtil {
 
     if (body.isOneShot()) {
       // Fallback - body cannot be read twice
+      return "[Preview unavailable]"
+    }
+
+    // MultipartBody does not propagate isOneShot() from its parts, so check each
+    // part explicitly. Reading a one-shot part here would drain the underlying
+    // stream and cause the real request to fail.
+    if (body is MultipartBody && body.parts().any { it.body().isOneShot() }) {
       return "[Preview unavailable]"
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/RequestBodyUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/RequestBodyUtil.kt
@@ -146,6 +146,8 @@ internal object RequestBodyUtil {
         }
       }
 
+      override fun isOneShot(): Boolean = true
+
       @Throws(IOException::class)
       override fun writeTo(sink: BufferedSink) {
         var source: Source? = null


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
So  the formData Upload in fetch is broken on 0.85 on main. 
I tracked down this PR https://github.com/facebook/react-native/pull/55456
Also reported here https://github.com/facebook/react-native/issues/56404
RCA:- 
```
body.isOneShot()                                                                                                                                                          
body.writeTo(buffer)  // This is  draining inner file InputStreams   
```
Fix is to walk to each children of multipart and check for Oneshot
## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[ANDROID][FIXED] - FormData uploads broken in debug builds
## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested on RN tester
<img width="416" height="600" alt="image" src="https://github.com/user-attachments/assets/20cae662-e2ba-4fc7-9f8d-d8e365eb95b2" />
