### PR TITLE
Fix unused parameter warnings in TimerManager

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -132,7 +132,9 @@ TimerHandle TimerManager::createRecurringTimer(
   return timerID;
 }
 
-void TimerManager::deleteTimer(jsi::Runtime& runtime, TimerHandle timerHandle) {
+void TimerManager::deleteTimer(
+    jsi::Runtime& /* runtime */,
+    TimerHandle timerHandle) {
   if (timerHandle < 0) {
     /**
      * Do nothing for negative values to match web spec.
@@ -150,7 +152,7 @@ void TimerManager::deleteTimer(jsi::Runtime& runtime, TimerHandle timerHandle) {
 }
 
 void TimerManager::deleteRecurringTimer(
-    jsi::Runtime& runtime,
+    jsi::Runtime& /* runtime */,
     TimerHandle timerHandle) {
   if (timerHandle < 0) {
     /**


### PR DESCRIPTION
Summary:
Fixed clang-diagnostic-unused-parameter warnings in TimerManager.cpp by commenting out the unused 'runtime' parameter names in two functions:
- deleteTimer() at line 135
- deleteRecurringTimer() at line 152-153

Both functions accept a jsi::Runtime& parameter for API compatibility but don't use it internally. The fix maintains the function signatures while suppressing the warnings by commenting out the parameter names.

Changelog: [Internal]

Differential Revision: D101108602


