### PR TITLE
Remove invalid float enum example from RN Codegen

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
@@ -177,34 +177,6 @@ const SIMPLE_NATIVE_MODULES: SchemaType = {
             },
           ],
         },
-        FloatEnum: {
-          type: 'EnumDeclarationWithMembers',
-          name: 'FloatEnum',
-          memberType: 'NumberTypeAnnotation',
-          members: [
-            {
-              name: 'POINT_ZERO',
-              value: {
-                type: 'NumberLiteralTypeAnnotation',
-                value: 0.0,
-              },
-            },
-            {
-              name: 'POINT_ONE',
-              value: {
-                type: 'NumberLiteralTypeAnnotation',
-                value: 0.1,
-              },
-            },
-            {
-              name: 'POINT_TWO',
-              value: {
-                type: 'NumberLiteralTypeAnnotation',
-                value: 0.2,
-              },
-            },
-          ],
-        },
         StringEnum: {
           type: 'EnumDeclarationWithMembers',
           name: 'StringEnum',
@@ -527,15 +499,6 @@ const SIMPLE_NATIVE_MODULES: SchemaType = {
                   optional: false,
                   typeAnnotation: {
                     name: 'NumEnum',
-                    type: 'EnumDeclaration',
-                    memberType: 'NumberTypeAnnotation',
-                  },
-                },
-                {
-                  name: 'enumFloat',
-                  optional: false,
-                  typeAnnotation: {
-                    name: 'FloatEnum',
                     type: 'EnumDeclaration',
                     memberType: 'NumberTypeAnnotation',
                   },

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -1739,38 +1739,6 @@ struct Bridging<NativeSampleTurboModuleNumEnum> {
   }
 };
 
-#pragma mark - NativeSampleTurboModuleFloatEnum
-
-enum class NativeSampleTurboModuleFloatEnum { POINT_ZERO = 0, POINT_ONE, POINT_TWO };
-
-template <>
-struct Bridging<NativeSampleTurboModuleFloatEnum> {
-  static NativeSampleTurboModuleFloatEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue) {
-    double value = (double)rawValue.asNumber();
-    if (value == 0) {
-      return NativeSampleTurboModuleFloatEnum::POINT_ZERO;
-    } else if (value == 0.1) {
-      return NativeSampleTurboModuleFloatEnum::POINT_ONE;
-    } else if (value == 0.2) {
-      return NativeSampleTurboModuleFloatEnum::POINT_TWO;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeSampleTurboModuleFloatEnum\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, NativeSampleTurboModuleFloatEnum value) {
-    if (value == NativeSampleTurboModuleFloatEnum::POINT_ZERO) {
-      return bridging::toJs(rt, 0);
-    } else if (value == NativeSampleTurboModuleFloatEnum::POINT_ONE) {
-      return bridging::toJs(rt, 0.1);
-    } else if (value == NativeSampleTurboModuleFloatEnum::POINT_TWO) {
-      return bridging::toJs(rt, 0.2);
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeSampleTurboModuleFloatEnum\\");
-    }
-  }
-};
-
 #pragma mark - NativeSampleTurboModuleStringEnum
 
 enum class NativeSampleTurboModuleStringEnum { HELLO, GoodBye };
@@ -1818,7 +1786,7 @@ protected:
     methodMap_[\\"getValueWithCallback\\"] = MethodMetadata {.argCount = 1, .invoker = __getValueWithCallback};
     methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {.argCount = 1, .invoker = __getValueWithPromise};
     methodMap_[\\"getValueWithOptionalArg\\"] = MethodMetadata {.argCount = 1, .invoker = __getValueWithOptionalArg};
-    methodMap_[\\"getEnums\\"] = MethodMetadata {.argCount = 3, .invoker = __getEnums};
+    methodMap_[\\"getEnums\\"] = MethodMetadata {.argCount = 2, .invoker = __getEnums};
   }
   
 private:
