### PR TITLE
Fix unused parameter warnings in ShadowNode.h (#56519)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -83,7 +83,7 @@ class ShadowNode : public Sealable, public DebugStringConvertible, public jsi::N
   ShadowNode(const ShadowNode &shadowNode) noexcept = delete;
   ShadowNode &operator=(const ShadowNode &other) noexcept = delete;
 
-  virtual ~ShadowNode() override = default;
+  ~ShadowNode() override = default;
 
   /*
    * Clones the shadow node using the ShadowNode's ComponentDescriptor.
@@ -118,7 +118,7 @@ class ShadowNode : public Sealable, public DebugStringConvertible, public jsi::N
    * Called, once a fully derived ShadowNode clone has been created via
    * ComponentDescriptor::cloneShadowNode.
    */
-  virtual void completeClone(const ShadowNode &sourceShadowNode, const ShadowNodeFragment &fragment) {}
+  virtual void completeClone(const ShadowNode & /* sourceShadowNode */, const ShadowNodeFragment & /* fragment */) {}
 
 #pragma mark - Getters
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -4613,14 +4613,14 @@ class facebook::react::ShadowNode : public facebook::react::Sealable, public fac
   public std::shared_ptr<facebook::react::ShadowNode> cloneTree(const facebook::react::ShadowNodeFamily& shadowNodeFamily, const std::function<std::shared_ptr<facebook::react::ShadowNode>(const facebook::react::ShadowNode& oldShadowNode)>& callback) const;
   public using AncestorList = std::vector<std::pair<std::reference_wrapper<const facebook::react::ShadowNode>, int>>;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child);
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&);
   public virtual void replaceChild(const facebook::react::ShadowNode& oldChild, const std::shared_ptr<const facebook::react::ShadowNode>& newChild, size_t suggestedIndex = std::numeric_limits<size_t>::max());
-  public virtual ~ShadowNode() override = default;
   public void sealRecursive() const;
   public void setMounted(bool mounted) const;
   public void setRuntimeShadowNodeReference(const std::shared_ptr<facebook::react::ShadowNodeWrapper>& runtimeShadowNodeReference) const;
   public void transferRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode, const facebook::react::ShadowNodeFragment& fragment) const;
   public void updateRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode) const;
+  public ~ShadowNode() override = default;
 }
 
 class facebook::react::ShadowNodeFamily : public facebook::jsi::NativeState {
@@ -5477,7 +5477,7 @@ class facebook::react::YogaLayoutableShadowNode : public facebook::react::Layout
   public using Shared = std::shared_ptr<const facebook::react::YogaLayoutableShadowNode>;
   public virtual bool getIsLayoutClean() const override;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child) override;
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment) override;
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&) override;
   public virtual void dirtyLayout() override;
   public virtual void layout(facebook::react::LayoutContext layoutContext) override;
   public virtual void layoutTree(facebook::react::LayoutContext layoutContext, facebook::react::LayoutConstraints layoutConstraints) override;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -4604,14 +4604,14 @@ class facebook::react::ShadowNode : public facebook::react::Sealable, public fac
   public std::shared_ptr<facebook::react::ShadowNode> cloneTree(const facebook::react::ShadowNodeFamily& shadowNodeFamily, const std::function<std::shared_ptr<facebook::react::ShadowNode>(const facebook::react::ShadowNode& oldShadowNode)>& callback) const;
   public using AncestorList = std::vector<std::pair<std::reference_wrapper<const facebook::react::ShadowNode>, int>>;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child);
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&);
   public virtual void replaceChild(const facebook::react::ShadowNode& oldChild, const std::shared_ptr<const facebook::react::ShadowNode>& newChild, size_t suggestedIndex = std::numeric_limits<size_t>::max());
-  public virtual ~ShadowNode() override = default;
   public void sealRecursive() const;
   public void setMounted(bool mounted) const;
   public void setRuntimeShadowNodeReference(const std::shared_ptr<facebook::react::ShadowNodeWrapper>& runtimeShadowNodeReference) const;
   public void transferRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode, const facebook::react::ShadowNodeFragment& fragment) const;
   public void updateRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode) const;
