### PR TITLE
support multiple old pseudo elements for same name but different source node (#56479)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.cpp
@@ -7,6 +7,7 @@
 
 #include "ViewTransitionModule.h"
 
+#include <glog/logging.h>
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <react/renderer/core/RawProps.h>
@@ -93,7 +94,20 @@ void ViewTransitionModule::applyViewTransitionName(
 
     if (auto it = oldPseudoElementNodesRepository_.find(name);
         it != oldPseudoElementNodesRepository_.end()) {
-      oldPseudoElementNodes_[name] = it->second.node;
+      // Find the pseudo element created from this specific source tag
+      auto& pseudoElementsBySourceTag = it->second;
+      auto innerIt = pseudoElementsBySourceTag.find(tag);
+      if (innerIt != pseudoElementsBySourceTag.end()) {
+        oldPseudoElementNodes_[name] = innerIt->second.node;
+      } else if (!pseudoElementsBySourceTag.empty()) {
+        // Fallback to first available entry for this name
+        oldPseudoElementNodes_[name] =
+            pseudoElementsBySourceTag.begin()->second.node;
+      }
+    } else {
+      LOG(WARNING)
+          << "applyViewTransitionName: old pseudo element shadow node doesn't exist for name "
+          << name;
     }
 
   } else {
@@ -158,7 +172,7 @@ void ViewTransitionModule::createViewTransitionInstance(
       if (!forNextTransition) {
         oldPseudoElementNodes_[name] = pseudoElementNode;
       }
-      oldPseudoElementNodesRepository_[name] = InactivePseudoElement{
+      oldPseudoElementNodesRepository_[name][view.tag] = InactivePseudoElement{
           .node = pseudoElementNode, .sourceTag = view.tag};
     }
   }
@@ -222,7 +236,12 @@ std::optional<MountingTransaction> ViewTransitionModule::pullTransaction(
       auto tag = mutation.oldChildShadowView.tag;
       for (auto it = oldPseudoElementNodesRepository_.begin();
            it != oldPseudoElementNodesRepository_.end();) {
-        if (it->second.sourceTag == tag) {
+        auto& pseudoElementsBySourceTag = it->second;
+        if (auto innerIt = pseudoElementsBySourceTag.find(tag);
+            innerIt != pseudoElementsBySourceTag.end()) {
+          pseudoElementsBySourceTag.erase(innerIt);
+        }
+        if (pseudoElementsBySourceTag.empty()) {
           it = oldPseudoElementNodesRepository_.erase(it);
         } else {
           ++it;

--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.h
@@ -124,7 +124,8 @@ class ViewTransitionModule : public UIManagerViewTransitionDelegate,
   // pseudo-element nodes created for entering nodes, to be copied into
   // oldPseudoElementNodes_ during the next applyViewTransitionName call.
   // Mutable because pullTransaction (const) needs to erase unmounted entries.
-  mutable std::unordered_map<std::string, InactivePseudoElement> oldPseudoElementNodesRepository_{};
+  mutable std::unordered_map<std::string, std::unordered_map<Tag /* sourceTag */, InactivePseudoElement>>
+      oldPseudoElementNodesRepository_{};
 
   LayoutMetrics captureLayoutMetricsFromRoot(const ShadowNode &shadowNode);
 


### PR DESCRIPTION
Summary:

## Changelog:

[General] [Fixed] - support multiple old pseudo elements for same name but different source node

We will need to track multiple old pseudo elements for same name but different source node when doing a series of shared transitions: 
1. go from component A to component B (A stays hidden with Activity but not unmounted)
2. go back to A (B unmounted)
3. hide A and show B again

A will lose its old pseudo element node, because at #1, B's old pseudo element node overrides A's (since they have the same vt name), and at #2, B's old node gets cleaned up. At #3, since createViewTransitionInstance won't be called for A again (react reconciler assumes the instance is only created once until a component is unmounted), there's no valid old node for A anymore.

Reviewed By: sammy-SC

Differential Revision: D101237889


