### PR TITLE
Fix unused parameter warning in propsConversions.h (#56500)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -101,7 +101,7 @@ void fromRawValue(const PropsParserContext &context, const RawValue &rawValue, T
 }
 
 template <typename T>
-void fromRawValue(const PropsParserContext &context, const RawValue &rawValue, T &result)
+void fromRawValue(const PropsParserContext & /* context */, const RawValue &rawValue, T &result)
 {
   result = (T)rawValue;
 }

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1012,8 +1012,6 @@ folly::dynamic facebook::react::toDynamic(const std::vector<T>& arrayValue);
 template <typename T>
 jni::local_ref<jni::JWeakReference<T>> facebook::react::makeJWeakReference(jni::alias_ref<T> ref);
 template <typename T>
-void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result);
-template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result, T defaultValue);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::optional<T>& result);
@@ -1021,6 +1019,8 @@ template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<T>& result);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<std::vector<T>>& result);
+template <typename T>
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext&, const facebook::react::RawValue& rawValue, T& result);
 template <typename TManager>
 std::shared_ptr<TManager> facebook::react::getManagerByName(std::shared_ptr<const facebook::react::ContextContainer>& contextContainer, const char name[]);
 uint8_t facebook::react::alphaFromColor(facebook::react::SharedColor color) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1012,8 +1012,6 @@ folly::dynamic facebook::react::toDynamic(const std::vector<T>& arrayValue);
 template <typename T>
 jni::local_ref<jni::JWeakReference<T>> facebook::react::makeJWeakReference(jni::alias_ref<T> ref);
 template <typename T>
-void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result);
-template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result, T defaultValue);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::optional<T>& result);
@@ -1021,6 +1019,8 @@ template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<T>& result);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<std::vector<T>>& result);
+template <typename T>
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext&, const facebook::react::RawValue& rawValue, T& result);
 template <typename TManager>
 std::shared_ptr<TManager> facebook::react::getManagerByName(std::shared_ptr<const facebook::react::ContextContainer>& contextContainer, const char name[]);
 uint8_t facebook::react::alphaFromColor(facebook::react::SharedColor color) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -4203,8 +4203,6 @@ bool facebook::react::floatEquality(T a, T b, T epsilon = static_cast<T>(faceboo
 template <typename T>
 facebook::react::ModuleConstants<T> facebook::react::typedConstants(typename T::Builder::Input&& value);
 template <typename T>
-void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result);
-template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result, T defaultValue);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::optional<T>& result);
@@ -4212,6 +4210,8 @@ template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<T>& result);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<std::vector<T>>& result);
+template <typename T>
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext&, const facebook::react::RawValue& rawValue, T& result);
 template <typename TManager>
 std::shared_ptr<TManager> facebook::react::getManagerByName(std::shared_ptr<const facebook::react::ContextContainer>& contextContainer, const char name[]);
 uint8_t facebook::react::alphaFromColor(facebook::react::SharedColor color) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -4203,8 +4203,6 @@ bool facebook::react::floatEquality(T a, T b, T epsilon = static_cast<T>(faceboo
 template <typename T>
 facebook::react::ModuleConstants<T> facebook::react::typedConstants(typename T::Builder::Input&& value);
 template <typename T>
-void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result);
-template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result, T defaultValue);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::optional<T>& result);
@@ -4212,6 +4210,8 @@ template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<T>& result);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<std::vector<T>>& result);
+template <typename T>
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext&, const facebook::react::RawValue& rawValue, T& result);
 template <typename TManager>
 std::shared_ptr<TManager> facebook::react::getManagerByName(std::shared_ptr<const facebook::react::ContextContainer>& contextContainer, const char name[]);
 uint8_t facebook::react::alphaFromColor(facebook::react::SharedColor color) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -581,8 +581,6 @@ T facebook::react::get(const std::unique_ptr<facebook::react::AnimatedPropBase>&
 template <typename T>
 bool facebook::react::floatEquality(T a, T b, T epsilon = static_cast<T>(facebook::react::kDefaultEpsilon));
 template <typename T>
-void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result);
-template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result, T defaultValue);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::optional<T>& result);
@@ -590,6 +588,8 @@ template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<T>& result);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<std::vector<T>>& result);
+template <typename T>
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext&, const facebook::react::RawValue& rawValue, T& result);
 template <typename TManager>
 std::shared_ptr<TManager> facebook::react::getManagerByName(std::shared_ptr<const facebook::react::ContextContainer>& contextContainer, const char name[]);
 uint8_t facebook::react::alphaFromColor(facebook::react::SharedColor color) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -581,8 +581,6 @@ T facebook::react::get(const std::unique_ptr<facebook::react::AnimatedPropBase>&
 template <typename T>
 bool facebook::react::floatEquality(T a, T b, T epsilon = static_cast<T>(facebook::react::kDefaultEpsilon));
 template <typename T>
-void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result);
-template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, T& result, T defaultValue);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::optional<T>& result);
@@ -590,6 +588,8 @@ template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<T>& result);
 template <typename T>
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& rawValue, std::vector<std::vector<T>>& result);
+template <typename T>
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext&, const facebook::react::RawValue& rawValue, T& result);
 template <typename TManager>
 std::shared_ptr<TManager> facebook::react::getManagerByName(std::shared_ptr<const facebook::react::ContextContainer>& contextContainer, const char name[]);
 uint8_t facebook::react::alphaFromColor(facebook::react::SharedColor color) noexcept;


### PR DESCRIPTION
Summary:

Fixed clang-diagnostic-unused-parameter warning in React Native's propsConversions.h by commenting out the unused `context` parameter in the `fromRawValue` template function.

This change maintains API compatibility while resolving the compiler warning.


Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D101111638


