### PR TITLE
Skip reporting benchmark results in test mode

### DIFF
--- a/private/react-native-fantom/src/Benchmark.js
+++ b/private/react-native-fantom/src/Benchmark.js
@@ -215,7 +215,9 @@ export function suite(
         'Failing focused test to prevent it from being committed',
       );
     }
-    reportBenchmarkResult(createBenchmarkResultsObject(bench, tasks));
+    if (!isTestOnly) {
+      reportBenchmarkResult(createBenchmarkResultsObject(bench, tasks));
+    }
   });
 
   const test = (name: string, fn: SyncFn, options?: FnOptions): SuiteAPI => {


### PR DESCRIPTION
Summary:
Avoid printing the result summary table when benchmarks are executed in
test mode. In test mode, benchmarks run only a single iteration with no
warmup, so the timing results are not meaningful for comparison.

The per-suite results table (console.table) was already skipped in test
mode, but the benchmark result was still reported to the runner, which
could cause the cross-variant comparison table to be printed with
meaningless data. This change skips the reportBenchmarkResult call
entirely when running in test mode.

Changelog: [Internal]

Differential Revision: D100795458


