### PR TITLE
Migrate RCTBlobManager to RCTTurboModuleWithJSIBindings

### DIFF
--- a/packages/react-native/Libraries/Blob/RCTBlobCollector.h
+++ b/packages/react-native/Libraries/Blob/RCTBlobCollector.h
@@ -16,7 +16,7 @@ class JSI_EXPORT RCTBlobCollector : public jsi::HostObject {
   RCTBlobCollector(RCTBlobManager *blobManager, const std::string &blobId);
   ~RCTBlobCollector();
 
-  static void install(RCTBlobManager *blobManager);
+  static void install(jsi::Runtime &runtime, RCTBlobManager *blobManager);
 
  private:
   const std::string blobId_;

--- a/packages/react-native/Libraries/Blob/RCTBlobCollector.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobCollector.mm
@@ -8,7 +8,6 @@
 #import "RCTBlobCollector.h"
 
 #import <React/RCTBlobManager.h>
-#import <React/RCTBridge+Private.h>
 
 namespace facebook::react {
 
@@ -26,32 +25,21 @@ RCTBlobCollector::~RCTBlobCollector()
   });
 }
 
-void RCTBlobCollector::install(RCTBlobManager *blobManager)
+void RCTBlobCollector::install(jsi::Runtime &runtime, RCTBlobManager *blobManager)
 {
-  __weak RCTCxxBridge *cxxBridge = (RCTCxxBridge *)blobManager.bridge;
-  [cxxBridge
-      dispatchBlock:^{
-        if ((cxxBridge == nullptr) || cxxBridge.runtime == nullptr) {
-          return;
-        }
-        jsi::Runtime &runtime = *(jsi::Runtime *)cxxBridge.runtime;
-        runtime.global().setProperty(
-            runtime,
-            "__blobCollectorProvider",
-            jsi::Function::createFromHostFunction(
-                runtime,
-                jsi::PropNameID::forAscii(runtime, "__blobCollectorProvider"),
-                1,
-                [blobManager](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) {
-                  auto blobId = args[0].asString(rt).utf8(rt);
-                  auto blobCollector = std::make_shared<RCTBlobCollector>(blobManager, blobId);
-                  auto blobCollectorJsObject = jsi::Object::createFromHostObject(rt, blobCollector);
-                  blobCollectorJsObject.setExternalMemoryPressure(
-                      rt, [blobManager lengthOfBlobWithId:[NSString stringWithUTF8String:blobId.c_str()]]);
-                  return blobCollectorJsObject;
-                }));
-      }
-              queue:RCTJSThread];
+  auto provider = jsi::Function::createFromHostFunction(
+      runtime,
+      jsi::PropNameID::forAscii(runtime, "__blobCollectorProvider"),
+      1,
+      [blobManager](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t /*count*/) {
+        auto blobId = args[0].asString(rt).utf8(rt);
+        auto blobCollector = std::make_shared<RCTBlobCollector>(blobManager, blobId);
+        auto blobCollectorJsObject = jsi::Object::createFromHostObject(rt, blobCollector);
+        blobCollectorJsObject.setExternalMemoryPressure(
+            rt, [blobManager lengthOfBlobWithId:[NSString stringWithUTF8String:blobId.c_str()]]);
+        return blobCollectorJsObject;
+      });
+  runtime.global().setProperty(runtime, "__blobCollectorProvider", std::move(provider));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/Libraries/Blob/RCTBlobManager.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobManager.mm
@@ -19,6 +19,8 @@
 #import "RCTBlobCollector.h"
 #import "RCTBlobPlugins.h"
 
+#import <ReactCommon/RCTTurboModuleWithJSIBindings.h>
+
 RCT_MOCK_DEF(RCTBlobManager, dispatch_async);
 #define dispatch_async RCT_MOCK_USE(RCTBlobManager, dispatch_async)
 
@@ -28,7 +30,8 @@ static NSString *const kBlobURIScheme = @"blob";
     RCTNetworkingRequestHandler,
     RCTNetworkingResponseHandler,
     RCTWebSocketContentHandler,
-    NativeBlobModuleSpec>
+    NativeBlobModuleSpec,
+    RCTTurboModuleWithJSIBindings>
 
 @end
 
@@ -52,7 +55,6 @@ RCT_EXPORT_MODULE(BlobModule)
 {
   std::lock_guard<std::mutex> lock(_blobsMutex);
   _blobs = [NSMutableDictionary new];
-  facebook::react::RCTBlobCollector::install(self);
 }
 
 + (BOOL)requiresMainQueueSetup
@@ -333,6 +335,13 @@ RCT_EXPORT_METHOD(release : (NSString *)blobId)
   return std::make_shared<facebook::react::NativeBlobModuleSpecJSI>(params);
 }
 
+#pragma mark - RCTTurboModuleWithJSIBindings
+
+- (void)installJSIBindingsWithRuntime:(facebook::jsi::Runtime &)runtime
+                          callInvoker:(const std::shared_ptr<facebook::react::CallInvoker> &)callInvoker
+{
+  facebook::react::RCTBlobCollector::install(runtime, self);
+}
 @end
 
 Class RCTBlobManagerCls(void)

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -6703,7 +6703,7 @@ class facebook::react::RAMBundleRegistry {
 
 class facebook::react::RCTBlobCollector : public facebook::jsi::HostObject {
   public RCTBlobCollector(RCTBlobManager* blobManager, const std::string& blobId);
-  public static void install(RCTBlobManager* blobManager);
+  public static void install(facebook::jsi::Runtime& runtime, RCTBlobManager* blobManager);
   public ~RCTBlobCollector();
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -6700,7 +6700,7 @@ class facebook::react::RAMBundleRegistry {
 
 class facebook::react::RCTBlobCollector : public facebook::jsi::HostObject {
   public RCTBlobCollector(RCTBlobManager* blobManager, const std::string& blobId);
-  public static void install(RCTBlobManager* blobManager);
+  public static void install(facebook::jsi::Runtime& runtime, RCTBlobManager* blobManager);
   public ~RCTBlobCollector();
 }
 


### PR DESCRIPTION
Summary:
Migrates RCTBlobManager on iOS from using private API (RCTBridge+Private.h / RCTCxxBridge) to using the standardized RCTTurboModuleWithJSIBindings protocol for installing JSI bindings. This aligns with the Android implementation and removes dependency on private React API.

Changelog: [Internal]

Differential Revision: D102145286


