### PR TITLE
Automatically set --runInBand when running benchmarks

### DIFF
--- a/private/react-native-fantom/src/Benchmark.js
+++ b/private/react-native-fantom/src/Benchmark.js
@@ -215,7 +215,9 @@ export function suite(
         'Failing focused test to prevent it from being committed',
       );
     }
-    reportBenchmarkResult(createBenchmarkResultsObject(bench, tasks));
+    if (!isTestOnly) {
+      reportBenchmarkResult(createBenchmarkResultsObject(bench, tasks));
+    }
   });
 
   const test = (name: string, fn: SyncFn, options?: FnOptions): SuiteAPI => {

--- a/scripts/fantom.sh
+++ b/scripts/fantom.sh
@@ -27,4 +27,8 @@ for arg in "$@"; do
   esac
 done
 
+if [[ -n "$FANTOM_RUN_BENCHMARKS" ]]; then
+  ARGS+=("--runInBand")
+fi
+
 yarn jest --config private/react-native-fantom/config/jest.config.js "${ARGS[@]}"


### PR DESCRIPTION
Summary:
When `--benchmarks` is passed to `yarn fantom`, automatically append
`--runInBand` to the Jest arguments. This ensures benchmarks run
sequentially in the same process, avoiding parallel test execution that
would introduce noise in performance measurements.

Changelog: [Internal]

Differential Revision: D100796022


