### PR TITLE
Fix stateful regex bug in benchmark detection

### DIFF
--- a/private/react-native-fantom/runner/getFantomTestConfigs.js
+++ b/private/react-native-fantom/runner/getFantomTestConfigs.js
@@ -72,9 +72,9 @@ export const DEFAULT_FEATURE_FLAGS: FantomTestConfigFeatureFlags = {
 
 const FANTOM_FLAG_FORMAT = /^(\w+):((?:\w+)|\*)$/;
 
-const FANTOM_BENCHMARK_FILENAME_RE = /[Bb]enchmark-itest\./g;
+const FANTOM_BENCHMARK_FILENAME_RE = /[Bb]enchmark-itest\./;
 const FANTOM_BENCHMARK_SUITE_RE =
-  /\n(Fantom\.)?unstable_benchmark(\s*)\.suite\(/g;
+  /\n(Fantom\.)?unstable_benchmark(\s*)\.suite\(/;
 
 const MAX_FANTOM_CONFIGURATION_VARIATIONS = 12;
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

The `FANTOM_BENCHMARK_FILENAME_RE` and `FANTOM_BENCHMARK_SUITE_RE` regexes used the `g` (global) flag, which makes `.test()` stateful — it preserves `lastIndex` between calls. When `getFantomTestConfigs` is called for multiple test files in the same process, the stale `lastIndex` from a previous successful match causes `.test()` to miss the match on the next file, returning `false`. This results in benchmark files intermittently getting the default dev config (`isJsOptimized: false`, `dev: true`), causing them to fail at runtime with "Benchmarks should not be run in development mode".

Removes the `g` flag from both regexes since they are used with `.test()` across different strings and should be stateless.

Differential Revision: D100603612


