### PR TITLE
Guard Tracing.end handler against missing Tracing.start in jsinspector-modern

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -90,6 +90,16 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     return true;
   } else if (req.method == "Tracing.end") {
+    if (!sessionState_.hasPendingTraceRecording) {
+      frontendChannel_(
+          cdp::jsonError(
+              req.id,
+              cdp::ErrorCode::InvalidRequest,
+              "Tracing has not been started"));
+
+      return true;
+    }
+
     auto tracingProfile = hostTargetController_.stopTracing();
 
     sessionState_.hasPendingTraceRecording = false;


### PR DESCRIPTION
Summary:
Add a guard in the `Tracing.end` CDP handler to check `sessionState_.hasPendingTraceRecording` before calling `stopTracing()`. This prevents a null-pointer crash (SIGSEGV) in `HostTargetTraceRecording::stop()` when `Tracing.end` is sent after `Tracing.start` was rejected (e.g. due to multiple registered host targets in the global inspector singleton).

The guard matches the existing pattern in `TracingAgent::~TracingAgent()` (line 29). When tracing was never started, it now returns an `InvalidRequest` error instead of crashing.

Changelog: [Internal]

Differential Revision: D101557975


