### PR TITLE
Build both coverage and non-coverage tester binaries in CI

### DIFF
--- a/private/react-native-fantom/runner/global-setup/build.js
+++ b/private/react-native-fantom/runner/global-setup/build.js
@@ -50,12 +50,25 @@ export default async function build(
   fs.mkdirSync(NATIVE_BUILD_OUTPUT_PATH, {recursive: true});
 
   if (isCI) {
+    // When `enableCoverage` is true (CI coverage runs), we still need the
+    // non-coverage tester binaries because some tests opt out of coverage
+    // (benchmarks via filename, or tests with the `@fantom_disable_coverage`
+    // pragma — see `runner/coverageUtils.js`). Without these, those tests
+    // would fail to spawn with ENOENT.
+    const coverageVariants = enableCoverage ? [false, true] : [false];
+
     for (const enableOptimized of [false, true]) {
       for (const hermesVariant of HermesVariant.members()) {
-        buildFantomTester(
-          {enableOptimized, hermesVariant, enableCoverage},
-          env,
-        );
+        for (const variantEnableCoverage of coverageVariants) {
+          buildFantomTester(
+            {
+              enableOptimized,
+              hermesVariant,
+              enableCoverage: variantEnableCoverage,
+            },
+            env,
+          );
+        }
         buildHermesCompiler({enableOptimized, hermesVariant, enableCoverage});
       }
     }


### PR DESCRIPTION
Summary:
The Fantom Jest `globalSetup` builds the `fantom-tester` native binaries
upfront, using `globalConfig.collectCoverage` to decide whether to build
the `-coverage` flavor.

However, `runner/coverageUtils.js`'s `shouldCollectCoverage()` returns
`false` for some tests even when `globalConfig.collectCoverage` is true:

- All benchmarks (filename matches `*Benchmark-itest.*`)
- Tests with the `fantom_disable_coverage` pragma

In CI coverage runs, those tests resolve their tester binary path with
`enableCoverage=false` (e.g. `fantom-tester-statichermesstable-opt`),
but `globalSetup` only built the `-coverage` variants, so spawn fails
with `ENOENT` and the test fails with an empty stdout/stderr and exit
code `-2`.

When `enableCoverage` is true, also build the non-coverage tester
variants so coverage-opt-out tests can find their binary.

Changelog: [Internal]

Differential Revision: D101819861


