### PR TITLE
Make useConcurrentRoot always true in renderElement (#56562)

### DIFF
--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -57,23 +57,25 @@ let cachedFabricRender;
 export function renderElement({
   element,
   rootTag,
-  useFabric,
-  useConcurrentRoot,
 }: {
   element: React.MixedElement,
   rootTag: number,
-  useFabric: boolean,
-  useConcurrentRoot: boolean,
 }): void {
   if (cachedFabricRender == null) {
     cachedFabricRender = getFabricRenderer().render;
   }
 
-  cachedFabricRender(element, rootTag, null, useConcurrentRoot, {
-    onCaughtError,
-    onUncaughtError,
-    onRecoverableError,
-  });
+  cachedFabricRender(
+    element,
+    rootTag,
+    /* callback */ null,
+    /* useConcurrentRoot */ true,
+    {
+      onCaughtError,
+      onUncaughtError,
+      onRecoverableError,
+    },
+  );
 }
 
 let cachedFabricDispatchCommand;

--- a/packages/react-native/Libraries/ReactNative/renderApplication.js
+++ b/packages/react-native/Libraries/ReactNative/renderApplication.js
@@ -97,8 +97,6 @@ export default function renderApplication<Props extends Object>(
   Renderer.renderElement({
     element: renderable,
     rootTag,
-    useFabric: true,
-    useConcurrentRoot: true,
   });
   performanceLogger.stopTimespan('renderApplication_React_render');
 }


### PR DESCRIPTION
Summary:

Changelog: [Internal]

All apps have migrated to concurrent root (as they're using Fabric), so the `useConcurrentRoot` parameter is no longer needed. This removes `useConcurrentRoot` (and `useFabric`) from `renderElement` in `RendererImplementation` and the profiling variant, hardcoding the underlying call to `true`, and stops passing them from `renderApplication`.

Reviewed By: javache

Differential Revision: D101981133