+  public ~ShadowNode() override = default;
 }
 
 class facebook::react::ShadowNodeFamily : public facebook::jsi::NativeState {
@@ -5468,7 +5468,7 @@ class facebook::react::YogaLayoutableShadowNode : public facebook::react::Layout
   public using Shared = std::shared_ptr<const facebook::react::YogaLayoutableShadowNode>;
   public virtual bool getIsLayoutClean() const override;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child) override;
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment) override;
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&) override;
   public virtual void dirtyLayout() override;
   public virtual void layout(facebook::react::LayoutContext layoutContext) override;
   public virtual void layoutTree(facebook::react::LayoutContext layoutContext, facebook::react::LayoutConstraints layoutConstraints) override;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -7197,14 +7197,14 @@ class facebook::react::ShadowNode : public facebook::react::Sealable, public fac
   public std::shared_ptr<facebook::react::ShadowNode> cloneTree(const facebook::react::ShadowNodeFamily& shadowNodeFamily, const std::function<std::shared_ptr<facebook::react::ShadowNode>(const facebook::react::ShadowNode& oldShadowNode)>& callback) const;
   public using AncestorList = std::vector<std::pair<std::reference_wrapper<const facebook::react::ShadowNode>, int>>;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child);
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&);
   public virtual void replaceChild(const facebook::react::ShadowNode& oldChild, const std::shared_ptr<const facebook::react::ShadowNode>& newChild, size_t suggestedIndex = std::numeric_limits<size_t>::max());
-  public virtual ~ShadowNode() override = default;
   public void sealRecursive() const;
   public void setMounted(bool mounted) const;
   public void setRuntimeShadowNodeReference(const std::shared_ptr<facebook::react::ShadowNodeWrapper>& runtimeShadowNodeReference) const;
   public void transferRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode, const facebook::react::ShadowNodeFragment& fragment) const;
   public void updateRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode) const;
+  public ~ShadowNode() override = default;
 }
 
 class facebook::react::ShadowNodeFamily : public facebook::jsi::NativeState {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -7188,14 +7188,14 @@ class facebook::react::ShadowNode : public facebook::react::Sealable, public fac
   public std::shared_ptr<facebook::react::ShadowNode> cloneTree(const facebook::react::ShadowNodeFamily& shadowNodeFamily, const std::function<std::shared_ptr<facebook::react::ShadowNode>(const facebook::react::ShadowNode& oldShadowNode)>& callback) const;
   public using AncestorList = std::vector<std::pair<std::reference_wrapper<const facebook::react::ShadowNode>, int>>;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child);
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&);
   public virtual void replaceChild(const facebook::react::ShadowNode& oldChild, const std::shared_ptr<const facebook::react::ShadowNode>& newChild, size_t suggestedIndex = std::numeric_limits<size_t>::max());
-  public virtual ~ShadowNode() override = default;
   public void sealRecursive() const;
   public void setMounted(bool mounted) const;
   public void setRuntimeShadowNodeReference(const std::shared_ptr<facebook::react::ShadowNodeWrapper>& runtimeShadowNodeReference) const;
   public void transferRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode, const facebook::react::ShadowNodeFragment& fragment) const;
   public void updateRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode) const;
+  public ~ShadowNode() override = default;
 }
 
 class facebook::react::ShadowNodeFamily : public facebook::jsi::NativeState {

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -3173,14 +3173,14 @@ class facebook::react::ShadowNode : public facebook::react::Sealable, public fac
   public std::shared_ptr<facebook::react::ShadowNode> cloneTree(const facebook::react::ShadowNodeFamily& shadowNodeFamily, const std::function<std::shared_ptr<facebook::react::ShadowNode>(const facebook::react::ShadowNode& oldShadowNode)>& callback) const;
   public using AncestorList = std::vector<std::pair<std::reference_wrapper<const facebook::react::ShadowNode>, int>>;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child);
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&);
   public virtual void replaceChild(const facebook::react::ShadowNode& oldChild, const std::shared_ptr<const facebook::react::ShadowNode>& newChild, size_t suggestedIndex = std::numeric_limits<size_t>::max());
