### PR TITLE
Re-throw errors from tasks and microtasks synchronously (#56513)

### DIFF
--- a/private/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/private/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -116,37 +116,27 @@ describe('Fantom', () => {
         LogBox.uninstall();
       });
 
-      // TODO: T223804378 when error handling is fixed, this should verify using `toThrow`
       it('should throw when running a task inside another task', () => {
-        let threw = false;
-
-        Fantom.runTask(() => {
-          // TODO replace with expect(() => { ... }).toThrow() when error handling is fixed
-          try {
+        expect(() => {
+          Fantom.runTask(() => {
             Fantom.runTask(() => {});
-          } catch {
-            threw = true;
-          }
-        });
-        expect(threw).toBe(true);
-
-        threw = false;
-
-        Fantom.runTask(() => {
-          queueMicrotask(() => {
-            try {
-              Fantom.runTask(() => {});
-            } catch {
-              threw = true;
-            }
           });
-        });
-        expect(threw).toBe(true);
+        }).toThrow(
+          'Nested `runTask` calls are not allowed. If you want to schedule a task from inside another task, use `scheduleTask` instead.',
+        );
+
+        expect(() => {
+          Fantom.runTask(() => {
+            queueMicrotask(() => {
+              Fantom.runTask(() => {});
+            });
+          });
+        }).toThrow(
+          'Nested `runTask` calls are not allowed. If you want to schedule a task from inside another task, use `scheduleTask` instead.',
+        );
       });
 
-      // TODO: fix error handling and make this pass
-      // eslint-disable-next-line jest/no-disabled-tests
-      it.skip('should re-throw errors from the task synchronously', () => {
+      it('should re-throw errors from the task synchronously', () => {
         expect(() => {
           Fantom.runTask(() => {
             throw new Error('test error');
@@ -154,9 +144,7 @@ describe('Fantom', () => {
         }).toThrow('test error');
       });
 
-      // TODO: fix error handling and make this pass
-      // eslint-disable-next-line jest/no-disabled-tests
-      it.skip('should re-throw errors from microtasks synchronously', () => {
+      it('should re-throw errors from microtasks synchronously', () => {
         expect(() => {
           Fantom.runTask(() => {
             queueMicrotask(() => {

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -20,6 +20,7 @@ import * as Benchmark from './Benchmark';
 import {getConstants} from './Constants';
 import getFantomRenderedOutput from './getFantomRenderedOutput';
 import {LogBox} from 'react-native';
+import ErrorUtils from 'react-native/Libraries/vendor/core/ErrorUtils';
 import NativeFantom, {
   NativeEventCategory,
 } from 'react-native/src/private/testing/fantom/specs/NativeFantom';
@@ -164,6 +165,24 @@ export function scheduleTask(task: () => void | Promise<void>) {
 
 let flushingQueue = false;
 let isLogBoxCheckEnabled = true;
+let pendingError: unknown = null;
+
+// Install a Fantom-specific global error handler that captures the first error
+// reported during the current work loop into `pendingError`. `runWorkLoop()`
+// re-throws the captured error after `flushMessageQueue()` returns, so errors
+// thrown inside `runTask` callbacks (or microtasks queued by them) propagate
+// out and become observable as Jest test failures.
+//
+// This overrides the handler installed by `setUpErrorHandling.js`, which in
+// Fantom (where LogBox is not installed) only `console.error`s the error.
+// Subsequent errors during the same work loop are ignored: only the first one
+// is re-thrown, since it is typically the most informative; subsequent errors
+// are usually follow-on noise.
+ErrorUtils.setGlobalHandler((error: unknown, _isFatal: boolean) => {
+  if (pendingError == null) {
+    pendingError = error;
+  }
+});
 
 /**
  * Runs a task on the event loop.
@@ -331,6 +350,10 @@ export function runWorkLoop(): void {
     runLogBoxCheck();
   }
 
+  // Clear any error captured outside of a work loop (e.g., during module setup)
+  // so it does not spuriously fail the next work loop.
+  pendingError = null;
+
   try {
     flushingQueue = true;
     NativeFantom.flushMessageQueue();
@@ -340,8 +363,19 @@ export function runWorkLoop(): void {
 
   if (__DEV__) {
     // We also do it after because a task might trigger the initialization of the environment that enables LogBox,
-    // which could be equally dangerous.
+    // which could be equally dangerous. If LogBox is now installed, this throws
+    // and intentionally takes precedence over any captured task error: the
+    // LogBox diagnostic is more actionable.
     runLogBoxCheck();
+  }
+
+  // Re-throw the first error captured by the global handler during this work
+  // loop, so the failure propagates out of `runTask` / `runWorkLoop` and Jest
+  // marks the test as failed with the original error.
+  const errorToThrow = pendingError;
+  pendingError = null;
+  if (errorToThrow != null) {
+    throw errorToThrow;
   }
 }
 


### PR DESCRIPTION
Summary:

Changelog: [internal]

Fantom previously did not propagate errors thrown inside `runTask` callbacks
(or microtasks queued by them) to Jest, so failing assertions inside tasks
were silently swallowed and only logged via `console.error`. Tests had to
work around this with manual `try`/`catch` blocks and a couple of
`it.skip`s with TODOs.

This installs a Fantom-specific global error handler (via `ErrorUtils.setGlobalHandler`)
that captures the first error reported during the current work loop into
`pendingError`. After `flushMessageQueue()` returns, `runWorkLoop()`
re-throws the captured error so it becomes observable as a Jest failure.

Only the first error in a work loop is re-thrown (subsequent ones are
typically follow-on noise), and `pendingError` is cleared at the start of
each work loop so errors captured during module setup do not spuriously
fail later loops. The post-loop `runLogBoxCheck()` continues to take
precedence, since LogBox diagnostics are more actionable.

With this in place:
- The 'should throw when running a task inside another task' test can use
  `expect(...).toThrow(...)` directly instead of manual try/catch.
- The two previously-skipped tests for re-throwing errors from tasks and
  microtasks are now enabled.

NOTE: this will cause some tests to start failing, but they're legit failures

Reviewed By: javache

Differential Revision: D101647822
