### PR TITLE
Clear AnimatedPropsRegistry on surface stop (#56485)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.cpp
@@ -93,10 +93,17 @@ AnimatedPropsRegistry::getMap(SurfaceId surfaceId) {
 
 void AnimatedPropsRegistry::clear(SurfaceId surfaceId) {
   auto lock = std::lock_guard(mutex_);
+  if (auto it = surfaceContexts_.find(surfaceId);
+      it != surfaceContexts_.end()) {
+    auto& surfaceContext = it->second;
+    surfaceContext.families.clear();
+    surfaceContext.map.clear();
+  }
+}
 
-  auto& surfaceContext = surfaceContexts_[surfaceId];
-  surfaceContext.families.clear();
-  surfaceContext.map.clear();
+void AnimatedPropsRegistry::clearOnSurfaceStop(SurfaceId surfaceId) {
+  auto lock = std::lock_guard(mutex_);
+  surfaceContexts_.erase(surfaceId);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
@@ -39,6 +39,7 @@ class AnimatedPropsRegistry {
  public:
   void update(const std::unordered_map<SurfaceId, SurfaceUpdates> &surfaceUpdates);
   void clear(SurfaceId surfaceId);
+  void clearOnSurfaceStop(SurfaceId surfaceId);
   std::pair<std::unordered_set<std::shared_ptr<const ShadowNodeFamily>> &, SnapshotMap &> getMap(SurfaceId surfaceId);
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -257,6 +257,10 @@ void AnimationBackend::clearRegistry(SurfaceId surfaceId) {
   animatedPropsRegistry_->clear(surfaceId);
 }
 
+void AnimationBackend::clearRegistryOnSurfaceStop(SurfaceId surfaceId) {
+  animatedPropsRegistry_->clearOnSurfaceStop(surfaceId);
+}
+
 void AnimationBackend::registerJSInvoker(
     std::shared_ptr<CallInvoker> jsInvoker) {
   if (!jsInvoker_) {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -55,6 +55,7 @@ class AnimationBackend : public UIManagerAnimationBackend {
   void synchronouslyUpdateProps(const std::unordered_map<Tag, AnimatedProps> &updates);
   void requestAsyncFlushForSurfaces(const std::set<SurfaceId> &surfaces);
   void clearRegistry(SurfaceId surfaceId) override;
+  void clearRegistryOnSurfaceStop(SurfaceId surfaceId) override;
   void registerJSInvoker(std::shared_ptr<CallInvoker> jsInvoker) override;
 
   void onAnimationFrame(AnimationTimestamp timestamp) override;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -272,8 +272,12 @@ void UIManager::setSurfaceProps(
 ShadowTree::Unique UIManager::stopSurface(SurfaceId surfaceId) const {
   TraceSection s("UIManager::stopSurface");
 
-  // Stop any ongoing animations.
+  // Stop any ongoing layout animations.
   stopSurfaceForAnimationDelegate(surfaceId);
+
+  if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+    animationBackend_->clearRegistryOnSurfaceStop(surfaceId);
+  }
 
   // Waiting for all concurrent commits to be finished and unregistering the
   // `ShadowTree`.

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
@@ -30,6 +30,7 @@ class UIManagerAnimationBackend {
   virtual CallbackId start(const Callback &callback) = 0;
   virtual void stop(CallbackId callbackId) = 0;
   virtual void clearRegistry(SurfaceId surfaceId) = 0;
+  virtual void clearRegistryOnSurfaceStop(SurfaceId surfaceId) = 0;
   virtual void trigger() = 0;
   virtual void pushAnimationMutations(const Callback &callback) = 0;
   virtual void registerJSInvoker(std::shared_ptr<CallInvoker> jsInvoker) = 0;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1536,6 +1536,7 @@ class facebook::react::AnimatedNode {
 class facebook::react::AnimatedPropsRegistry {
   public std::pair<std::unordered_set<std::shared_ptr<const facebook::react::ShadowNodeFamily>>&, facebook::react::SnapshotMap&> getMap(facebook::react::SurfaceId surfaceId);
   public void clear(facebook::react::SurfaceId surfaceId);
+  public void clearOnSurfaceStop(facebook::react::SurfaceId surfaceId);
   public void update(const std::unordered_map<facebook::react::SurfaceId, facebook::react::SurfaceUpdates>& surfaceUpdates);
 }
 
@@ -1545,6 +1546,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public using ResumeCallback = std::function<void()>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
@@ -5219,6 +5221,7 @@ class facebook::react::UIManagerAnimationBackend {
   public using Callback = std::function<facebook::react::AnimationMutations(facebook::react::AnimationTimestamp)>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1535,6 +1535,7 @@ class facebook::react::AnimatedNode {
 class facebook::react::AnimatedPropsRegistry {
   public std::pair<std::unordered_set<std::shared_ptr<const facebook::react::ShadowNodeFamily>>&, facebook::react::SnapshotMap&> getMap(facebook::react::SurfaceId surfaceId);
   public void clear(facebook::react::SurfaceId surfaceId);
+  public void clearOnSurfaceStop(facebook::react::SurfaceId surfaceId);
   public void update(const std::unordered_map<facebook::react::SurfaceId, facebook::react::SurfaceUpdates>& surfaceUpdates);
 }
 
@@ -1544,6 +1545,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public using ResumeCallback = std::function<void()>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
@@ -5210,6 +5212,7 @@ class facebook::react::UIManagerAnimationBackend {
   public using Callback = std::function<facebook::react::AnimationMutations(facebook::react::AnimationTimestamp)>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -4481,6 +4481,7 @@ class facebook::react::AnimatedNode {
 class facebook::react::AnimatedPropsRegistry {
   public std::pair<std::unordered_set<std::shared_ptr<const facebook::react::ShadowNodeFamily>>&, facebook::react::SnapshotMap&> getMap(facebook::react::SurfaceId surfaceId);
   public void clear(facebook::react::SurfaceId surfaceId);
+  public void clearOnSurfaceStop(facebook::react::SurfaceId surfaceId);
   public void update(const std::unordered_map<facebook::react::SurfaceId, facebook::react::SurfaceUpdates>& surfaceUpdates);
 }
 
@@ -4490,6 +4491,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public using ResumeCallback = std::function<void()>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
@@ -7788,6 +7790,7 @@ class facebook::react::UIManagerAnimationBackend {
   public using Callback = std::function<facebook::react::AnimationMutations(facebook::react::AnimationTimestamp)>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -4480,6 +4480,7 @@ class facebook::react::AnimatedNode {
 class facebook::react::AnimatedPropsRegistry {
   public std::pair<std::unordered_set<std::shared_ptr<const facebook::react::ShadowNodeFamily>>&, facebook::react::SnapshotMap&> getMap(facebook::react::SurfaceId surfaceId);
   public void clear(facebook::react::SurfaceId surfaceId);
+  public void clearOnSurfaceStop(facebook::react::SurfaceId surfaceId);
   public void update(const std::unordered_map<facebook::react::SurfaceId, facebook::react::SurfaceUpdates>& surfaceUpdates);
 }
 
@@ -4489,6 +4490,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public using ResumeCallback = std::function<void()>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
@@ -7779,6 +7781,7 @@ class facebook::react::UIManagerAnimationBackend {
   public using Callback = std::function<facebook::react::AnimationMutations(facebook::react::AnimationTimestamp)>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -864,6 +864,7 @@ class facebook::react::AnimatedNode {
 class facebook::react::AnimatedPropsRegistry {
   public std::pair<std::unordered_set<std::shared_ptr<const facebook::react::ShadowNodeFamily>>&, facebook::react::SnapshotMap&> getMap(facebook::react::SurfaceId surfaceId);
   public void clear(facebook::react::SurfaceId surfaceId);
+  public void clearOnSurfaceStop(facebook::react::SurfaceId surfaceId);
   public void update(const std::unordered_map<facebook::react::SurfaceId, facebook::react::SurfaceUpdates>& surfaceUpdates);
 }
 
@@ -873,6 +874,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public using ResumeCallback = std::function<void()>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
@@ -3685,6 +3687,7 @@ class facebook::react::UIManagerAnimationBackend {
   public using Callback = std::function<facebook::react::AnimationMutations(facebook::react::AnimationTimestamp)>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -863,6 +863,7 @@ class facebook::react::AnimatedNode {
 class facebook::react::AnimatedPropsRegistry {
   public std::pair<std::unordered_set<std::shared_ptr<const facebook::react::ShadowNodeFamily>>&, facebook::react::SnapshotMap&> getMap(facebook::react::SurfaceId surfaceId);
   public void clear(facebook::react::SurfaceId surfaceId);
+  public void clearOnSurfaceStop(facebook::react::SurfaceId surfaceId);
   public void update(const std::unordered_map<facebook::react::SurfaceId, facebook::react::SurfaceUpdates>& surfaceUpdates);
 }
 
@@ -872,6 +873,7 @@ class facebook::react::AnimationBackend : public facebook::react::UIManagerAnima
   public using ResumeCallback = std::function<void()>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) override;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) override;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) override;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) override;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) override;
@@ -3676,6 +3678,7 @@ class facebook::react::UIManagerAnimationBackend {
   public using Callback = std::function<facebook::react::AnimationMutations(facebook::react::AnimationTimestamp)>;
   public virtual facebook::react::CallbackId start(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void clearRegistry(facebook::react::SurfaceId surfaceId) = 0;
+  public virtual void clearRegistryOnSurfaceStop(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void onAnimationFrame(facebook::react::AnimationTimestamp timestamp) = 0;
   public virtual void pushAnimationMutations(const facebook::react::UIManagerAnimationBackend::Callback& callback) = 0;
   public virtual void registerJSInvoker(std::shared_ptr<facebook::react::CallInvoker> jsInvoker) = 0;


### PR DESCRIPTION
Summary:

## Changelog:

[Internal] [Fixed] - Clear AnimatedPropsRegistry on surface stop

When `useSharedAnimatedBackend` is enabled, the `AnimatedPropsRegistry` accumulates
`SurfaceContext` entries (containing `shared_ptr<ShadowNodeFamily>` and `PropsSnapshot`
data) for each surface that has animated views. These entries are never cleaned up when
a surface is destroyed via `UIManager::stopSurface()`, because that method only calls
the legacy `stopSurfaceForAnimationDelegate()` — the shared backend's registry is untouched.

We also see increased `RetryableMountingLayerException` errors in production which stack trace
shows there are mount items committing to surface that no longer exists.

This change:
1. Adds `animationBackend_->clearRegistry(surfaceId)` to `UIManager::stopSurface()`
2. Changes `AnimatedPropsRegistry::clear()` to fully erase the `surfaceContexts_` map
   entry instead of just clearing its contents

Reviewed By: christophpurrer

Differential Revision: D101354994
