### PR TITLE
feat(ios): store prebuilt tarballs in shared cache folder

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -157,9 +157,10 @@ class ReactNativeCoreUtils
         end
 
         rncore_log("Resolved stable ReactNativeCore-prebuilt version:")
-        rncore_log("  #{Pathname.new(destinationDebug).relative_path_from(Pathname.pwd).to_s}")
-        rncore_log("  #{Pathname.new(destinationRelease).relative_path_from(Pathname.pwd).to_s}")
+        rncore_log("  #{destinationDebug}")
+        rncore_log("  #{destinationRelease}")
 
+        ensure_pods_symlink()
         return {:http => URI::File.build(path: destinationDebug).to_s }
     end
 
@@ -185,8 +186,8 @@ class ReactNativeCoreUtils
             dSymsDebug = download_nightly_rncore(@@react_native_path, @@react_native_version, :debug, true)
             dSymsRelease = download_nightly_rncore(@@react_native_path, @@react_native_version, :release, true)
             rncore_log("Resolved nightly dSYMs")
-            rncore_log("  #{Pathname.new(dSymsDebug).relative_path_from(Pathname.pwd).to_s}")
-            rncore_log("  #{Pathname.new(dSymsRelease).relative_path_from(Pathname.pwd).to_s}")
+            rncore_log("  #{dSymsDebug}")
+            rncore_log("  #{dSymsRelease}")
 
             # Make sure that the dSYMs are processed
             process_dsyms(destinationDebug, dSymsDebug)
@@ -194,8 +195,9 @@ class ReactNativeCoreUtils
         end
 
         rncore_log("Resolved nightly ReactNativeCore-prebuilt version:")
-        rncore_log("  #{Pathname.new(destinationDebug).relative_path_from(Pathname.pwd).to_s}")
-        rncore_log("  #{Pathname.new(destinationRelease).relative_path_from(Pathname.pwd).to_s}")
+        rncore_log("  #{destinationDebug}")
+        rncore_log("  #{destinationRelease}")
+        ensure_pods_symlink()
         return {:http => URI::File.build(path: destinationDebug).to_s }
     end
 
@@ -410,11 +412,11 @@ class ReactNativeCoreUtils
 
         unless File.exist?(destination_path)
           # Download to a temporary file first so we don't cache incomplete downloads.
