### PR TITLE
Skip cloneElement for Fragment children in TouchableHighlight

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -304,6 +304,12 @@ class TouchableHighlightImpl extends React.Component<
 
   render(): React.Node {
     const child = React.Children.only<$FlowFixMe>(this.props.children);
+    if (__DEV__ && child.type === React.Fragment) {
+      console.error(
+        'TouchableHighlight does not support React.Fragment as a child. ' +
+          'Wrap the children in a single host element such as <View>.',
+      );
+    }
 
     // BACKWARD-COMPATIBILITY: Focus and blur events were never supported before
     // adopting `Pressability`, so preserve that behavior.
@@ -376,12 +382,14 @@ class TouchableHighlightImpl extends React.Component<
         testID={this.props.testID}
         ref={this.props.hostRef}
         {...eventHandlersWithoutBlurAndFocus}>
-        {cloneElement(child, {
-          style: StyleSheet.compose(
-            child.props.style,
-            this.state.extraStyles?.child,
-          ),
-        })}
+        {child.type === React.Fragment
+          ? child
+          : cloneElement(child, {
+              style: StyleSheet.compose(
+                child.props.style,
+                this.state.extraStyles?.child,
+              ),
+            })}
         {__DEV__ ? (
           <PressabilityDebugView color="green" hitSlop={this.props.hitSlop} />
         ) : null}

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-itest.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-itest.js
@@ -395,6 +395,48 @@ describe('<TouchableHighlight>', () => {
           </rn-view>,
         );
       });
+
+      // Regression test for #54933: a `React.Fragment` cannot accept the
+      // underlay style applied via `cloneElement`, so the highlight effect
+      // is silently broken. Render the Fragment unchanged and surface an
+      // actionable dev error pointing the user at wrapping in <View>.
+      it('logs a dev error when given a React.Fragment as a child', () => {
+        const originalConsoleError = console.error;
+        const mockConsoleError = jest.fn();
+        // $FlowFixMe[cannot-write]
+        console.error = mockConsoleError;
+
+        try {
+          const root = Fantom.createRoot();
+
+          Fantom.runTask(() => {
+            root.render(
+              <TouchableHighlight>
+                <React.Fragment>
+                  <Text>First</Text>
+                  <Text>Second</Text>
+                </React.Fragment>
+              </TouchableHighlight>,
+            );
+          });
+
+          expect(
+            root.getRenderedOutput({props: ['accessible']}).toJSX(),
+          ).toEqual(
+            <rn-view accessible="true">
+              <rn-paragraph key="0">First</rn-paragraph>
+              <rn-paragraph key="1">Second</rn-paragraph>
+            </rn-view>,
+          );
+          expect(mockConsoleError).toHaveBeenCalledTimes(1);
+          expect(mockConsoleError.mock.calls[0][0]).toContain(
+            'TouchableHighlight does not support React.Fragment as a child',
+          );
+        } finally {
+          // $FlowFixMe[cannot-write]
+          console.error = originalConsoleError;
+        }
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #54933.

Passing a `React.Fragment` as the child of `TouchableHighlight` currently produces this warning:

Warning: Invalid prop `style` supplied to `React.Fragment`.
React.Fragment can only have `key` and `children` props.

This happens because `TouchableHighlight` unconditionally calls `cloneElement(child, {style})` on its single child, including when that child is a Fragment.

This PR skips that clone when `child.type === React.Fragment` and renders the Fragment as-is.

That avoids passing an invalid `style` prop to `React.Fragment` while preserving the existing render path for Fragment children.

## Changelog:

[General] [Fixed] - Suppress `React.Fragment` style warning when used as a child of `TouchableHighlight`

## Test Plan

- Added a Fantom regression test in `TouchableHighlight-itest.js` that renders `<TouchableHighlight><Fragment>...</Fragment></TouchableHighlight>`
- Verified the expected rendered output
- Verified `console.error` is not called
- `yarn flow focus-check packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js`
- `yarn lint` on the changed files
- `yarn prettier --list-different` on the changed files
