### PR TITLE
Guard tvOS-unavailable APIs in RCTRedBox2Controller

### DIFF
--- a/packages/react-native/React/CoreModules/RCTRedBox2Controller.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox2Controller.mm
@@ -99,7 +99,9 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
   _stackTraceTableView.delegate = self;
   _stackTraceTableView.dataSource = self;
   _stackTraceTableView.backgroundColor = [UIColor clearColor];
+#if !TARGET_OS_TV
   _stackTraceTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+#endif
   _stackTraceTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
   _stackTraceTableView.bounces = NO;
   [self.view addSubview:_stackTraceTableView];


### PR DESCRIPTION
Summary:
`separatorStyle` and `UITableViewCellSeparatorStyleNone` are unavailable on tvOS, causing the airwave-tvos-appletvos build to fail. Wrap them with `#if !TARGET_OS_TV`, matching the existing pattern in `RCTRedBoxController.mm`.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D102001404


