### PR TITLE
Use relevant revision as base when updating mounted flag with branching enabled

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -425,7 +425,7 @@ CommitStatus ShadowTree::tryCommit(
     {
       std::scoped_lock dispatchLock(EventEmitter::DispatchMutex());
       updateMountedFlag(
-          currentRevision_.rootShadowNode->getChildren(),
+          oldRevision.rootShadowNode->getChildren(),
           newRootShadowNode->getChildren(),
           commitOptions.source);
     }


### PR DESCRIPTION
Summary:
Changelog: [GENERAL][FIXED] Uses relevant revision as base for mounted flag updates

Similarly to the commit itself, which is already handled above, `updateMountedFlag` should be using relevant revision to compare the new tree. During react commits, it should compare to the react revision if it exists, and the main revision in all other cases.

Differential Revision: D100800154


