### PR TITLE
Fix -Wnullable-to-nonnull-conversion for Xcode 26.4 (#56518)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -209,7 +209,8 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 
                                  CGFloat baseline = [layoutManager locationForGlyphAtIndex:range.location].y;
                                  auto line = LineMeasurement{
-                                     std::string([renderedString UTF8String]),
+                                     std::string(
+                                         [renderedString UTF8String] != nullptr ? [renderedString UTF8String] : ""),
                                      rect,
                                      overallRect.size.height - baseline,
                                      font.capHeight,

--- a/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewCommon.mm
+++ b/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewCommon.mm
@@ -11,7 +11,8 @@
 
 - (void)setBackgroundColorWithColorString:(NSString *)colorString
 {
-  UIColor *color = [UIView UIColorFromHexString:std::string([colorString UTF8String])];
+  const char *colorUTF8 = [colorString UTF8String];
+  UIColor *color = [UIView UIColorFromHexString:std::string(colorUTF8 != nullptr ? colorUTF8 : "")];
   self.backgroundColor = color;
 }
 
@@ -23,7 +24,8 @@
     id colorString = [overlayColors objectAtIndex:i];
     CGRect rect = CGRectMake(viewBounds.origin.x + width * i, viewBounds.origin.y, width, viewBounds.size.height);
     UIView *overlayView = [[UIView alloc] initWithFrame:rect];
-    UIColor *color = [UIView UIColorFromHexString:std::string([colorString UTF8String])];
+    const char *colorUTF8 = [colorString UTF8String];
+    UIColor *color = [UIView UIColorFromHexString:std::string(colorUTF8 != nullptr ? colorUTF8 : "")];
     overlayView.backgroundColor = color;
     [self addSubview:overlayView];
   }


### PR DESCRIPTION
Summary:

The fix adds null-coalescing fallbacks (`?: ""`) for UTF8String calls that return `const char * _Nullable` but are passed to `std::string` constructors or C++ functions expecting `const char * _Nonnull`.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D101668743
