### PR TITLE
Merge promoted React revision immediately when on the main thread

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)schedulerShouldMergeReactRevision:(facebook::react::SurfaceId)surfaceId;
 
+- (BOOL)schedulerShouldPromoteReactRevision:(facebook::react::SurfaceId)surfaceId;
+
 - (void)schedulerDidDispatchCommand:(const facebook::react::ShadowView &)shadowView
                         commandName:(const std::string &)commandName
                                args:(const folly::dynamic &)args;

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -43,6 +43,12 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     [scheduler.delegate schedulerShouldMergeReactRevision:surfaceId];
   }
 
+  bool schedulerShouldPromoteReactRevision(SurfaceId surfaceId) override
+  {
+    RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
+    return [scheduler.delegate schedulerShouldPromoteReactRevision:surfaceId];
+  }
+
   void schedulerDidRequestPreliminaryViewAllocation(const ShadowNode &shadowNode) override
   {
     // Does nothing.

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -316,6 +316,20 @@ using namespace facebook::react;
   });
 }
 
+- (BOOL)schedulerShouldPromoteReactRevision:(SurfaceId)surfaceId
+{
+  if (!RCTIsMainQueue()) {
+    return NO;
+  }
+
+  auto scheduler = [self scheduler];
+  scheduler.uiManager->getShadowTreeRegistry().visit(surfaceId, [](const ShadowTree &shadowTree) {
+    shadowTree.promoteReactRevision();
+    shadowTree.mergeReactRevision();
+  });
+  return YES;
+}
+
 - (void)schedulerDidDispatchCommand:(const ShadowView &)shadowView
                         commandName:(const std::string &)commandName
                                args:(const folly::dynamic &)args

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<17abc72a4045c5695818f254be1783b5>>
+ * @generated SignedSource<<404892ee783081aa311bb8faa55b231f>>
  */
 
 /**
@@ -67,7 +67,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableExclusivePropsUpdateAndroid(): Boolean = false
 
-  override fun enableFabricCommitBranching(): Boolean = false
+  override fun enableFabricCommitBranching(): Boolean = true
 
   override fun enableFabricLogs(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -70,9 +70,9 @@ class FabricMountingManager final {
 
   void scheduleReactRevisionMerge(SurfaceId surfaceId);
 
- private:
   bool isOnMainThread();
 
+ private:
   jni::global_ref<JFabricUIManager::javaobject> javaUIManager_;
 
   std::recursive_mutex commitMutex_;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -711,6 +711,23 @@ void FabricUIManagerBinding::schedulerShouldMergeReactRevision(
   }
 }
 
+bool FabricUIManagerBinding::schedulerShouldPromoteReactRevision(
+    SurfaceId surfaceId) {
+  std::shared_lock lock(installMutex_);
+  auto mountingManager =
+      getMountingManager("schedulerShouldPromoteReactRevision");
+  if (!mountingManager || !mountingManager->isOnMainThread()) {
+    return false;
+  }
+
+  scheduler_->getUIManager()->getShadowTreeRegistry().visit(
+      surfaceId, [](const ShadowTree& shadowTree) {
+        shadowTree.promoteReactRevision();
+        shadowTree.mergeReactRevision();
+      });
+  return true;
+}
+
 void FabricUIManagerBinding::mergeReactRevision(SurfaceId surfaceId) {
   std::shared_lock lock(installMutex_);
   scheduler_->getUIManager()->getShadowTreeRegistry().visit(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -99,6 +99,8 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
 
   void schedulerShouldMergeReactRevision(SurfaceId surfaceId) override;
 
+  bool schedulerShouldPromoteReactRevision(SurfaceId surfaceId) override;
+
   void mergeReactRevision(SurfaceId surfaceId);
 
   void schedulerDidRequestPreliminaryViewAllocation(const ShadowNode &shadowNode) override;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<33fd238aafa83c5a42803d3f11d55944>>
+ * @generated SignedSource<<c5368d536f9c9b5ee0f6a08d53b51929>>
  */
 
 /**
@@ -116,7 +116,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableFabricCommitBranching() override {
-    return false;
+    return true;
   }
 
   bool enableFabricLogs() override {

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -377,6 +377,15 @@ void Scheduler::uiManagerShouldRemoveEventListener(
 
 void Scheduler::uiManagerDidFinishReactCommit(const ShadowTree& shadowTree) {
   auto surfaceId = shadowTree.getSurfaceId();
+
+  // If the commit is happening on the main thread, it should be merged
+  // immediately instead of being scheduled. This allows for synchronous
+  // events to be handled correctly.
+  if (delegate_ != nullptr &&
+      delegate_->schedulerShouldPromoteReactRevision(surfaceId)) {
+    return;
+  }
+
   runtimeScheduler_->scheduleRenderingUpdate(
       surfaceId, [surfaceId, uiManager = uiManager_]() {
         uiManager->getShadowTreeRegistry().visit(

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -45,6 +45,15 @@ class SchedulerDelegate {
   virtual void schedulerShouldMergeReactRevision(SurfaceId surfaceId) = 0;
 
   /*
+   * Called when a React commit finishes and the JS revision needs to be
+   * promoted. If the platform is currently on the main thread, it should
+   * promote and merge the revision immediately, returning true.
+   * If not on the main thread, it should return false and the caller will
+   * schedule the promotion at the end of the event loop.
+   */
+  virtual bool schedulerShouldPromoteReactRevision(SurfaceId surfaceId) = 0;
+
+  /*
    * Called right after a new ShadowNode was created.
    */
   virtual void schedulerDidRequestPreliminaryViewAllocation(const ShadowNode &shadowNode) = 0;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.cpp
