### PR TITLE
Validate NPM token before creating a release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,6 +28,21 @@ jobs:
           token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0
           fetch-tags: 'true'
+      - name: Verify NPM token
+        run: |
+          if [[ -z "$GHA_NPM_TOKEN" ]]; then
+            echo "⚠️ No NPM token found. Skipping validation."
+            exit 0
+          fi
+          echo "//registry.npmjs.org/:_authToken=$GHA_NPM_TOKEN" > ~/.npmrc
+          if ! npm whoami > /dev/null 2>&1; then
+            echo "❌ NPM token is invalid or expired. Aborting release."
+            exit 1
+          fi
+          echo "✅ NPM token is valid ($(npm whoami))"
+          rm -f ~/.npmrc
+        env:
+          GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
       - name: Check if on stable branch
         id: check_stable_branch
         run: |


### PR DESCRIPTION
Summary:
Add an early NPM token validation step to the create-release workflow.
This runs `npm whoami` right after checkout to fail fast if the token is
expired or invalid, avoiding wasted CI time on a release that would fail
at the publish step.

The step gracefully skips when no token is present (e.g. fork PRs).

Reviewed By: christophpurrer

Differential Revision: D101377190

## Changelog:
[Internal] -