@@ -1927,12 +1895,11 @@ private:
 
   static jsi::Value __getEnums(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
     static_assert(
-      bridging::getParameterCount(&T::getEnums) == 4,
-      \\"Expected getEnums(...) to have 4 parameters\\");
+      bridging::getParameterCount(&T::getEnums) == 3,
+      \\"Expected getEnums(...) to have 3 parameters\\");
     return bridging::callFromJs<jsi::String>(rt, &T::getEnums,  static_cast<NativeSampleTurboModuleCxxSpec*>(&turboModule)->jsInvoker_, static_cast<T*>(&turboModule),
       count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asNumber(),
-      count <= 1 ? throw jsi::JSError(rt, \\"Expected argument in position 1 to be passed\\") : args[1].asNumber(),
-      count <= 2 ? throw jsi::JSError(rt, \\"Expected argument in position 2 to be passed\\") : args[2].asString(rt));
+      count <= 1 ? throw jsi::JSError(rt, \\"Expected argument in position 1 to be passed\\") : args[1].asString(rt));
   }
 };
 

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleHObjCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleHObjCpp-test.js.snap
@@ -1056,7 +1056,6 @@ namespace JS {
                         resolve:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject;
 - (NSString *)getEnums:(double)enumInt
-             enumFloat:(double)enumFloat
             enumString:(NSString *)enumString;
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants>)constantsToExport;
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants>)getConstants;

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJavaSpec-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJavaSpec-test.js.snap
@@ -505,7 +505,7 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   @DoNotStrip
-  public abstract String getEnums(double enumInt, double enumFloat, String enumString);
+  public abstract String getEnums(double enumInt, String enumString);
 }
 ",
 }

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniCpp-test.js.snap
@@ -428,7 +428,7 @@ static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getVal
 
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getEnums(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
   static jmethodID cachedMethodId = nullptr;
-  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, StringKind, \\"getEnums\\", \\"(DDLjava/lang/String;)Ljava/lang/String;\\", args, count, cachedMethodId);
+  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, StringKind, \\"getEnums\\", \\"(DLjava/lang/String;)Ljava/lang/String;\\", args, count, cachedMethodId);
 }
 
 NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const JavaTurboModule::InitParams &params)
@@ -446,7 +446,7 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const JavaTurboMo
   methodMap_[\\"getValueWithCallback\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithCallback};
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithPromise};
   methodMap_[\\"getValueWithOptionalArg\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithOptionalArg};
-  methodMap_[\\"getEnums\\"] = MethodMetadata {3, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnums};
+  methodMap_[\\"getEnums\\"] = MethodMetadata {2, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnums};
 }
 
 std::shared_ptr<TurboModule> simple_native_modules_ModuleProvider(const std::string &moduleName, const JavaTurboModule::InitParams &params) {

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleMm-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleMm-test.js.snap
@@ -575,7 +575,7 @@ namespace facebook::react {
     }
 
     static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getEnums(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, StringKind, \\"getEnums\\", @selector(getEnums:enumFloat:enumString:), args, count);
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, StringKind, \\"getEnums\\", @selector(getEnums:enumString:), args, count);
     }
 
     static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -621,7 +621,7 @@ namespace facebook::react {
         methodMap_[\\"getValueWithOptionalArg\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithOptionalArg};
         
         
-        methodMap_[\\"getEnums\\"] = MethodMetadata {3, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnums};
+        methodMap_[\\"getEnums\\"] = MethodMetadata {2, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnums};
         
         
         methodMap_[\\"getConstants\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants};


### PR DESCRIPTION
Summary:
C++ enums cannot have float values - they must be int or long. This removes the invalid FloatEnum example (with values 0.0, 0.1, 0.2) from the react-native-codegen test fixtures and the corresponding enumFloat parameter reference. All affected test snapshots have been regenerated.

Changelog: [Internal]

Differential Revision: D101433764


