### PR TITLE
unbreak ViewTransition fantom tests

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.cpp
@@ -455,7 +455,7 @@ ViewTransitionModule::getViewTransitionInstance(
       auto pseudoElementIt = oldPseudoElementNodes_.find(name);
       auto nativeTag = pseudoElementIt != oldPseudoElementNodes_.end()
           ? pseudoElementIt->second->getTag()
-          : view.tag;
+          : -1;
       return ViewTransitionInstance{
           .x = view.layoutMetrics.originFromRoot.x,
           .y = view.layoutMetrics.originFromRoot.y,


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Fixed] - unbreak ViewTransition fantom tests

this gets broken after my recent changes to viewtransition runtime

Reviewed By: NickGerleman

Differential Revision: D101224031


