### PR TITLE
fix(ios): center TextInput text when lineHeight > fontSize on Fabric

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -11,6 +11,7 @@
 #import <React/UIView+React.h>
 
 #import <React/RCTBackedTextInputDelegateAdapter.h>
+#import <React/RCTBackedTextInputViewLineHeightUtils.h>
 #import <React/RCTTextAttributes.h>
 
 @implementation RCTUITextView {
@@ -364,6 +365,7 @@ static UIColor *defaultPlaceholderColor(void)
     [textAttributes setValue:defaultPlaceholderFont() forKey:NSFontAttributeName];
   }
 
+  RCTApplyPlaceholderBaselineOffset(textAttributes);
   return textAttributes;
 }
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewLineHeightUtils.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewLineHeightUtils.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*
+ * When the configured `lineHeight` (encoded in `paragraphStyle.maximumLineHeight`)
+ * exceeds the font's natural line height, UIKit's draw paths anchor glyphs to the
+ * bottom of the paragraph line box. These helpers contain the small set of
+ * transformations needed to re-center the glyph and the caret across the various
+ * UIKit rendering paths used by `<TextInput>`.
+ */
+
+/*
+ * Returns a copy of `defaultTextAttributes` with `paragraphStyle.{min,max}LineHeight`
+ * zeroed when greater than the font's line height. UITextField / UITextView feed
+ * `defaultTextAttributes` into `typingAttributes`, so handing them a stripped copy
+ * makes the typed-text path render at the font's natural metrics — vertical centering
+ * then positions the glyph in the bounds and the caret rect (sized from the same line
+ * box) shrinks to match. Returns the input dictionary unchanged if no strip is needed.
+ */
+NSDictionary<NSAttributedStringKey, id> *RCTStripDefaultTextAttributesLineHeight(
+    NSDictionary<NSAttributedStringKey, id> *defaultTextAttributes);
+
+/*
+ * Per-range zero of `paragraphStyle.{min,max}LineHeight` on `attributedString`,
+ * preserving any other paragraph-style fields (alignment, indent) the user may have
+ * set on nested <Text>. No-ops on ranges that already have a zero line-height stub.
+ */
+void RCTStripAttributedStringLineHeights(NSMutableAttributedString *attributedString);
+
+/*
+ * Adds `NSBaselineOffsetAttributeName` to `placeholderAttributes` when
+ * `paragraphStyle.maximumLineHeight > font.lineHeight`. The placeholder UILabel
+ * draw path used by both UITextField.attributedPlaceholder and
+ * RCTUITextView._placeholderView honors baseline offset, so a single uniform offset
+ * is all that's needed to re-center the placeholder glyph in the line box.
+ */
+void RCTApplyPlaceholderBaselineOffset(NSMutableDictionary<NSAttributedStringKey, id> *placeholderAttributes);
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewLineHeightUtils.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewLineHeightUtils.mm
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTBackedTextInputViewLineHeightUtils.h"
+
+static BOOL RCTNeedsLineHeightStrip(NSDictionary<NSAttributedStringKey, id> *attributes)
+{
+  UIFont *font = attributes[NSFontAttributeName];
+  NSParagraphStyle *paragraphStyle = attributes[NSParagraphStyleAttributeName];
+  return font && paragraphStyle && paragraphStyle.maximumLineHeight > font.lineHeight;
+}
+
+NSDictionary<NSAttributedStringKey, id> *RCTStripDefaultTextAttributesLineHeight(
+    NSDictionary<NSAttributedStringKey, id> *defaultTextAttributes)
+{
+  if (!RCTNeedsLineHeightStrip(defaultTextAttributes)) {
+    return defaultTextAttributes;
+  }
+  NSMutableDictionary<NSAttributedStringKey, id> *stripped = [defaultTextAttributes mutableCopy];
+  NSMutableParagraphStyle *strippedStyle = [defaultTextAttributes[NSParagraphStyleAttributeName] mutableCopy];
+  strippedStyle.minimumLineHeight = 0;
+  strippedStyle.maximumLineHeight = 0;
+  stripped[NSParagraphStyleAttributeName] = strippedStyle;
+  return stripped;
+}
+
+void RCTStripAttributedStringLineHeights(NSMutableAttributedString *attributedString)
+{
+  [attributedString
+      enumerateAttribute:NSParagraphStyleAttributeName
+                 inRange:NSMakeRange(0, attributedString.length)
+                 options:0
+              usingBlock:^(NSParagraphStyle *style, NSRange range, __unused BOOL *stop) {
+                if (!style || (style.maximumLineHeight == 0 && style.minimumLineHeight == 0)) {
+                  return;
+                }
+                NSMutableParagraphStyle *stripped = [style mutableCopy];
+                stripped.minimumLineHeight = 0;
+                stripped.maximumLineHeight = 0;
+                [attributedString addAttribute:NSParagraphStyleAttributeName value:stripped range:range];
+              }];
+}
+
+void RCTApplyPlaceholderBaselineOffset(NSMutableDictionary<NSAttributedStringKey, id> *placeholderAttributes)
+{
+  if (!RCTNeedsLineHeightStrip(placeholderAttributes)) {
+    return;
+  }
+  NSParagraphStyle *paragraphStyle = placeholderAttributes[NSParagraphStyleAttributeName];
+  UIFont *font = placeholderAttributes[NSFontAttributeName];
+  placeholderAttributes[NSBaselineOffsetAttributeName] =
+      @((paragraphStyle.maximumLineHeight - font.lineHeight) / 2.0);
+}

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -8,6 +8,7 @@
 #import <React/RCTUITextField.h>
 
 #import <React/RCTBackedTextInputDelegateAdapter.h>
