### PR TITLE
don't include duplicate RCTDefines.h

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.h
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.h
@@ -7,8 +7,9 @@
 
 #import <Foundation/Foundation.h>
 
+#import <React/RCTDefines.h>
+
 #import "RCTBundleManager.h"
-#import "RCTDefines.h"
 
 RCT_EXTERN NSString *_Nonnull const RCTBundleURLProviderUpdatedNotification;
 RCT_EXTERN const NSUInteger kRCTBundleURLProviderDefaultPort;

--- a/packages/react-native/React/Base/Surface/RCTSurfaceRootView.mm
+++ b/packages/react-native/React/Base/Surface/RCTSurfaceRootView.mm
@@ -7,7 +7,7 @@
 
 #import "RCTSurfaceRootView.h"
 
-#import "RCTDefines.h"
+#import <React/RCTDefines.h>
 
 @implementation RCTSurfaceRootView
 

--- a/packages/react-native/React/Base/Surface/RCTSurfaceView.mm
+++ b/packages/react-native/React/Base/Surface/RCTSurfaceView.mm
@@ -8,7 +8,8 @@
 #import "RCTSurfaceView.h"
 #import "RCTSurfaceView+Internal.h"
 
-#import "RCTDefines.h"
+#import <React/RCTDefines.h>
+
 #import "RCTSurface.h"
 #import "RCTSurfaceProtocol.h"
 #import "RCTSurfaceRootView.h"

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -6,8 +6,10 @@
  */
 
 #import "RCTSurfaceHostingView.h"
+
+#import <React/RCTDefines.h>
+
 #import "RCTConstants.h"
-#import "RCTDefines.h"
 #import "RCTSurface.h"
 #import "RCTSurfaceDelegate.h"
 #import "RCTSurfaceView.h"

--- a/packages/react-native/React/Modules/RCTUIManager.mm
+++ b/packages/react-native/React/Modules/RCTUIManager.mm
@@ -8,6 +8,7 @@
 #import "RCTUIManager.h"
 
 #import <AVFoundation/AVFoundation.h>
+#import <React/RCTDefines.h>
 #import <React/RCTSurfacePresenterStub.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 
@@ -17,7 +18,6 @@
 #import "RCTComponent.h"
 #import "RCTComponentData.h"
 #import "RCTConvert.h"
-#import "RCTDefines.h"
 #import "RCTEventDispatcherProtocol.h"
 #import "RCTLayoutAnimation.h"
 #import "RCTLayoutAnimationGroup.h"

--- a/packages/react-native/React/Profiler/RCTProfile.m
+++ b/packages/react-native/React/Profiler/RCTProfile.m
@@ -13,13 +13,13 @@
 #import <objc/runtime.h>
 #import <stdatomic.h>
 
+#import <React/RCTDefines.h>
 #import <UIKit/UIKit.h>
 
 #import "RCTAssert.h"
 #import "RCTBridge+Private.h"
 #import "RCTBridge.h"
 #import "RCTComponentData.h"
-#import "RCTDefines.h"
 #import "RCTLog.h"
 #import "RCTModuleData.h"
 #import "RCTReloadCommand.h"

--- a/packages/react-native/React/Profiler/RCTProfileTrampoline-arm.S
+++ b/packages/react-native/React/Profiler/RCTProfileTrampoline-arm.S
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "RCTDefines.h"
+#include <React/RCTDefines.h>
 #include "RCTMacros.h"
 
 #if RCT_PROFILE && defined(__arm__)

--- a/packages/react-native/React/Profiler/RCTProfileTrampoline-arm64.S
+++ b/packages/react-native/React/Profiler/RCTProfileTrampoline-arm64.S
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "RCTDefines.h"
+#include <React/RCTDefines.h>
 #include "RCTMacros.h"
 
 #if RCT_PROFILE && defined(__arm64__)

--- a/packages/react-native/React/Profiler/RCTProfileTrampoline-i386.S
+++ b/packages/react-native/React/Profiler/RCTProfileTrampoline-i386.S
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "RCTDefines.h"
+#include <React/RCTDefines.h>
 #include "RCTMacros.h"
 
 #if RCT_PROFILE && defined(__i386__)

--- a/packages/react-native/React/Profiler/RCTProfileTrampoline-x86_64.S
+++ b/packages/react-native/React/Profiler/RCTProfileTrampoline-x86_64.S
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "RCTDefines.h"
+#include <React/RCTDefines.h>
 #include "RCTMacros.h"
 
 #if RCT_PROFILE && defined(__x86_64__)


### PR DESCRIPTION
Summary: RCTDefines.h belongs to two modules at once, which is causing include issues. Make it only part of the RCTDefines target and modify includes to find it correctly.

Reviewed By: javache

Differential Revision: D100817032


