### PR TITLE
Fix unused parameter warnings in StubErrorUtils.h (#56499)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
@@ -45,8 +45,7 @@ class StubErrorUtils : public jsi::HostObject {
           runtime,
           name,
           1,
-          [this](
-              jsi::Runtime &runtime, const jsi::Value &, const jsi::Value *arguments, size_t) noexcept -> jsi::Value {
+          [this](jsi::Runtime &, const jsi::Value &, const jsi::Value *, size_t) noexcept -> jsi::Value {
             reportFatalCallCount_++;
             return jsi::Value::undefined();
           });


### PR DESCRIPTION
Summary:

Fixed clang-diagnostic-unused-parameter warnings in StubErrorUtils.h by removing unused parameter names while keeping the types. This is a test stub file where the parameters are required by the JSI API but not used in the lambda function body.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=4e4747b6-3945-11f1-bb83-31e48279e63b&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=4e4747b6-3945-11f1-bb83-31e48279e63b&tab=Trace)

Differential Revision: D101110380


