### PR TITLE
fix(ios): prevent RCTGenericDelegateSplitter crash when UIKit invokes selector on empty delegates

### DIFF
--- a/packages/react-native/React/Fabric/Utils/RCTGenericDelegateSplitter.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTGenericDelegateSplitter.mm
@@ -7,6 +7,8 @@
 
 #import "RCTGenericDelegateSplitter.h"
 
+#import <objc/runtime.h>
+
 @implementation RCTGenericDelegateSplitter {
   NSHashTable *_delegates;
 }
@@ -73,7 +75,17 @@
       return [delegate methodSignatureForSelector:selector];
     }
   }
-  return nil;
+  // Fallback: prevent `unrecognized selector` crash when UIKit invokes a cached
+  // delegate selector after all weak delegates have been released (e.g. background
+  // suspension with in-flight UIScrollViewScrollAnimation). Resolve the signature
+  // from UIScrollViewDelegate's optional methods first; otherwise use a permissive
+  // `v@:@` signature so forwardInvocation: can safely no-op.
+  struct objc_method_description desc =
+      protocol_getMethodDescription(@protocol(UIScrollViewDelegate), selector, NO, YES);
+  if (desc.types != NULL) {
+    return [NSMethodSignature signatureWithObjCTypes:desc.types];
+  }
+  return [NSMethodSignature signatureWithObjCTypes:"v@:@"];
 }
 
 - (void)forwardInvocation:(NSInvocation *)invocation


### PR DESCRIPTION
## Summary:

\`RCTGenericDelegateSplitter\` crashes with \`NSInvalidArgumentException: -[RCTGenericDelegateSplitter <selector>]: unrecognized selector sent to instance\` when UIKit dispatches a cached delegate selector after all weak delegates have been deallocated.

### Root cause

The splitter stores delegates in an \`NSHashTable weakObjectsHashTable\`. When the splitter is installed as \`UIScrollView.delegate\` (i.e. there are 2+ delegates, or the update block wires it that way), UIKit caches which optional selectors the delegate responds to. If iOS subsequently deallocates the underlying delegate objects — for example under memory pressure while the app is suspended — the weak hash table silently drops the references and the splitter's \`_delegates.count\` goes to zero, while the splitter itself is still retained by \`UIScrollView\`.

When the app returns to foreground, \`UIAnimator\` resumes an in-flight \`UIScrollViewScrollAnimation\` left over from \`setContentOffset:animated:YES\`. UIKit calls into the cached delegate (the splitter) and the Objective-C runtime asks for a method signature:

\`\`\`objc
- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector
{
  for (id delegate in _delegates) {
    if ([delegate respondsToSelector:selector]) {
      return [delegate methodSignatureForSelector:selector];
    }
  }
  return nil; // <-- _delegates is empty: returns nil, runtime raises doesNotRecognizeSelector
}
\`\`\`

Returning \`nil\` here causes the runtime to invoke \`-doesNotRecognizeSelector:\`, producing the crash.

### Crash stack (observed in production)

\`\`\`
NSInvalidArgumentException:
-[RCTGenericDelegateSplitter scrollViewDidScroll:]: unrecognized selector sent to instance

…
-[UIAnimator _advanceAnimationsOnScreenWithIdentifier:withTimestamp:]
-[UIScrollViewScrollAnimation setProgress:]
-[RCTEnhancedScrollView setContentOffset:] (RCTEnhancedScrollView.mm:99)
-[UIScrollView setContentOffset:]
-[UIScrollView _notifyDidScroll]
__forwarding_prep_0___
___forwarding___
-[NSObject(NSObject) doesNotRecognizeSelector:]
objc_exception_throw
\`\`\`

### Impact

Observed in a production React Native 0.82.1 app (Fabric / New Architecture):

- 273 fatal occurrences / 128 affected users over ~3 months
- iOS 17.6 through 26.3.1 (not limited to a single iOS version)
- All iPhone models from iPhone 13 through iPhone 17 Pro
- Strongly correlates with low \`free_memory\` (<400MB) and long background suspension before the crash
- All events \`handled: no\`, \`level: fatal\`

### Fix

Fall back to a valid \`NSMethodSignature\` when no delegate handles the selector, so \`forwardInvocation:\` can safely no-op instead of raising. The signature is resolved from \`UIScrollViewDelegate\`'s protocol method descriptions (all methods on that protocol are optional), with a permissive \`v@:@\` signature as a last resort.

This converts an unrecoverable crash into a silent drop of an orphan callback. \`RCTGenericDelegateSplitter\` is only installed as a delegate for \`RCTEnhancedScrollView\` / \`RCTScrollViewComponentView\` in the current code base, so the protocol lookup covers all real call sites; the \`v@:@\` fallback exists only for defense in depth.

### Related

- Commit e7ef9921d3f91b02cfec4bbfd88b4968434e201c addressed a closely related dealloc-ordering crash in \`RCTScrollViewComponentView\` by setting \`_scrollView.delegate = nil\` on dealloc. That fix does not cover the foreground-resume path described here, because the splitter survives but its weak delegates do not.

## Changelog:

[IOS] [FIXED] - Prevent RCTGenericDelegateSplitter crash when UIKit invokes a cached selector after all weak delegates have been released

## Test Plan:

### Manual reproduction (before fix)

1. Build a Fabric-enabled RN 0.82.1 app with a screen that calls \`scrollRef.scrollTo({ y, animated: true })\` (e.g. tab re-tap → scroll to top).
2. Trigger the animated scroll and immediately send the app to background.
3. Induce memory pressure (open heavy Safari tabs / other apps, or use Xcode Debug → Simulate Memory Warning in the background process).
4. Return the app to foreground after several minutes.
5. Expected without patch: crash with \`unrecognized selector\` inside \`UIAnimator → UIScrollViewScrollAnimation setProgress: → RCTEnhancedScrollView setContentOffset: → _notifyDidScroll\`.

### With fix applied

- Same scenario no longer crashes.
- Normal scroll interaction, \`scrollTo({animated: true/false})\`, pull-to-refresh, zoom, \`scrollViewShouldScrollToTop\`, and momentum scrolling behave unchanged in foreground (verified on iPhone 15 Pro / iOS 26.3.1 and iPhone 13 / iOS 17.6).

### Runtime sanity

Call \`-methodSignatureForSelector:\` on an instance with zero delegates for representative selectors (\`scrollViewDidScroll:\`, \`viewForZoomingInScrollView:\`, \`scrollViewShouldScrollToTop:\`). Each returns a non-nil signature; \`-forwardInvocation:\` with the resulting invocation completes without raising.