### PR TITLE
[LOCAL][0.83] Skip Hermes nightly override on stable branches

### DIFF
--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -10,6 +10,10 @@ inputs:
   flavor:
     description: The flavor of the build. Must be one of "Debug", "Release".
     default: Debug
+  use-hermes-nightly:
+    description: Whether to override pinned Hermes versions with the latest nightly
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -26,10 +30,12 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Set nightly Hermes versions
+      if: ${{ inputs.use-hermes-nightly == 'true' }}
       shell: bash
       run: |
         node ./scripts/releases/use-hermes-nightly.js
     - name: Run yarn install again, with the correct hermes version
+      if: ${{ inputs.use-hermes-nightly == 'true' }}
       uses: ./.github/actions/yarn-install
     - name: Download ReactNativeDependencies
       uses: actions/download-artifact@v4

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Whether we want to run E2E tests or not
     required: false
     default: false
+  use-hermes-nightly:
+    description: Whether to override pinned Hermes versions with the latest nightly
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -34,10 +38,12 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Set nightly Hermes versions
+      if: ${{ inputs.use-hermes-nightly == 'true' }}
       shell: bash
       run: |
         node ./scripts/releases/use-hermes-nightly.js
     - name: Run yarn install again, with the correct hermes version
+      if: ${{ inputs.use-hermes-nightly == 'true' }}
       uses: ./.github/actions/yarn-install
     - name: Prepare IOS Tests
       if: ${{ inputs.run-unit-tests == 'true' }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           ruby-version: "3.2.0"
           flavor: Debug
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   test_ios_rntester:
     runs-on: macos-15-large
@@ -76,6 +77,7 @@ jobs:
         with:
           use-frameworks: ${{ matrix.frameworks }}
           flavor: ${{ matrix.flavor }}
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   test_e2e_ios_rntester:
     runs-on: macos-15-large
@@ -397,10 +399,12 @@ jobs:
       - name: Run yarn install
         uses: ./.github/actions/yarn-install
       - name: Set nightly Hermes versions
+        if: ${{ !endsWith(github.ref_name, '-stable') }}
         shell: bash
         run: |
           node ./scripts/releases/use-hermes-nightly.js
       - name: Run yarn install again, with the correct hermes version
+        if: ${{ !endsWith(github.ref_name, '-stable') }}
         uses: ./.github/actions/yarn-install
       - name: Prepare the Helloworld application
         shell: bash
@@ -434,6 +438,7 @@ jobs:
         with:
           ruby-version: 3.2.0
           flavor: Debug
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   test_ios_helloworld:
     runs-on: macos-15
@@ -456,6 +461,7 @@ jobs:
         with:
           flavor: ${{ matrix.flavor }}
           use-frameworks: ${{ matrix.use_frameworks }}
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   test_js:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `test-ios-rntester`, `test-ios-helloworld` composite actions and the inline `test_android_helloworld` job in `test-all.yml` unconditionally run `use-hermes-nightly.js`, which replaces the pinned Hermes version with the latest nightly from npm. On stable/release branches, this is incorrect — the pinned version from `version.properties` should be used.

This wasn't a problem before because the Hermes V0 nightlies happened to be ABI-compatible, but as of the April 22 nightly (`0.17.0-commitly-202604221946`), JSI symbol exports appear to be broken, causing linker failures in `test_ios_rntester` and downstream jobs.

The `prebuild-ios-core` workflow already handles this correctly via a `use-hermes-nightly` input gated by `!endsWith(github.ref_name, '-stable')`. This PR applies the same pattern to the three remaining places.

## Changelog

Changelog: [Internal]

## Test Plan

CI — the `test_ios_rntester` and `test_ios_helloworld` jobs should now use the pinned Hermes 0.14.1 on 0.83-stable instead of the broken nightly.