### PR TITLE
Revert: Bump minimum whatwg-fetch 3.0.0 -> 3.6.20 (#56415)

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -191,7 +191,7 @@
     "semver": "^7.1.3",
     "stacktrace-parser": "^0.1.10",
     "tinyglobby": "^0.2.15",
-    "whatwg-fetch": "^3.6.20",
+    "whatwg-fetch": "^3.0.0",
     "ws": "^7.5.10",
     "yargs": "^17.6.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9368,7 +9368,7 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
-whatwg-fetch@^3.6.20:
+whatwg-fetch@^3.0.0:
   version "3.6.20"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
   integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==


### PR DESCRIPTION
Summary:

Reverting due to some internal applications relying on bugs in older whatwg-fetch versions.

Changelog: [Internal]

Differential Revision: D100389704
