### PR TITLE
Add E2E test retry jobs for PRs to handle flakiness

### DIFF
--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -77,6 +77,7 @@ runs:
       if: always()
       with:
         name: e2e_android_${{ steps.normalize-app-id.outputs.app-id }}_report_${{ inputs.flavor }}_${{ inputs.emulator-arch }}_NewArch
+        overwrite: true
         path: |
           report.xml
           screen.mp4
@@ -85,4 +86,5 @@ runs:
       uses: actions/upload-artifact@v6
       with:
         name: maestro-logs-android-${{ steps.normalize-app-id.outputs.app-id }}-${{ inputs.flavor }}-${{ inputs.emulator-arch }}-NewArch
+        overwrite: true
         path: /tmp/MaestroLogs

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -69,6 +69,7 @@ runs:
       uses: actions/upload-artifact@v6
       with:
         name: e2e_ios_${{ inputs.app-id }}_report_${{ inputs.flavor }}_NewArch
+        overwrite: true
         path: |
           video_record_1.mov
           video_record_2.mov
@@ -81,4 +82,5 @@ runs:
       uses: actions/upload-artifact@v6
       with:
         name: maestro-logs-${{ inputs.app-id }}-${{ inputs.flavor }}-NewArch
+        overwrite: true
         path: /tmp/MaestroLogs

--- a/.github/workflows/e2e-android-rntester.yml
+++ b/.github/workflows/e2e-android-rntester.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      fail-on-error:
+        type: boolean
+        default: false
     outputs:
       status:
         description: "The result of the E2E tests (success or failure)"
@@ -13,6 +17,8 @@ on:
 jobs:
   test:
     runs-on: 4-core-ubuntu
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +38,8 @@ jobs:
       - name: Print folder structure
         run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
       - name: Run E2E Tests
+        id: run-tests
+        continue-on-error: true
         uses: ./.github/actions/maestro-android
         timeout-minutes: 60
         with:
@@ -39,6 +47,10 @@ jobs:
           app-id: com.facebook.react.uiapp
           maestro-flow: ./packages/rn-tester/.maestro
           flavor: ${{ matrix.flavor }}
+      - name: Report status
+        id: report-status
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        run: echo "status=failure" >> $GITHUB_OUTPUT
 
   report:
     needs: test
@@ -49,8 +61,11 @@ jobs:
     steps:
       - id: check
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.outputs.status }}" == "failure" ]]; then
             echo "status=failure" >> $GITHUB_OUTPUT
           else
             echo "status=success" >> $GITHUB_OUTPUT
           fi
+      - name: Fail if needed
+        if: ${{ inputs.fail-on-error && steps.check.outputs.status == 'failure' }}
+        run: exit 1

--- a/.github/workflows/e2e-android-rntester.yml
+++ b/.github/workflows/e2e-android-rntester.yml
@@ -1,5 +1,8 @@
 name: E2E Android RNTester
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/e2e-android-rntester.yml
+++ b/.github/workflows/e2e-android-rntester.yml
@@ -1,0 +1,53 @@
+name: E2E Android RNTester
+
+on:
+  workflow_call:
+    outputs:
+      status:
+        description: "The result of the E2E tests (success or failure)"
+        value: ${{ jobs.report.outputs.status }}
+
+jobs:
+  test:
+    runs-on: 4-core-ubuntu
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [debug, release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Install node dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Download APK
+        uses: actions/download-artifact@v7
+        with:
+          name: rntester-${{ matrix.flavor }}
+          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
+      - name: Print folder structure
+        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
+      - name: Run E2E Tests
+        uses: ./.github/actions/maestro-android
+        timeout-minutes: 60
+        with:
+          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/app-x86-${{ matrix.flavor }}.apk
+          app-id: com.facebook.react.uiapp
+          maestro-flow: ./packages/rn-tester/.maestro
+          flavor: ${{ matrix.flavor }}
+
+  report:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.check.outputs.status }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -1,5 +1,8 @@
 name: E2E Android Template App
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -1,0 +1,91 @@
+name: E2E Android Template App
+
+on:
+  workflow_call:
+    outputs:
+      status:
+        description: "The result of the E2E tests (success or failure)"
+        value: ${{ jobs.report.outputs.status }}
+
+jobs:
+  test:
+    runs-on: 4-core-ubuntu
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [debug, release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Run yarn
+        uses: ./.github/actions/yarn-install
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+      - name: Download Maven Local
+        uses: actions/download-artifact@v7
+        with:
+          name: maven-local
+          path: /tmp/react-native-tmp/maven-local
+      - name: Download React Native Package
+        uses: actions/download-artifact@v7
+        with:
+          name: react-native-package
+          path: /tmp/react-native-tmp
+      - name: Print /tmp folder
+        run: ls -lR /tmp/react-native-tmp
+      - name: Prepare artifacts
+        id: prepare-artifacts
+        run: |
+          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
+          echo "React Native tgs is $REACT_NATIVE_PKG"
+
+          MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
+          echo "Maven local path is $MAVEN_LOCAL"
+
+          # For stable branches, we want to use the stable branch of the template
+          # In all the other cases, we want to use "main"
+          BRANCH=${{ github.ref_name }}
+          if ! [[ $BRANCH == *-stable* ]]; then
+            BRANCH=main
+          fi
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+
+          echo "Feed maven local to gradle.properties"
+          cd /tmp/RNTestProject
+          echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
+
+          # Build
+          cd android
+          CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
+          ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
+
+      - name: Run E2E Tests
+        uses: ./.github/actions/maestro-android
+        timeout-minutes: 60
+        with:
+          app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
+          app-id: com.rntestproject
+          maestro-flow: ./scripts/e2e/.maestro/
+          install-java: 'false'
+          flavor: ${{ matrix.flavor }}
+          working-directory: /tmp/RNTestProject
+
+  report:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.check.outputs.status }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      fail-on-error:
+        type: boolean
+        default: false
     outputs:
       status:
         description: "The result of the E2E tests (success or failure)"
@@ -13,6 +17,8 @@ on:
 jobs:
   test:
     runs-on: 4-core-ubuntu
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +74,8 @@ jobs:
           ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
 
       - name: Run E2E Tests
+        id: run-tests
+        continue-on-error: true
         uses: ./.github/actions/maestro-android
         timeout-minutes: 60
         with:
@@ -77,6 +85,10 @@ jobs:
           install-java: 'false'
           flavor: ${{ matrix.flavor }}
           working-directory: /tmp/RNTestProject
+      - name: Report status
+        id: report-status
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        run: echo "status=failure" >> $GITHUB_OUTPUT
 
   report:
     needs: test
@@ -87,8 +99,11 @@ jobs:
     steps:
       - id: check
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.outputs.status }}" == "failure" ]]; then
             echo "status=failure" >> $GITHUB_OUTPUT
           else
             echo "status=success" >> $GITHUB_OUTPUT
           fi
+      - name: Fail if needed
+        if: ${{ inputs.fail-on-error && steps.check.outputs.status == 'failure' }}
+        run: exit 1

--- a/.github/workflows/e2e-ios-rntester.yml
+++ b/.github/workflows/e2e-ios-rntester.yml
@@ -1,5 +1,8 @@
 name: E2E iOS RNTester
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/e2e-ios-rntester.yml
+++ b/.github/workflows/e2e-ios-rntester.yml
@@ -1,0 +1,52 @@
+name: E2E iOS RNTester
+
+on:
+  workflow_call:
+    outputs:
+      status:
+        description: "The result of the E2E tests (success or failure)"
+        value: ${{ jobs.report.outputs.status }}
+
+jobs:
+  test:
+    runs-on: macos-15-large
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+      - name: Download App
+        uses: actions/download-artifact@v7
+        with:
+          name: RNTesterApp-NewArch-${{ matrix.flavor }}
+          path: /tmp/RNTesterBuild/RNTester.app
+      - name: Check downloaded folder content
+        run: ls -lR /tmp/RNTesterBuild
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+      - name: Run E2E Tests
+        uses: ./.github/actions/maestro-ios
+        with:
+          app-path: "/tmp/RNTesterBuild/RNTester.app"
+          app-id: com.meta.RNTester.localDevelopment
+          maestro-flow: ./packages/rn-tester/.maestro/
+          flavor: ${{ matrix.flavor }}
+
+  report:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.check.outputs.status }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/e2e-ios-rntester.yml
+++ b/.github/workflows/e2e-ios-rntester.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      fail-on-error:
+        type: boolean
+        default: false
     outputs:
       status:
         description: "The result of the E2E tests (success or failure)"