@@ -43,6 +43,11 @@ void SchedulerDelegateImpl::schedulerShouldMergeReactRevision(
       [](const ShadowTree& shadowTree) { shadowTree.mergeReactRevision(); });
 }
 
+bool SchedulerDelegateImpl::schedulerShouldPromoteReactRevision(
+    SurfaceId /*surfaceId*/) {
+  return false;
+}
+
 void SchedulerDelegateImpl::schedulerDidRequestPreliminaryViewAllocation(
     const ShadowNode& shadowNode) {}
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.h
@@ -35,6 +35,8 @@ class SchedulerDelegateImpl : public SchedulerDelegate {
 
   void schedulerShouldMergeReactRevision(SurfaceId surfaceId) override;
 
+  bool schedulerShouldPromoteReactRevision(SurfaceId surfaceId) override;
+
   void schedulerDidRequestPreliminaryViewAllocation(const ShadowNode &shadowNode) override;
 
   void schedulerDidDispatchCommand(

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -287,7 +287,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     enableFabricCommitBranching: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         description:
           'Enables Fabric commit branching to fix starvation problems and atomic JS updates.',

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1ec2592998e830300fc777070dfdc49d>>
+ * @generated SignedSource<<4e307a9c3ceae21cc7f1e201c58a51ad>>
  * @flow strict
  * @noformat
  */
@@ -287,7 +287,7 @@ export const enableExclusivePropsUpdateAndroid: Getter<boolean> = createNativeFl
 /**
  * Enables Fabric commit branching to fix starvation problems and atomic JS updates.
  */
-export const enableFabricCommitBranching: Getter<boolean> = createNativeFlagGetter('enableFabricCommitBranching', false);
+export const enableFabricCommitBranching: Getter<boolean> = createNativeFlagGetter('enableFabricCommitBranching', true);
 /**
  * This feature flag enables logs for Fabric.
  */

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1824,13 +1824,15 @@ class facebook::react::BindingsInstallerHolder : public jni::HybridClass<faceboo
   public void installBindings(facebook::jsi::Runtime& runtime, const std::shared_ptr<facebook::react::CallInvoker>& callInvoker);
 }
 
-class facebook::react::BlobCollector : public jni::HybridClass<facebook::react::BlobCollector>, public facebook::jsi::HostObject {
+class facebook::react::BlobCollector : public facebook::jsi::HostObject {
   public BlobCollector(jni::global_ref<jobject> blobModule, std::string blobId);
   public size_t getBlobLength();
-  public static constexpr auto kJavaDescriptor;
-  public static void nativeInstall(jni::alias_ref<jclass>, jni::alias_ref<jobject> blobModule, jlong jsContextNativePointer);
-  public static void registerNatives();
   public ~BlobCollector();
+}
+
+class facebook::react::BlobModuleJSIBindings : public jni::JavaClass<facebook::react::BlobModuleJSIBindings> {
+  public static constexpr char* kJavaDescriptor;
+  public static void registerNatives();
 }
 
 class facebook::react::BridgelessNativeMethodCallInvoker : public facebook::react::NativeMethodCallInvoker {
@@ -2311,6 +2313,7 @@ class facebook::react::ExecutorDelegate {
 class facebook::react::FabricMountingManager {
   public FabricMountingManager(const facebook::react::FabricMountingManager&) = delete;
   public FabricMountingManager(jni::global_ref<JFabricUIManager::javaobject>& javaUIManager);
+  public bool isOnMainThread();
   public bool isViewAllocated(facebook::react::SurfaceId surfaceId, facebook::react::Tag tag);
   public void destroyUnmountedShadowNode(const facebook::react::ShadowNodeFamily& family);
   public void dispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args);
@@ -4477,6 +4480,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
 }
 
 class facebook::react::SchedulerDelegate {
+  public virtual bool schedulerShouldPromoteReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerDidDispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args) = 0;
   public virtual void schedulerDidFinishTransaction(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
   public virtual void schedulerDidRequestPreliminaryViewAllocation(const facebook::react::ShadowNode& shadowNode) = 0;
@@ -7440,7 +7444,7 @@ struct facebook::react::NativePerformanceEntry {
 }
 
 struct facebook::react::PerformanceEntrySorter {
-  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs);
+  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs) const;
 }
 
 struct facebook::react::PerformanceEventTiming : public facebook::react::AbstractPerformanceEntry {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1822,13 +1822,15 @@ class facebook::react::BindingsInstallerHolder : public jni::HybridClass<faceboo
   public void installBindings(facebook::jsi::Runtime& runtime, const std::shared_ptr<facebook::react::CallInvoker>& callInvoker);
 }
 
-class facebook::react::BlobCollector : public jni::HybridClass<facebook::react::BlobCollector>, public facebook::jsi::HostObject {
+class facebook::react::BlobCollector : public facebook::jsi::HostObject {
   public BlobCollector(jni::global_ref<jobject> blobModule, std::string blobId);
   public size_t getBlobLength();
-  public static constexpr auto kJavaDescriptor;
-  public static void nativeInstall(jni::alias_ref<jclass>, jni::alias_ref<jobject> blobModule, jlong jsContextNativePointer);
-  public static void registerNatives();
   public ~BlobCollector();
+}
+
+class facebook::react::BlobModuleJSIBindings : public jni::JavaClass<facebook::react::BlobModuleJSIBindings> {
+  public static constexpr char* kJavaDescriptor;
+  public static void registerNatives();
 }
 
 class facebook::react::BridgelessNativeMethodCallInvoker : public facebook::react::NativeMethodCallInvoker {
@@ -2309,6 +2311,7 @@ class facebook::react::ExecutorDelegate {
 class facebook::react::FabricMountingManager {
   public FabricMountingManager(const facebook::react::FabricMountingManager&) = delete;
   public FabricMountingManager(jni::global_ref<JFabricUIManager::javaobject>& javaUIManager);
+  public bool isOnMainThread();
   public bool isViewAllocated(facebook::react::SurfaceId surfaceId, facebook::react::Tag tag);
   public void destroyUnmountedShadowNode(const facebook::react::ShadowNodeFamily& family);
   public void dispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args);
@@ -4474,6 +4477,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
 }
 
 class facebook::react::SchedulerDelegate {
+  public virtual bool schedulerShouldPromoteReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerDidDispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args) = 0;
   public virtual void schedulerDidFinishTransaction(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
   public virtual void schedulerDidRequestPreliminaryViewAllocation(const facebook::react::ShadowNode& shadowNode) = 0;
@@ -7431,7 +7435,7 @@ struct facebook::react::NativePerformanceEntry {
 }
 
 struct facebook::react::PerformanceEntrySorter {
-  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs);
+  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs) const;
 }
 
 struct facebook::react::PerformanceEventTiming : public facebook::react::AbstractPerformanceEntry {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -3349,6 +3349,7 @@ protocol RCTSafeAreaViewViewProtocol : public NSObject {
 }
 
 protocol RCTSchedulerDelegate {
+  public virtual BOOL schedulerShouldPromoteReactRevision:(facebook::react::SurfaceId surfaceId);
   public virtual void schedulerDidDispatchCommand:commandName:args:(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args);
   public virtual void schedulerDidFinishTransaction:(std::shared_ptr<const facebook::react::MountingCoordinator> mountingCoordinator);
   public virtual void schedulerDidSendAccessibilityEvent:eventType:(const facebook::react::ShadowView& shadowView, const std::string& eventType);
@@ -7064,6 +7065,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
 }
 
 class facebook::react::SchedulerDelegate {
+  public virtual bool schedulerShouldPromoteReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerDidDispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args) = 0;
   public virtual void schedulerDidFinishTransaction(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
   public virtual void schedulerDidRequestPreliminaryViewAllocation(const facebook::react::ShadowNode& shadowNode) = 0;
@@ -9891,7 +9893,7 @@ struct facebook::react::NativePerformanceEntry {
 }
 
 struct facebook::react::PerformanceEntrySorter {
-  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs);
+  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs) const;
 }
 
 struct facebook::react::PerformanceEventTiming : public facebook::react::AbstractPerformanceEntry {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -3349,6 +3349,7 @@ protocol RCTSafeAreaViewViewProtocol : public NSObject {
 }
 
 protocol RCTSchedulerDelegate {
+  public virtual BOOL schedulerShouldPromoteReactRevision:(facebook::react::SurfaceId surfaceId);
   public virtual void schedulerDidDispatchCommand:commandName:args:(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args);
   public virtual void schedulerDidFinishTransaction:(std::shared_ptr<const facebook::react::MountingCoordinator> mountingCoordinator);
   public virtual void schedulerDidSendAccessibilityEvent:eventType:(const facebook::react::ShadowView& shadowView, const std::string& eventType);
@@ -7061,6 +7062,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
 }
 
 class facebook::react::SchedulerDelegate {
+  public virtual bool schedulerShouldPromoteReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerDidDispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args) = 0;
   public virtual void schedulerDidFinishTransaction(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
   public virtual void schedulerDidRequestPreliminaryViewAllocation(const facebook::react::ShadowNode& shadowNode) = 0;
@@ -9882,7 +9884,7 @@ struct facebook::react::NativePerformanceEntry {
 }
 
 struct facebook::react::PerformanceEntrySorter {
-  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs);
+  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs) const;
 }
 
 struct facebook::react::PerformanceEventTiming : public facebook::react::AbstractPerformanceEntry {

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -3045,6 +3045,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
 }
 
 class facebook::react::SchedulerDelegate {
+  public virtual bool schedulerShouldPromoteReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerDidDispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args) = 0;
   public virtual void schedulerDidFinishTransaction(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
   public virtual void schedulerDidRequestPreliminaryViewAllocation(const facebook::react::ShadowNode& shadowNode) = 0;
@@ -5629,7 +5630,7 @@ struct facebook::react::NativePerformanceEntry {
 }
 
 struct facebook::react::PerformanceEntrySorter {
-  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs);
+  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs) const;
 }
 
 struct facebook::react::PerformanceEventTiming : public facebook::react::AbstractPerformanceEntry {

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -3042,6 +3042,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
 }
 
 class facebook::react::SchedulerDelegate {
+  public virtual bool schedulerShouldPromoteReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerDidDispatchCommand(const facebook::react::ShadowView& shadowView, const std::string& commandName, const folly::dynamic& args) = 0;
   public virtual void schedulerDidFinishTransaction(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
   public virtual void schedulerDidRequestPreliminaryViewAllocation(const facebook::react::ShadowNode& shadowNode) = 0;
@@ -5620,7 +5621,7 @@ struct facebook::react::NativePerformanceEntry {
 }
 
 struct facebook::react::PerformanceEntrySorter {
-  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs);
+  public bool operator()(const facebook::react::PerformanceEntry& lhs, const facebook::react::PerformanceEntry& rhs) const;
 }
 
 struct facebook::react::PerformanceEventTiming : public facebook::react::AbstractPerformanceEntry {


### PR DESCRIPTION
Summary:
Changelog: [GENERAL][FIXED] When a React revision is being promoted on the main thread, merge it immediately instead of scheduling a rendering update

In the current implementation, when React is committing on the main thread, the merge is scheduled at the end of the event loop anyway. This change breaks synchronous events if they cause another render. Instead of merging the new tree immediately, it was scheduled, resulting in a visible flash of an incorrect state.

Differential Revision: D100942119


