### PR TITLE
Remove lowercase `timestamp` fallback in event timestamp injection (#56512)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -147,8 +147,7 @@ void UIManagerBinding::dispatchEventToJS(
   // Add timestamp to payload if not already set
   if (payload.isObject()) {
     auto payloadObject = payload.asObject(runtime);
-    if (!payloadObject.hasProperty(runtime, "timeStamp") &&
-        !payloadObject.hasProperty(runtime, "timestamp")) {
+    if (!payloadObject.hasProperty(runtime, "timeStamp")) {
       payloadObject.setProperty(
           runtime, "timeStamp", eventTimestamp.toDOMHighResTimeStamp());
     }

--- a/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
+++ b/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
@@ -55,38 +55,6 @@ describe('Event Dispatching', () => {
       );
     });
 
-    it('provides the native event timestamp (lower case) when available', () => {
-      const root = Fantom.createRoot();
-
-      const ref = React.createRef<React.ElementRef<typeof View>>();
-
-      const onPointerUp = jest.fn((e: PointerEvent) => {
-        e.persist();
-      });
-
-      Fantom.runTask(() => {
-        root.render(<View ref={ref} onPointerUp={onPointerUp} />);
-      });
-
-      expect(onPointerUp).toHaveBeenCalledTimes(0);
-
-      const NATIVE_EVENT_TIMESTAMP = 1234;
-
-      Fantom.dispatchNativeEvent(
-        ref,
-        'onPointerUp',
-        {x: 0, y: 0, timestamp: NATIVE_EVENT_TIMESTAMP},
-        {
-          category: Fantom.NativeEventCategory.Discrete,
-        },
-      );
-
-      expect(onPointerUp).toHaveBeenCalledTimes(1);
-      expect(onPointerUp.mock.calls[0][0].timeStamp).toBe(
-        NATIVE_EVENT_TIMESTAMP,
-      );
-    });
-
     it('provides a default timeStamp when the native event timeStamp is NOT available', () => {
       const root = Fantom.createRoot();
 


### PR DESCRIPTION
Summary:

Changelog: [internal]

`UIManagerBinding::dispatchEvent` injects a `timeStamp` property into the event payload when one is not already present. A previous change extended this check to also skip injection when a lowercase `timestamp` property was present, so that native events using the lowercase form would have their timestamp preserved.

That was done to fix a failing Fantom test but what was wrong was the test itself. This removes the test and reverts that previous fix.

Reviewed By: javache

Differential Revision: D101649991
