### PR TITLE
Validate NPM token before nightly publish

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,6 +89,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Verify NPM token
+        run: |
+          if [[ -z "$GHA_NPM_TOKEN" ]]; then
+            echo "⚠️ No NPM token found. Skipping validation."
+            exit 0
+          fi
+          echo "//registry.npmjs.org/:_authToken=$GHA_NPM_TOKEN" > ~/.npmrc
+          if ! npm whoami > /dev/null 2>&1; then
+            echo "❌ NPM token is invalid or expired. Aborting release."
+            exit 1
+          fi
+          echo "✅ NPM token is valid ($(npm whoami))"
+          rm -f ~/.npmrc
       - name: Build and Publish NPM Package
         uses: ./.github/actions/build-npm-package
         with:


### PR DESCRIPTION
Summary:
Adds an NPM token validation step to the `build_npm_package` job of the
React Native nightly workflow. Mirrors the same check we recently added
to `create-release.yml` and the Hermes `rn-build-hermes.yml` workflows
so we fail fast (with a clear message) instead of failing partway
through the publish step when the token is expired or missing.

## Changelog:
[Internal] -

Reviewed By: fabriziocucci

Differential Revision: D101594276


