### PR TITLE
Fix unused parameter warnings in NativeFantomTestSpecificMethods.cpp (#56492)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/NativeFantomTestSpecificMethods.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/NativeFantomTestSpecificMethods.cpp
@@ -46,8 +46,8 @@ void NativeFantomTestSpecificMethods::registerForcedCloneCommitHook(
 }
 
 void NativeFantomTestSpecificMethods::takeFunctionAndNoop(
-    jsi::Runtime& runtime,
-    jsi::Function function) {}
+    jsi::Runtime& /* runtime */,
+    jsi::Function /* callback */) {}
 
 void NativeFantomTestSpecificMethods::setRootNodeSize(
     jsi::Runtime& runtime,


### PR DESCRIPTION
Summary:

Fixed clang-diagnostic-unused-parameter warnings by commenting out unused parameters in the takeFunctionAndNoop method. This method appears to be a no-op function that takes a callback but doesn't use it, likely for testing purposes.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D101108571
