### PR TITLE
Use latest-v1 tag for hermes-compiler instead of nightly

### DIFF
--- a/scripts/try-set-nightly-hermes-compiler.js
+++ b/scripts/try-set-nightly-hermes-compiler.js
@@ -17,7 +17,7 @@ function main() {
 
  if (hermesCompilerVersion === '0.0.0') {
    console.log(`Hermes compiler version not set. Updating to the latest nightly release.`);
-   execSync('yarn workspace react-native add hermes-compiler@nightly --exact', { stdio: 'inherit' });
+   execSync('yarn workspace react-native add hermes-compiler@latest-v1 --exact', { stdio: 'inherit' });
  } else {
    console.log(`Hermes compiler version set to ${hermesCompilerVersion}. Not setting nightly hermes.`);
  }


### PR DESCRIPTION
## Summary
- Hermes V1 is the default now, so we need to resolve to that, not to nightlies which points to legacy hermes
- Switch the postinstall script to use `latest-v1` instead, which points to the correct latest release.

## Changelog:
[General][Fixed] - Use `latest-v1` tag for hermes-compiler instead of legacy hermes `nightly` tag

## Test plan
Run `yarn install` from the repo root and verify that `hermes-compiler` resolves to the latest version published under the `latest-v1` tag.