### PR TITLE
Fix stuck loading banner after a reload

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -51,8 +51,25 @@ RCT_EXPORT_MODULE()
                                              selector:@selector(hide)
                                                  name:RCTJavaScriptDidFailToLoadNotification
                                                object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(hide)
+                                                 name:@"RCTInstanceDidLoadBundle"
+                                               object:nil];
   }
   return self;
+}
+
+- (void)dealloc
+{
+  [self clearInitialMessageDelay];
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+  UIWindow *window = _window;
+  _window = nil;
+  if (window) {
+    RCTExecuteOnMainQueue(^{
+      window.hidden = YES;
+    });
+  }
 }
 
 + (void)setEnabled:(BOOL)enabled


### PR DESCRIPTION
## Summary:
Fixes an issue on iOS where the "Loading from Metro..." banner can remain stuck on screen after a reload.

`RCTInstance._loadScriptFromSource` posts `RCTInstanceDidLoadBundle`, not `RCTJavaScriptDidLoadNotification`. The legacy notification is never posted, so the existing native hide path is dead.

Also, `RCTDevLoadingView` has no cleanup. Without hiding the window and clearing it's reference, it remains alive and stuck on screen.

## Changelog:

[IOS] [FIXED] - Fix "Loading from Metro..." banner getting stuck after reloads in quick succession. 

## Test Plan:

1. Launch an app on iOS
2. Trigger a reload while the "Loading from Metro..." banner is still visible. Bundle cache should be empty so it takes some time.
3. Immediately trigger a second reload  while the banner is visible
4. Confirm: banner is gone once the new bundle finishes loading (previously it would remain stuck indefinitely)
