### PR TITLE
fix(jest): mock getBoundingClientRect on host components in tests

### DIFF
--- a/packages/jest-preset/jest/MockNativeMethods.js
+++ b/packages/jest-preset/jest/MockNativeMethods.js
@@ -15,6 +15,18 @@ const MockNativeMethods = {
   setNativeProps: jest.fn(),
   focus: jest.fn(),
   blur: jest.fn(),
+  getBoundingClientRect: jest.fn(function () {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    };
+  }),
 } as {
   measure: () => void,
   measureInWindow: () => void,
@@ -22,6 +34,16 @@ const MockNativeMethods = {
   setNativeProps: () => void,
   focus: () => void,
   blur: () => void,
+  getBoundingClientRect: () => {
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    top: number,
+    left: number,
+    right: number,
+    bottom: number,
+  },
 };
 
 export default MockNativeMethods;

--- a/packages/jest-preset/jest/__tests__/getBoundingClientRect-test.js
+++ b/packages/jest-preset/jest/__tests__/getBoundingClientRect-test.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import * as React from 'react';
+import View from 'react-native/Libraries/Components/View/View';
+import TestRenderer from 'react-test-renderer';
+
+describe('getBoundingClientRect on mocked host components', () => {
+  test('View ref has getBoundingClientRect as a function', async () => {
+    let viewRef: $FlowFixMe = null;
+
+    await TestRenderer.act(() => {
+      TestRenderer.create(
+        <View
+          ref={(ref: $FlowFixMe) => {
+            viewRef = ref;
+          }}
+        />,
+      );
+    });
+
+    expect(viewRef).not.toBeNull();
+    expect(typeof viewRef.getBoundingClientRect).toBe('function');
+  });
+
+  test('calling getBoundingClientRect on a View ref does not throw', async () => {
+    let rect: $FlowFixMe = null;
+
+    await TestRenderer.act(() => {
+      TestRenderer.create(
+        <View
+          ref={(ref: $FlowFixMe) => {
+            if (ref) {
+              rect = ref.getBoundingClientRect();
+            }
+          }}
+        />,
+      );
+    });
+
+    expect(rect).toEqual({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    });
+  });
+});

--- a/packages/jest-preset/jest/__tests__/mockNativeMethods-test.js
+++ b/packages/jest-preset/jest/__tests__/mockNativeMethods-test.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import MockNativeMethods from '../MockNativeMethods';
+
+describe('MockNativeMethods', () => {
+  test('provides mock for measure', () => {
+    expect(jest.isMockFunction(MockNativeMethods.measure)).toBe(true);
+  });
+
+  test('provides mock for measureInWindow', () => {
+    expect(jest.isMockFunction(MockNativeMethods.measureInWindow)).toBe(true);
+  });
+
+  test('provides mock for measureLayout', () => {
+    expect(jest.isMockFunction(MockNativeMethods.measureLayout)).toBe(true);
+  });
+
+  test('provides mock for setNativeProps', () => {
+    expect(jest.isMockFunction(MockNativeMethods.setNativeProps)).toBe(true);
+  });
+
+  test('provides mock for focus', () => {
+    expect(jest.isMockFunction(MockNativeMethods.focus)).toBe(true);
+  });
+
+  test('provides mock for blur', () => {
+    expect(jest.isMockFunction(MockNativeMethods.blur)).toBe(true);
+  });
+
+  test('provides mock for getBoundingClientRect', () => {
+    expect(jest.isMockFunction(MockNativeMethods.getBoundingClientRect)).toBe(
+      true,
+    );
+  });
+
+  test('getBoundingClientRect returns a DOMRect-like object with zero values', () => {
+    const rect = MockNativeMethods.getBoundingClientRect();
+    expect(rect).toEqual({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    });
+  });
+});

--- a/packages/jest-preset/jest/mockNativeComponent.js
+++ b/packages/jest-preset/jest/mockNativeComponent.js
@@ -39,6 +39,27 @@ export default function mockNativeComponent<TProps extends {...}>(
     measureInWindow: () => void = jest.fn();
     measureLayout: () => void = jest.fn();
     setNativeProps: () => void = jest.fn();
+    getBoundingClientRect: () => {
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+      top: number,
+      left: number,
+      right: number,
+      bottom: number,
+    } = jest.fn(function () {
+      return {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      };
+    });
   };
 
   if (viewName === 'RCTView') {


### PR DESCRIPTION
## Summary:

Jest mocks for host components (`MockNativeMethods`, `mockNativeComponent`) exposed `measure`, `measureInWindow`, `measureLayout`, `setNativeProps`, `focus`, and `blur`, but not `getBoundingClientRect`. In production, `ReadOnlyElement` / `ReactNativeElement` implements `getBoundingClientRect()`; refs from `react-test-renderer` in unit tests therefore threw `TypeError: getBoundingClientRect is not a function` when user code called it (see #54916).

This change adds a `getBoundingClientRect` mock that returns a zero-valued DOMRect-like object (`x`, `y`, `width`, `height`, `top`, `left`, `right`, `bottom`), matching the fallback behavior when there is no native node. Tests were added for the mock helpers and for calling `getBoundingClientRect` on a mocked `View` ref via `react-test-renderer`.

Fixes #54916.

## Changelog:

[INTERNAL] [FIXED] - Mock getBoundingClientRect on Jest host component refs so unit tests match ReadOnlyElement and no longer throw when calling ref.getBoundingClientRect().

## Test Plan:

Ran:

`yarn test packages/jest-preset/jest/__tests__/`

All tests passed, including `mockNativeMethods-test.js`, `getBoundingClientRect-test.js`, and `setup-test.js`.