### PR TITLE
Strip computed properties in build-types transform

### DIFF
--- a/scripts/js-api/build-types/transforms/flow/stripPrivateProperties.js
+++ b/scripts/js-api/build-types/transforms/flow/stripPrivateProperties.js
@@ -26,12 +26,18 @@ const visitors: TransformVisitor = context => ({
     }
   },
   PropertyDefinition(node): void {
-    if (node.key.type === 'Identifier' && node.key.name.startsWith('_')) {
+    if (
+      node.computed === true ||
+      (node.key.type === 'Identifier' && node.key.name.startsWith('_'))
+    ) {
       context.removeNode(node);
     }
   },
   MethodDefinition(node): void {
-    if (node.key.type === 'Identifier' && node.key.name.startsWith('_')) {
+    if (
+      node.computed === true ||
+      (node.key.type === 'Identifier' && node.key.name.startsWith('_'))
+    ) {
       context.removeNode(node);
     }
   },


### PR DESCRIPTION
Summary:
Changelog: [internal]

Update the `stripPrivateProperties` Flow transform to also remove
computed properties and methods from type definitions. These are
implementation details that should not be part of the public API.

Previously only underscore-prefixed identifiers were stripped. Now
`PropertyDefinition` and `MethodDefinition` nodes with
`node.computed === true` are also removed.

Differential Revision: D100969511


