### PR TITLE
Remove legacy Paper renderer shim cleanup from artifact commit workflow (#36297) (#56483)

### DIFF
--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -51,6 +51,7 @@ const getMethod: (<MethodName extends keyof ReactFabricType>(
   return function (arg1, arg2, arg3, arg4, arg5, arg6) {
     if (cachedImpl == null) {
       // $FlowExpectedError[prop-missing]
+      // $FlowExpectedError[invalid-computed-prop]
       cachedImpl = getRenderer()[methodName];
     }
 

--- a/packages/react-native/Libraries/Renderer/shims/ReactNative.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNative.js
@@ -7,16 +7,15 @@
  * @noformat
  * @nolint
  * @flow
- * @generated SignedSource<<7a063365bcf9d96b1cd8714d309e5b92>>
+ * @generated SignedSource<<5908e4e900f26a939c59a16d2c252af3>>
  *
  * This file is no longer sync'd from the facebook/react repository.
  * The version compatibility check is removed. Use at your own risk.
  */
 'use strict';
 
-import type {ReactNativeType} from './ReactNativeTypes';
-
-let ReactNative: ReactNativeType;
+// The underlying type no longer exists
+let ReactNative: $FlowFixMe;
 
 if (__DEV__) {
   ReactNative = require('../implementations/ReactNativeRenderer-dev');

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict
- * @generated SignedSource<<c0e57723772ea5f1aa8c3c897ac3c216>>
+ * @generated SignedSource<<4ab83fd2606d6a4d374ef914f231d9c1>>
  */
 
 import type {
@@ -136,36 +136,6 @@ export type RenderRootOptions = {
     errorInfo: {+componentStack?: ?string},
   ) => void,
   onDefaultTransitionIndicator?: () => void | (() => void),
-};
-
-/**
- * Flat ReactNative renderer bundles are too big for Flow to parse efficiently.
- * Provide minimal Flow typing for the high-level RN API and call it a day.
- */
-export type ReactNativeType = {
-  findHostInstance_DEPRECATED<TElementType: React.ElementType>(
-    componentOrHandle: ?(React.ElementRef<TElementType> | number),
-  ): ?PublicInstance,
-  findNodeHandle<TElementType: React.ElementType>(
-    componentOrHandle: ?(React.ElementRef<TElementType> | number),
-  ): ?number,
-  isChildPublicInstance(parent: PublicInstance, child: PublicInstance): boolean,
-  dispatchCommand(
-    handle: PublicInstance,
-    command: string,
-    args: Array<mixed>,
-  ): void,
-  sendAccessibilityEvent(handle: PublicInstance, eventType: string): void,
-  render(
-    element: React.MixedElement,
-    containerTag: number,
-    callback: ?() => void,
-    options: ?RenderRootOptions,
-  ): ?React.ElementRef<React.ElementType>,
-  unmountComponentAtNode(containerTag: number): void,
-  unmountComponentAtNodeAndRemoveContainer(containerTag: number): void,
-  +unstable_batchedUpdates: <T>(fn: (T) => void, bookkeeping: T) => void,
-  ...
 };
 
 export opaque type Node = mixed;


### PR DESCRIPTION
Summary:

## Summary

PR #36285 deleted the Paper (legacy) renderer, including the shim file
`scripts/rollup/shims/react-native/ReactNative.js`. However, the
`runtime_commit_artifacts` workflow still tries to `rm` this file after
moving build artifacts into `compiled-rn/`. Since the file no longer
exists in the build output, `rm` (without `-f`) fails and kills the
entire step.

This has caused **every run of the Commit Artifacts workflow to fail
since #36285 landed on April 16**, blocking both `builds/facebook-www`
and `builds/facebook-fbsource` branches from receiving new build
artifacts. This in turn blocks DiffTrain from syncing React changes into
Meta's internal monorepo.

DiffTrain build for [bf45a68dd35ed08860b6a70fed641dfe6d7d290d](https://github.com/facebook/react/commit/bf45a68dd35ed08860b6a70fed641dfe6d7d290d)

Reviewed By: zeyap

Differential Revision: D101329586