+#import <React/RCTBackedTextInputViewLineHeightUtils.h>
 #import <React/RCTTextAttributes.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
@@ -92,8 +93,13 @@
     return;
   }
 
+  // Keep the unstripped attributes available for `_placeholderTextAttributes`, which
+  // needs the configured `lineHeight` to compute the placeholder's baseline offset.
+  // Hand UIKit a copy with the paragraphStyle line-height zeroed so the typed-text
+  // path renders at the font's natural metrics — vertical centering then positions
+  // the glyph in the bounds and the caret rect shrinks to match.
   _defaultTextAttributes = defaultTextAttributes;
-  [super setDefaultTextAttributes:defaultTextAttributes];
+  [super setDefaultTextAttributes:RCTStripDefaultTextAttributesLineHeight(defaultTextAttributes)];
   [self _updatePlaceholder];
 }
 
@@ -169,6 +175,7 @@
     [textAttributes removeObjectForKey:NSForegroundColorAttributeName];
   }
 
+  RCTApplyPlaceholderBaselineOffset(textAttributes);
   return textAttributes;
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -12,6 +12,7 @@
 #import <react/renderer/textlayoutmanager/RCTAttributedTextUtils.h>
 #import <react/renderer/textlayoutmanager/TextLayoutManager.h>
 
+#import <React/RCTBackedTextInputViewLineHeightUtils.h>
 #import <React/RCTBackedTextInputViewProtocol.h>
 #import <React/RCTScrollViewComponentView.h>
 #import <React/RCTUITextField.h>
@@ -47,6 +48,12 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   UIView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
   NSUInteger _mostRecentEventCount;
   NSAttributedString *_lastStringStateWasUpdatedWith;
