### PR TITLE
Add redbox subspec to React-debug pod

### DIFF
--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -25,11 +25,16 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
-  s.exclude_files          = "**/tests/**/*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/debug"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "DEFINES_MODULE" => "YES" }
 
   resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_debug")
+
+  s.subspec "redbox" do |ss|
+    ss.source_files         = podspec_sources("redbox/*.{cpp,h}", "redbox/*.h")
+    ss.exclude_files        = "redbox/tests/**/*.{cpp,h}"
+    ss.header_dir           = "react/debug/redbox"
+  end
 end


### PR DESCRIPTION
## Summary

Same fix as #56584 (targeting 0.83-stable), applied to main.

Add a `redbox` subspec to `React-debug.podspec` with its own `header_dir`, following the same pattern `React-Fabric` uses for its subdirectories.

Without this, static library builds (without `USE_FRAMEWORKS`) flatten all headers into the top-level `header_dir` (`react/debug`), so imports like `<react/debug/redbox/RedBoxErrorParser.h>` fail because the `redbox/` subdirectory is lost.

On main this is currently masked because `test_e2e_ios_templateapp` uses prebuilt `React.framework`, but it would break any from-source static library build that includes `React-CoreModules`.

Changelog: [Internal]

## Test Plan

CI