@@ -13,6 +17,8 @@ on:
 jobs:
   test:
     runs-on: macos-15-large
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,12 +38,18 @@ jobs:
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
       - name: Run E2E Tests
+        id: run-tests
+        continue-on-error: true
         uses: ./.github/actions/maestro-ios
         with:
           app-path: "/tmp/RNTesterBuild/RNTester.app"
           app-id: com.meta.RNTester.localDevelopment
           maestro-flow: ./packages/rn-tester/.maestro/
           flavor: ${{ matrix.flavor }}
+      - name: Report status
+        id: report-status
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        run: echo "status=failure" >> $GITHUB_OUTPUT
 
   report:
     needs: test
@@ -48,8 +60,11 @@ jobs:
     steps:
       - id: check
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.outputs.status }}" == "failure" ]]; then
             echo "status=failure" >> $GITHUB_OUTPUT
           else
             echo "status=success" >> $GITHUB_OUTPUT
           fi
+      - name: Fail if needed
+        if: ${{ inputs.fail-on-error && steps.check.outputs.status == 'failure' }}
+        run: exit 1

--- a/.github/workflows/e2e-ios-templateapp.yml
+++ b/.github/workflows/e2e-ios-templateapp.yml
@@ -1,0 +1,110 @@
+name: E2E iOS Template App
+
+on:
+  workflow_call:
+    outputs:
+      status:
+        description: "The result of the E2E tests (success or failure)"
+        value: ${{ jobs.report.outputs.status }}
+
+jobs:
+  test:
+    runs-on: macos-15-large
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Run yarn
+        uses: ./.github/actions/yarn-install
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.10
+      - name: Download React Native Package
+        uses: actions/download-artifact@v7
+        with:
+          name: react-native-package
+          path: /tmp/react-native-tmp
+      - name: Print /tmp folder
+        run: ls -lR /tmp/react-native-tmp
+      - name: Download ReactNativeDependencies
+        uses: actions/download-artifact@v7
+        with:
+          name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
+          path: /tmp/third-party
+      - name: Print third-party folder
+        shell: bash
+        run: ls -lR /tmp/third-party
+      - name: Download React Native Prebuilds
+        uses: actions/download-artifact@v7
+        with:
+          name: ReactCore${{ matrix.flavor }}.xcframework.tar.gz
+          path: /tmp/ReactCore
+      - name: Print ReactCore folder
+        shell: bash
+        run: ls -lR /tmp/ReactCore
+      - name: Configure git
+        shell: bash
+        run: |
+            git config --global user.email "react-native-bot@meta.com"
+            git config --global user.name "React Native Bot"
+      - name: Prepare artifacts
+        run: |
+          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
+          echo "React Native tgs is $REACT_NATIVE_PKG"
+
+          # For stable branches, we want to use the stable branch of the template
+          # In all the other cases, we want to use "main"
+          BRANCH=${{ github.ref_name }}
+          if ! [[ $BRANCH == *-stable* ]]; then
+            BRANCH=main
+          fi
+
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+
+          cd /tmp/RNTestProject/ios
+          bundle install
+          NEW_ARCH_ENABLED=1
+
+          export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
+          # Disable prebuilds for now, as they are causing issues with E2E tests for 0.82-stable branch
+          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
+          RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
+
+          xcodebuild \
+            -scheme "RNTestProject" \
+            -workspace RNTestProject.xcworkspace \
+            -configuration "${{ matrix.flavor }}" \
+            -sdk "iphonesimulator" \
+            -destination "generic/platform=iOS Simulator" \
+            -derivedDataPath "/tmp/RNTestProject"
+      - name: Run E2E Tests
+        uses: ./.github/actions/maestro-ios
+        with:
+          app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
+          app-id: org.reactjs.native.example.RNTestProject
+          maestro-flow: ./scripts/e2e/.maestro/
+          flavor: ${{ matrix.flavor }}
+          working-directory: /tmp/RNTestProject
+
+  report:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.check.outputs.status }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/e2e-ios-templateapp.yml
+++ b/.github/workflows/e2e-ios-templateapp.yml
@@ -1,5 +1,8 @@
 name: E2E iOS Template App
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/e2e-ios-templateapp.yml
+++ b/.github/workflows/e2e-ios-templateapp.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      fail-on-error:
+        type: boolean
+        default: false
     outputs:
       status:
         description: "The result of the E2E tests (success or failure)"
@@ -13,6 +17,8 @@ on:
 jobs:
   test:
     runs-on: macos-15-large
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -89,6 +95,8 @@ jobs:
             -destination "generic/platform=iOS Simulator" \
             -derivedDataPath "/tmp/RNTestProject"
       - name: Run E2E Tests
+        id: run-tests
+        continue-on-error: true
         uses: ./.github/actions/maestro-ios
         with:
           app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
@@ -96,6 +104,10 @@ jobs:
           maestro-flow: ./scripts/e2e/.maestro/
           flavor: ${{ matrix.flavor }}
           working-directory: /tmp/RNTestProject
+      - name: Report status
+        id: report-status
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        run: echo "status=failure" >> $GITHUB_OUTPUT
 
   report:
     needs: test
@@ -106,8 +118,11 @@ jobs:
     steps:
       - id: check
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.outputs.status }}" == "failure" ]]; then
             echo "status=failure" >> $GITHUB_OUTPUT
           else
             echo "status=success" >> $GITHUB_OUTPUT
           fi
+      - name: Fail if needed
+        if: ${{ inputs.fail-on-error && steps.check.outputs.status == 'failure' }}
+        run: exit 1

--- a/.github/workflows/fantom-tests.yml
+++ b/.github/workflows/fantom-tests.yml
@@ -1,0 +1,39 @@
+name: Fantom Tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    outputs:
+      status:
+        description: "The result of the Fantom tests (success or failure)"
+        value: ${{ jobs.report.outputs.status }}
+
+jobs:
+  test:
+    runs-on: 8-core-ubuntu
+    container:
+      image: reactnativecommunity/react-native-android:latest
+      env:
+        TERM: "dumb"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run Fantom Tests
+        uses: ./.github/actions/run-fantom-tests
+
+  report:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.check.outputs.status }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/fantom-tests.yml
+++ b/.github/workflows/fantom-tests.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      fail-on-error:
+        type: boolean
+        default: false
     outputs:
       status:
         description: "The result of the Fantom tests (success or failure)"
@@ -13,6 +17,8 @@ on:
 jobs:
   test:
     runs-on: 8-core-ubuntu
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     container:
       image: reactnativecommunity/react-native-android:latest
       env:
@@ -21,7 +27,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run Fantom Tests
+        id: run-tests
+        continue-on-error: true
         uses: ./.github/actions/run-fantom-tests
+      - name: Report status
+        id: report-status
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        run: echo "status=failure" >> $GITHUB_OUTPUT
 
   report:
     needs: test
@@ -32,8 +44,11 @@ jobs:
     steps:
       - id: check
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.outputs.status }}" == "failure" ]]; then
             echo "status=failure" >> $GITHUB_OUTPUT
           else
             echo "status=success" >> $GITHUB_OUTPUT
           fi
