### PR TITLE
Downgrade image timeout in test environment from RCTLogError to RCTLogWarn (#56494)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
@@ -92,7 +92,11 @@ using namespace facebook::react;
 
   auto result = dispatch_group_wait(imageWaitGroup, dispatch_time(DISPATCH_TIME_NOW, 20 * NSEC_PER_SEC));
   if (result != 0) {
-    RCTLogError(@"Image timed out in test environment for url: %@", loaderRequest.imageURL);
+    // Downgraded from RCTLogError to RCTLogWarn: image timeouts in test
+    // environments are transient infrastructure issues, not fatal app errors.
+    // RCTLogError triggers a native redbox that blocks the entire UI and cannot
+    // be dismissed on iOS, causing E2E test failures.
+    RCTLogWarn(@"Image timed out in test environment for url: %@", loaderRequest.imageURL);
   }
   return imageRequest;
 }


### PR DESCRIPTION
Summary:

Changelog: [Internal]

## Problem

`RCTSyncImageManager` (used exclusively in test environments) calls `RCTLogError` when a network image fails to load within 20 seconds. On iOS, `RCTLogError` triggers a **native redbox** — a full-screen red overlay that:

1. **Covers the entire app UI**, making all elements invisible to E2E test assertions
2. **Cannot be dismissed on iOS** — `NativeExceptionsManager.dismissRedbox()` is a no-op (empty method in `RCTExceptionsManager.mm`)
3. **Cannot be suppressed by JavaScript-side mechanisms** — `LogBox.ignoreAllLogs()` and `suppress_warning` mobile config only affect JS-level LogBox, not native `RCTLogError` redboxes
4. **Instantly fails any E2E test** at the next `toBeVisible()` / `toHaveText()` assertion because the redbox overlay blocks all UI elements

This causes **~2-5% infrastructure flakiness** across all iOS E2E tests that render components with network images (e.g., recommendation cards, ad previews, profile images), due to transient image load timeouts in the CI test sandbox.

### Error Flow
```
Image URL request in test sandbox
  → Network timeout (sandbox cant fetch from lookaside.facebook.com)
    → RCTSyncImageManager.mm dispatch_group_wait expires (20s)
      → RCTLogError(@"Image timed out in test environment for url: %@")
        → RCTLog.mm: level >= RCTLOG_REDBOX_LEVEL
          → Native RedBox overlay shown (full-screen, undismissable on iOS)
            → All toBeVisible() assertions fail
              → Test marked as FAILED
```

Differential Revision: D101052445
