### PR TITLE
Use per-session output directory for Fantom native builds (#56521)

### DIFF
--- a/private/react-native-fantom/runner/executables/hermesc.js
+++ b/private/react-native-fantom/runner/executables/hermesc.js
@@ -11,7 +11,7 @@
 import type {HermesVariant, SyncCommandResult} from '../utils';
 
 import {isCI} from '../EnvironmentOptions';
-import {NATIVE_BUILD_OUTPUT_PATH} from '../paths';
+import {getNativeBuildOutputPath} from '../paths';
 import {
   getBuckModesForPlatform,
   getBuckOptionsForHermes,
@@ -35,7 +35,7 @@ function getHermesCompilerPath({
   hermesVariant,
 }: HermescOptions): string {
   return path.join(
-    NATIVE_BUILD_OUTPUT_PATH,
+    getNativeBuildOutputPath(),
     `hermesc-${(hermesVariant as string).toLowerCase()}-${enableOptimized ? 'opt' : 'dev'}`,
   );
 }

--- a/private/react-native-fantom/runner/executables/tester.js
+++ b/private/react-native-fantom/runner/executables/tester.js
@@ -15,7 +15,7 @@ import type {
 } from '../utils';
 
 import {debugCpp, isCI, profileCpp} from '../EnvironmentOptions';
-import {CPP_TRACES_OUTPUT_PATH, NATIVE_BUILD_OUTPUT_PATH} from '../paths';
+import {CPP_TRACES_OUTPUT_PATH, getNativeBuildOutputPath} from '../paths';
 import {
   getBuckModesForPlatform,
   getBuckOptionsForHermes,
@@ -43,7 +43,7 @@ export function getFantomTesterPath({
   ...options
 }: TesterOptions): string {
   return path.join(
-    NATIVE_BUILD_OUTPUT_PATH,
+    getNativeBuildOutputPath(),
     `fantom-tester-${(hermesVariant as string).toLowerCase()}-${options.enableOptimized ? 'opt' : 'dev'}${options.enableCoverage ? '-coverage' : ''}`,
   );
 }

--- a/private/react-native-fantom/runner/global-setup/build.js
+++ b/private/react-native-fantom/runner/global-setup/build.js
@@ -14,7 +14,7 @@ import {createBundle} from '../bundling';
 import {isCI} from '../EnvironmentOptions';
 import {build as buildHermesCompiler} from '../executables/hermesc';
 import {build as buildFantomTester} from '../executables/tester';
-import {NATIVE_BUILD_OUTPUT_PATH} from '../paths';
+import {getNativeBuildOutputPath} from '../paths';
 import {HermesVariant} from '../utils';
 // $FlowExpectedError[untyped-import]
 import fs from 'fs';
@@ -43,11 +43,7 @@ export default async function build(
   enableCoverage: boolean,
   env: EnvironmentOverrides,
 ): Promise<void> {
-  try {
-    fs.rmSync(NATIVE_BUILD_OUTPUT_PATH, {recursive: true});
-  } catch {}
-
-  fs.mkdirSync(NATIVE_BUILD_OUTPUT_PATH, {recursive: true});
+  fs.mkdirSync(getNativeBuildOutputPath(), {recursive: true});
 
   if (isCI) {
     for (const enableOptimized of [false, true]) {

--- a/private/react-native-fantom/runner/paths.js
+++ b/private/react-native-fantom/runner/paths.js
@@ -21,6 +21,17 @@ export const NATIVE_BUILD_OUTPUT_PATH: string = path.join(
   OUTPUT_PATH,
   'native-builds',
 );
+
+export function getNativeBuildOutputPath(): string {
+  const fantomRunID = process.env.__FANTOM_RUN_ID__;
+  if (fantomRunID == null) {
+    throw new Error(
+      'Expected Fantom run ID to be set by global setup, but it was not (process.env.__FANTOM_RUN_ID__ is null)',
+    );
+  }
+  return path.join(NATIVE_BUILD_OUTPUT_PATH, fantomRunID);
+}
+
 export const JS_TRACES_OUTPUT_PATH: string = path.join(
   OUTPUT_PATH,
   'js-traces',


### PR DESCRIPTION
Summary:

Fixes a race condition where multiple concurrent Jest processes sharing the same checkout could delete each others native binaries. The `globalSetup` in `build.js` previously called `fs.rmSync` on the shared `native-builds/` directory before rebuilding, which could delete binaries that another process workers were actively using (causing `ENOENT` when spawning the fantom-tester binary).

Each Jest session now writes native binaries to `native-builds/<run-id>/`, matching the existing pattern used for JS build outputs (`getTestBuildOutputPath`). The buck isolation directory is shared across sessions so builds remain cached.

Changelog: [Internal]

Reviewed By: christophpurrer, lenaic

Differential Revision: D101692926