-  public virtual ~ShadowNode() override = default;
   public void sealRecursive() const;
   public void setMounted(bool mounted) const;
   public void setRuntimeShadowNodeReference(const std::shared_ptr<facebook::react::ShadowNodeWrapper>& runtimeShadowNodeReference) const;
   public void transferRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode, const facebook::react::ShadowNodeFragment& fragment) const;
   public void updateRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode) const;
+  public ~ShadowNode() override = default;
 }
 
 class facebook::react::ShadowNodeFamily : public facebook::jsi::NativeState {
@@ -3892,7 +3892,7 @@ class facebook::react::YogaLayoutableShadowNode : public facebook::react::Layout
   public using Shared = std::shared_ptr<const facebook::react::YogaLayoutableShadowNode>;
   public virtual bool getIsLayoutClean() const override;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child) override;
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment) override;
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&) override;
   public virtual void dirtyLayout() override;
   public virtual void layout(facebook::react::LayoutContext layoutContext) override;
   public virtual void layoutTree(facebook::react::LayoutContext layoutContext, facebook::react::LayoutConstraints layoutConstraints) override;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -3164,14 +3164,14 @@ class facebook::react::ShadowNode : public facebook::react::Sealable, public fac
   public std::shared_ptr<facebook::react::ShadowNode> cloneTree(const facebook::react::ShadowNodeFamily& shadowNodeFamily, const std::function<std::shared_ptr<facebook::react::ShadowNode>(const facebook::react::ShadowNode& oldShadowNode)>& callback) const;
   public using AncestorList = std::vector<std::pair<std::reference_wrapper<const facebook::react::ShadowNode>, int>>;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child);
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&);
   public virtual void replaceChild(const facebook::react::ShadowNode& oldChild, const std::shared_ptr<const facebook::react::ShadowNode>& newChild, size_t suggestedIndex = std::numeric_limits<size_t>::max());
-  public virtual ~ShadowNode() override = default;
   public void sealRecursive() const;
   public void setMounted(bool mounted) const;
   public void setRuntimeShadowNodeReference(const std::shared_ptr<facebook::react::ShadowNodeWrapper>& runtimeShadowNodeReference) const;
   public void transferRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode, const facebook::react::ShadowNodeFragment& fragment) const;
   public void updateRuntimeShadowNodeReference(const std::shared_ptr<const facebook::react::ShadowNode>& destinationShadowNode) const;
+  public ~ShadowNode() override = default;
 }
 
 class facebook::react::ShadowNodeFamily : public facebook::jsi::NativeState {
@@ -3883,7 +3883,7 @@ class facebook::react::YogaLayoutableShadowNode : public facebook::react::Layout
   public using Shared = std::shared_ptr<const facebook::react::YogaLayoutableShadowNode>;
   public virtual bool getIsLayoutClean() const override;
   public virtual void appendChild(const std::shared_ptr<const facebook::react::ShadowNode>& child) override;
-  public virtual void completeClone(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment) override;
+  public virtual void completeClone(const facebook::react::ShadowNode&, const facebook::react::ShadowNodeFragment&) override;
   public virtual void dirtyLayout() override;
   public virtual void layout(facebook::react::LayoutContext layoutContext) override;
   public virtual void layoutTree(facebook::react::LayoutContext layoutContext, facebook::react::LayoutConstraints layoutConstraints) override;


### PR DESCRIPTION
Summary:

Fixed clang-diagnostic-unused-parameter warnings in ShadowNode.h by commenting out unused parameter names in the completeClone method. This addresses warnings for parameters `sourceShadowNode` and `fragment` that were declared but not used in the function body.

Also applied lint patch to remove redundant `virtual` keyword from the destructor declaration.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D101108467


