### PR TITLE
Set hermes_build_mode constraint when building tester with coverage

### DIFF
--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -123,6 +123,25 @@ export function getBuckModesForPlatform({
     );
   }
 
+  // When coverage instrumentation is enabled, the active build platform
+  // may not carry a `hermes_build_mode` constraint, causing
+  // `rn_build_mode()` in `tools/build_defs/oss/rn_defs.bzl` to fall back
+  // to the non-debug path. That leaves `REACT_NATIVE_DEBUG` undefined,
+  // which breaks dev-mode tests that use debug-only native APIs (e.g.
+  // timer mocking via `installHighResTimeStampMock`).
+  //
+  // Explicitly stack the `hermes_build_mode` constraint so the build
+  // reflects the test's intended dev/opt mode regardless of how the
+  // coverage build is configured.
+  if (enableCoverage) {
+    result.push(
+      '--modifier',
+      enableOptimized
+        ? 'fbsource//xplat/hermes/constraints:opt'
+        : 'fbsource//xplat/hermes/constraints:dev',
+    );
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Summary:
The Fantom test runner spawns native `fantom-tester` binaries built in
either dev or opt mode based on each test's `fantom_mode` pragma. When
collecting C++ code coverage of the tester binary, however, the build
may switch to a coverage-instrumented build configuration that does not
define `REACT_NATIVE_DEBUG`.

That breaks dev-mode tests that rely on debug-only native APIs. For
example, `installHighResTimeStampMock` in
`private/react-native-fantom/tester/src/NativeFantom.cpp` is gated on
`#ifdef REACT_NATIVE_DEBUG` and throws "Mocking timers is not supported
in optimized builds" otherwise. Tests like `LongTasksAPI-itest.js` (no
`fantom_mode` pragma → defaults to dev) fail in CI coverage runs with
that error.

When invoking buck with coverage enabled, layer the `hermes_build_mode`
constraint on top of the build platform so `rn_build_mode()` (in
`tools/build_defs/oss/rn_defs.bzl`) picks up the right value and adds
`-DREACT_NATIVE_DEBUG` for dev tests.

Differential Revision: D101832028


