### PR TITLE
Add BackHandler to dismiss LogBox toasts on back press (#56474)

### DIFF
--- a/packages/react-native/Libraries/LogBox/LogBoxInspectorContainer.js
+++ b/packages/react-native/Libraries/LogBox/LogBoxInspectorContainer.js
@@ -12,6 +12,7 @@ import type LogBoxLog from './Data/LogBoxLog';
 
 import View from '../Components/View/View';
 import StyleSheet from '../StyleSheet/StyleSheet';
+import BackHandler from '../Utilities/BackHandler';
 import * as LogBoxData from './Data/LogBoxData';
 import LogBoxInspector from './UI/LogBoxInspector';
 import * as React from 'react';
@@ -23,6 +24,27 @@ type Props = Readonly<{
 }>;
 
 export class _LogBoxInspectorContainer extends React.Component<Props> {
+  _backHandler: ?{remove: () => void, ...} = null;
+
+  componentDidMount() {
+    this._backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => {
+        if (this.props.selectedLogIndex < 0) {
+          return false;
+        }
+        this._handleMinimize();
+        return true;
+      },
+    );
+  }
+
+  componentWillUnmount() {
+    if (this._backHandler) {
+      this._backHandler.remove();
+    }
+  }
+
   render(): React.Node {
     return (
       <View style={StyleSheet.absoluteFill}>

--- a/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
+++ b/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
@@ -11,6 +11,7 @@
 import SafeAreaView from '../../src/private/components/safeareaview/SafeAreaView_INTERNAL_DO_NOT_USE';
 import View from '../Components/View/View';
 import StyleSheet from '../StyleSheet/StyleSheet';
+import BackHandler from '../Utilities/BackHandler';
 import * as LogBoxData from './Data/LogBoxData';
 import LogBoxLog from './Data/LogBoxLog';
 import LogBoxLogNotification from './UI/LogBoxNotification';
@@ -22,8 +23,28 @@ type Props = Readonly<{
   isDisabled?: ?boolean,
 }>;
 
-export function _LogBoxNotificationContainer(props: Props): React.Node {
+function useLogBoxBackHandler(focused: boolean, logCount: number): void {
+  React.useEffect(() => {
+    if (!focused || logCount === 0) {
+      return;
+    }
+    const subscription = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => {
+        LogBoxData.clearWarnings();
+        LogBoxData.clearErrors();
+        return true;
+      },
+    );
+    return () => subscription.remove();
+  }, [focused, logCount]);
+}
+
+export function LogBoxNotificationContainer(props: Props): React.Node {
   const {logs} = props;
+  const [focused, setFocused] = React.useState(false);
+
+  useLogBoxBackHandler(focused, logs.length);
 
   const onDismissWarns = () => {
     LogBoxData.clearWarnings();
@@ -68,6 +89,7 @@ export function _LogBoxNotificationContainer(props: Props): React.Node {
             totalLogCount={warnings.length}
             onPressOpen={() => openLog(warnings[warnings.length - 1])}
             onPressDismiss={onDismissWarns}
+            onFocusChange={setFocused}
           />
         </View>
       )}
@@ -79,6 +101,7 @@ export function _LogBoxNotificationContainer(props: Props): React.Node {
             totalLogCount={errors.length}
             onPressOpen={() => openLog(errors[errors.length - 1])}
             onPressDismiss={onDismissErrors}
+            onFocusChange={setFocused}
           />
         </View>
       )}
@@ -101,5 +124,5 @@ const styles = StyleSheet.create({
 });
 
 export default LogBoxData.withSubscription(
-  _LogBoxNotificationContainer,
+  LogBoxNotificationContainer,
 ) as React.ComponentType<{}>;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxButton.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxButton.js
@@ -12,7 +12,7 @@ import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import type {GestureResponderEvent} from '../../Types/CoreEventTypes';
 
-import TouchableWithoutFeedback from '../../Components/Touchable/TouchableWithoutFeedback';
+import Pressable from '../../Components/Pressable/Pressable';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import * as LogBoxStyle from './LogBoxStyle';
@@ -28,9 +28,10 @@ component LogBoxButton(
   children?: React.Node,
   hitSlop?: ?EdgeInsetsProp,
   onPress?: ?(event: GestureResponderEvent) => void,
+  onFocusChange?: ?(focused: boolean) => void,
   style?: ViewStyleProp,
 ) {
-  const [pressed, setPressed] = useState(false);
+  const [focused, setFocused] = useState(false);
 
   let resolvedBackgroundColor = backgroundColor;
   if (!resolvedBackgroundColor) {
@@ -40,32 +41,54 @@ component LogBoxButton(
     };
   }
 
-  const content = (
-    <View
-      id={id}
-      style={StyleSheet.compose(
-        {
-          backgroundColor: pressed
-            ? resolvedBackgroundColor.pressed
-            : resolvedBackgroundColor.default,
-        },
-        style,
-      )}>
-      {children}
-    </View>
-  );
+  if (onPress == null) {
+    return (
+      <View
+        id={id}
+        style={StyleSheet.compose(
+          {backgroundColor: resolvedBackgroundColor.default},
+          style,
+        )}>
+        {children}
+      </View>
+    );
+  }
 
-  return onPress == null ? (
-    content
-  ) : (
-    <TouchableWithoutFeedback
+  return (
+    <Pressable
+      id={id}
+      focusable={true}
       hitSlop={hitSlop}
       onPress={onPress}
-      onPressIn={() => setPressed(true)}
-      onPressOut={() => setPressed(false)}>
-      {content}
-    </TouchableWithoutFeedback>
+      onFocus={() => {
+        setFocused(true);
+        onFocusChange?.(true);
+      }}
+      onBlur={() => {
+        setFocused(false);
+        onFocusChange?.(false);
+      }}
+      style={({pressed}) =>
+        StyleSheet.compose(
+          {
+            backgroundColor: pressed
+              ? resolvedBackgroundColor.pressed
+              : resolvedBackgroundColor.default,
+          },
+          focused ? StyleSheet.compose(style, styles.focusRing) : style,
+        )
+      }>
+      {children}
+    </Pressable>
   );
 }
+
+const styles = StyleSheet.create({
+  focusRing: {
+    borderWidth: 2,
+    borderColor: LogBoxStyle.getTextColor(0.6),
+    borderRadius: 4,
+  },
+});
 
 export default LogBoxButton;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
@@ -57,6 +57,9 @@ export default function LogBoxInspector(props: Props): React.Node {
   }, []);
 
   useEffect(() => {
+    if (log == null) {
+      return;
+    }
     const subscription = BackHandler.addEventListener(
       'hardwareBackPress',
       () => {
@@ -65,7 +68,7 @@ export default function LogBoxInspector(props: Props): React.Node {
       },
     );
     return () => subscription.remove();
-  }, [onMinimize]);
+  }, [log, onMinimize]);
 
   function _handleRetry() {
     LogBoxData.retrySymbolicateLogNow(log);

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrame.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrame.js
@@ -19,6 +19,8 @@ import LogBoxButton from './LogBoxButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
+const noop = () => {};
+
 component LogBoxInspectorStackFrame(
   frame: StackFrame,
   onPress?: ?(event: GestureResponderEvent) => void,
@@ -38,7 +40,7 @@ component LogBoxInspectorStackFrame(
           default: 'transparent',
           pressed: onPress ? LogBoxStyle.getBackgroundColor(1) : 'transparent',
         }}
-        onPress={onPress}
+        onPress={onPress ?? noop}
         style={styles.frame}>
         <Text
           id="logbox_stack_frame_text"

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxNotification.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxNotification.js
@@ -26,6 +26,7 @@ type Props = Readonly<{
   level: 'warn' | 'error',
   onPressOpen: () => void,
   onPressDismiss: () => void,
+  onFocusChange?: ?(focused: boolean) => void,
 }>;
 
 export default function LogBoxNotification(props: Props): React.Node {
@@ -41,6 +42,7 @@ export default function LogBoxNotification(props: Props): React.Node {
       <LogBoxButton
         id={`logbox_open_button_${level}`}
         onPress={props.onPressOpen}
+        onFocusChange={props.onFocusChange}
         style={styles.press}
         backgroundColor={{
           default: LogBoxStyle.getBackgroundColor(1),

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
@@ -14,11 +14,11 @@ const LogBoxButton = require('../LogBoxButton').default;
 const render = require('@react-native/jest-preset/jest/renderer');
 const React = require('react');
 
-// Mock `TouchableWithoutFeedback` because we are interested in snapshotting the
-// behavior of `LogBoxButton`, not `TouchableWithoutFeedback`.
-jest.mock('../../../Components/Touchable/TouchableWithoutFeedback', () => ({
+// Mock `Pressable` because we are interested in snapshotting the
+// behavior of `LogBoxButton`, not `Pressable`.
+jest.mock('../../../Components/Pressable/Pressable', () => ({
   __esModule: true,
-  default: 'TouchableWithoutFeedback',
+  default: 'Pressable',
 }));
 
 describe('LogBoxButton', () => {
@@ -36,7 +36,7 @@ describe('LogBoxButton', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render TouchableWithoutFeedback and pass through props', async () => {
+  it('should render Pressable and pass through props', async () => {
     const output = await render.create(
       <LogBoxButton
         backgroundColor={{

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxButton-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxButton-test.js.snap
@@ -1,24 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LogBoxButton should render TouchableWithoutFeedback and pass through props 1`] = `
-<TouchableWithoutFeedback
+exports[`LogBoxButton should render Pressable and pass through props 1`] = `
+<Pressable
+  focusable={true}
   hitSlop={Object {}}
+  onBlur={[Function]}
+  onFocus={[Function]}
   onPress={[Function]}
-  onPressIn={[Function]}
-  onPressOut={[Function]}
+  style={[Function]}
 >
-  <View
-    style={
-      Object {
-        "backgroundColor": "black",
-      }
-    }
-  >
-    <Text>
-      Press me
-    </Text>
-  </View>
-</TouchableWithoutFeedback>
+  <Text>
+    Press me
+  </Text>
+</Pressable>
 `;
 
 exports[`LogBoxButton should render only a view without an onPress 1`] = `

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorStackFrame-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorStackFrame-test.js.snap
@@ -156,6 +156,7 @@ exports[`LogBoxInspectorStackFrame should render stack frame without press feedb
         "pressed": "transparent",
       }
     }
+    onPress={[Function]}
     style={
       Object {
         "borderRadius": 5,

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorStackFrames-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorStackFrames-test.js.snap
@@ -78,6 +78,35 @@ exports[`LogBoxInspectorStackFrames should render stack frames with 1 frame coll
       }
     >
       <View
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -149,9 +178,20 @@ exports[`LogBoxInspectorStackFrames should render stack frames with 1 frame coll
             "selected": undefined,
           }
         }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
         accessible={true}
+        collapsable={false}
         focusable={true}
+        onBlur={[Function]}
         onClick={[Function]}
+        onFocus={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
@@ -10,32 +10,39 @@
 
 'use strict';
 
+const BackHandler: $FlowFixMe = require('../../Utilities/BackHandler').default;
+const LogBoxData = require('../Data/LogBoxData');
 const LogBoxLog = require('../Data/LogBoxLog').default;
 const {
-  _LogBoxNotificationContainer: LogBoxNotificationContainer,
-} = require('../LogBoxNotificationContainer');
+  _LogBoxInspectorContainer: LogBoxInspectorContainer,
+} = require('../LogBoxInspectorContainer');
 const render = require('@react-native/jest-preset/jest/renderer');
 const React = require('react');
 
-// Mock `LogBoxLogNotification` because we are interested in snapshotting the
-// behavior of `LogBoxNotificationContainer`, not `LogBoxLogNotification`.
-jest.mock('../UI/LogBoxNotification', () => ({
+// Mock `LogBoxInspector` because we are interested in snapshotting the behavior
+// of `LogBoxInspectorContainer`, not `LogBoxInspector`.
+jest.mock('../UI/LogBoxInspector', () => ({
   __esModule: true,
-  default: 'LogBoxLogNotification',
+  default: 'LogBoxInspector',
 }));
 
-describe('LogBoxNotificationContainer', () => {
-  it('should render null with no logs', async () => {
-    const output = await render.create(
-      <LogBoxNotificationContainer selectedLogIndex={-1} logs={[]} />,
-    );
+jest.mock('../../Utilities/BackHandler', () =>
+  require('../../Utilities/__mocks__/BackHandler'),
+);
 
-    expect(output).toMatchSnapshot();
+describe('LogBoxInspectorContainer', () => {
+  let output;
+
+  afterEach(async () => {
+    if (output) {
+      await render.unmount(output);
+      output = null;
+    }
   });
 
-  it('should render null with no selected log and disabled', async () => {
-    const output = await render.create(
-      <LogBoxNotificationContainer
+  it('should render inspector with logs, even when disabled', async () => {
+    output = await render.create(
+      <LogBoxInspectorContainer
         isDisabled
         selectedLogIndex={-1}
         logs={[
@@ -50,63 +57,6 @@ describe('LogBoxNotificationContainer', () => {
             category: 'Some kind of message',
             componentStack: [],
           }),
-        ]}
-      />,
-    );
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it('should render the latest warning notification', async () => {
-    const output = await render.create(
-      <LogBoxNotificationContainer
-        selectedLogIndex={-1}
-        logs={[
-          new LogBoxLog({
-            level: 'warn',
-            isComponentError: false,
-            message: {
-              content: 'Some kind of message',
-              substitutions: [],
-            },
-            stack: [],
-            category: 'Some kind of message',
-            componentStack: [],
-          }),
-          new LogBoxLog({
-            level: 'warn',
-            isComponentError: false,
-            message: {
-              content: 'Some kind of message (latest)',
-              substitutions: [],
-            },
-            stack: [],
-            category: 'Some kind of message (latest)',
-            componentStack: [],
-          }),
-        ]}
-      />,
-    );
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it('should render the latest error notification', async () => {
-    const output = await render.create(
-      <LogBoxNotificationContainer
-        selectedLogIndex={-1}
-        logs={[
-          new LogBoxLog({
-            level: 'error',
-            isComponentError: false,
-            message: {
-              content: 'Some kind of message',
-              substitutions: [],
-            },
-            stack: [],
-            category: 'Some kind of message',
-            componentStack: [],
-          }),
           new LogBoxLog({
             level: 'error',
             isComponentError: false,
@@ -125,51 +75,18 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render both an error and warning notification', async () => {
-    const output = await render.create(
-      <LogBoxNotificationContainer
-        selectedLogIndex={-1}
-        logs={[
-          new LogBoxLog({
-            level: 'warn',
-            isComponentError: false,
-            message: {
-              content: 'Some kind of message',
-              substitutions: [],
-            },
-            stack: [],
-            category: 'Some kind of message',
-            componentStack: [],
-          }),
-          new LogBoxLog({
-            level: 'error',
-            isComponentError: false,
-            message: {
-              content: 'Some kind of message (latest)',
-              substitutions: [],
-            },
-            stack: [],
-            category: 'Some kind of message (latest)',
-            componentStack: [],
-          }),
-        ]}
-      />,
-    );
+  it('should minimize inspector on back press when a log is selected', async () => {
+    const spy = jest.spyOn(LogBoxData, 'setSelectedLog');
 
-    expect(output).toMatchSnapshot();
-  });
-
-  it('should render selected fatal error even when disabled', async () => {
-    const output = await render.create(
-      <LogBoxNotificationContainer
-        isDisabled
+    output = await render.create(
+      <LogBoxInspectorContainer
         selectedLogIndex={0}
         logs={[
           new LogBoxLog({
-            level: 'fatal',
+            level: 'warn',
             isComponentError: false,
             message: {
-              content: 'Should be selected',
+              content: 'Some kind of message',
               substitutions: [],
             },
             stack: [],
@@ -180,39 +97,72 @@ describe('LogBoxNotificationContainer', () => {
       />,
     );
 
-    expect(output).toMatchSnapshot();
+    BackHandler.mockPressBack();
+
+    expect(spy).toHaveBeenCalledWith(-1);
+    expect(BackHandler.exitApp).not.toHaveBeenCalled();
+
+    spy.mockRestore();
   });
 
-  it('should render selected syntax error even when disabled', async () => {
-    const output = await render.create(
-      <LogBoxNotificationContainer
-        isDisabled
-        selectedLogIndex={0}
+  it('should not intercept back press when no log is selected', async () => {
+    const spy = jest.spyOn(LogBoxData, 'setSelectedLog');
+
+    output = await render.create(
+      <LogBoxInspectorContainer
+        selectedLogIndex={-1}
         logs={[
           new LogBoxLog({
-            level: 'syntax',
+            level: 'warn',
             isComponentError: false,
             message: {
-              content: 'Should be selected',
+              content: 'Some kind of message',
               substitutions: [],
             },
             stack: [],
-            category: 'Some kind of syntax error message',
+            category: 'Some kind of message',
             componentStack: [],
-            codeFrame: {
-              fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',
-              location: {row: 199, column: 0},
-              content: `  197 | });
-  198 |
-> 199 | export default CrashReactApp;
-      | ^
-  200 |`,
-            },
           }),
         ]}
       />,
     );
 
-    expect(output).toMatchSnapshot();
+    BackHandler.mockPressBack();
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it('should remove back handler on unmount', async () => {
+    const spy = jest.spyOn(LogBoxData, 'setSelectedLog');
+
+    output = await render.create(
+      <LogBoxInspectorContainer
+        selectedLogIndex={0}
+        logs={[
+          new LogBoxLog({
+            level: 'warn',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message',
+            componentStack: [],
+          }),
+        ]}
+      />,
+    );
+
+    await render.unmount(output);
+    output = null;
+
+    BackHandler.mockPressBack();
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
   });
 });

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
@@ -10,25 +10,137 @@
 
 'use strict';
 
+const BackHandler: $FlowFixMe = require('../../Utilities/BackHandler').default;
+const LogBoxData = require('../Data/LogBoxData');
 const LogBoxLog = require('../Data/LogBoxLog').default;
-const {
-  _LogBoxInspectorContainer: LogBoxInspectorContainer,
-} = require('../LogBoxInspectorContainer');
+const {LogBoxNotificationContainer} = require('../LogBoxNotificationContainer');
 const render = require('@react-native/jest-preset/jest/renderer');
 const React = require('react');
 
-// Mock `LogBoxInspector` because we are interested in snapshotting the behavior
-// of `LogBoxNotificationContainer`, not `LogBoxInspector`.
-jest.mock('../UI/LogBoxInspector', () => ({
+// Mock `LogBoxLogNotification` because we are interested in snapshotting the
+// behavior of `LogBoxNotificationContainer`, not `LogBoxLogNotification`.
+jest.mock('../UI/LogBoxNotification', () => ({
   __esModule: true,
-  default: 'LogBoxInspector',
+  default: 'LogBoxLogNotification',
 }));
 
+jest.mock('../../Utilities/BackHandler', () =>
+  require('../../Utilities/__mocks__/BackHandler'),
+);
+
 describe('LogBoxNotificationContainer', () => {
-  it('should render inspector with logs, even when disabled', async () => {
-    const output = await render.create(
-      <LogBoxInspectorContainer
+  let output;
+
+  afterEach(async () => {
+    if (output) {
+      await render.unmount(output);
+      output = null;
+    }
+  });
+
+  it('should render null with no logs', async () => {
+    output = await render.create(
+      <LogBoxNotificationContainer selectedLogIndex={-1} logs={[]} />,
+    );
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should render null with no selected log and disabled', async () => {
+    output = await render.create(
+      <LogBoxNotificationContainer
         isDisabled
+        selectedLogIndex={-1}
+        logs={[
+          new LogBoxLog({
+            level: 'warn',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message',
+            componentStack: [],
+          }),
+        ]}
+      />,
+    );
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should render the latest warning notification', async () => {
+    output = await render.create(
+      <LogBoxNotificationContainer
+        selectedLogIndex={-1}
+        logs={[
+          new LogBoxLog({
+            level: 'warn',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message',
+            componentStack: [],
+          }),
+          new LogBoxLog({
+            level: 'warn',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message (latest)',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message (latest)',
+            componentStack: [],
+          }),
+        ]}
+      />,
+    );
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should render the latest error notification', async () => {
+    output = await render.create(
+      <LogBoxNotificationContainer
+        selectedLogIndex={-1}
+        logs={[
+          new LogBoxLog({
+            level: 'error',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message',
+            componentStack: [],
+          }),
+          new LogBoxLog({
+            level: 'error',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message (latest)',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message (latest)',
+            componentStack: [],
+          }),
+        ]}
+      />,
+    );
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should render both an error and warning notification', async () => {
+    output = await render.create(
+      <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
           new LogBoxLog({
@@ -58,5 +170,193 @@ describe('LogBoxNotificationContainer', () => {
     );
 
     expect(output).toMatchSnapshot();
+  });
+
+  it('should render selected fatal error even when disabled', async () => {
+    output = await render.create(
+      <LogBoxNotificationContainer
+        isDisabled
+        selectedLogIndex={0}
+        logs={[
+          new LogBoxLog({
+            level: 'fatal',
+            isComponentError: false,
+            message: {
+              content: 'Should be selected',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message',
+            componentStack: [],
+          }),
+        ]}
+      />,
+    );
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should render selected syntax error even when disabled', async () => {
+    output = await render.create(
+      <LogBoxNotificationContainer
+        isDisabled
+        selectedLogIndex={0}
+        logs={[
+          new LogBoxLog({
+            level: 'syntax',
+            isComponentError: false,
+            message: {
+              content: 'Should be selected',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of syntax error message',
+            componentStack: [],
+            codeFrame: {
+              fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',
+              location: {row: 199, column: 0},
+              content: `  197 | });
+  198 |
+> 199 | export default CrashReactApp;
+      | ^
+  200 |`,
+            },
+          }),
+        ]}
+      />,
+    );
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should clear warnings and errors on back press when focused', async () => {
+    const clearWarningsSpy = jest.spyOn(LogBoxData, 'clearWarnings');
+    const clearErrorsSpy = jest.spyOn(LogBoxData, 'clearErrors');
+
+    output = await render.create(
+      <LogBoxNotificationContainer
+        selectedLogIndex={-1}
+        logs={[
+          new LogBoxLog({
+            level: 'warn',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message',
+            componentStack: [],
+          }),
+        ]}
+      />,
+    );
+
+    // Simulate focus on the notification toast
+    const notification = output.root.findByProps({level: 'warn'});
+    await require('react-test-renderer').act(() => {
+      notification.props.onFocusChange(true);
+    });
+
+    BackHandler.mockPressBack();
+
+    expect(clearWarningsSpy).toHaveBeenCalled();
+    expect(clearErrorsSpy).toHaveBeenCalled();
+    expect(BackHandler.exitApp).not.toHaveBeenCalled();
+
+    clearWarningsSpy.mockRestore();
+    clearErrorsSpy.mockRestore();
+  });
+
+  it('should not intercept back press when not focused', async () => {
+    const clearWarningsSpy = jest.spyOn(LogBoxData, 'clearWarnings');
+    const clearErrorsSpy = jest.spyOn(LogBoxData, 'clearErrors');
+
+    output = await render.create(
+      <LogBoxNotificationContainer
+        selectedLogIndex={-1}
+        logs={[
+          new LogBoxLog({
+            level: 'warn',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message',
+            componentStack: [],
+          }),
+        ]}
+      />,
+    );
+
+    BackHandler.mockPressBack();
+
+    expect(clearWarningsSpy).not.toHaveBeenCalled();
+    expect(clearErrorsSpy).not.toHaveBeenCalled();
+
+    clearWarningsSpy.mockRestore();
+    clearErrorsSpy.mockRestore();
+  });
+
+  it('should not intercept back press when no logs exist', async () => {
+    const clearWarningsSpy = jest.spyOn(LogBoxData, 'clearWarnings');
+    const clearErrorsSpy = jest.spyOn(LogBoxData, 'clearErrors');
+
+    output = await render.create(
+      <LogBoxNotificationContainer selectedLogIndex={-1} logs={[]} />,
+    );
+
+    BackHandler.mockPressBack();
+
+    expect(clearWarningsSpy).not.toHaveBeenCalled();
+    expect(clearErrorsSpy).not.toHaveBeenCalled();
+
+    clearWarningsSpy.mockRestore();
+    clearErrorsSpy.mockRestore();
+  });
+
+  it('should remove back handler on unmount', async () => {
+    const clearWarningsSpy = jest.spyOn(LogBoxData, 'clearWarnings');
+    const clearErrorsSpy = jest.spyOn(LogBoxData, 'clearErrors');
+
+    output = await render.create(
+      <LogBoxNotificationContainer
+        selectedLogIndex={-1}
+        logs={[
+          new LogBoxLog({
+            level: 'warn',
+            isComponentError: false,
+            message: {
+              content: 'Some kind of message',
+              substitutions: [],
+            },
+            stack: [],
+            category: 'Some kind of message',
+            componentStack: [],
+          }),
+        ]}
+      />,
+    );
+
+    // Focus then unmount
+    const notification = output.root.findByProps({level: 'warn'});
+    await require('react-test-renderer').act(() => {
+      notification.props.onFocusChange(true);
+    });
+
+    if (output != null) {
+      await render.unmount(output);
+      output = null;
+    }
+
+    BackHandler.mockPressBack();
+
+    expect(clearWarningsSpy).not.toHaveBeenCalled();
+    expect(clearErrorsSpy).not.toHaveBeenCalled();
+
+    clearWarningsSpy.mockRestore();
+    clearErrorsSpy.mockRestore();
   });
 });

--- a/packages/react-native/Libraries/LogBox/__tests__/__snapshots__/LogBoxInspectorContainer-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/__tests__/__snapshots__/LogBoxInspectorContainer-test.js.snap
@@ -1,28 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LogBoxNotificationContainer should render both an error and warning notification 1`] = `
-<RCTSafeAreaView
+exports[`LogBoxInspectorContainer should render inspector with logs, even when disabled 1`] = `
+<View
   style={
     Object {
-      "bottom": 20,
-      "left": 10,
+      "bottom": 0,
+      "left": 0,
       "position": "absolute",
-      "right": 10,
+      "right": 0,
+      "top": 0,
     }
   }
 >
-  <View
-    style={
-      Object {
-        "borderRadius": 8,
-        "marginBottom": 5,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <LogBoxLogNotification
-      level="warn"
-      log={
+  <LogBoxInspector
+    logs={
+      Array [
         LogBoxLog {
           "category": "Some kind of message",
           "codeFrame": undefined,
@@ -48,25 +40,7 @@ exports[`LogBoxNotificationContainer should render both an error and warning not
             "status": "NONE",
           },
           "type": undefined,
-        }
-      }
-      onPressDismiss={[Function]}
-      onPressOpen={[Function]}
-      totalLogCount={1}
-    />
-  </View>
-  <View
-    style={
-      Object {
-        "borderRadius": 8,
-        "marginBottom": 5,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <LogBoxLogNotification
-      level="error"
-      log={
+        },
         LogBoxLog {
           "category": "Some kind of message (latest)",
           "codeFrame": undefined,
@@ -92,136 +66,13 @@ exports[`LogBoxNotificationContainer should render both an error and warning not
             "status": "NONE",
           },
           "type": undefined,
-        }
-      }
-      onPressDismiss={[Function]}
-      onPressOpen={[Function]}
-      totalLogCount={1}
-    />
-  </View>
-</RCTSafeAreaView>
-`;
-
-exports[`LogBoxNotificationContainer should render null with no logs 1`] = `null`;
-
-exports[`LogBoxNotificationContainer should render null with no selected log and disabled 1`] = `null`;
-
-exports[`LogBoxNotificationContainer should render selected fatal error even when disabled 1`] = `null`;
-
-exports[`LogBoxNotificationContainer should render selected syntax error even when disabled 1`] = `null`;
-
-exports[`LogBoxNotificationContainer should render the latest error notification 1`] = `
-<RCTSafeAreaView
-  style={
-    Object {
-      "bottom": 20,
-      "left": 10,
-      "position": "absolute",
-      "right": 10,
+        },
+      ]
     }
-  }
->
-  <View
-    style={
-      Object {
-        "borderRadius": 8,
-        "marginBottom": 5,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <LogBoxLogNotification
-      level="error"
-      log={
-        LogBoxLog {
-          "category": "Some kind of message (latest)",
-          "codeFrame": undefined,
-          "componentStack": Array [],
-          "count": 1,
-          "extraData": undefined,
-          "isComponentError": false,
-          "level": "error",
-          "message": Object {
-            "content": "Some kind of message (latest)",
-            "substitutions": Array [],
-          },
-          "onNotificationPress": undefined,
-          "stack": Array [],
-          "symbolicated": Object {
-            "error": null,
-            "stack": null,
-            "status": "NONE",
-          },
-          "symbolicatedComponentStack": Object {
-            "error": null,
-            "stack": null,
-            "status": "NONE",
-          },
-          "type": undefined,
-        }
-      }
-      onPressDismiss={[Function]}
-      onPressOpen={[Function]}
-      totalLogCount={2}
-    />
-  </View>
-</RCTSafeAreaView>
-`;
-
-exports[`LogBoxNotificationContainer should render the latest warning notification 1`] = `
-<RCTSafeAreaView
-  style={
-    Object {
-      "bottom": 20,
-      "left": 10,
-      "position": "absolute",
-      "right": 10,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "borderRadius": 8,
-        "marginBottom": 5,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <LogBoxLogNotification
-      level="warn"
-      log={
-        LogBoxLog {
-          "category": "Some kind of message (latest)",
-          "codeFrame": undefined,
-          "componentStack": Array [],
-          "count": 1,
-          "extraData": undefined,
-          "isComponentError": false,
-          "level": "warn",
-          "message": Object {
-            "content": "Some kind of message (latest)",
-            "substitutions": Array [],
-          },
-          "onNotificationPress": undefined,
-          "stack": Array [],
-          "symbolicated": Object {
-            "error": null,
-            "stack": null,
-            "status": "NONE",
-          },
-          "symbolicatedComponentStack": Object {
-            "error": null,
-            "stack": null,
-            "status": "NONE",
-          },
-          "type": undefined,
-        }
-      }
-      onPressDismiss={[Function]}
-      onPressOpen={[Function]}
-      totalLogCount={2}
-    />
-  </View>
-</RCTSafeAreaView>
+    onChangeSelectedIndex={[Function]}
+    onDismiss={[Function]}
+    onMinimize={[Function]}
+    selectedIndex={-1}
+  />
+</View>
 `;

--- a/packages/react-native/Libraries/LogBox/__tests__/__snapshots__/LogBoxNotificationContainer-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/__tests__/__snapshots__/LogBoxNotificationContainer-test.js.snap
@@ -1,20 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LogBoxNotificationContainer should render inspector with logs, even when disabled 1`] = `
-<View
+exports[`LogBoxNotificationContainer should render both an error and warning notification 1`] = `
+<RCTSafeAreaView
   style={
     Object {
-      "bottom": 0,
-      "left": 0,
+      "bottom": 20,
+      "left": 10,
       "position": "absolute",
-      "right": 0,
-      "top": 0,
+      "right": 10,
     }
   }
 >
-  <LogBoxInspector
-    logs={
-      Array [
+  <View
+    style={
+      Object {
+        "borderRadius": 8,
+        "marginBottom": 5,
+        "overflow": "hidden",
+      }
+    }
+  >
+    <LogBoxLogNotification
+      level="warn"
+      log={
         LogBoxLog {
           "category": "Some kind of message",
           "codeFrame": undefined,
@@ -40,7 +48,26 @@ exports[`LogBoxNotificationContainer should render inspector with logs, even whe
             "status": "NONE",
           },
           "type": undefined,
-        },
+        }
+      }
+      onFocusChange={[Function]}
+      onPressDismiss={[Function]}
+      onPressOpen={[Function]}
+      totalLogCount={1}
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "borderRadius": 8,
+        "marginBottom": 5,
+        "overflow": "hidden",
+      }
+    }
+  >
+    <LogBoxLogNotification
+      level="error"
+      log={
         LogBoxLog {
           "category": "Some kind of message (latest)",
           "codeFrame": undefined,
@@ -66,13 +93,139 @@ exports[`LogBoxNotificationContainer should render inspector with logs, even whe
             "status": "NONE",
           },
           "type": undefined,
-        },
-      ]
+        }
+      }
+      onFocusChange={[Function]}
+      onPressDismiss={[Function]}
+      onPressOpen={[Function]}
+      totalLogCount={1}
+    />
+  </View>
+</RCTSafeAreaView>
+`;
+
+exports[`LogBoxNotificationContainer should render null with no logs 1`] = `null`;
+
+exports[`LogBoxNotificationContainer should render null with no selected log and disabled 1`] = `null`;
+
+exports[`LogBoxNotificationContainer should render selected fatal error even when disabled 1`] = `null`;
+
+exports[`LogBoxNotificationContainer should render selected syntax error even when disabled 1`] = `null`;
+
+exports[`LogBoxNotificationContainer should render the latest error notification 1`] = `
+<RCTSafeAreaView
+  style={
+    Object {
+      "bottom": 20,
+      "left": 10,
+      "position": "absolute",
+      "right": 10,
     }
-    onChangeSelectedIndex={[Function]}
-    onDismiss={[Function]}
-    onMinimize={[Function]}
-    selectedIndex={-1}
-  />
-</View>
+  }
+>
+  <View
+    style={
+      Object {
+        "borderRadius": 8,
+        "marginBottom": 5,
+        "overflow": "hidden",
+      }
+    }
+  >
+    <LogBoxLogNotification
+      level="error"
+      log={
+        LogBoxLog {
+          "category": "Some kind of message (latest)",
+          "codeFrame": undefined,
+          "componentStack": Array [],
+          "count": 1,
+          "extraData": undefined,
+          "isComponentError": false,
+          "level": "error",
+          "message": Object {
+            "content": "Some kind of message (latest)",
+            "substitutions": Array [],
+          },
+          "onNotificationPress": undefined,
+          "stack": Array [],
+          "symbolicated": Object {
+            "error": null,
+            "stack": null,
+            "status": "NONE",
+          },
+          "symbolicatedComponentStack": Object {
+            "error": null,
+            "stack": null,
+            "status": "NONE",
+          },
+          "type": undefined,
+        }
+      }
+      onFocusChange={[Function]}
+      onPressDismiss={[Function]}
+      onPressOpen={[Function]}
+      totalLogCount={2}
+    />
+  </View>
+</RCTSafeAreaView>
+`;
+
+exports[`LogBoxNotificationContainer should render the latest warning notification 1`] = `
+<RCTSafeAreaView
+  style={
+    Object {
+      "bottom": 20,
+      "left": 10,
+      "position": "absolute",
+      "right": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderRadius": 8,
+        "marginBottom": 5,
+        "overflow": "hidden",
+      }
+    }
+  >
+    <LogBoxLogNotification
+      level="warn"
+      log={
+        LogBoxLog {
+          "category": "Some kind of message (latest)",
+          "codeFrame": undefined,
+          "componentStack": Array [],
+          "count": 1,
+          "extraData": undefined,
+          "isComponentError": false,
+          "level": "warn",
+          "message": Object {
+            "content": "Some kind of message (latest)",
+            "substitutions": Array [],
+          },
+          "onNotificationPress": undefined,
+          "stack": Array [],
+          "symbolicated": Object {
+            "error": null,
+            "stack": null,
+            "status": "NONE",
+          },
+          "symbolicatedComponentStack": Object {
+            "error": null,
+            "stack": null,
+            "status": "NONE",
+          },
+          "type": undefined,
+        }
+      }
+      onFocusChange={[Function]}
+      onPressDismiss={[Function]}
+      onPressOpen={[Function]}
+      totalLogCount={2}
+    />
+  </View>
+</RCTSafeAreaView>
 `;


### PR DESCRIPTION
Summary:

On Android, pressing the hardware back button while LogBox notification toasts or the full inspector overlay are visible has no effect on the JS side. The only way to dismiss notifications is the on-screen X button, and the only way to close the inspector is via Minimize/Dismiss.

This adds `BackHandler` listeners to both JS containers:

**Notification toasts**: A new `LogBoxNotificationBackHandler` component mounts alongside the toasts and registers a `hardwareBackPress` listener that calls `clearWarnings()` + `clearErrors()`, equivalent to pressing X on every visible toast. The component returns null and auto-cleans the listener on unmount.

**Inspector overlay**: `LogBoxInspectorContainer` registers a `hardwareBackPress` listener in `componentDidMount` that calls `_handleMinimize()` (`setSelectedLog(-1)`), closing the overlay non-destructively — same as pressing the Minimize button.

Changelog: [Android][Added] - Allow LogBox notification toasts and inspector overlay to be dismissed via Android back button

Differential Revision: D101178179
