### PR TITLE
[0.83] Provide symbol fallbacks for legacy Hermes Registration API when HERMES_V1_ENABLED

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.cpp
@@ -8,7 +8,11 @@
 #include "Registration.h"
 #include "ConnectionDemux.h"
 
-#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
+#if defined(HERMES_ENABLE_DEBUGGER)
+
+#include <hermes/hermes.h>
+
+#if !defined(HERMES_V1_ENABLED)
 
 namespace facebook::hermes::inspector_modern::chrome {
 
@@ -34,4 +38,42 @@ void disableDebugging(DebugSessionToken session) {
 
 } // namespace facebook::hermes::inspector_modern::chrome
 
-#endif // defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
+#else
+
+namespace facebook::hermes::inspector_modern {
+class RuntimeAdapter {
+  // Backwards compatibility definition fallback for libraries that are compiled
+  // without `HERMES_V1_ENABLED` but are linked against React Native with
+  // `HERMES_V1_ENABLED` which doesn't provide this symbol.
+ public:
+  virtual ~RuntimeAdapter() = 0;
+  virtual HermesRuntime& getRuntime() = 0;
+  virtual void tickleJs();
+};
+
+namespace chrome {
+
+using DebugSessionToken = int;
+
+DebugSessionToken enableDebugging(
+    std::unique_ptr<RuntimeAdapter>,
+    const std::string&) {
+  // Backwards compatibility fallback for libraries that are compiled without
+  // `HERMES_V1_ENABLED` but are linked against React Native with
+  // `HERMES_V1_ENABLED` which doesn't provide this symbol.
+  return -1;
+};
+
+void disableDebugging(DebugSessionToken) {
+  // Backwards compatibility fallback for libraries that are compiled without
+  // `HERMES_V1_ENABLED` but are linked against React Native with
+  // `HERMES_V1_ENABLED` which doesn't provide this symbol.
+}
+
+} // namespace chrome
+
+} // namespace facebook::hermes::inspector_modern
+
+#endif // !defined(HERMES_V1_ENABLED)
+
+#endif // defined(HERMES_ENABLE_DEBUGGER)


### PR DESCRIPTION
## Summary

When prebuilt binaries are compiled with `HERMES_V1_ENABLED`, the `enableDebugging`/`disableDebugging` symbols were stripped entirely, causing linker errors for libraries depending on the legacy `inspector-modern/chrome/Registration.h` API (e.g. react-native-worklets).

Add no-op fallback implementations in the `HERMES_V1_ENABLED` path to preserve backward compatibility.

Cherry-picked from https://github.com/facebook/react-native/pull/55400.

Changelog: [General][Fixed] - Provide symbol fallbacks for `inspector-modern/chrome/Registration.h` when `HERMES_V1_ENABLED` is set

## Test Plan

In an Expo project using Reanimated.

**Before**

<img width="590" height="141" alt="image" src="https://github.com/user-attachments/assets/f1f6fbcc-9f3a-4853-94d1-430a562df480" />

**After**

1. Modify `Registration.cpp` inside `node_modules`.
2. Update `app.json` to build React Native from source.

```json
{
  "expo": {
    "ios": {
      "buildReactNativeFromSource": true
    }
  }
}
```

3. Update `ios/Podfile.properties.json` to use Hermes V1.

```json
"expo.useHermesV1": "true",
```

✅ Builds