### PR TITLE
Expose dispatchTrustedEvent and setEventInitTimeStamp in ReactNativePrivateInterface

### DIFF
--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -9,6 +9,8 @@
  */
 
 import typeof CustomEvent from '../../src/private/webapis/dom/events/CustomEvent';
+import typeof {setEventInitTimeStamp} from '../../src/private/webapis/dom/events/internals/EventInternals';
+import typeof {dispatchTrustedEvent} from '../../src/private/webapis/dom/events/internals/EventTargetInternals';
 import typeof BatchedBridge from '../BatchedBridge/BatchedBridge';
 import typeof legacySendAccessibilityEvent from '../Components/AccessibilityInfo/legacySendAccessibilityEvent';
 import typeof TextInputState from '../Components/TextInput/TextInputState';
@@ -132,5 +134,13 @@ module.exports = {
   get getInternalInstanceHandleFromPublicInstance(): getInternalInstanceHandleFromPublicInstance {
     return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
       .getInternalInstanceHandleFromPublicInstance;
+  },
+  get dispatchTrustedEvent(): dispatchTrustedEvent {
+    return require('../../src/private/webapis/dom/events/internals/EventTargetInternals')
+      .dispatchTrustedEvent;
+  },
+  get setEventInitTimeStamp(): setEventInitTimeStamp {
+    return require('../../src/private/webapis/dom/events/internals/EventInternals')
+      .setEventInitTimeStamp;
   },
 };

--- a/packages/react-native/src/private/setup/setUpDOM.js
+++ b/packages/react-native/src/private/setup/setUpDOM.js
@@ -73,4 +73,16 @@ export default function setUpDOM() {
     'HTMLElement',
     () => require('../webapis/dom/nodes/ReactNativeElement').default,
   );
+
+  polyfillGlobal('Event', () => require('../webapis/dom/events/Event').default);
+
+  polyfillGlobal(
+    'EventTarget',
+    () => require('../webapis/dom/events/EventTarget').default,
+  );
+
+  polyfillGlobal(
+    'CustomEvent',
+    () => require('../webapis/dom/events/CustomEvent').default,
+  );
 }

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -712,26 +712,4 @@ function getNode(nodeOrRef: NodeOrRef): ReadOnlyNode {
   }
 }
 
-/**
- * Quick and dirty polyfills required by tinybench.
- */
-
-if (typeof global.Event === 'undefined') {
-  global.Event =
-    require('react-native/src/private/webapis/dom/events/Event').default;
-} else {
-  console.warn(
-    'The global Event class is already defined. If this API is already defined by React Native, you might want to remove this logic.',
-  );
-}
-
-if (typeof global.EventTarget === 'undefined') {
-  global.EventTarget =
-    require('react-native/src/private/webapis/dom/events/EventTarget').default;
-} else {
-  console.warn(
-    'The global Event class is already defined. If this API is already defined by React Native, you might want to remove this logic.',
-  );
-}
-
 global.__FANTOM_PACKAGE_LOADED__ = true;


### PR DESCRIPTION
Summary:
Changelog: [internal]

The React Native renderer needs access to these internals to dispatch events under the new EventTarget-based event dispatching pipeline.

Differential Revision: D100462549


