### PR TITLE
Fix unused parameter warnings in HostPlatformViewTraitsInitializer.h (#56491)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -12,12 +12,12 @@
 
 namespace facebook::react::HostPlatformViewTraitsInitializer {
 
-inline bool formsStackingContext(const ViewProps &props)
+inline bool formsStackingContext(const ViewProps & /*props*/)
 {
   return false;
 }
 
-inline bool formsView(const ViewProps &props)
+inline bool formsView(const ViewProps & /*props*/)
 {
   return false;
 }


### PR DESCRIPTION
Summary:

Fixed clang-diagnostic-unused-parameter warnings in HostPlatformViewTraitsInitializer.h by commenting out unused parameter names while maintaining API compatibility.

Changes:
- `formsStackingContext`: Commented out unused 'props' parameter
- `formsView`: Commented out unused 'props' parameter
- `isKeyboardFocusable`: Already had parameter commented out correctly

Changelog: [Internal]

Reviewed By: zeyap

Differential Revision: D101108434
