### PR TITLE
Remove reference to type that will not be generated (#56482)

### DIFF
--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -51,6 +51,7 @@ const getMethod: (<MethodName extends keyof ReactFabricType>(
   return function (arg1, arg2, arg3, arg4, arg5, arg6) {
     if (cachedImpl == null) {
       // $FlowExpectedError[prop-missing]
+      // $FlowExpectedError[invalid-computed-prop]
       cachedImpl = getRenderer()[methodName];
     }
 

--- a/packages/react-native/Libraries/Renderer/shims/ReactNative.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNative.js
@@ -7,16 +7,15 @@
  * @noformat
  * @nolint
  * @flow
- * @generated SignedSource<<7a063365bcf9d96b1cd8714d309e5b92>>
+ * @generated SignedSource<<5908e4e900f26a939c59a16d2c252af3>>
  *
  * This file is no longer sync'd from the facebook/react repository.
  * The version compatibility check is removed. Use at your own risk.
  */
 'use strict';
 
-import type {ReactNativeType} from './ReactNativeTypes';
-
-let ReactNative: ReactNativeType;
+// The underlying type no longer exists
+let ReactNative: $FlowFixMe;
 
 if (__DEV__) {
   ReactNative = require('../implementations/ReactNativeRenderer-dev');


### PR DESCRIPTION
Summary:

Changelog: [internal]

`ReactNativeType` is the type of the legacy renderer, which is being removed. This removes the references to it so the removal can land without Flow errors.

Differential Revision: D101352959


