### PR TITLE
Fix unused parameter warnings in conversions.h (#56472)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -17,7 +17,7 @@
 
 namespace facebook::react {
 
-inline void fromRawValue(const PropsParserContext &context, const RawValue &value, ImageSource &result)
+inline void fromRawValue(const PropsParserContext & /* context */, const RawValue &value, ImageSource &result)
 {
   if (value.hasType<std::string>()) {
     result = {
@@ -116,7 +116,7 @@ inline std::string toString(const ImageSource &value)
   return "{uri: " + value.uri + "}";
 }
 
-inline void fromRawValue(const PropsParserContext &context, const RawValue &value, ImageResizeMode &result)
+inline void fromRawValue(const PropsParserContext & /* context */, const RawValue &value, ImageResizeMode &result)
 {
   react_native_expect(value.hasType<std::string>());
   if (!value.hasType<std::string>()) {


### PR DESCRIPTION
Summary:

Fix clang-diagnostic-unused-parameter warnings by commenting out the unused 'context' parameter in two fromRawValue functions. This maintains API compatibility while resolving the lint warnings.

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D101108449
