### PR TITLE
Move CI validation for debugCpp and profileCpp to EnvironmentOptions

### DIFF
--- a/private/react-native-fantom/runner/EnvironmentOptions.js
+++ b/private/react-native-fantom/runner/EnvironmentOptions.js
@@ -107,6 +107,14 @@ export function validateEnvironmentVariables(): void {
     }
   }
 
+  if (isCI && debugCpp) {
+    throw new Error('Cannot run Fantom with C++ debugging on CI');
+  }
+
+  if (isCI && profileCpp) {
+    throw new Error('Cannot run Fantom with C++ profiling on CI');
+  }
+
   // Enabling memory instrumentation is only necessary when taking JS heap
   // snapshots in optimized builds (where it is disabled by default).
   // This isn't supported in CI or in OSS because that would require adding

--- a/private/react-native-fantom/runner/executables/tester.js
+++ b/private/react-native-fantom/runner/executables/tester.js
@@ -125,14 +125,6 @@ export function run(
   options: TesterOptions,
   env: EnvironmentOverrides,
 ): AsyncCommandResult {
-  if (isCI && debugCpp) {
-    throw new Error('Cannot run Fantom with C++ debugging on CI');
-  }
-
-  if (isCI && profileCpp) {
-    throw new Error('Cannot run Fantom with C++ profiling on CI');
-  }
-
   if (!isCI && !debugCpp) {
     build(options, env);
   }


### PR DESCRIPTION
Summary:
Changelog: [internal]

Moved the CI validation checks for `debugCpp` and `profileCpp` from the `run()` function in `tester.js` to `validateEnvironmentVariables()` in `EnvironmentOptions.js`, alongside the existing CI/OSS validation for memory instrumentation.

This centralizes all environment option validation in one place, so invalid configurations are caught early during environment setup rather than at tester execution time.

Differential Revision: D101159820


