### PR TITLE
fix typo: componentWillRecieveProps -> componentWillReceiveProps

### DIFF
--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -7333,14 +7333,14 @@ __DEV__ &&
           "%s has a method called componentDidReceiveProps(). But there is no such lifecycle method. If you meant to update the state in response to changing props, use componentWillReceiveProps(). If you meant to fetch data or run side-effects or mutations after React has updated the UI, use componentDidUpdate().",
           name
         );
-      "function" === typeof instance.componentWillRecieveProps &&
+      "function" === typeof instance.componentWillReceiveProps &&
         console.error(
-          "%s has a method called componentWillRecieveProps(). Did you mean componentWillReceiveProps()?",
+          "%s has a method called componentWillReceiveProps(). Did you mean componentWillReceiveProps()?",
           name
         );
-      "function" === typeof instance.UNSAFE_componentWillRecieveProps &&
+      "function" === typeof instance.UNSAFE_componentWillReceiveProps &&
         console.error(
-          "%s has a method called UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?",
+          "%s has a method called UNSAFE_componentWillReceiveProps(). Did you mean UNSAFE_componentWillReceiveProps()?",
           name
         );
       var hasMutatedProps = instance.props !== newProps;


### PR DESCRIPTION
Good day,

This PR fixes a typo in the development mode warning messages where 'componentWillRecieveProps' should be 'componentWillReceiveProps'.

This is a simple typo fix that corrects the method name in the console.error messages used to warn developers about deprecated lifecycle methods.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof