### PR TITLE
fix(android): intercept ESCAPE key ACTION_DOWN in Modal to prevent premature dismiss

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -305,23 +305,34 @@ public class ReactModalHostView(context: ThemedReactContext) :
     newDialog.setOnKeyListener(
         object : DialogInterface.OnKeyListener {
           override fun onKey(dialog: DialogInterface, keyCode: Int, event: KeyEvent): Boolean {
-            if (event.action == KeyEvent.ACTION_UP) {
+            if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_ESCAPE) {
               // We need to stop the BACK button and ESCAPE key from closing the dialog by default
-              // so we capture that event and instead inform JS so that it can make the decision as
-              // to whether or not to allow the back/escape key to close the dialog. If it chooses
-              // to, it can just set visible to false on the Modal and the Modal will go away
-              if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_ESCAPE) {
+              // so we capture those events and instead inform JS so that it can make the decision
+              // as to whether or not to allow the back/escape key to close the dialog. If it
+              // chooses to, it can just set visible to false on the Modal and the Modal will go
+              // away.
+              // We must intercept both ACTION_DOWN and ACTION_UP for ESCAPE because
+              // Dialog.onKeyDown() will directly call cancel() on ACTION_DOWN for
+              // KEYCODE_ESCAPE (unlike KEYCODE_BACK which only starts tracking on ACTION_DOWN
+              // and defers to onBackPressed() on ACTION_UP). If we don't intercept
+              // ACTION_DOWN, the dialog is dismissed before our ACTION_UP handler runs.
+              if (event.action == KeyEvent.ACTION_DOWN) {
+                // Consume ACTION_DOWN to prevent Dialog.onKeyDown() from closing the dialog.
+                // For BACK this prevents the default key tracking; for ESCAPE this prevents
+                // Dialog.cancel() from being called directly.
+                return true
+              } else if (event.action == KeyEvent.ACTION_UP) {
                 handleCloseAction()
                 return true
-              } else {
-                // We redirect the rest of the key events to the current activity, since the
-                // activity expects to receive those events and react to them, ie. in the case of
-                // the dev menu
-                val innerCurrentActivity =
-                    (this@ReactModalHostView.context as ReactContext).currentActivity
-                if (innerCurrentActivity != null) {
-                  return innerCurrentActivity.onKeyUp(keyCode, event)
-                }
+              }
+            } else if (event.action == KeyEvent.ACTION_UP) {
+              // We redirect the rest of the key events to the current activity, since the
+              // activity expects to receive those events and react to them, ie. in the case of
+              // the dev menu
+              val innerCurrentActivity =
+                  (this@ReactModalHostView.context as ReactContext).currentActivity
+              if (innerCurrentActivity != null) {
+                return innerCurrentActivity.onKeyUp(keyCode, event)
               }
             }
             return false


### PR DESCRIPTION
## Summary:

Fix Android Modal's handling of the ESCAPE key so that JavaScript is reliably notified (via `onRequestClose`) instead of the dialog dismissing itself before JS sees the event.

## Problem

`ReactModalHostView` installs an `OnKeyListener` that only reacts on `ACTION_UP` for `KEYCODE_BACK` / `KEYCODE_ESCAPE`, calling `handleCloseAction()` to let JS decide whether to close.

However, Android's `Dialog.onKeyDown()` handles these two keys asymmetrically:

- `KEYCODE_BACK` — `ACTION_DOWN` only calls `event.startTracking()`; the dialog is dismissed on `ACTION_UP` via `onBackPressed()`. Our `ACTION_UP` interception works fine.
- `KEYCODE_ESCAPE` — `ACTION_DOWN` directly calls `Dialog.cancel()`. By the time our `ACTION_UP` handler would run, the dialog is already being dismissed, so `onRequestClose` is never delivered to JS.

Net effect: pressing ESCAPE on Android closes the Modal unconditionally, bypassing JS (breaks apps that rely on `onRequestClose` for confirmation dialogs, unsaved-changes prompts, etc.).

## Fix

Restructure the key listener to branch on `keyCode` first:

- For `KEYCODE_BACK` / `KEYCODE_ESCAPE`:
  - Consume `ACTION_DOWN` (`return true`) to prevent `Dialog.onKeyDown()` from dismissing the dialog.
  - On `ACTION_UP`, call `handleCloseAction()` as before, giving JS the final say.
- For all other keys, preserve the previous behavior of forwarding `ACTION_UP` to the current `Activity` (needed by the dev menu, etc.).

## Test Plan:

- Render a `<Modal visible>` on Android, attach `onRequestClose` handler, press the hardware BACK button — handler fires, modal stays open unless JS sets `visible={false}`. (Regression coverage: unchanged behavior.)
- Same setup, press ESCAPE on a connected keyboard / emulator — handler now fires correctly; previously the modal closed without JS notification.
- Open the dev menu shortcut while a modal is not showing — still works (non-BACK/ESCAPE keys still forwarded to Activity).

## Changelog:

[ANDROID] [FIXED] - Modal's `onRequestClose` is now correctly invoked when pressing ESCAPE on Android (previously the dialog was dismissed before JS was notified).
