### PR TITLE
Skip Hermes nightly override on stable branches

### DIFF
--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -10,6 +10,10 @@ inputs:
   flavor:
     description: The flavor of the build. Must be one of "Debug", "Release".
     default: Debug
+  use-hermes-nightly:
+    description: Whether to override pinned Hermes versions with the latest nightly
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -24,10 +28,12 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Set nightly Hermes versions
+      if: ${{ inputs.use-hermes-nightly == 'true' }}
       shell: bash
       run: |
         node ./scripts/releases/use-hermes-nightly.js
     - name: Run yarn install again, with the correct hermes version
+      if: ${{ inputs.use-hermes-nightly == 'true' }}
       uses: ./.github/actions/yarn-install
     - name: Download ReactNativeDependencies
       uses: actions/download-artifact@v7

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Whether we have to build with Dynamic Frameworks. If this is set to true, it builds from source
     required: false
     default: false
+  use-hermes-nightly:
+    description: Whether to override pinned Hermes versions with the latest nightly
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -33,10 +37,12 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Set nightly Hermes versions
+      if: ${{ inputs.use-hermes-nightly == 'true' }}
       shell: bash
       run: |
         node ./scripts/releases/use-hermes-nightly.js
     - name: Run yarn install again, with the correct hermes version
+      if: ${{ inputs.use-hermes-nightly == 'true' }}
       uses: ./.github/actions/yarn-install
     - name: Prepare IOS Tests
       if: ${{ inputs.run-unit-tests == 'true' }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           ruby-version: "3.2.0"
           flavor: Debug
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   test_ios_rntester_dynamic_frameworks:
     runs-on: macos-15-large
@@ -133,6 +134,7 @@ jobs:
           flavor: ${{ matrix.flavor }}
           use-frameworks: true
           run-unit-tests: false # tests for dynamic frameworks are already run in the test_ios_rntester job; this is to just a test build from source (no prebuilds)
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   test_ios_rntester:
     runs-on: macos-15-large
@@ -152,6 +154,7 @@ jobs:
         with:
           use-frameworks: ${{ matrix.frameworks }}
           flavor: ${{ matrix.flavor }}
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   test_e2e_ios_rntester:
     runs-on: macos-15-large
@@ -499,10 +502,12 @@ jobs:
       - name: Run yarn install
         uses: ./.github/actions/yarn-install
       - name: Set nightly Hermes versions
+        if: ${{ !endsWith(github.ref_name, '-stable') }}
         shell: bash
         run: |
           node ./scripts/releases/use-hermes-nightly.js
       - name: Run yarn install again, with the correct hermes version
+        if: ${{ !endsWith(github.ref_name, '-stable') }}
         uses: ./.github/actions/yarn-install
       - name: Prepare the Helloworld application
         shell: bash
@@ -536,6 +541,7 @@ jobs:
         with:
           ruby-version: 3.2.0
           flavor: Debug
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   test_ios_helloworld:
     runs-on: macos-15
@@ -558,6 +564,7 @@ jobs:
         with:
           flavor: ${{ matrix.flavor }}
           use-frameworks: ${{ matrix.use_frameworks }}
+          use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Same fix as #56582, rebased onto main.

The `test-ios-rntester`, `test-ios-helloworld` composite actions and the inline `test_android_helloworld` job unconditionally run `use-hermes-nightly.js`, overriding the pinned Hermes version with the latest npm nightly. On `-stable` branches, this causes linker failures when the nightly Hermes has ABI-incompatible changes (as happened with `0.17.0-commitly-202604221946`).

The `prebuild-ios-core` workflow already correctly gates this behind a `use-hermes-nightly` input. This PR applies the same pattern everywhere else.

Also adds the guard to `test_ios_rntester_dynamic_frameworks` which exists on main but not on 0.83.

## Changelog

[Internal]

## Test Plan

CI on a `-stable` branch should use the pinned Hermes version from `version.properties` instead of the nightly.