### PR TITLE
Support PlatformColor for StatusBar backgroundColor on Android

### DIFF
--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -529,12 +529,14 @@ class StatusBar extends React.Component<StatusBarProps> {
           console.warn(
             `\`StatusBar._updatePropsStack\`: Color ${mergedProps.backgroundColor.value} parsed to null or undefined`,
           );
-        } else {
-          invariant(
-            typeof processedColor === 'number',
-            'Unexpected color given in StatusBar._updatePropsStack',
-          );
+        } else if (typeof processedColor === 'number') {
           NativeStatusBarManagerAndroid.setColor(
+            processedColor,
+            mergedProps.backgroundColor.animated,
+          );
+        } else {
+          NativeStatusBarManagerAndroid.setColorObject(
+            // $FlowFixMe[incompatible-type] - Opaque NativeColorValue on Android matches the spec shape {resource_paths: Array<string>}.
             processedColor,
             mergedProps.backgroundColor.animated,
           );

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt
@@ -16,9 +16,11 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import com.facebook.common.logging.FLog
 import com.facebook.fbreact.specs.NativeStatusBarManagerAndroidSpec
+import com.facebook.react.bridge.ColorPropConverter
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.interfaces.ExtraWindowEventListener
@@ -79,7 +81,24 @@ internal class StatusBarModule(reactContext: ReactApplicationContext?) :
 
   @Suppress("DEPRECATION")
   override fun setColor(colorDouble: Double, animated: Boolean) {
-    val color = colorDouble.toInt()
+    applyStatusBarColor(colorDouble.toInt(), animated)
+  }
+
+  @Suppress("DEPRECATION")
+  override fun setColorObject(color: ReadableMap, animated: Boolean) {
+    val resolved = ColorPropConverter.getColor(color, reactApplicationContext)
+    if (resolved == null) {
+      FLog.w(
+          ReactConstants.TAG,
+          "StatusBarModule: Ignored status bar change, unable to resolve color.",
+      )
+      return
+    }
+    applyStatusBarColor(resolved, animated)
+  }
+
+  @Suppress("DEPRECATION")
+  private fun applyStatusBarColor(color: Int, animated: Boolean) {
     val activity = reactApplicationContext.getCurrentActivity()
     if (activity == null) {
       FLog.w(

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeStatusBarManagerAndroid.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeStatusBarManagerAndroid.js
@@ -12,12 +12,20 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
+export type NativePlatformColorValue = {
+  readonly resource_paths: Array<string>,
+};
+
 export interface Spec extends TurboModule {
   readonly getConstants: () => {
     readonly HEIGHT: number,
     readonly DEFAULT_BACKGROUND_COLOR: number,
   };
   readonly setColor: (color: number, animated: boolean) => void;
+  readonly setColorObject: (
+    color: NativePlatformColorValue,
+    animated: boolean,
+  ) => void;
   readonly setTranslucent: (translucent: boolean) => void;
 
   /**
@@ -45,6 +53,10 @@ const NativeStatusBarManager = {
 
   setColor(color: number, animated: boolean): void {
     NativeModule.setColor(color, animated);
+  },
+
+  setColorObject(color: NativePlatformColorValue, animated: boolean): void {
+    NativeModule.setColorObject(color, animated);
   },
 
   setTranslucent(translucent: boolean): void {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -8615,6 +8615,12 @@ struct facebook::react::NativeSourceCodeSourceCodeConstants {
   public bool operator==(const facebook::react::NativeSourceCodeSourceCodeConstants& other) const;
 }
 
+template <typename P0>
+struct facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValue {
+  public P0 resource_paths;
+  public bool operator==(const facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValue& other) const;
+}
+
 template <typename R, typename... Args>
 class facebook::react::SyncCallback<R(Args...)> {
   public R call(Args... args) const;
@@ -9455,6 +9461,14 @@ struct facebook::react::NativeSourceCodeSourceCodeConstantsBridging {
   public static T types;
   public static facebook::jsi::Object toJs(facebook::jsi::Runtime& rt, const T& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
   public static facebook::jsi::String scriptURLToJs(facebook::jsi::Runtime& rt, decltype(types.scriptURL) value);
+}
+
+template <typename T>
+struct facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValueBridging {
+  public static T fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
+  public static T types;
+  public static facebook::jsi::Array resource_pathsToJs(facebook::jsi::Runtime& rt, decltype(types.resource_paths) value);
+  public static facebook::jsi::Object toJs(facebook::jsi::Runtime& rt, const T& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
 }
 
 template <typename T>

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -8391,6 +8391,12 @@ struct facebook::react::NativeSourceCodeSourceCodeConstants {
   public bool operator==(const facebook::react::NativeSourceCodeSourceCodeConstants& other) const;
 }
 
+template <typename P0>
+struct facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValue {
+  public P0 resource_paths;
+  public bool operator==(const facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValue& other) const;
+}
+
 template <typename R, typename... Args>
 class facebook::react::SyncCallback<R(Args...)> {
   public R call(Args... args) const;
@@ -9090,6 +9096,13 @@ struct facebook::react::NativeSampleTurboModuleObjectStructBridging {
 
 template <typename T>
 struct facebook::react::NativeSourceCodeSourceCodeConstantsBridging {
+  public static T fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
+  public static T types;
+  public static facebook::jsi::Object toJs(facebook::jsi::Runtime& rt, const T& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
+}
+
+template <typename T>
+struct facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValueBridging {
   public static T fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
   public static T types;
   public static facebook::jsi::Object toJs(facebook::jsi::Runtime& rt, const T& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -8606,6 +8606,12 @@ struct facebook::react::NativeSourceCodeSourceCodeConstants {
   public bool operator==(const facebook::react::NativeSourceCodeSourceCodeConstants& other) const;
 }
 
+template <typename P0>
+struct facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValue {
+  public P0 resource_paths;
+  public bool operator==(const facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValue& other) const;
+}
+
 template <typename R, typename... Args>
 class facebook::react::SyncCallback<R(Args...)> {
   public R call(Args... args) const;
@@ -9305,6 +9311,13 @@ struct facebook::react::NativeSampleTurboModuleObjectStructBridging {
 
 template <typename T>
 struct facebook::react::NativeSourceCodeSourceCodeConstantsBridging {
+  public static T fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
+  public static T types;
+  public static facebook::jsi::Object toJs(facebook::jsi::Runtime& rt, const T& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
+}
+
+template <typename T>
+struct facebook::react::NativeStatusBarManagerAndroidNativePlatformColorValueBridging {
   public static T fromJs(facebook::jsi::Runtime& rt, const facebook::jsi::Object& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);
   public static T types;
   public static facebook::jsi::Object toJs(facebook::jsi::Runtime& rt, const T& value, const std::shared_ptr<facebook::react::CallInvoker>& jsInvoker);


### PR DESCRIPTION
## Summary

Fixes #48402.

Passing a `PlatformColor(...)` value to `StatusBar.backgroundColor` on Android currently throws `Unexpected color given in StatusBar._updatePropsStack`.

The failure happens because `processColor` returns an object for `PlatformColor`, while the `StatusBar` TurboModule only accepts numeric colors through `setColor`.

This change adds a `setColorObject` TurboModule method that accepts a `{resource_paths: Array<string>}` payload and resolves it natively via `ColorPropConverter.getColor`.

`StatusBar._updatePropsStack` now dispatches to:
- `setColor` for numeric colors
- `setColorObject` for `PlatformColor` values

To avoid duplicating behavior, the shared animation and color-application logic is moved into a private `applyStatusBarColor` helper.

## Changelog:

[Android] [Fixed] - Allow `PlatformColor` values to be used with `StatusBar.backgroundColor`

## Test Plan

- `yarn jest packages/react-native/Libraries/Components/StatusBar`
- `yarn flow focus-check` on `StatusBar.js` and the spec
- `yarn eslint`
- `yarn prettier --check`
