### PR TITLE
Exclude metainternal from C++ API snapshots (#56545)

### DIFF
--- a/scripts/cxx-api/config.yml
+++ b/scripts/cxx-api/config.yml
@@ -6,6 +6,7 @@ exclude_patterns:
   - "*/test/*"
   - "*/test_helper/*"
   - "*/stubs/*"
+  - "*/metainternal/*"
 
 exclude_symbols:
   - "Fantom"


### PR DESCRIPTION
Summary:

Add */metainternal/* to top-level exclude_patterns in the C++ API snapshot config. 
This directory may contain internal headers that are not part of the public React Native
C++ API surface.

Changelog: [Internal]

Differential Revision: D101879633