+  // The most-recent attributedString JS pushed via `_setAttributedString:`, kept
+  // unstripped (with the configured `lineHeight`). Used as the source of truth
+  // for state pushes — the displayed `attributedText` may have its paragraph-style
+  // line-height zeroed for single-line rendering, but the shadow node measures
+  // from state and needs the real line-height to keep the cell stable.
+  NSAttributedString *_sourceAttributedString;
 
   /*
    * UIKit uses either UITextField or UITextView as its UIKit element for <TextInput>. UITextField is for single line
@@ -712,10 +719,10 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   return {
       .text = RCTStringFromNSString(_backedTextInputView.attributedText.string),
       .selectionRange = [self _selectionRange],
-      .eventCount = static_cast<int>(_mostRecentEventCount),
+      .contentSize = RCTSizeFromCGSize(_backedTextInputView.contentSize),
       .contentOffset = RCTPointFromCGPoint(_backedTextInputView.contentOffset),
       .contentInset = RCTEdgeInsetsFromUIEdgeInsets(_backedTextInputView.contentInset),
-      .contentSize = RCTSizeFromCGSize(_backedTextInputView.contentSize),
+      .eventCount = static_cast<int>(_mostRecentEventCount),
       .layoutMeasurement = RCTSizeFromCGSize(_backedTextInputView.bounds.size),
       .zoomScale = _backedTextInputView.zoomScale,
   };
@@ -729,7 +736,21 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   NSAttributedString *attributedString = _backedTextInputView.attributedText;
   auto data = _state->getData();
   _lastStringStateWasUpdatedWith = attributedString;
-  data.attributedStringBox = RCTAttributedStringBoxFromNSAttributedString(attributedString);
+
+  // Single-line rendering may have stripped the paragraph-style line-height from
+  // the displayed `attributedText`, but the shadow node measures from state and
+  // needs the configured `lineHeight`. Use the saved unstripped source string
+  // when its content still matches the field; if the user has typed since the
+  // last push, fall back to building a fresh string from the field's text and
+  // the (unstripped) `defaultTextAttributes`.
+  NSAttributedString *sourceString = _sourceAttributedString;
+  if (![sourceString.string isEqualToString:attributedString.string]) {
+    sourceString = [[NSAttributedString alloc] initWithString:attributedString.string
+                                                   attributes:_backedTextInputView.defaultTextAttributes];
+    _sourceAttributedString = sourceString;
+  }
+
+  data.attributedStringBox = RCTAttributedStringBoxFromNSAttributedString(sourceString);
   _mostRecentEventCount += _comingFromJS ? 0 : 1;
   data.mostRecentEventCount = _mostRecentEventCount;
   _state->updateState(std::move(data));
@@ -768,6 +789,46 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
 - (void)_setAttributedString:(NSAttributedString *)attributedString
 {
+  // Save the unstripped source for layout / state push before any display
+  // transformation runs. `_updateState` reads this back so the shadow node
+  // measures from the configured `lineHeight`, not the render-time strip.
+  _sourceAttributedString = [attributedString copy];
+
+  // When `lineHeight > font.lineHeight`, UIKit's draw paths anchor glyphs to the
+  // bottom of the paragraph line box. UITextView honors NSBaselineOffsetAttributeName
+  // to re-center; UITextField does not, so for single-line we zero the paragraph-style
+  // line-height (UITextField then renders at the font's natural metrics, and its
+  // built-in vertical centering positions the glyph in the bounds).
+  NSDictionary<NSAttributedStringKey, id> *defaults = _backedTextInputView.defaultTextAttributes;
+  NSParagraphStyle *defaultParagraphStyle = defaults[NSParagraphStyleAttributeName];
+  UIFont *defaultFont = defaults[NSFontAttributeName];
+  if (attributedString.length > 0 && defaultParagraphStyle && defaultFont &&
+      defaultParagraphStyle.maximumLineHeight > defaultFont.lineHeight) {
+    NSMutableAttributedString *mutableString = [attributedString mutableCopy];
+    if ([_backedTextInputView isKindOfClass:[RCTUITextView class]]) {
+      // UIKit's typingAttributes drop NSParagraphStyle on the round-trip, so chars typed
+      // since the last state push arrive without a paragraph style. Re-seed those ranges
+      // (and ranges with a zero-line-height stub) from the default so UITextView resolves a
+      // consistent line-box height across the whole string. RCTApplyBaselineOffset then
+      // computes the centering offset using the max font.lineHeight present on each line —
+      // correct for mixed-font input from nested <Text> children.
+      [mutableString enumerateAttribute:NSParagraphStyleAttributeName
+                                inRange:NSMakeRange(0, mutableString.length)
+                                options:0
+                             usingBlock:^(NSParagraphStyle *style, NSRange range, __unused BOOL *stop) {
+                               if (!style || style.maximumLineHeight == 0) {
+                                 [mutableString addAttribute:NSParagraphStyleAttributeName
+                                                       value:defaultParagraphStyle
+                                                       range:range];
+                               }
+                             }];
+      RCTApplyBaselineOffset(mutableString);
+    } else {
+      RCTStripAttributedStringLineHeights(mutableString);
+    }
+    attributedString = mutableString;
+  }
+
   if ([self _textOf:attributedString equals:_backedTextInputView.attributedText]) {
     return;
   }

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1189,6 +1189,33 @@ module.exports = [
     render: () => <TextStylesExample />,
   },
   {
+    title: 'lineHeight baseline',
+    name: 'lineHeightBaseline',
+    render: function (): React.Node {
+      const inputStyle = {
+        fontSize: 16,
+        lineHeight: 32,
+        borderColor: '#ccc',
+        borderWidth: 1,
+        padding: 8,
+      };
+      return (
+        <View>
+          <WithLabel label="single-line">
+            <ExampleTextInput placeholder="placeholder" style={inputStyle} />
+          </WithLabel>
+          <WithLabel label="multi-line">
+            <ExampleTextInput
+              multiline
+              placeholder="placeholder"
+              style={inputStyle}
+            />
+          </WithLabel>
+        </View>
+      );
+    },
+  },
+  {
     title: 'showSoftInputOnFocus',
     render: function (): React.Node {
       return (


### PR DESCRIPTION
## Summary

On iOS, when a `TextInput` has `lineHeight > fontSize`, UIKit anchors typed text and the placeholder to the bottom of the paragraph line box, and sizes the single-line caret to the full line-box height instead of the font height.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/f1fa6266-2800-4797-b251-333feea7c626" width="320" /> | <img src="https://github.com/user-attachments/assets/598eac8e-f2e6-4812-945a-103f59b85bc4" width="320" /> |

`fontSize: 16, lineHeight: 80`. iOS 26 simulator, Fabric.

## Why

The fix splits two ways because UIKit's draw paths don't all honor the same attributes:

| Surface | Honors `NSBaselineOffsetAttributeName`? |
|---|---|
| Multi-line typed text (`UITextView`) | yes |
| Placeholder (single + multi, `UILabel`) | yes |
| Single-line typed text + caret (`UITextField` / `UIFieldEditor`) | **no** |

- **Multi-line typed text + placeholder**: apply a baseline offset to re-center the glyph. Multi-line typed text reuses the existing `RCTApplyBaselineOffset` helper that `<Text>` already uses, so per-fragment fonts (nested `<Text>` with different `fontSize`) are handled correctly.
- **Single-line typed text + caret**: zero `paragraphStyle.minimumLineHeight` / `maximumLineHeight` per range on the attributed string handed to UIKit. UITextField then renders at the font's natural line height and its built-in vertical centering positions the glyph in the bounds; the caret rect — derived from the same line box — shrinks to match. Other `paragraphStyle` fields (alignment, indent) are preserved per range. The shadow node measures from `TextInputState`, so `_updateState` re-inflates stripped line heights from `defaultTextAttributes` before pushing — without that step the cell would shrink to the font's natural height after the first keystroke.

The typed-text fix lives in `RCTTextInputComponentView._setAttributedString:` (single Fabric entry point, preserves the `_textOf:equals:` early-return). The placeholder fix lives in `_placeholderTextAttributes` of each backing view.

## Performance

When `lineHeight ≤ font.lineHeight` (common case): **zero allocations** — guarded out before any mutation.

## Changelog:

[IOS] [FIXED] - Center typed TextInput text, placeholder, and single-line caret when `lineHeight > fontSize`.

## Test Plan

RN Tester → **TextInput → lineHeight baseline**. Verified on iOS 26 simulator (iPhone 16 Pro / iPhone 17 Pro Max) on Fabric, including nested `<Text>` mixed-font cases. Confirmed cell height stays stable across edits.

Related: #38359, #39145, #53092.