-          rncore_log("Downloading ReactNativeCore-prebuilt #{dsyms ? "dSYMs " : ""}#{configuration ? configuration.to_s : ""} tarball from #{tarball_url} to #{Pathname.new(destination_path).relative_path_from(Pathname.pwd).to_s}")
+          rncore_log("Downloading ReactNativeCore-prebuilt #{dsyms ? "dSYMs " : ""}#{configuration ? configuration.to_s : ""} tarball from #{tarball_url} to #{destination_path}")
           tmp_file = "#{artifacts_dir()}/reactnative-core.download"
           `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
         else
-          rncore_log("Using downloaded ReactNativeCore-prebuilt #{dsyms ? "dSYMs " : ""}#{configuration ? configuration.to_s : ""} tarball at #{Pathname.new(destination_path).relative_path_from(Pathname.pwd).to_s}")
+          rncore_log("Using downloaded ReactNativeCore-prebuilt #{dsyms ? "dSYMs " : ""}#{configuration ? configuration.to_s : ""} tarball at #{destination_path}")
         end
 
         return destination_path
@@ -429,7 +431,19 @@ class ReactNativeCoreUtils
     end
 
     def self.artifacts_dir()
-        return File.join(Pod::Config.instance.project_pods_root, "ReactNativeCore-artifacts")
+        return ENV['RCT_PREBUILT_CACHE_DIR'] || "/tmp/react-native-prebuilt"
+    end
+
+    def self.ensure_pods_symlink()
+        pods_artifacts = File.join(Pod::Config.instance.project_pods_root, "ReactNativeCore-artifacts")
+        if File.symlink?(pods_artifacts)
+            return if File.readlink(pods_artifacts) == artifacts_dir()
+            FileUtils.rm(pods_artifacts)
+        elsif File.exist?(pods_artifacts)
+            FileUtils.rm_rf(pods_artifacts)
+        end
+        FileUtils.mkdir_p(File.dirname(pods_artifacts))
+        FileUtils.ln_sf(artifacts_dir(), pods_artifacts)
     end
 
     # This function checks that ReactNativeCore artifact exists on the maven repo

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -161,6 +161,7 @@ class ReactNativeDependenciesUtils
         destinationDebug = download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
         download_stable_rndeps(@@react_native_path, @@react_native_version, :release)
 
+        ensure_pods_symlink()
         return {:http => URI::File.build(path: destinationDebug).to_s }
     end
 
@@ -228,8 +229,8 @@ class ReactNativeDependenciesUtils
         destinationDebug = download_nightly_rndeps(@@react_native_path, @@react_native_version, :debug)
         download_nightly_rndeps(@@react_native_path, @@react_native_version, :release)
 
+        ensure_pods_symlink()
         return {:http => URI::File.build(path: destinationDebug).to_s }
-        return {:http => url}
     end
 
     def self.download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
@@ -255,7 +256,19 @@ class ReactNativeDependenciesUtils
     end
 
     def self.artifacts_dir()
-        return File.join(Pod::Config.instance.project_pods_root, "ReactNativeDependencies-artifacts")
+        return ENV['RCT_PREBUILT_CACHE_DIR'] || "/tmp/react-native-prebuilt"
+    end
+
+    def self.ensure_pods_symlink()
+        pods_artifacts = File.join(Pod::Config.instance.project_pods_root, "ReactNativeDependencies-artifacts")
+        if File.symlink?(pods_artifacts)
+            return if File.readlink(pods_artifacts) == artifacts_dir()
+            FileUtils.rm(pods_artifacts)
+        elsif File.exist?(pods_artifacts)
+            FileUtils.rm_rf(pods_artifacts)
+        end
+        FileUtils.mkdir_p(File.dirname(pods_artifacts))
+        FileUtils.ln_sf(artifacts_dir(), pods_artifacts)
     end
 
     # This function checks that ReactNativeDependencies artifact exists on the maven repo

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -194,6 +194,7 @@ def podspec_source_download_prebuild_release_tarball(react_native_path, version)
     hermes_log("Using release tarball from URL: #{url}")
     download_stable_hermes(react_native_path, version, :debug)
     download_stable_hermes(react_native_path, version, :release)
+    ensure_hermes_pods_symlink()
     return {:http => url}
 end
 
@@ -206,7 +207,19 @@ end
 # HELPERS
 
 def artifacts_dir()
-    return File.join(Pod::Config.instance.project_pods_root, "hermes-engine-artifacts")
+    return ENV['RCT_PREBUILT_CACHE_DIR'] || "/tmp/react-native-prebuilt"
+end
+
+def ensure_hermes_pods_symlink()
+    pods_artifacts = File.join(Pod::Config.instance.project_pods_root, "hermes-engine-artifacts")
+    if File.symlink?(pods_artifacts)
+        return if File.readlink(pods_artifacts) == artifacts_dir()
+        FileUtils.rm(pods_artifacts)
+    elsif File.exist?(pods_artifacts)
+        FileUtils.rm_rf(pods_artifacts)
+    end
+    FileUtils.mkdir_p(File.dirname(pods_artifacts))
+    FileUtils.ln_sf(artifacts_dir(), pods_artifacts)
 end
 
 def hermestag_file(react_native_path)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In order to be able to share cache across repos/pod installs and keep Podfile.lock checksums stable this PR uses the /tmp folder as a persistent path across machines for prebuilt tarball cache as suggested by @cipolleschi. To keep it consistent, the approach is applied to Hermes too. 

This PR superseds https://github.com/facebook/react-native/pull/56434

Closes https://github.com/facebook/react-native/issues/55446

## Changelog:

[iOS] [Added] - Store prebuilt tarballs in shared cache folder, making Podfile checksums stable

## Test Plan:

Tested with local patch.