### PR TITLE
Fix event timestamp injection to check both casing variants

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -147,7 +147,8 @@ void UIManagerBinding::dispatchEventToJS(
   // Add timestamp to payload if not already set
   if (payload.isObject()) {
     auto payloadObject = payload.asObject(runtime);
-    if (!payloadObject.hasProperty(runtime, "timeStamp")) {
+    if (!payloadObject.hasProperty(runtime, "timeStamp") &&
+        !payloadObject.hasProperty(runtime, "timestamp")) {
       payloadObject.setProperty(
           runtime, "timeStamp", eventTimestamp.toDOMHighResTimeStamp());
     }


### PR DESCRIPTION
Summary:
UIManagerBinding::dispatchEvent checks for an existing timeStamp property before injecting one, but only checks the camelCase variant. Native events that use lowercase timestamp (e.g. pointer events) would have a duplicate timeStamp injected with the current time, which then takes precedence in the SyntheticEvent timestamp resolution chain (event.timeStamp || event.timestamp).

This adds a check for both timeStamp and timestamp before auto-injecting, preserving the original native event timestamp when present in either casing.

Root cause: https://github.com/facebook/react-native/pull/55878 only checked for timeStamp (camelCase).

Changelog: [General][Fixed] - Fix event timestamp injection overriding native timestamps with lowercase property name

Reviewed By: mdvacca

Differential Revision: D101522871