+      - name: Fail if needed
+        if: ${{ inputs.fail-on-error && steps.check.outputs.status == 'failure' }}
+        run: exit 1

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -154,626 +154,64 @@ jobs:
           flavor: ${{ matrix.flavor }}
 
   test_e2e_ios_rntester:
-    runs-on: macos-15-large
-    needs:
-      [test_ios_rntester]
+    needs: test_ios_rntester
+    uses: ./.github/workflows/e2e-ios-rntester.yml
     continue-on-error: ${{ github.event_name == 'pull_request' }}
-    outputs:
-      status: ${{ steps.report-status.outputs.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [Debug, Release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
-      - name: Download App
-        uses: actions/download-artifact@v7
-        with:
-          name: RNTesterApp-NewArch-${{ matrix.flavor }}
-          path: /tmp/RNTesterBuild/RNTester.app
-      - name: Check downloaded folder content
-        run: ls -lR /tmp/RNTesterBuild
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-        uses: ./.github/actions/maestro-ios
-        with:
-          app-path: "/tmp/RNTesterBuild/RNTester.app"
-          app-id: com.meta.RNTester.localDevelopment
-          maestro-flow: ./packages/rn-tester/.maestro/
-          flavor: ${{ matrix.flavor }}
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_ios_rntester_retry_1:
-    runs-on: macos-15-large
     needs: test_e2e_ios_rntester
     if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_rntester.outputs.status == 'failure' }}
+    uses: ./.github/workflows/e2e-ios-rntester.yml
     continue-on-error: true
-    outputs:
-      status: ${{ steps.report-status.outputs.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [Debug, Release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
-      - name: Download App
-        uses: actions/download-artifact@v7
-        with:
-          name: RNTesterApp-NewArch-${{ matrix.flavor }}
-          path: /tmp/RNTesterBuild/RNTester.app
-      - name: Check downloaded folder content
-        run: ls -lR /tmp/RNTesterBuild
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: true
-        uses: ./.github/actions/maestro-ios
-        with:
-          app-path: "/tmp/RNTesterBuild/RNTester.app"
-          app-id: com.meta.RNTester.localDevelopment
-          maestro-flow: ./packages/rn-tester/.maestro/
-          flavor: ${{ matrix.flavor }}
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_ios_rntester_retry_2:
-    runs-on: macos-15-large
     needs: test_e2e_ios_rntester_retry_1
     if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_rntester_retry_1.outputs.status == 'failure' }}
+    uses: ./.github/workflows/e2e-ios-rntester.yml
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [Debug, Release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
-      - name: Download App
-        uses: actions/download-artifact@v7
-        with:
-          name: RNTesterApp-NewArch-${{ matrix.flavor }}
-          path: /tmp/RNTesterBuild/RNTester.app
-      - name: Check downloaded folder content
-        run: ls -lR /tmp/RNTesterBuild
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: true
-        uses: ./.github/actions/maestro-ios
-        with:
-          app-path: "/tmp/RNTesterBuild/RNTester.app"
-          app-id: com.meta.RNTester.localDevelopment
-          maestro-flow: ./packages/rn-tester/.maestro/
-          flavor: ${{ matrix.flavor }}
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_ios_templateapp:
-    runs-on: macos-15-large
     needs: [build_npm_package, prebuild_apple_dependencies]
+    uses: ./.github/workflows/e2e-ios-templateapp.yml
     continue-on-error: ${{ github.event_name == 'pull_request' }}
-    outputs:
-      status: ${{ steps.report-status.outputs.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [Debug, Release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Run yarn
-        uses: ./.github/actions/yarn-install
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.6.10
-      - name: Download React Native Package
-        uses: actions/download-artifact@v7
-        with:
-          name: react-native-package
-          path: /tmp/react-native-tmp
-      - name: Print /tmp folder
-        run: ls -lR /tmp/react-native-tmp
-      - name: Download ReactNativeDependencies
-        uses: actions/download-artifact@v7
-        with:
-          name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
-          path: /tmp/third-party
-      - name: Print third-party folder
-        shell: bash
-        run: ls -lR /tmp/third-party
-      - name: Download React Native Prebuilds
-        uses: actions/download-artifact@v7
-        with:
-          name: ReactCore${{ matrix.flavor }}.xcframework.tar.gz
-          path: /tmp/ReactCore
-      - name: Print ReactCore folder
-        shell: bash
-        run: ls -lR /tmp/ReactCore
-      - name: Configure git
-        shell: bash
-        run: |
-            git config --global user.email "react-native-bot@meta.com"
-            git config --global user.name "React Native Bot"
-      - name: Prepare artifacts
-        run: |
-          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
-          echo "React Native tgs is $REACT_NATIVE_PKG"
-
-          # For stable branches, we want to use the stable branch of the template
-          # In all the other cases, we want to use "main"
-          BRANCH=${{ github.ref_name }}
-          if ! [[ $BRANCH == *-stable* ]]; then
-            BRANCH=main
-          fi
-
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
-
-          cd /tmp/RNTestProject/ios
-          bundle install
-          NEW_ARCH_ENABLED=1
-
-          export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
-          # Disable prebuilds for now, as they are causing issues with E2E tests for 0.82-stable branch
-          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
-          RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
-
-          xcodebuild \
-            -scheme "RNTestProject" \
-            -workspace RNTestProject.xcworkspace \
-            -configuration "${{ matrix.flavor }}" \
-            -sdk "iphonesimulator" \
-            -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "/tmp/RNTestProject"
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-        uses: ./.github/actions/maestro-ios
-        with:
-          app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
-          app-id: org.reactjs.native.example.RNTestProject
-          maestro-flow: ./scripts/e2e/.maestro/
-          flavor: ${{ matrix.flavor }}
-          working-directory: /tmp/RNTestProject
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_ios_templateapp_retry_1:
-    runs-on: macos-15-large
-    needs: [test_e2e_ios_templateapp, build_npm_package, prebuild_apple_dependencies]
+    needs: test_e2e_ios_templateapp
     if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_templateapp.outputs.status == 'failure' }}
+    uses: ./.github/workflows/e2e-ios-templateapp.yml
     continue-on-error: true
-    outputs:
-      status: ${{ steps.report-status.outputs.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [Debug, Release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Run yarn
-        uses: ./.github/actions/yarn-install
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.6.10
-      - name: Download React Native Package
-        uses: actions/download-artifact@v7
-        with:
-          name: react-native-package
-          path: /tmp/react-native-tmp
-      - name: Print /tmp folder
-        run: ls -lR /tmp/react-native-tmp
-      - name: Download ReactNativeDependencies
-        uses: actions/download-artifact@v7
-        with:
-          name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
-          path: /tmp/third-party
-      - name: Print third-party folder
-        shell: bash
-        run: ls -lR /tmp/third-party
-      - name: Download React Native Prebuilds
-        uses: actions/download-artifact@v7
-        with:
-          name: ReactCore${{ matrix.flavor }}.xcframework.tar.gz
-          path: /tmp/ReactCore
-      - name: Print ReactCore folder
-        shell: bash
-        run: ls -lR /tmp/ReactCore
-      - name: Configure git
-        shell: bash
-        run: |
-            git config --global user.email "react-native-bot@meta.com"
-            git config --global user.name "React Native Bot"
-      - name: Prepare artifacts
-        run: |
-          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
-          echo "React Native tgs is $REACT_NATIVE_PKG"
-
-          BRANCH=${{ github.ref_name }}
-          if ! [[ $BRANCH == *-stable* ]]; then
-            BRANCH=main
-          fi
-
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
-
-          cd /tmp/RNTestProject/ios
-          bundle install
-          NEW_ARCH_ENABLED=1
-
-          export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
-          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
-          RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
-
-          xcodebuild \
-            -scheme "RNTestProject" \
-            -workspace RNTestProject.xcworkspace \
-            -configuration "${{ matrix.flavor }}" \
-            -sdk "iphonesimulator" \
-            -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "/tmp/RNTestProject"
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: true
-        uses: ./.github/actions/maestro-ios
-        with:
-          app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
-          app-id: org.reactjs.native.example.RNTestProject
-          maestro-flow: ./scripts/e2e/.maestro/
-          flavor: ${{ matrix.flavor }}
-          working-directory: /tmp/RNTestProject
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_ios_templateapp_retry_2:
-    runs-on: macos-15-large
-    needs: [test_e2e_ios_templateapp_retry_1, build_npm_package, prebuild_apple_dependencies]
+    needs: test_e2e_ios_templateapp_retry_1
     if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_templateapp_retry_1.outputs.status == 'failure' }}
+    uses: ./.github/workflows/e2e-ios-templateapp.yml
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [Debug, Release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Run yarn
-        uses: ./.github/actions/yarn-install
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.6.10
-      - name: Download React Native Package
-        uses: actions/download-artifact@v7
-        with:
-          name: react-native-package
-          path: /tmp/react-native-tmp
-      - name: Print /tmp folder
-        run: ls -lR /tmp/react-native-tmp
-      - name: Download ReactNativeDependencies
-        uses: actions/download-artifact@v7
-        with:
-          name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
-          path: /tmp/third-party
-      - name: Print third-party folder
-        shell: bash
-        run: ls -lR /tmp/third-party
-      - name: Download React Native Prebuilds
-        uses: actions/download-artifact@v7
-        with:
-          name: ReactCore${{ matrix.flavor }}.xcframework.tar.gz
-          path: /tmp/ReactCore
-      - name: Print ReactCore folder
-        shell: bash
-        run: ls -lR /tmp/ReactCore
-      - name: Configure git
-        shell: bash
-        run: |
-            git config --global user.email "react-native-bot@meta.com"
-            git config --global user.name "React Native Bot"
-      - name: Prepare artifacts
-        run: |
-          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
-          echo "React Native tgs is $REACT_NATIVE_PKG"
-
-          BRANCH=${{ github.ref_name }}
-          if ! [[ $BRANCH == *-stable* ]]; then
-            BRANCH=main
-          fi
-
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
-
-          cd /tmp/RNTestProject/ios
-          bundle install
-          NEW_ARCH_ENABLED=1
-
-          export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
-          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
-          RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
-
-          xcodebuild \
-            -scheme "RNTestProject" \
-            -workspace RNTestProject.xcworkspace \
-            -configuration "${{ matrix.flavor }}" \
-            -sdk "iphonesimulator" \
-            -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "/tmp/RNTestProject"
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: true
-        uses: ./.github/actions/maestro-ios
-        with:
-          app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
-          app-id: org.reactjs.native.example.RNTestProject
-          maestro-flow: ./scripts/e2e/.maestro/
-          flavor: ${{ matrix.flavor }}
-          working-directory: /tmp/RNTestProject
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_android_templateapp:
-    runs-on: 4-core-ubuntu
     needs: build_npm_package
+    uses: ./.github/workflows/e2e-android-templateapp.yml
     continue-on-error: ${{ github.event_name == 'pull_request' }}
-    outputs:
-      status: ${{ steps.report-status.outputs.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [debug, release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Run yarn
-        uses: ./.github/actions/yarn-install
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-      - name: Download Maven Local
-        uses: actions/download-artifact@v7
-        with:
-          name: maven-local
-          path: /tmp/react-native-tmp/maven-local
-      - name: Download React Native Package
-        uses: actions/download-artifact@v7
-        with:
-          name: react-native-package
-          path: /tmp/react-native-tmp
-      - name: Print /tmp folder
-        run: ls -lR /tmp/react-native-tmp
-      - name: Prepare artifacts
-        id: prepare-artifacts
-        run: |
-          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
-          echo "React Native tgs is $REACT_NATIVE_PKG"
-
-          MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
-          echo "Maven local path is $MAVEN_LOCAL"
-
-          # For stable branches, we want to use the stable branch of the template
-          # In all the other cases, we want to use "main"
-          BRANCH=${{ github.ref_name }}
-          if ! [[ $BRANCH == *-stable* ]]; then
-            BRANCH=main
-          fi
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
-
-          echo "Feed maven local to gradle.properties"
-          cd /tmp/RNTestProject
-          echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
-
-          # Build
-          cd android
-          CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
-          ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
-
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-        uses: ./.github/actions/maestro-android
-        timeout-minutes: 60
-        with:
-          app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
-          app-id: com.rntestproject
-          maestro-flow: ./scripts/e2e/.maestro/
-          install-java: 'false'
-          flavor: ${{ matrix.flavor }}
-          working-directory: /tmp/RNTestProject
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_android_templateapp_retry_1:
-    runs-on: 4-core-ubuntu
-    needs: [test_e2e_android_templateapp, build_npm_package]
+    needs: test_e2e_android_templateapp
     if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_templateapp.outputs.status == 'failure' }}
+    uses: ./.github/workflows/e2e-android-templateapp.yml
     continue-on-error: true
-    outputs:
-      status: ${{ steps.report-status.outputs.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [debug, release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Run yarn
-        uses: ./.github/actions/yarn-install
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-      - name: Download Maven Local
-        uses: actions/download-artifact@v7
-        with:
-          name: maven-local
-          path: /tmp/react-native-tmp/maven-local
-      - name: Download React Native Package
-        uses: actions/download-artifact@v7
-        with:
-          name: react-native-package
-          path: /tmp/react-native-tmp
-      - name: Print /tmp folder
-        run: ls -lR /tmp/react-native-tmp
-      - name: Prepare artifacts
-        id: prepare-artifacts
-        run: |
-          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
-          echo "React Native tgs is $REACT_NATIVE_PKG"
-
-          MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
-          echo "Maven local path is $MAVEN_LOCAL"
-
-          BRANCH=${{ github.ref_name }}
-          if ! [[ $BRANCH == *-stable* ]]; then
-            BRANCH=main
-          fi
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
-
-          echo "Feed maven local to gradle.properties"
-          cd /tmp/RNTestProject
-          echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
-
-          cd android
-          CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
-          ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
-
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: true
-        uses: ./.github/actions/maestro-android
-        timeout-minutes: 60
-        with:
-          app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
-          app-id: com.rntestproject
-          maestro-flow: ./scripts/e2e/.maestro/
-          install-java: 'false'
-          flavor: ${{ matrix.flavor }}
-          working-directory: /tmp/RNTestProject
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_android_templateapp_retry_2:
-    runs-on: 4-core-ubuntu
-    needs: [test_e2e_android_templateapp_retry_1, build_npm_package]
+    needs: test_e2e_android_templateapp_retry_1
     if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_templateapp_retry_1.outputs.status == 'failure' }}
+    uses: ./.github/workflows/e2e-android-templateapp.yml
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [debug, release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Run yarn
-        uses: ./.github/actions/yarn-install
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-      - name: Download Maven Local
-        uses: actions/download-artifact@v7
-        with:
-          name: maven-local
-          path: /tmp/react-native-tmp/maven-local
-      - name: Download React Native Package
-        uses: actions/download-artifact@v7
-        with:
-          name: react-native-package
-          path: /tmp/react-native-tmp
-      - name: Print /tmp folder
-        run: ls -lR /tmp/react-native-tmp
-      - name: Prepare artifacts
-        id: prepare-artifacts
-        run: |
-          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
-          echo "React Native tgs is $REACT_NATIVE_PKG"
-
-          MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
-          echo "Maven local path is $MAVEN_LOCAL"
-
-          BRANCH=${{ github.ref_name }}
-          if ! [[ $BRANCH == *-stable* ]]; then
-            BRANCH=main
-          fi
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
-
-          echo "Feed maven local to gradle.properties"
-          cd /tmp/RNTestProject
-          echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
-
-          cd android
-          CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
-          ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
-
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: true
-        uses: ./.github/actions/maestro-android
-        timeout-minutes: 60
-        with:
-          app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
-          app-id: com.rntestproject
-          maestro-flow: ./scripts/e2e/.maestro/
-          install-java: 'false'
-          flavor: ${{ matrix.flavor }}
-          working-directory: /tmp/RNTestProject
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   build_fantom_runner:
     runs-on: 8-core-ubuntu
@@ -839,121 +277,24 @@ jobs:
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
   test_e2e_android_rntester:
-    runs-on: 4-core-ubuntu
-    needs: [build_android]
+    needs: build_android
+    uses: ./.github/workflows/e2e-android-rntester.yml
     continue-on-error: ${{ github.event_name == 'pull_request' }}
-    outputs:
-      status: ${{ steps.report-status.outputs.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [debug, release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Install node dependencies
-        uses: ./.github/actions/yarn-install
-      - name: Download APK
-        uses: actions/download-artifact@v7
-        with:
-          name: rntester-${{ matrix.flavor }}
-          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
-      - name: Print folder structure
-        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-        uses: ./.github/actions/maestro-android
-        timeout-minutes: 60
-        with:
-          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/app-x86-${{ matrix.flavor }}.apk
-          app-id: com.facebook.react.uiapp
-          maestro-flow: ./packages/rn-tester/.maestro
-          flavor: ${{ matrix.flavor }}
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_android_rntester_retry_1:
-    runs-on: 4-core-ubuntu
     needs: test_e2e_android_rntester
     if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_rntester.outputs.status == 'failure' }}
+    uses: ./.github/workflows/e2e-android-rntester.yml
     continue-on-error: true
-    outputs:
-      status: ${{ steps.report-status.outputs.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [debug, release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Install node dependencies
-        uses: ./.github/actions/yarn-install
-      - name: Download APK
-        uses: actions/download-artifact@v7
-        with:
-          name: rntester-${{ matrix.flavor }}
-          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
-      - name: Print folder structure
-        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: true
-        uses: ./.github/actions/maestro-android
-        timeout-minutes: 60
-        with:
-          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/app-x86-${{ matrix.flavor }}.apk
-          app-id: com.facebook.react.uiapp
-          maestro-flow: ./packages/rn-tester/.maestro
-          flavor: ${{ matrix.flavor }}
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   test_e2e_android_rntester_retry_2:
-    runs-on: 4-core-ubuntu
     needs: test_e2e_android_rntester_retry_1
     if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_rntester_retry_1.outputs.status == 'failure' }}
+    uses: ./.github/workflows/e2e-android-rntester.yml
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [debug, release]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Install node dependencies
-        uses: ./.github/actions/yarn-install
-      - name: Download APK
-        uses: actions/download-artifact@v7
-        with:
-          name: rntester-${{ matrix.flavor }}
-          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
-      - name: Print folder structure
-        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
-      - name: Run E2E Tests
-        id: run-e2e
-        continue-on-error: true
-        uses: ./.github/actions/maestro-android
-        timeout-minutes: 60
-        with:
-          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/app-x86-${{ matrix.flavor }}.apk
-          app-id: com.facebook.react.uiapp
-          maestro-flow: ./packages/rn-tester/.maestro
-          flavor: ${{ matrix.flavor }}
-      - name: Report E2E status
-        id: report-status
-        if: always()
-        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+    secrets: inherit
 
   build_npm_package:
     runs-on: 8-core-ubuntu

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -8,6 +8,9 @@ on:
       - main
       - "*-stable"
 
+permissions:
+  contents: read
+
 jobs:
   set_release_type:
     runs-on: ubuntu-latest
@@ -510,6 +513,9 @@ jobs:
   # This job only handles Fantom test retries on main.
   rerun-failed-jobs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     needs: [run_fantom_tests]
     if: ${{ github.ref == 'refs/heads/main' && always() }}
     steps:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -161,14 +161,14 @@ jobs:
 
   test_e2e_ios_rntester_retry_1:
     needs: test_e2e_ios_rntester
-    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_rntester.outputs.status == 'failure' }}
+    if: ${{ always() && needs.test_e2e_ios_rntester.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-rntester.yml
     continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_rntester_retry_2:
     needs: test_e2e_ios_rntester_retry_1
-    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_rntester_retry_1.outputs.status == 'failure' }}
+    if: ${{ always() && needs.test_e2e_ios_rntester_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-rntester.yml
     continue-on-error: true
     secrets: inherit
@@ -181,14 +181,14 @@ jobs:
 
   test_e2e_ios_templateapp_retry_1:
     needs: test_e2e_ios_templateapp
-    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_templateapp.outputs.status == 'failure' }}
+    if: ${{ always() && needs.test_e2e_ios_templateapp.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-templateapp.yml
     continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_templateapp_retry_2:
     needs: test_e2e_ios_templateapp_retry_1
-    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_templateapp_retry_1.outputs.status == 'failure' }}
+    if: ${{ always() && needs.test_e2e_ios_templateapp_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-templateapp.yml
     continue-on-error: true
     secrets: inherit
@@ -201,14 +201,14 @@ jobs:
 
   test_e2e_android_templateapp_retry_1:
     needs: test_e2e_android_templateapp
-    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_templateapp.outputs.status == 'failure' }}
+    if: ${{ always() && needs.test_e2e_android_templateapp.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-templateapp.yml
     continue-on-error: true
     secrets: inherit
 
   test_e2e_android_templateapp_retry_2:
     needs: test_e2e_android_templateapp_retry_1
-    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_templateapp_retry_1.outputs.status == 'failure' }}
+    if: ${{ always() && needs.test_e2e_android_templateapp_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-templateapp.yml
     continue-on-error: true
     secrets: inherit
@@ -284,14 +284,14 @@ jobs:
 
   test_e2e_android_rntester_retry_1:
     needs: test_e2e_android_rntester
-    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_rntester.outputs.status == 'failure' }}
+    if: ${{ always() && needs.test_e2e_android_rntester.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-rntester.yml
     continue-on-error: true
     secrets: inherit
 
   test_e2e_android_rntester_retry_2:
     needs: test_e2e_android_rntester_retry_1
-    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_rntester_retry_1.outputs.status == 'failure' }}
+    if: ${{ always() && needs.test_e2e_android_rntester_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-rntester.yml
     continue-on-error: true
     secrets: inherit
@@ -506,18 +506,11 @@ jobs:
         shell: bash
         run: node scripts/debugger-shell/build-binary.js
 
-  # This job should help with the E2E flakyness.
-  # In case E2E tests fails, it launches a new retry-workflow workflow, passing the current run_id as input.
-  # The retry-workflow reruns only the failed jobs of the current test-all workflow using
-  # ```
-  # gh run rerun ${{ inputs.run_id }} --failed
-  # ```
-  # From https://stackoverflow.com/a/78314483 it seems like that adding the extra workflow
-  # rather then calling directly this command should improve stability of this solution.
-  # This is exactly the same as rerunning failed tests from the GH UI, but automated.
+  # E2E test retries are now handled by the retry_1/retry_2 reusable workflow jobs above.
+  # This job only handles Fantom test retries on main.
   rerun-failed-jobs:
     runs-on: ubuntu-latest
-    needs: [test_e2e_ios_rntester, test_e2e_android_rntester, test_e2e_ios_templateapp, test_e2e_android_templateapp, run_fantom_tests]
+    needs: [run_fantom_tests]
     if: ${{ github.ref == 'refs/heads/main' && always() }}
     steps:
       - name: Checkout
@@ -531,19 +524,10 @@ jobs:
             exit 0
           fi
 
-          RNTESTER_ANDROID_FAILED=${{ needs.test_e2e_android_rntester.result == 'failure' }}
-          TEMPLATE_ANDROID_FAILED=${{ needs.test_e2e_android_templateapp.result == 'failure' }}
-          RNTESTER_IOS_FAILED=${{ needs.test_e2e_ios_rntester.result == 'failure' }}
-          TEMPLATE_IOS_FAILED=${{ needs.test_e2e_ios_templateapp.result == 'failure' }}
           FANTOM_TESTS_FAILED=${{ needs.run_fantom_tests.result == 'failure' }}
-
-          echo "RNTESTER_ANDROID_FAILED: $RNTESTER_ANDROID_FAILED"
-          echo "TEMPLATE_ANDROID_FAILED: $TEMPLATE_ANDROID_FAILED"
-          echo "RNTESTER_IOS_FAILED: $RNTESTER_IOS_FAILED"
-          echo "TEMPLATE_IOS_FAILED: $TEMPLATE_IOS_FAILED"
           echo "FANTOM_TESTS_FAILED: $FANTOM_TESTS_FAILED"
 
-          if [[ $RNTESTER_ANDROID_FAILED == "true" || $TEMPLATE_ANDROID_FAILED == "true" || $RNTESTER_IOS_FAILED == "true" || $TEMPLATE_IOS_FAILED == "true" || $FANTOM_TESTS_FAILED == "true" ]]; then
+          if [[ $FANTOM_TESTS_FAILED == "true" ]]; then
             echo "Rerunning failed jobs in the current workflow"
             gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}
           fi

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -159,7 +159,7 @@ jobs:
   test_e2e_ios_rntester:
     needs: test_ios_rntester
     uses: ./.github/workflows/e2e-ios-rntester.yml
-    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_rntester_retry_1:
@@ -173,13 +173,12 @@ jobs:
     needs: test_e2e_ios_rntester_retry_1
     if: ${{ always() && needs.test_e2e_ios_rntester_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-rntester.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_templateapp:
     needs: [build_npm_package, prebuild_apple_dependencies]
     uses: ./.github/workflows/e2e-ios-templateapp.yml
-    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_templateapp_retry_1:
@@ -193,13 +192,12 @@ jobs:
     needs: test_e2e_ios_templateapp_retry_1
     if: ${{ always() && needs.test_e2e_ios_templateapp_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-templateapp.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_android_templateapp:
     needs: build_npm_package
     uses: ./.github/workflows/e2e-android-templateapp.yml
-    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    continue-on-error: true
     secrets: inherit
 
   test_e2e_android_templateapp_retry_1:
@@ -213,7 +211,6 @@ jobs:
     needs: test_e2e_android_templateapp_retry_1
     if: ${{ always() && needs.test_e2e_android_templateapp_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-templateapp.yml
-    continue-on-error: true
     secrets: inherit
 
   build_fantom_runner:
@@ -241,17 +238,23 @@ jobs:
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
   run_fantom_tests:
-    runs-on: 8-core-ubuntu
-    needs: [build_fantom_runner]
-    container:
-      image: reactnativecommunity/react-native-android:latest
-      env:
-        TERM: "dumb"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run Fantom Tests
-        uses: ./.github/actions/run-fantom-tests
+    needs: build_fantom_runner
+    uses: ./.github/workflows/fantom-tests.yml
+    continue-on-error: true
+    secrets: inherit
+
+  run_fantom_tests_retry_1:
+    needs: run_fantom_tests
+    if: ${{ always() && needs.run_fantom_tests.outputs.status == 'failure' }}
+    uses: ./.github/workflows/fantom-tests.yml
+    continue-on-error: true
+    secrets: inherit
+
+  run_fantom_tests_retry_2:
+    needs: run_fantom_tests_retry_1
+    if: ${{ always() && needs.run_fantom_tests_retry_1.outputs.status == 'failure' }}
+    uses: ./.github/workflows/fantom-tests.yml
+    secrets: inherit
 
   build_android:
     runs-on: 8-core-ubuntu
@@ -282,7 +285,7 @@ jobs:
   test_e2e_android_rntester:
     needs: build_android
     uses: ./.github/workflows/e2e-android-rntester.yml
-    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    continue-on-error: true
     secrets: inherit
 
   test_e2e_android_rntester_retry_1:
@@ -296,7 +299,6 @@ jobs:
     needs: test_e2e_android_rntester_retry_1
     if: ${{ always() && needs.test_e2e_android_rntester_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-rntester.yml
-    continue-on-error: true
     secrets: inherit
 
   build_npm_package:
@@ -509,31 +511,3 @@ jobs:
         shell: bash
         run: node scripts/debugger-shell/build-binary.js
 
-  # E2E test retries are now handled by the retry_1/retry_2 reusable workflow jobs above.
-  # This job only handles Fantom test retries on main.
-  rerun-failed-jobs:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
-    needs: [run_fantom_tests]
-    if: ${{ github.ref == 'refs/heads/main' && always() }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Rerun failed jobs in the current workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          SHOULD_RETRY=${{fromJSON(github.run_attempt) < 3}}
-          if [[ $SHOULD_RETRY == "false" ]]; then
-            exit 0
-          fi
-
-          FANTOM_TESTS_FAILED=${{ needs.run_fantom_tests.result == 'failure' }}
-          echo "FANTOM_TESTS_FAILED: $FANTOM_TESTS_FAILED"
-
-          if [[ $FANTOM_TESTS_FAILED == "true" ]]; then
-            echo "Rerunning failed jobs in the current workflow"
-            gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}
-          fi

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -159,58 +159,58 @@ jobs:
   test_e2e_ios_rntester:
     needs: test_ios_rntester
     uses: ./.github/workflows/e2e-ios-rntester.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_rntester_retry_1:
     needs: test_e2e_ios_rntester
     if: ${{ always() && needs.test_e2e_ios_rntester.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-rntester.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_rntester_retry_2:
     needs: test_e2e_ios_rntester_retry_1
     if: ${{ always() && needs.test_e2e_ios_rntester_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-rntester.yml
+    with:
+      fail-on-error: true
     secrets: inherit
 
   test_e2e_ios_templateapp:
     needs: [build_npm_package, prebuild_apple_dependencies]
     uses: ./.github/workflows/e2e-ios-templateapp.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_templateapp_retry_1:
     needs: test_e2e_ios_templateapp
     if: ${{ always() && needs.test_e2e_ios_templateapp.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-templateapp.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_ios_templateapp_retry_2:
     needs: test_e2e_ios_templateapp_retry_1
     if: ${{ always() && needs.test_e2e_ios_templateapp_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-ios-templateapp.yml
+    with:
+      fail-on-error: true
     secrets: inherit
 
   test_e2e_android_templateapp:
     needs: build_npm_package
     uses: ./.github/workflows/e2e-android-templateapp.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_android_templateapp_retry_1:
     needs: test_e2e_android_templateapp
     if: ${{ always() && needs.test_e2e_android_templateapp.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-templateapp.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_android_templateapp_retry_2:
     needs: test_e2e_android_templateapp_retry_1
     if: ${{ always() && needs.test_e2e_android_templateapp_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-templateapp.yml
+    with:
+      fail-on-error: true
     secrets: inherit
 
   build_fantom_runner:
@@ -240,20 +240,20 @@ jobs:
   run_fantom_tests:
     needs: build_fantom_runner
     uses: ./.github/workflows/fantom-tests.yml
-    continue-on-error: true
     secrets: inherit
 
   run_fantom_tests_retry_1:
     needs: run_fantom_tests
     if: ${{ always() && needs.run_fantom_tests.outputs.status == 'failure' }}
     uses: ./.github/workflows/fantom-tests.yml
-    continue-on-error: true
     secrets: inherit
 
   run_fantom_tests_retry_2:
     needs: run_fantom_tests_retry_1
     if: ${{ always() && needs.run_fantom_tests_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/fantom-tests.yml
+    with:
+      fail-on-error: true
     secrets: inherit
 
   build_android:
@@ -285,20 +285,20 @@ jobs:
   test_e2e_android_rntester:
     needs: build_android
     uses: ./.github/workflows/e2e-android-rntester.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_android_rntester_retry_1:
     needs: test_e2e_android_rntester
     if: ${{ always() && needs.test_e2e_android_rntester.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-rntester.yml
-    continue-on-error: true
     secrets: inherit
 
   test_e2e_android_rntester_retry_2:
     needs: test_e2e_android_rntester_retry_1
     if: ${{ always() && needs.test_e2e_android_rntester_retry_1.outputs.status == 'failure' }}
     uses: ./.github/workflows/e2e-android-rntester.yml
+    with:
+      fail-on-error: true
     secrets: inherit
 
   build_npm_package:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -157,6 +157,9 @@ jobs:
     runs-on: macos-15-large
     needs:
       [test_ios_rntester]
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -176,16 +179,101 @@ jobs:
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
       - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: ./.github/actions/maestro-ios
         with:
           app-path: "/tmp/RNTesterBuild/RNTester.app"
           app-id: com.meta.RNTester.localDevelopment
           maestro-flow: ./packages/rn-tester/.maestro/
           flavor: ${{ matrix.flavor }}
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+
+  test_e2e_ios_rntester_retry_1:
+    runs-on: macos-15-large
+    needs: test_e2e_ios_rntester
+    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_rntester.outputs.status == 'failure' }}
+    continue-on-error: true
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+      - name: Download App
+        uses: actions/download-artifact@v7
+        with:
+          name: RNTesterApp-NewArch-${{ matrix.flavor }}
+          path: /tmp/RNTesterBuild/RNTester.app
+      - name: Check downloaded folder content
+        run: ls -lR /tmp/RNTesterBuild
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+      - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: true
+        uses: ./.github/actions/maestro-ios
+        with:
+          app-path: "/tmp/RNTesterBuild/RNTester.app"
+          app-id: com.meta.RNTester.localDevelopment
+          maestro-flow: ./packages/rn-tester/.maestro/
+          flavor: ${{ matrix.flavor }}
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+
+  test_e2e_ios_rntester_retry_2:
+    runs-on: macos-15-large
+    needs: test_e2e_ios_rntester_retry_1
+    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_rntester_retry_1.outputs.status == 'failure' }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+      - name: Download App
+        uses: actions/download-artifact@v7
+        with:
+          name: RNTesterApp-NewArch-${{ matrix.flavor }}
+          path: /tmp/RNTesterBuild/RNTester.app
+      - name: Check downloaded folder content
+        run: ls -lR /tmp/RNTesterBuild
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+      - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: true
+        uses: ./.github/actions/maestro-ios
+        with:
+          app-path: "/tmp/RNTesterBuild/RNTester.app"
+          app-id: com.meta.RNTester.localDevelopment
+          maestro-flow: ./packages/rn-tester/.maestro/
+          flavor: ${{ matrix.flavor }}
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
 
   test_e2e_ios_templateapp:
     runs-on: macos-15-large
     needs: [build_npm_package, prebuild_apple_dependencies]
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -262,6 +350,8 @@ jobs:
             -destination "generic/platform=iOS Simulator" \
             -derivedDataPath "/tmp/RNTestProject"
       - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: ./.github/actions/maestro-ios
         with:
           app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
@@ -269,10 +359,203 @@ jobs:
           maestro-flow: ./scripts/e2e/.maestro/
           flavor: ${{ matrix.flavor }}
           working-directory: /tmp/RNTestProject
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+
+  test_e2e_ios_templateapp_retry_1:
+    runs-on: macos-15-large
+    needs: [test_e2e_ios_templateapp, build_npm_package, prebuild_apple_dependencies]
+    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_templateapp.outputs.status == 'failure' }}
+    continue-on-error: true
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Run yarn
+        uses: ./.github/actions/yarn-install
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.10
+      - name: Download React Native Package
+        uses: actions/download-artifact@v7
+        with:
+          name: react-native-package
+          path: /tmp/react-native-tmp
+      - name: Print /tmp folder
+        run: ls -lR /tmp/react-native-tmp
+      - name: Download ReactNativeDependencies
+        uses: actions/download-artifact@v7
+        with:
+          name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
+          path: /tmp/third-party
+      - name: Print third-party folder
+        shell: bash
+        run: ls -lR /tmp/third-party
+      - name: Download React Native Prebuilds
+        uses: actions/download-artifact@v7
+        with:
+          name: ReactCore${{ matrix.flavor }}.xcframework.tar.gz
+          path: /tmp/ReactCore
+      - name: Print ReactCore folder
+        shell: bash
+        run: ls -lR /tmp/ReactCore
+      - name: Configure git
+        shell: bash
+        run: |
+            git config --global user.email "react-native-bot@meta.com"
+            git config --global user.name "React Native Bot"
+      - name: Prepare artifacts
+        run: |
+          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
+          echo "React Native tgs is $REACT_NATIVE_PKG"
+
+          BRANCH=${{ github.ref_name }}
+          if ! [[ $BRANCH == *-stable* ]]; then
+            BRANCH=main
+          fi
+
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+
+          cd /tmp/RNTestProject/ios
+          bundle install
+          NEW_ARCH_ENABLED=1
+
+          export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
+          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
+          RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
+
+          xcodebuild \
+            -scheme "RNTestProject" \
+            -workspace RNTestProject.xcworkspace \
+            -configuration "${{ matrix.flavor }}" \
+            -sdk "iphonesimulator" \
+            -destination "generic/platform=iOS Simulator" \
+            -derivedDataPath "/tmp/RNTestProject"
+      - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: true
+        uses: ./.github/actions/maestro-ios
+        with:
+          app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
+          app-id: org.reactjs.native.example.RNTestProject
+          maestro-flow: ./scripts/e2e/.maestro/
+          flavor: ${{ matrix.flavor }}
+          working-directory: /tmp/RNTestProject
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+
+  test_e2e_ios_templateapp_retry_2:
+    runs-on: macos-15-large
+    needs: [test_e2e_ios_templateapp_retry_1, build_npm_package, prebuild_apple_dependencies]
+    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_ios_templateapp_retry_1.outputs.status == 'failure' }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Run yarn
+        uses: ./.github/actions/yarn-install
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.10
+      - name: Download React Native Package
+        uses: actions/download-artifact@v7
+        with:
+          name: react-native-package
+          path: /tmp/react-native-tmp
+      - name: Print /tmp folder
+        run: ls -lR /tmp/react-native-tmp
+      - name: Download ReactNativeDependencies
+        uses: actions/download-artifact@v7
+        with:
+          name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
+          path: /tmp/third-party
+      - name: Print third-party folder
+        shell: bash
+        run: ls -lR /tmp/third-party
+      - name: Download React Native Prebuilds
+        uses: actions/download-artifact@v7
+        with:
+          name: ReactCore${{ matrix.flavor }}.xcframework.tar.gz
+          path: /tmp/ReactCore
+      - name: Print ReactCore folder
+        shell: bash
+        run: ls -lR /tmp/ReactCore
+      - name: Configure git
+        shell: bash
+        run: |
+            git config --global user.email "react-native-bot@meta.com"
+            git config --global user.name "React Native Bot"
+      - name: Prepare artifacts
+        run: |
+          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
+          echo "React Native tgs is $REACT_NATIVE_PKG"
+
+          BRANCH=${{ github.ref_name }}
+          if ! [[ $BRANCH == *-stable* ]]; then
+            BRANCH=main
+          fi
+
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+
+          cd /tmp/RNTestProject/ios
+          bundle install
+          NEW_ARCH_ENABLED=1
+
+          export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
+          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
+          RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
+
+          xcodebuild \
+            -scheme "RNTestProject" \
+            -workspace RNTestProject.xcworkspace \
+            -configuration "${{ matrix.flavor }}" \
+            -sdk "iphonesimulator" \
+            -destination "generic/platform=iOS Simulator" \
+            -derivedDataPath "/tmp/RNTestProject"
+      - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: true
+        uses: ./.github/actions/maestro-ios
+        with:
+          app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
+          app-id: org.reactjs.native.example.RNTestProject
+          maestro-flow: ./scripts/e2e/.maestro/
+          flavor: ${{ matrix.flavor }}
+          working-directory: /tmp/RNTestProject
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
 
   test_e2e_android_templateapp:
     runs-on: 4-core-ubuntu
     needs: build_npm_package
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -328,6 +611,8 @@ jobs:
           ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
 
       - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: ./.github/actions/maestro-android
         timeout-minutes: 60
         with:
@@ -337,6 +622,158 @@ jobs:
           install-java: 'false'
           flavor: ${{ matrix.flavor }}
           working-directory: /tmp/RNTestProject
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+
+  test_e2e_android_templateapp_retry_1:
+    runs-on: 4-core-ubuntu
+    needs: [test_e2e_android_templateapp, build_npm_package]
+    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_templateapp.outputs.status == 'failure' }}
+    continue-on-error: true
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [debug, release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Run yarn
+        uses: ./.github/actions/yarn-install
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+      - name: Download Maven Local
+        uses: actions/download-artifact@v7
+        with:
+          name: maven-local
+          path: /tmp/react-native-tmp/maven-local
+      - name: Download React Native Package
+        uses: actions/download-artifact@v7
+        with:
+          name: react-native-package
+          path: /tmp/react-native-tmp
+      - name: Print /tmp folder
+        run: ls -lR /tmp/react-native-tmp
+      - name: Prepare artifacts
+        id: prepare-artifacts
+        run: |
+          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
+          echo "React Native tgs is $REACT_NATIVE_PKG"
+
+          MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
+          echo "Maven local path is $MAVEN_LOCAL"
+
+          BRANCH=${{ github.ref_name }}
+          if ! [[ $BRANCH == *-stable* ]]; then
+            BRANCH=main
+          fi
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+
+          echo "Feed maven local to gradle.properties"
+          cd /tmp/RNTestProject
+          echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
+
+          cd android
+          CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
+          ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
+
+      - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: true
+        uses: ./.github/actions/maestro-android
+        timeout-minutes: 60
+        with:
+          app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
+          app-id: com.rntestproject
+          maestro-flow: ./scripts/e2e/.maestro/
+          install-java: 'false'
+          flavor: ${{ matrix.flavor }}
+          working-directory: /tmp/RNTestProject
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+
+  test_e2e_android_templateapp_retry_2:
+    runs-on: 4-core-ubuntu
+    needs: [test_e2e_android_templateapp_retry_1, build_npm_package]
+    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_templateapp_retry_1.outputs.status == 'failure' }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [debug, release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Run yarn
+        uses: ./.github/actions/yarn-install
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+      - name: Download Maven Local
+        uses: actions/download-artifact@v7
+        with:
+          name: maven-local
+          path: /tmp/react-native-tmp/maven-local
+      - name: Download React Native Package
+        uses: actions/download-artifact@v7
+        with:
+          name: react-native-package
+          path: /tmp/react-native-tmp
+      - name: Print /tmp folder
+        run: ls -lR /tmp/react-native-tmp
+      - name: Prepare artifacts
+        id: prepare-artifacts
+        run: |
+          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
+          echo "React Native tgs is $REACT_NATIVE_PKG"
+
+          MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
+          echo "Maven local path is $MAVEN_LOCAL"
+
+          BRANCH=${{ github.ref_name }}
+          if ! [[ $BRANCH == *-stable* ]]; then
+            BRANCH=main
+          fi
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+
+          echo "Feed maven local to gradle.properties"
+          cd /tmp/RNTestProject
+          echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
+
+          cd android
+          CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
+          ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
+
+      - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: true
+        uses: ./.github/actions/maestro-android
+        timeout-minutes: 60
+        with:
+          app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
+          app-id: com.rntestproject
+          maestro-flow: ./scripts/e2e/.maestro/
+          install-java: 'false'
+          flavor: ${{ matrix.flavor }}
+          working-directory: /tmp/RNTestProject
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
 
   build_fantom_runner:
     runs-on: 8-core-ubuntu
@@ -404,6 +841,9 @@ jobs:
   test_e2e_android_rntester:
     runs-on: 4-core-ubuntu
     needs: [build_android]
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -423,6 +863,8 @@ jobs:
       - name: Print folder structure
         run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
       - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: ./.github/actions/maestro-android
         timeout-minutes: 60
         with:
@@ -430,6 +872,88 @@ jobs:
           app-id: com.facebook.react.uiapp
           maestro-flow: ./packages/rn-tester/.maestro
           flavor: ${{ matrix.flavor }}
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+
+  test_e2e_android_rntester_retry_1:
+    runs-on: 4-core-ubuntu
+    needs: test_e2e_android_rntester
+    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_rntester.outputs.status == 'failure' }}
+    continue-on-error: true
+    outputs:
+      status: ${{ steps.report-status.outputs.status }}
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [debug, release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Install node dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Download APK
+        uses: actions/download-artifact@v7
+        with:
+          name: rntester-${{ matrix.flavor }}
+          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
+      - name: Print folder structure
+        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
+      - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: true
+        uses: ./.github/actions/maestro-android
+        timeout-minutes: 60
+        with:
+          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/app-x86-${{ matrix.flavor }}.apk
+          app-id: com.facebook.react.uiapp
+          maestro-flow: ./packages/rn-tester/.maestro
+          flavor: ${{ matrix.flavor }}
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
+
+  test_e2e_android_rntester_retry_2:
+    runs-on: 4-core-ubuntu
+    needs: test_e2e_android_rntester_retry_1
+    if: ${{ github.event_name == 'pull_request' && always() && needs.test_e2e_android_rntester_retry_1.outputs.status == 'failure' }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [debug, release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Install node dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Download APK
+        uses: actions/download-artifact@v7
+        with:
+          name: rntester-${{ matrix.flavor }}
+          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
+      - name: Print folder structure
+        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
+      - name: Run E2E Tests
+        id: run-e2e
+        continue-on-error: true
+        uses: ./.github/actions/maestro-android
+        timeout-minutes: 60
+        with:
+          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/app-x86-${{ matrix.flavor }}.apk
+          app-id: com.facebook.react.uiapp
+          maestro-flow: ./packages/rn-tester/.maestro
+          flavor: ${{ matrix.flavor }}
+      - name: Report E2E status
+        id: report-status
+        if: always()
+        run: echo "status=${{ steps.run-e2e.outcome }}" >> $GITHUB_OUTPUT
 
   build_npm_package:
     runs-on: 8-core-ubuntu


### PR DESCRIPTION
## Summary
- Adds retry jobs (up to 2 retries) for all 4 E2E test jobs on PRs to handle flakiness
- Original E2E jobs use `continue-on-error` on PRs so failures don't block the workflow; on `main`, behavior is unchanged and the existing `rerun-failed-jobs` mechanism continues to work
- Each retry runs on a fresh runner (addressing environment-level flakes) and is triggered via step-level outcome captured as a job output
- Added `overwrite: true` to artifact uploads in maestro composite actions so retry jobs don't conflict on artifact names

### How it works
- **On PRs:** E2E job fails → `retry_1` triggers → if that fails → `retry_2` triggers. All have `continue-on-error` so the workflow stays green.
- **On `main`:** `continue-on-error` is `false`, retry jobs are skipped (PR-only), and `rerun-failed-jobs` handles retries as before.

### Known limitation
Since these are matrix jobs (Debug/Release), the job output uses the last-to-complete matrix combination's value. If only one flavor fails and the passing one finishes last, the retry may not trigger. In the common flakiness pattern (environment-level issues), both flavors tend to be affected, so this works well in practice.

## Changelog:
[Internal] - Add E2E test retry jobs for PRs

## Test plan
- CI will validate the workflow syntax
- On a PR where E2E tests pass: retry jobs should be skipped
- On a PR where E2E tests fail due to flakiness: retry jobs should trigger and (ideally) pass on a fresh runner
- On pushes to `main`: existing `rerun-failed-jobs` behavior is preserved (retry jobs are skipped)