### PR TITLE
Fix unused parameters in EventQueueProcessorTest.cpp (#56493)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
@@ -48,8 +48,8 @@ class EventQueueProcessorTest : public testing::Test {
       eventPriorities_.push_back(priority);
     };
 
-    auto dummyEventPipeConclusion = [](jsi::Runtime& runtime) {};
-    auto dummyStatePipe = [](const StateUpdate& stateUpdate) {};
+    auto dummyEventPipeConclusion = [](jsi::Runtime&) {};
+    auto dummyStatePipe = [](const StateUpdate&) {};
     auto mockEventLogger = std::make_shared<MockEventLogger>();
 
     eventProcessor_ = std::make_unique<EventQueueProcessor>(


### PR DESCRIPTION
Summary:

Fixed clang-diagnostic-unused-parameter warnings in EventQueueProcessorTest.cpp by removing unused parameter names from lambda functions.

Changes:
- Line 51: Removed parameter name 'runtime' from dummyEventPipeConclusion lambda
- Line 52: Removed parameter name 'stateUpdate' from dummyStatePipe lambda

This is a standard C++ practice for handling unused parameters - keeping the type for API compatibility while removing the name to silence the warning.

Changelog: [Internal]

Reviewed By: zeyap

Differential Revision: D101110552


