### PR TITLE
Respect enum values for TurboModule c++ codegen (#56478)

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -152,7 +152,7 @@ struct Bridging<NativeEnumTurboModuleStatusLowerCaseEnum> {
 
 #pragma mark - NativeEnumTurboModuleStatusNumEnum
 
-enum class NativeEnumTurboModuleStatusNumEnum { Active, Paused, Off };
+enum class NativeEnumTurboModuleStatusNumEnum { Active = 2, Paused = 1, Off = 0 };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
@@ -1749,7 +1749,7 @@ struct Bridging<NativeEnumTurboModuleStatusLowerCaseEnum> {
 
 #pragma mark - NativeEnumTurboModuleStatusNumEnum
 
-enum class NativeEnumTurboModuleStatusNumEnum { Active, Paused, Off };
+enum class NativeEnumTurboModuleStatusNumEnum { Active = 2, Paused = 1, Off = 0 };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusNumEnum> {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -537,7 +537,15 @@ function generateEnum(
 
   return EnumTemplate({
     enumName,
-    values: members.map(member => toSafeCppString(member.name)).join(', '),
+    values: members
+      .map(member => {
+        const name = toSafeCppString(member.name);
+        if (Number.isInteger(member.value.value)) {
+          return `${name} = ${member.value.value}`;
+        }
+        return name;
+      })
+      .join(', '),
     fromCases,
     toCases,
     nativeEnumMemberType,

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -156,7 +156,7 @@ namespace facebook::react {
 
 #pragma mark - NativeSampleTurboModuleEnumInt
 
-enum class NativeSampleTurboModuleEnumInt { IA, IB };
+enum class NativeSampleTurboModuleEnumInt { IA = 23, IB = 42 };
 
 template <>
 struct Bridging<NativeSampleTurboModuleEnumInt> {
@@ -1713,7 +1713,7 @@ namespace facebook::react {
 
 #pragma mark - NativeSampleTurboModuleNumEnum
 
-enum class NativeSampleTurboModuleNumEnum { ONE, TWO };
+enum class NativeSampleTurboModuleNumEnum { ONE = 1, TWO = 2 };
 
 template <>
 struct Bridging<NativeSampleTurboModuleNumEnum> {
@@ -1741,7 +1741,7 @@ struct Bridging<NativeSampleTurboModuleNumEnum> {
 
 #pragma mark - NativeSampleTurboModuleFloatEnum
 
-enum class NativeSampleTurboModuleFloatEnum { POINT_ZERO, POINT_ONE, POINT_TWO };
+enum class NativeSampleTurboModuleFloatEnum { POINT_ZERO = 0, POINT_ONE, POINT_TWO };
 
 template <>
 struct Bridging<NativeSampleTurboModuleFloatEnum> {


### PR DESCRIPTION
Summary:

Changelog:
[General] [Fixed] - Respect enum values for TurboModule c++ codegen

Defining an enum like this:

```js
export enum CustomPropertyEditor {
  BitMask = 0,
  Entity = 1,
  Slider = 2,
  AudioEvent = 3,
  CollisionLayer = 4,
  MaterialComponentDeprecatedProperty = 5,
  MeshMaterialList = 6,
  Submesh = 7,
  // CoreUiLayout (8) removed — rendered identically to ClassOrList
  MaterialMapJson = 9,
  AnimationTable = 10,
  SkeletonAsset = 11,
  NavMeshAreaType = 12,
  VFXAsset = 13,
  Table = 14,
  VariableTable = 15,
  AudioBus = 16,
  LodSettings = 17,
  WorldSearch = 18,
  EntityMaterialList = 19,
  NpcId = 20,
  LightingModelVersion = 21,
  PlatformSelector = 22,
  ComponentReference = 23,
}
```
(notice number 8 ), will cause the generated enum to actually look like:
```
  enum class NativeEditableObjectModuleCustomPropertyEditor {
    BitMask, Entity, Slider, AudioEvent, CollisionLayer,
    MaterialComponentDeprecatedProperty, MeshMaterialList, Submesh,
    MaterialMapJson, AnimationTable, ...
  };
```

in other words, the values don't match up after the core ui value. This is quite dangerous and I'm surprised no one has ever noticed that 

This diff fixes things such that if an integer value is explicitly assigned, the value is preserved in the generated enum.

Reviewed By: christophpurrer

Differential Revision: D101229471


