### PR TITLE
Add Android 17 safety comment for JNI-written static field

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
@@ -137,6 +137,9 @@ constructor(
     public const val NAME: String = NativeAppearanceSpec.NAME
     private const val APPEARANCE_CHANGED_EVENT_NAME = "appearanceChanged"
 
+    // Must remain `var` (not `val`) — this field is set from JNI in
+    // configurePlatformColorCacheInvalidationHook.cpp. Android 17+ crashes
+    // if JNI modifies a static final field (which `val` compiles to).
     @DoNotStrip private var invalidatePlatformColorCache: Runnable? = null
   }
 }


### PR DESCRIPTION
Summary:
AppearanceModule.invalidatePlatformColorCache is set from native via JNI (configurePlatformColorCacheInvalidationHook.cpp). Android 17 crashes if JNI modifies a static final field. Since Kotlin `val` compiles to static final, this field must remain `var`. Added a comment to prevent accidental refactoring.

See https://developer.android.com/about/versions/17/behavior-changes-17#static-final-fields


Changelog: [Internal]

Differential Revision: D100831802


