### PR TITLE
Skip use-hermes-nightly when hermes-compiler is already pinned

### DIFF
--- a/scripts/releases/use-hermes-nightly.js
+++ b/scripts/releases/use-hermes-nightly.js
@@ -15,7 +15,7 @@ const {updateHermesVersionsToNightly} = require('./utils/hermes-utils');
 
 async function main() {
   const {packageJson} = await getReactNativePackage();
-  const hermesCompilerVersion = packageJson.dependencies['hermes-compiler'];
+  const hermesCompilerVersion = packageJson.dependencies?.['hermes-compiler'];
 
   if (hermesCompilerVersion !== '0.0.0') {
     return;

--- a/scripts/releases/use-hermes-nightly.js
+++ b/scripts/releases/use-hermes-nightly.js
@@ -10,9 +10,17 @@
 
 'use strict';
 
+const {getReactNativePackage} = require('../shared/monorepoUtils');
 const {updateHermesVersionsToNightly} = require('./utils/hermes-utils');
 
 async function main() {
+  const {packageJson} = await getReactNativePackage();
+  const hermesCompilerVersion = packageJson.dependencies['hermes-compiler'];
+
+  if (hermesCompilerVersion !== '0.0.0') {
+    return;
+  }
+
   await updateHermesVersionsToNightly();
 }
 


### PR DESCRIPTION
## Summary:
`use-hermes-nightly` unconditionally overwrites the `hermes-compiler` with whatever the `latest-v1` tag currently points to. On release branches, where `hermes-compiler` is pinned to a specific version, it replaces the pin. This doesn't cause an issue until the `latest-v1` tag moves off the pinned version.

Looks to have been introduced by #53837.

## Changelog:

[INTERNAL] [FIXED] - Preserve pinned `hermes-compiler` version when running `use-hermes-nightly` on release branches.

## Test Plan:
With `hermes-compiler` manually set to a real version, the script returns early without modifying `package.json` or `hermes-engine/version.properties`.