### PR TITLE
Respect theme `enforceNavigationBarContrast` attribute

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -117,7 +117,7 @@ internal fun Window.enableEdgeToEdge() {
     val attrs = intArrayOf(android.R.attr.enforceNavigationBarContrast)
     val typedArray = context.theme.obtainStyledAttributes(attrs)
 
-    val isContrastEnforced =
+    val enforceNavigationBarContrast =
         try {
           typedArray.getBoolean(0, true)
         } finally {
@@ -125,15 +125,18 @@ internal fun Window.enableEdgeToEdge() {
         }
 
     isStatusBarContrastEnforced = false
-    isNavigationBarContrastEnforced = isContrastEnforced
+    isNavigationBarContrastEnforced = enforceNavigationBarContrast
 
-    if (isContrastEnforced) {
+    if (enforceNavigationBarContrast) {
       insetsController.isAppearanceLightNavigationBars = !isDarkMode
     }
   } else {
-    val isAppearanceLight = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isDarkMode
-    navigationBarColor = if (isAppearanceLight) LightNavigationBarColor else DarkNavigationBarColor
-    insetsController.isAppearanceLightNavigationBars = isAppearanceLight
+    val isAppearanceLightNavigationBars =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isDarkMode
+
+    navigationBarColor =
+        if (isAppearanceLightNavigationBars) LightNavigationBarColor else DarkNavigationBarColor
+    insetsController.isAppearanceLightNavigationBars = isAppearanceLightNavigationBars
   }
 
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -106,23 +106,40 @@ private fun Window.statusBarShow() {
 internal fun Window.enableEdgeToEdge() {
   WindowCompat.setDecorFitsSystemWindows(this, false)
 
+  val insetsController = WindowInsetsControllerCompat(this, decorView)
   val isDarkMode = UiModeUtils.isDarkMode(context)
 
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-    isStatusBarContrastEnforced = false
-    isNavigationBarContrastEnforced = true
-  }
-
   statusBarColor = Color.TRANSPARENT
-  navigationBarColor =
-      when {
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> Color.TRANSPARENT
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isDarkMode -> LightNavigationBarColor
-        else -> DarkNavigationBarColor
-      }
 
-  WindowInsetsControllerCompat(this, decorView).run {
-    isAppearanceLightNavigationBars = !isDarkMode
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+    navigationBarColor = Color.TRANSPARENT
+
+    val attrs = intArrayOf(android.R.attr.enforceNavigationBarContrast)
+    val typedArray = context.theme.obtainStyledAttributes(attrs)
+
+    val isContrastEnforced =
+        try {
+          typedArray.getBoolean(0, true)
+        } finally {
+          typedArray.recycle()
+        }
+
+    isStatusBarContrastEnforced = false
+    isNavigationBarContrastEnforced = isContrastEnforced
+
+    if (isContrastEnforced) {
+      insetsController.isAppearanceLightNavigationBars = !isDarkMode
+    }
+  } else {
+    val isAppearanceLight = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isDarkMode
+
+    navigationBarColor =
+        when {
+          isAppearanceLight -> LightNavigationBarColor
+          else -> DarkNavigationBarColor
+        }
+
+    insetsController.isAppearanceLightNavigationBars = isAppearanceLight
   }
 
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -132,13 +132,7 @@ internal fun Window.enableEdgeToEdge() {
     }
   } else {
     val isAppearanceLight = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isDarkMode
-
-    navigationBarColor =
-        when {
-          isAppearanceLight -> LightNavigationBarColor
-          else -> DarkNavigationBarColor
-        }
-
+    navigationBarColor = if (isAppearanceLight) LightNavigationBarColor else DarkNavigationBarColor
     insetsController.isAppearanceLightNavigationBars = isAppearanceLight
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -114,8 +114,8 @@ internal fun Window.enableEdgeToEdge() {
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
     navigationBarColor = Color.TRANSPARENT
 
-    val attrs = intArrayOf(android.R.attr.enforceNavigationBarContrast)
-    val typedArray = context.theme.obtainStyledAttributes(attrs)
+    val attributes = intArrayOf(android.R.attr.enforceNavigationBarContrast)
+    val typedArray = context.theme.obtainStyledAttributes(attributes)
 
     val enforceNavigationBarContrast =
         try {


### PR DESCRIPTION
## Summary:

This PR adds respect of the theme's `enforceNavigationBarContrast` attribute in `WindowUtil` `enableEdgeToEdge` (this will allow us to delete our [EdgeToEdgePackage.kt](https://github.com/expo/expo/blob/main/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/edgeToEdge/EdgeToEdgePackage.kt) file, and prevent a glitch where the navigation bar is semi-opaque for a short instant when user explicitly set `android:enforceNavigationBarContrast` to `false`).

## Changelog:

[ANDROID] [CHANGED] - Respect theme `enforceNavigationBarContrast` attribute

## Test Plan:

- Verified edge-to-edge rendering on API 30+ (transparent status/navigation bars, correct display cutout behavior).
- Verified navigation bar contrast enforcement respects the theme attribute on API 29+ (with `android:enforceNavigationBarContrast` to `true` (default) and `false`).
- Verified fallback navigation bar colors on API 26-28 (light/dark scrim) and API < 26 (dark scrim).