### PR TITLE
Document FANTOM_FORCE_CI_MODE for full local runs (#56531)

### DIFF
--- a/private/react-native-fantom/__docs__/README.md
+++ b/private/react-native-fantom/__docs__/README.md
@@ -303,6 +303,24 @@ memory heap and print a message indicating where it was saved. E.g.:
 You can have multiple calls to `Fantom.takeJSMemoryHeapSnapshot()` in your test,
 and each one will create a different file.
 
+### Running the full suite locally
+
+When running the entire suite locally, set `FANTOM_FORCE_CI_MODE=1`:
+
+```shell
+FANTOM_FORCE_CI_MODE=1 yarn fantom
+```
+
+In CI mode, `globalSetup` pre-builds the entire
+`(hermesVariant × enableOptimized)` binary matrix once up-front (see
+[`global-setup/build.js`](../runner/global-setup/build.js)) and per-test buck2
+invocations are skipped. This eliminates buck2 daemon contention from the worker
+pool, which can otherwise cause sporadic build failures when many workers race
+to build different binary variants at the same time.
+
+CI environments (`SANDCASTLE`, `GITHUB_ACTIONS`) auto-detect this mode — see
+[`runner/EnvironmentOptions.js`](../runner/EnvironmentOptions.js).
+
 ### FAQ
 
 #### How is this different from Jest tests?


### PR DESCRIPTION
Summary:

Add a section to the Fantom `__docs__/README.md` that recommends running the full suite locally with `FANTOM_FORCE_CI_MODE=1`. In CI mode, `globalSetup` pre-builds the entire `(hermesVariant × enableOptimized)` binary matrix once up-front and per-test buck2 invocations are skipped, which eliminates buck2 daemon contention from the worker pool — a common source of sporadic build failures when many workers race to build different binary variants at the same time.

CI environments (`SANDCASTLE`, `GITHUB_ACTIONS`) already auto-detect this mode; this just documents it for local use.

Changelog: [Internal]

Reviewed By: andrewdacenko

Differential Revision: D101795648
