### PR TITLE
Retry only failed Fantom tests instead of full suite on CI

### DIFF
--- a/.github/actions/run-fantom-tests/action.yml
+++ b/.github/actions/run-fantom-tests/action.yml
@@ -27,11 +27,17 @@ runs:
       run: |
         for attempt in 1 2 3; do
           echo "Attempt $attempt of 3"
-          if yarn fantom; then
-            exit 0
+          if [ "$attempt" -eq 1 ]; then
+            if yarn fantom; then
+              exit 0
+            fi
+          else
+            if yarn fantom --onlyFailures; then
+              exit 0
+            fi
           fi
           if [ "$attempt" -lt 3 ]; then
-            echo "Attempt $attempt failed. Retrying..."
+            echo "Attempt $attempt failed. Retrying only failed tests..."
           fi
         done
         echo "All 3 attempts failed."


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The Fantom CI retry loop previously re-ran the entire test suite on each attempt. This wastes time and can introduce new flaky failures that weren't in the original run (e.g., a FlatList race condition appearing on attempt 2 but not attempt 1).

This changes the retry logic to use Jest's `--onlyFailures` flag on attempts 2 and 3, so only the test suites that actually failed get re-run. For example, if 1 out of 99 suites fails with a SIGSEGV, the retry runs just that 1 suite instead of all 99 — reducing retry time from ~80s to seconds.

Differential Revision: D100618771


