### PR TITLE
Move TransformHelper from jni-common to jni

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TransformHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TransformHelper.kt
@@ -9,12 +9,16 @@ package com.facebook.react.uimanager
 
 import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.NativeArray
+import com.facebook.react.bridge.ReactNativeJNISoLoader
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.common.ReactConstants
 
 public object TransformHelper {
+  init {
+    ReactNativeJNISoLoader.staticInit()
+  }
 
   private val helperMatrix: ThreadLocal<DoubleArray> =
       object : ThreadLocal<DoubleArray>() {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
@@ -11,7 +11,6 @@
 #include "JReactMarker.h"
 #include "NativeArray.h"
 #include "NativeMap.h"
-#include "TransformHelper.h"
 #include "WritableNativeArray.h"
 #include "WritableNativeMap.h"
 
@@ -28,7 +27,6 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     ReadableNativeMap::registerNatives();
     WritableNativeArray::registerNatives();
     WritableNativeMap::registerNatives();
-    TransformHelper::registerNatives();
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -11,7 +11,7 @@
 #include <fbjni/fbjni.h>
 
 #include "InspectorNetworkRequestListener.h"
-#include "JavaScriptExecutorHolder.h"
+#include "TransformHelper.h"
 
 #ifndef WITH_GLOGINIT
 #define WITH_GLOGINIT 1
@@ -34,6 +34,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     FLAGS_minloglevel = 0;
 #endif
     InspectorNetworkRequestListener::registerNatives();
+    TransformHelper::registerNatives();
   });
 }
 


### PR DESCRIPTION
Summary:
Moves `TransformHelper.cpp/h` from the `jni-common` BUCK target to `jni`. This lets `jni-common` drop deps on `cxxreact:bridge`, `cxxreact:module`, and `react/renderer/components/view:view`, replacing them with lighter `cxxreact:tracesection` and `jsi:jsi`. The `view` dep moves to `jni` where `TransformHelper` now lives.

Adds `ReactNativeJNISoLoader.staticInit()` to `TransformHelper.kt` to ensure the native library is loaded before JNI calls, and registers `TransformHelper` natives in `OnLoad.cpp` instead of `OnLoad-common.cpp`.

Changelog: [Internal]

Differential Revision: D101003509


