### PR TITLE
Add Android SDK compatibility constants to AndroidVersion.kt

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/AndroidVersion.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/AndroidVersion.kt
@@ -21,17 +21,33 @@ internal object AndroidVersion {
   internal const val VERSION_CODE_VANILLA_ICE_CREAM: Int = 35
 
   /**
-   * This is the version code for Android 16 (SDK Level 36). Delete it once we bump up the default
-   * compile SDK version to 36.
+   * This is the version code for Android 16 (SDK Level 36). Internally at Meta this code is also
+   * compiled against SDK 34, so we need to retain this constant instead of using
+   * [Build.VERSION_CODES.BAKLAVA] directly.
    */
-  private const val VERSION_CODE_BAKLAVA: Int = 36
+  internal const val VERSION_CODE_BAKLAVA: Int = 36
+
+  /**
+   * android.R.attr.windowOptOutEdgeToEdgeEnforcement added in API 35. Internally at Meta this code
+   * is compiled against an SDK that may not have this attribute defined.
+   */
+  internal const val ATTR_WINDOW_OPT_OUT_EDGE_TO_EDGE_ENFORCEMENT: Int = 0x01010678
+
+  /**
+   * This method is used to check if the current device is running Android 15 (SDK Level 35) or
+   * higher and the app is targeting Android 15 (SDK Level 35) or higher.
+   */
+  @JvmStatic
+  internal fun isAtLeastTargetSdk35(context: Context): Boolean =
+      Build.VERSION.SDK_INT >= VERSION_CODE_VANILLA_ICE_CREAM &&
+          context.applicationInfo.targetSdkVersion >= VERSION_CODE_VANILLA_ICE_CREAM
 
   /**
    * This method is used to check if the current device is running Android 16 (SDK Level 36) or
    * higher and the app is targeting Android 16 (SDK Level 36) or higher.
    */
   @JvmStatic
-  fun isAtLeastTargetSdk36(context: Context): Boolean =
+  internal fun isAtLeastTargetSdk36(context: Context): Boolean =
       Build.VERSION.SDK_INT >= VERSION_CODE_BAKLAVA &&
           context.applicationInfo.targetSdkVersion >= VERSION_CODE_BAKLAVA
 }


### PR DESCRIPTION
Summary:
Add VERSION_CODE_BAKLAVA (API 36) and ATTR_WINDOW_OPT_OUT_EDGE_TO_EDGE_ENFORCEMENT constants to AndroidVersion.kt.

These constants are needed because internally at Meta, this code is compiled against SDK 34 in certain cases, which doesn't have Build.VERSION_CODES.BAKLAVA or android.R.attr.windowOptOutEdgeToEdgeEnforcement defined.

Changelog: 
[Internal] Adding additional constants to AndroidVersion.kt

----

Differential Revision: D100755751


