### PR TITLE
Remove legacy arch fallback from LayoutConformance (#56440)

### DIFF
--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
@@ -18,40 +18,14 @@ export type LayoutConformanceProps = Readonly<{
    * compatibility: Layout with the same behavior as previous versions of React Native
    */
   mode: 'strict' | 'compatibility',
-
   children: React.Node,
 }>;
 
-// We want a graceful fallback for apps using legacy arch, but need to know
-// ahead of time whether the component is available, so we test for global.
-// This does not correctly handle mixed arch apps (which is okay, since we just
-// degrade the error experience).
-const isFabricUIManagerInstalled = global?.nativeFabricUIManager != null;
-
-function LayoutConformance(props: LayoutConformanceProps): React.Node {
+export default component LayoutConformance(...props: LayoutConformanceProps) {
   return (
     <LayoutConformanceNativeComponent {...props} style={styles.container} />
   );
 }
-
-function UnimplementedLayoutConformance(
-  props: LayoutConformanceProps,
-): React.Node {
-  if (__DEV__) {
-    const warnOnce = require('../../Utilities/warnOnce').default;
-
-    warnOnce(
-      'layoutconformance-unsupported',
-      '"LayoutConformance" is only supported in the New Architecture',
-    );
-  }
-
-  return props.children;
-}
-
-export default (isFabricUIManagerInstalled
-  ? LayoutConformance
-  : UnimplementedLayoutConformance) as component(...LayoutConformanceProps);
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Summary:

Remove the `isFabricUIManagerInstalled` guard and `UnimplementedLayoutConformance` fallback since the legacy architecture is no longer supported. Convert to Flow component syntax.

Changelog: [Internal] - Removed legacy architecture fallback from `LayoutConformance`

Differential Revision: D100817102


