### PR TITLE
MapBufferBuilder: fix size_t→int32 partial-write in putString/putMapBuffer length encoding

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -84,11 +84,16 @@ void MapBufferBuilder::putLong(MapBuffer::Key key, int64_t value) {
 }
 
 void MapBufferBuilder::putString(MapBuffer::Key key, const std::string& value) {
-  auto strSize = value.size();
+  // The wire format encodes lengths and offsets as int32_t (see
+  // MapBuffer::getString). Without an explicit narrowing cast, `auto` deduces
+  // size_t (8 bytes on 64-bit) and `memcpy(&x, ..., INT_SIZE)` then copies only
+  // the first 4 bytes of an 8-byte value: silent truncation on little-endian,
+  // wrong (high) bytes on big-endian.
+  auto strSize = static_cast<int32_t>(value.size());
   const char* strData = value.data();
 
   // format [length of string (int)] + [Array of Characters in the string]
-  auto offset = dynamicData_.size();
+  auto offset = static_cast<int32_t>(dynamicData_.size());
   dynamicData_.resize(offset + INT_SIZE + strSize, 0);
   memcpy(dynamicData_.data() + offset, &strSize, INT_SIZE);
   memcpy(dynamicData_.data() + offset + INT_SIZE, strData, strSize);
@@ -102,9 +107,12 @@ void MapBufferBuilder::putString(MapBuffer::Key key, const std::string& value) {
 }
 
 void MapBufferBuilder::putMapBuffer(MapBuffer::Key key, const MapBuffer& map) {
-  auto mapBufferSize = map.size();
+  // Wire format encodes lengths and offsets as int32_t (see
+  // MapBuffer::getMapBuffer). Cast explicitly so memcpy(&x, ..., INT_SIZE)
+  // copies the full value, not the first 4 bytes of an 8-byte size_t.
+  auto mapBufferSize = static_cast<int32_t>(map.size());
 
-  auto offset = dynamicData_.size();
+  auto offset = static_cast<int32_t>(dynamicData_.size());
 
   // format [length of buffer (int)] + [bytes of MapBuffer]
   dynamicData_.resize(offset + INT_SIZE + mapBufferSize, 0);


### PR DESCRIPTION
Summary:
The MapBuffer wire format encodes lengths and offsets as `int32_t` (`MapBuffer::getString` / `getMapBuffer` read them as `*reinterpret_cast<const int32_t*>(...)`). But in `putString` and `putMapBuffer`:

```cpp
auto strSize = value.size();                               // size_t — 8 bytes on 64-bit
memcpy(dynamicData_.data() + offset, &strSize, INT_SIZE);  // copies first 4 of 8 bytes
```

`auto` deduces `size_t` from `.size()`, and `memcpy(&size_t_var, ..., 4)` writes only the **first 4 bytes** of an 8-byte object:
- **little-endian:** writes the low 4 bytes — silent truncation if size > UINT32_MAX
- **big-endian:** writes the high 4 bytes — encodes **zero** for normal sizes, producing a corrupt buffer the reader then trusts

`putMapBufferList` already had the correct pattern: `auto offset = static_cast<int32_t>(dynamicData_.size())`. This diff applies that same explicit `static_cast<int32_t>` to `putString` (`strSize`, `offset`) and `putMapBuffer` (`mapBufferSize`, `offset`) so the value being `memcpy`'d is exactly `INT_SIZE` bytes wide.

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D100376322


