### PR TITLE
Fix unused parameter warnings in StubWebSocketClient.h (#56527)

### DIFF
--- a/private/react-native-fantom/tester/src/stubs/StubWebSocketClient.h
+++ b/private/react-native-fantom/tester/src/stubs/StubWebSocketClient.h
@@ -20,15 +20,15 @@ class StubWebSocketClient : public IWebSocketClient {
   StubWebSocketClient(StubWebSocketClient &&other) = delete;
   StubWebSocketClient &operator=(StubWebSocketClient &&other) = delete;
 
-  void setOnClosedCallback(OnClosedCallback &&callback) noexcept override {}
+  void setOnClosedCallback(OnClosedCallback && /*callback*/) noexcept override {}
 
-  void setOnMessageCallback(OnMessageCallback &&callback) noexcept override {}
+  void setOnMessageCallback(OnMessageCallback && /*callback*/) noexcept override {}
 
-  void connect(const std::string &url, OnConnectCallback &&onConnectCallback = nullptr) override {}
+  void connect(const std::string & /*url*/, OnConnectCallback && /*onConnectCallback*/ = nullptr) override {}
 
-  void close(const std::string &reason) override {}
+  void close(const std::string & /*reason*/) override {}
 
-  void send(const std::string &message) override {}
+  void send(const std::string & /*message*/) override {}
 
   void ping() override {}
 };


### PR DESCRIPTION
Summary:

Removed parameter names from unused parameters in StubWebSocketClient stub implementation to fix clang-diagnostic-unused-parameter warnings. This stub class implements IWebSocketClient interface with empty method bodies, so all parameters were unused.

Changelog: [Internal]

Reviewed By: philIip

Differential Revision: D101110612
