### PR TITLE
fix(ios): make prebuilt binaries podfile checksums stable

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -160,7 +160,7 @@ class ReactNativeCoreUtils
         rncore_log("  #{Pathname.new(destinationDebug).relative_path_from(Pathname.pwd).to_s}")
         rncore_log("  #{Pathname.new(destinationRelease).relative_path_from(Pathname.pwd).to_s}")
 
-        return {:http => URI::File.build(path: destinationDebug).to_s }
+        return {:http => stable_tarball_url(@@react_native_version, :debug) }
     end
 
     def self.podspec_source_download_prebuilt_nightly_tarball()
@@ -196,7 +196,7 @@ class ReactNativeCoreUtils
         rncore_log("Resolved nightly ReactNativeCore-prebuilt version:")
         rncore_log("  #{Pathname.new(destinationDebug).relative_path_from(Pathname.pwd).to_s}")
         rncore_log("  #{Pathname.new(destinationRelease).relative_path_from(Pathname.pwd).to_s}")
-        return {:http => URI::File.build(path: destinationDebug).to_s }
+        return {:http => nightly_tarball_url(@@react_native_version, :debug) }
     end
 
     def self.process_dsyms(frameworkTarball, dSymsTarball)

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -158,10 +158,10 @@ class ReactNativeDependenciesUtils
 
         url = release_tarball_url(@@react_native_version, :debug)
         rndeps_log("Using tarball from URL: #{url}")
-        destinationDebug = download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
+        download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
         download_stable_rndeps(@@react_native_path, @@react_native_version, :release)
 
-        return {:http => URI::File.build(path: destinationDebug).to_s }
+        return {:http => url }
     end
 
     def self.release_tarball_url(version, build_type)
@@ -225,10 +225,9 @@ class ReactNativeDependenciesUtils
 
         url = nightly_tarball_url(version, :debug)
         rndeps_log("Using tarball from URL: #{url}")
-        destinationDebug = download_nightly_rndeps(@@react_native_path, @@react_native_version, :debug)
+        download_nightly_rndeps(@@react_native_path, @@react_native_version, :debug)
         download_nightly_rndeps(@@react_native_path, @@react_native_version, :release)
 
-        return {:http => URI::File.build(path: destinationDebug).to_s }
         return {:http => url}
     end
 


### PR DESCRIPTION
## Summary:

Currently the podspecs for `React-Core-prebuilt`/`ReactNativeDependencies` use an absolute path to the downloaded tarball which makes the Podfile.lock checksums inconsistent across machines depending on where the project is checked out. Previously Hermes binaries [had the same issue](https://github.com/facebook/react-native/issues/54891) so this PR applies a similar fix by using the tarball URL instead of the local path. 

Closes https://github.com/facebook/react-native/issues/55446

## Changelog:

[iOS] [Fixed] - Make prebuilt binaries podfile checksums stable

## Test Plan:

Tested with `yarn patch`.