### PR TITLE
Fix C++ syntax in Objective-C header breaking React module build

### DIFF
--- a/packages/react-native/React/CoreModules/RCTRedBox2Controller+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBox2Controller+Internal.h
@@ -11,7 +11,7 @@
 
 #if RCT_DEV_MENU
 
-using RCTRedBox2ButtonPressHandler = void (^)(void);
+typedef void (^RCTRedBox2ButtonPressHandler)(void);
 
 @interface RCTRedBox2Controller : UIViewController <RCTRedBox2Controlling, UITableViewDelegate, UITableViewDataSource>
 


### PR DESCRIPTION
Summary:
`RCTRedBox2Controller+Internal.h` used a C++ `using` type alias, which fails when compiled as plain Objective-C. This header is currently included in the `React-Core` umbrella header (via the `CoreModulesHeaders` subspec), so it gets compiled in a pure-ObjC context and breaks the RNTester iOS CI build.

Here, we replace the `using` with an equivalent `typedef`.

NOTE: The underlying issue is that this `+Internal.h` header should not be in the umbrella header at all. I will follow up to make the RedBox 2.0 internal headers private at the CocoaPods level.

Changelog: [Internal]

Differential Revision: D102005814


