### PR TITLE
Fix RCTTextLayoutManager nullable conversion (#56547)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -208,9 +208,9 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                          .width = usedRect.size.width, .height = usedRect.size.height}};
 
                                  CGFloat baseline = [layoutManager locationForGlyphAtIndex:range.location].y;
+                                 const char *renderedUTF8 = [renderedString UTF8String];
                                  auto line = LineMeasurement{
-                                     std::string(
-                                         [renderedString UTF8String] != nullptr ? [renderedString UTF8String] : ""),
+                                     std::string(renderedUTF8 != nullptr ? renderedUTF8 : ""),
                                      rect,
                                      overallRect.size.height - baseline,
                                      font.capHeight,


### PR DESCRIPTION
Summary:

The original fix in `RCTTextLayoutManager.mm` used the pattern `[obj UTF8String] != nullptr ? [obj UTF8String] : ""`, but Clang's null analysis still types the first operand as `_Nullable`, so `-Wnullable-to-nonnull-conversion` is still triggered as a hard error under Xcode 26.4. Switch to the local-variable pattern that was already used correctly for `RNTMyNativeViewCommon.mm`:

```
const char *renderedUTF8 = [renderedString UTF8String];
... std::string(renderedUTF8 != nullptr ? renderedUTF8 : "") ...
```

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D101920741
