### PR TITLE
Expose Event, EventTarget and CustomEvent as globals

### DIFF
--- a/packages/react-native/src/private/setup/setUpDOM.js
+++ b/packages/react-native/src/private/setup/setUpDOM.js
@@ -73,4 +73,16 @@ export default function setUpDOM() {
     'HTMLElement',
     () => require('../webapis/dom/nodes/ReactNativeElement').default,
   );
+
+  polyfillGlobal('Event', () => require('../webapis/dom/events/Event').default);
+
+  polyfillGlobal(
+    'EventTarget',
+    () => require('../webapis/dom/events/EventTarget').default,
+  );
+
+  polyfillGlobal(
+    'CustomEvent',
+    () => require('../webapis/dom/events/CustomEvent').default,
+  );
 }

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -712,26 +712,4 @@ function getNode(nodeOrRef: NodeOrRef): ReadOnlyNode {
   }
 }
 
-/**
- * Quick and dirty polyfills required by tinybench.
- */
-
-if (typeof global.Event === 'undefined') {
-  global.Event =
-    require('react-native/src/private/webapis/dom/events/Event').default;
-} else {
-  console.warn(
-    'The global Event class is already defined. If this API is already defined by React Native, you might want to remove this logic.',
-  );
-}
-
-if (typeof global.EventTarget === 'undefined') {
-  global.EventTarget =
-    require('react-native/src/private/webapis/dom/events/EventTarget').default;
-} else {
-  console.warn(
-    'The global Event class is already defined. If this API is already defined by React Native, you might want to remove this logic.',
-  );
-}
-
 global.__FANTOM_PACKAGE_LOADED__ = true;


### PR DESCRIPTION
Summary:
Registers Event, EventTarget and CustomEvent as global polyfills in `setUpDOM.js`. These are standard Web APIs that DOM nodes need access to.

Removes the Event/EventTarget polyfills from the Fantom test setup since they are now provided globally by setUpDOM.js.

Changelog: [internal]

Marking as internal for now, until we ship to stable, even though this isn't gated. We shouldn't communicate this yet.

Differential Revision: D100462548


