### PR TITLE
fix: tabIndex focusable, Pressability responder disabled, hover-out timer

### DIFF
--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -80,7 +80,7 @@ component View(
     }
 
     if (tabIndex !== undefined) {
-      processedProps.focusable = !tabIndex;
+      processedProps.focusable = tabIndex >= 0;
     }
 
     if (

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -447,7 +447,7 @@ export default class Pressability {
     const responderEventHandlers = {
       onStartShouldSetResponder: (): boolean => {
         const {disabled} = this._config;
-        return !disabled ?? true;
+        return disabled !== true;
       },
 
       onResponderGrant: (event: GestureResponderEvent): void | boolean => {
@@ -642,7 +642,7 @@ export default class Pressability {
                     );
                     if (delayHoverOut > 0) {
                       event.persist();
-                      this._hoverInDelayTimeout = setTimeout(() => {
+                      this._hoverOutDelayTimeout = setTimeout(() => {
                         onHoverOut(event);
                       }, delayHoverOut);
                     } else {


### PR DESCRIPTION
## Summary:

 The changes correct tabIndex-to-focusable mapping in View.js, fix a dead null-coalescing branch in the responder disabled check, and fix a hover-out timeout being stored in the wrong variable (_hoverInDelayTimeout instead of _hoverOutDelayTimeout).

## Changelog:

### Fixed

- View: Derive focusable from tabIndex with tabIndex >= 0 so positive tabIndex values (e.g. 1, 2) correctly mark the view as focusable; the previous !tabIndex logic treated any positive index as not focusable.
- Pressability: Use disabled !== true for onStartShouldSetResponder so disabled handling matches onPress and avoids the misleading !disabled ?? true pattern (the ?? true branch was unreachable).
- Pressability: Store delayed onHoverOut timers on _hoverOutDelayTimeout instead of _hoverInDelayTimeout so hover-out delays are cancelled correctly.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Fix View tabIndex→focusable mapping and Pressability disabled/hover-out bugs

## Test Plan
Not needed
