### PR TITLE
fix(hit-testing): ignore views with non-invertible transforms (scale 0)

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -97,8 +97,25 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   }
 }
 
+// Rejects hits against views whose 2D transform collapses an axis (e.g. `scaleX: 0`,
+// `scaleY: 0`, or any other non-invertible affine). Such views are visually degenerate, and
+// UIKit's `-convertPoint:fromView:` falls back to the original matrix when
+// `CGAffineTransformInvert` can't invert, so without this check the degenerate transform is
+// applied to the touch point and the view can still register hits along the collapsed axis.
+static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
+{
+  CATransform3D t = layer.transform;
+  // Determinant of the 2x2 projection onto the XY plane. Anything non-zero is invertible; we
+  // treat values within float epsilon as zero to avoid numerical issues near machine precision.
+  CGFloat det = t.m11 * t.m22 - t.m12 * t.m21;
+  return fabs(det) < (CGFloat)1e-6;
+}
+
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
 {
+  if (RCTLayerTransformCollapsesAxis(self.layer)) {
+    return NO;
+  }
   if (UIEdgeInsetsEqualToEdgeInsets(self.hitTestEdgeInsets, UIEdgeInsetsZero)) {
     return [super pointInside:point withEvent:event];
   }

--- a/packages/react-native/React/Tests/Mounting/RCTViewComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Mounting/RCTViewComponentViewTests.mm
@@ -142,4 +142,45 @@ static Props::Shared makeViewProps(bool removeClippedSubviews)
   XCTAssertNil(child2.superview);
 }
 
+#pragma mark - hitTest against non-invertible transforms (#50797)
+
+- (void)testHitTestReturnsNilForZeroScaleYView
+{
+  RCTViewComponentView *view = [RCTViewComponentView new];
+  view.frame = CGRectMake(0, 0, 100, 100);
+  view.layer.transform = CATransform3DMakeScale(1, 0, 1);
+
+  XCTAssertNil([view hitTest:CGPointMake(50, 50) withEvent:nil]);
+}
+
+- (void)testHitTestReturnsNilForZeroScaleXView
+{
+  RCTViewComponentView *view = [RCTViewComponentView new];
+  view.frame = CGRectMake(0, 0, 100, 100);
+  view.layer.transform = CATransform3DMakeScale(0, 1, 1);
+
+  XCTAssertNil([view hitTest:CGPointMake(50, 50) withEvent:nil]);
+}
+
+- (void)testHitTestReturnsSelfForIdentityTransform
+{
+  RCTViewComponentView *view = [RCTViewComponentView new];
+  view.frame = CGRectMake(0, 0, 100, 100);
+
+  XCTAssertEqual([view hitTest:CGPointMake(50, 50) withEvent:nil], view);
+}
+
+- (void)testHitTestAfterScaleTransitionedToZeroReturnsNil
+{
+  // #50797 variant: a view scaled to 0.9 first and then to 0.0 should stop receiving hits.
+  RCTViewComponentView *view = [RCTViewComponentView new];
+  view.frame = CGRectMake(0, 0, 100, 100);
+
+  view.layer.transform = CATransform3DMakeScale(1, 0.9, 1);
+  XCTAssertEqual([view hitTest:CGPointMake(50, 50) withEvent:nil], view);
+
+  view.layer.transform = CATransform3DMakeScale(1, 0, 1);
+  XCTAssertNil([view hitTest:CGPointMake(50, 50) withEvent:nil]);
+}
+
 @end

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
@@ -212,7 +212,11 @@ public object TouchTargetHelper {
       for (i in childrenCount - 1 downTo 0) {
         val child = viewGroup.getChildAt(i)
         val childPoint = tempPoint
-        getChildPoint(eventCoords[0], eventCoords[1], viewGroup, child, childPoint)
+        if (!getChildPoint(eventCoords[0], eventCoords[1], viewGroup, child, childPoint)) {
+          // Child's transform is non-invertible (e.g. scaleX: 0 or scaleY: 0): the child is
+          // visually degenerate, so it must not receive touches.
+          continue
+        }
         // The childPoint value will contain the view coordinates relative to the child.
         // We need to store the existing X,Y for the viewGroup away as it is possible this child
         // will not actually be the target and so we restore them if not
@@ -277,7 +281,13 @@ public object TouchTargetHelper {
   /**
    * Returns the coordinates of a touch in the child View. It is transform-aware and will invert the
    * transform Matrix to find the true local points. This code is taken from {@link
-   * ViewGroup#isTransformedTouchPointInView()}
+   * ViewGroup#isTransformedTouchPointInView()}.
+   *
+   * Returns `true` when [outLocalPoint] was populated with coordinates in the child's coordinate
+   * space. Returns `false` when the child's transform matrix is not invertible (for example
+   * `scaleX: 0` or `scaleY: 0`). On `false`, [outLocalPoint] is left in an indeterminate state and
+   * callers must skip the child — the shared [inverseMatrix] field is retained from the previous
+   * successful `invert`, so using it here would leak coordinates from another view.
    */
   private fun getChildPoint(
       x: Float,
@@ -285,21 +295,24 @@ public object TouchTargetHelper {
       parent: ViewGroup,
       child: View,
       outLocalPoint: PointF,
-  ) {
+  ): Boolean {
     var localX = x + parent.scrollX - child.left
     var localY = y + parent.scrollY - child.top
     val matrix = child.matrix
     if (!matrix.isIdentity) {
+      val inverseMatrix = inverseMatrix
+      if (!matrix.invert(inverseMatrix)) {
+        return false
+      }
       val localXY = matrixTransformCoords
       localXY[0] = localX
       localXY[1] = localY
-      val inverseMatrix = inverseMatrix
-      matrix.invert(inverseMatrix)
       inverseMatrix.mapPoints(localXY)
       localX = localXY[0]
       localY = localXY[1]
     }
     outLocalPoint.set(localX, localY)
+    return true
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/TouchTargetHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/TouchTargetHelperTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+import android.content.Context
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import com.facebook.react.views.view.ReactViewGroup
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Regression tests for facebook/react-native#50797: a view with a non-invertible transform (e.g.
+ * `scaleX: 0` or `scaleY: 0`) must not receive touches, and must not silently reuse the cached
+ * inverse matrix of a previously-processed view.
+ */
+@RunWith(RobolectricTestRunner::class)
+class TouchTargetHelperTest {
+
+  private lateinit var context: Context
+  private lateinit var root: ViewGroup
+
+  @Before
+  fun setUp() {
+    ReactNativeFeatureFlagsForTests.setUp()
+    context = RuntimeEnvironment.getApplication()
+    root = FrameLayout(context)
+    root.id = ROOT_TAG
+    root.measure(500, 500)
+    root.layout(0, 0, 500, 500)
+  }
+
+  @Test
+  fun normalChild_receivesTouchInsideItsBounds() {
+    val child = ReactViewGroup(context)
+    child.id = CHILD_TAG
+    root.addView(child)
+    child.layout(0, 0, 200, 200)
+
+    val tag = TouchTargetHelper.findTargetTagForTouch(100f, 100f, root)
+
+    assertThat(tag).isEqualTo(CHILD_TAG)
+  }
+
+  @Test
+  fun zeroScaleY_childDoesNotReceiveTouch() {
+    val child = ReactViewGroup(context)
+    child.id = CHILD_TAG
+    root.addView(child)
+    child.layout(0, 0, 200, 200)
+    child.scaleY = 0f
+
+    val tag = TouchTargetHelper.findTargetTagForTouch(100f, 100f, root)
+
+    // Touch falls through to the root because the child is visually degenerate.
+    assertThat(tag).isEqualTo(ROOT_TAG)
+  }
+
+  @Test
+  fun zeroScaleX_childDoesNotReceiveTouch() {
+    val child = ReactViewGroup(context)
+    child.id = CHILD_TAG
+    root.addView(child)
+    child.layout(0, 0, 200, 200)
+    child.scaleX = 0f
+
+    val tag = TouchTargetHelper.findTargetTagForTouch(100f, 100f, root)
+
+    assertThat(tag).isEqualTo(ROOT_TAG)
+  }
+
+  @Test
+  fun zeroScaleYParent_childInsideIsNotTouchable() {
+    val parent = ReactViewGroup(context)
+    parent.id = PARENT_TAG
+    val child = ReactViewGroup(context)
+    child.id = CHILD_TAG
+    root.addView(parent)
+    parent.addView(child)
+    parent.layout(0, 0, 200, 200)
+    child.layout(0, 0, 200, 200)
+    parent.scaleY = 0f
+
+    val tag = TouchTargetHelper.findTargetTagForTouch(100f, 100f, root)
+
+    // Neither the zero-scaled parent nor its child should receive the touch.
+    assertThat(tag).isEqualTo(ROOT_TAG)
+  }
+
+  @Test
+  fun zeroScaleY_doesNotInheritHitRegionFromSibling() {
+    // This is the exact #50797 symptom: a zero-scaled subtree "inherits" the hit region of
+    // another view because `Matrix.invert` fails silently and the cached inverse from the
+    // previous successful invert is reused.
+    val scaledSibling = ReactViewGroup(context)
+    scaledSibling.id = SIBLING_TAG
+    val zeroScaled = ReactViewGroup(context)
+    zeroScaled.id = CHILD_TAG
+    root.addView(scaledSibling)
+    root.addView(zeroScaled)
+    // Sibling: a normally-hit-testable view with a non-identity (invertible) transform, so that
+    // `inverseMatrix` gets populated during traversal.
+    scaledSibling.layout(0, 0, 200, 200)
+    scaledSibling.scaleY = 0.5f
+    // Zero-scaled view is placed somewhere the touch would only land on if the sibling's
+    // inverse matrix were (wrongly) applied to it.
+    zeroScaled.layout(300, 300, 500, 500)
+    zeroScaled.scaleY = 0f
+
+    val tag = TouchTargetHelper.findTargetTagForTouch(100f, 100f, root)
+
+    // Must hit the sibling (visible, scale 0.5) — never the zero-scaled view.
+    assertThat(tag).isEqualTo(SIBLING_TAG)
+  }
+
+  @Test
+  fun scaleTransitionedToZero_stopsReceivingTouches() {
+    // Second variant of #50797: a view whose scale shrinks from 0.9 to 0 keeps responding to
+    // touches over its previous hit region because the cached inverse from the 0.9 frame is
+    // reused after `invert` fails.
+    val child = ReactViewGroup(context)
+    child.id = CHILD_TAG
+    root.addView(child)
+    child.layout(0, 0, 200, 200)
+
+    // Warm the cache with an invertible transform.
+    child.scaleY = 0.9f
+    val warmTag = TouchTargetHelper.findTargetTagForTouch(100f, 100f, root)
+    assertThat(warmTag).isEqualTo(CHILD_TAG)
+
+    // Now collapse the view.
+    child.scaleY = 0f
+    val coldTag = TouchTargetHelper.findTargetTagForTouch(100f, 100f, root)
+
+    assertThat(coldTag).isEqualTo(ROOT_TAG)
+  }
+
+  @Test
+  fun zeroScaleChild_doesNotAppearInTouchPath() {
+    val child = ReactViewGroup(context)
+    child.id = CHILD_TAG
+    root.addView(child)
+    child.layout(0, 0, 200, 200)
+    child.scaleY = 0f
+
+    val eventCoords = FloatArray(2)
+    val path = TouchTargetHelper.findTargetPathAndCoordinatesForTouch(100f, 100f, root, eventCoords)
+
+    val ids: List<Int> = path.map(TouchTargetHelper.ViewTarget::getViewId)
+    assertThat(ids).doesNotContain(CHILD_TAG)
+  }
+
+  private companion object {
+    const val ROOT_TAG = 1
+    const val PARENT_TAG = 2
+    const val CHILD_TAG = 3
+    const val SIBLING_TAG = 4
+  }
+}

--- a/packages/rn-tester/js/examples/Transform/TransformExample.js
+++ b/packages/rn-tester/js/examples/Transform/TransformExample.js
@@ -16,8 +16,10 @@ import {useEffect, useState} from 'react';
 import {
   Animated,
   Easing,
+  Pressable,
   StyleSheet,
   Text,
+  TextInput,
   View,
   useAnimatedValue,
 } from 'react-native';
@@ -157,6 +159,56 @@ function TranslateMatrix2D() {
 }
 function TranslateMatrix3D() {
   return <View style={styles.translateMatrix3D} />;
+}
+
+// Regression example for #50797: a view with `scaleY: 0` (or any non-invertible transform)
+// must not receive touches. The first row uses a literal `scaleY: 0`; the second row lets you
+// type a scale so you can verify touches disappear exactly when scale reaches 0 and come back
+// when it's non-zero. "last tapped" should never show "zero-scale" for the first row.
+function ScaleZeroHitTestExample(): React.Node {
+  const [text, setText] = useState('0.5');
+  const [scale, setScale] = useState(0.5);
+  const [lastTapped, setLastTapped] = useState('(none)');
+
+  return (
+    <View testID="transform-scale-zero-hit-test">
+      <View style={styles.scaleZeroRow}>
+        <View style={styles.scaleZeroHidden}>
+          <Pressable
+            testID="scale-zero-hidden-pressable"
+            onPress={() => setLastTapped('zero-scale')}
+            style={styles.scaleZeroTarget}
+          />
+        </View>
+      </View>
+      <View style={styles.scaleZeroRow}>
+        <View style={{height: 100, transform: [{scaleY: scale}]}}>
+          <Pressable
+            testID="scale-zero-variable-pressable"
+            onPress={() => setLastTapped(`variable (scaleY=${scale})`)}
+            style={styles.scaleZeroTarget}
+          />
+        </View>
+      </View>
+      <View style={styles.scaleZeroInputRow}>
+        <Text>Scale for second row:</Text>
+        <TextInput
+          testID="scale-zero-input"
+          value={text}
+          keyboardType="numeric"
+          style={styles.scaleZeroInput}
+          onChangeText={next => {
+            setText(next);
+            const parsed = parseFloat(next);
+            if (isFinite(parsed)) {
+              setScale(parsed);
+            }
+          }}
+        />
+      </View>
+      <Text testID="scale-zero-last-tapped">Last tapped: {lastTapped}</Text>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -333,6 +385,30 @@ const styles = StyleSheet.create({
     width: 50,
     backgroundColor: 'green',
   },
+  scaleZeroRow: {
+    backgroundColor: 'green',
+    marginTop: 10,
+  },
+  scaleZeroHidden: {
+    height: 100,
+    transform: [{scaleY: 0}],
+  },
+  scaleZeroTarget: {
+    flex: 1,
+    backgroundColor: 'red',
+  },
+  scaleZeroInputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 12,
+    columnGap: 8,
+  },
+  scaleZeroInput: {
+    flex: 1,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
 });
 
 exports.title = 'Transforms';
@@ -500,6 +576,15 @@ exports.examples = [
       "transform: 'matrix(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)'",
     render(): React.Node {
       return <TranslateMatrix3D />;
+    },
+  },
+  {
+    title: 'Zero-scale hit test (regression for #50797)',
+    name: 'scale-zero-hit-test',
+    description:
+      'A view with scaleY: 0 must not receive touches and must not inherit a sibling view’s hit region',
+    render(): React.Node {
+      return <ScaleZeroHitTestExample />;
     },
   },
 ] as Array<RNTesterModuleExample>;


### PR DESCRIPTION
## Summary

Fixes #50797. 

A view with a non-invertible transform (e.g. `transform: [{scaleY: 0}]` or `{scaleX: 0}`) still received touches on both Android and iOS. On Android the view appeared to "inherit" a hit region from another view in the hierarchy; on iOS the view registered taps along the collapsed axis. Both symptoms collapse to the same native behaviour: when a transform can't be inverted, the platform APIs silently fall back to stale or degenerate data during hit testing.

### Root cause

**Android.** `TouchTargetHelper.getChildPoint` calls `Matrix.invert(inverseMatrix)` without checking its return value. `Matrix.invert` returns `false` for a non-invertible matrix and **leaves its destination unchanged**. `inverseMatrix` is a class-level field reused across every child-point conversion, so on failure we apply *the previous view's* inverse to the current view's touch point: the exact "inherits from another view" behavior. It is also why shrinking a view from `scaleY: 0.9` to `0.0` leaves a 90 % hit region: the 0.9 frame populated the cache.

**iOS.** `CGAffineTransformInvert` is documented to return the original matrix when it can't invert. `-[UIView convertPoint:fromView:]` uses that "inverse" during hit testing, so the touch point gets collapsed onto the degenerate axis (e.g. y = 0 for `scaleY: 0`) and the inherited `pointInside:` still reports a hit against a visually invisible view.

### Fix

- **Android** (`TouchTargetHelper.kt`): `getChildPoint` now returns `Boolean`. It returns `false` when `Matrix.invert` fails; the child iteration loop skips such children. One behaviour change, no epsilon tuning, no shared state leaks. Resolves both symptom variants via the same code path.
- **iOS** (`RCTViewComponentView.mm`, Fabric): add a small `RCTLayerTransformCollapsesAxis` helper that tests the determinant of the 2 × 2 XY projection of `layer.transform` and return `NO` from the existing `pointInside:` override when it collapses.
- **Tests.** `TouchTargetHelperTest` (new, Robolectric): initial `scaleX`/`scaleY: 0`, zero-scale parent, the "inherits from sibling" regression, the 0.9 to 0.0 transition, and the touch-path accumulator. `RCTViewComponentViewTests` gets four parallel iOS cases. All pass locally.
- **RNTester.** New Transforms entry "Zero-scale hit test (regression for #50797)". Reproduces both variants and exposes a scale input so you can step through the transition interactively.

### Why not #53769?

PR #53769 solved the Android side with a `hasZeroScale(view)` early-return plus an epsilon comparison on individual matrix entries, and handled the `invert` failure in `getChildPoint` by *falling back to untransformed coordinates*. That still lets the degenerate view be hit with its pre-transform bounds; the early-return then has to catch the miss. This branch fixes the root cause once: if the matrix can't be inverted we don't descend into the child. The iOS fix is the matching change on the Fabric side.

## Changelog:

[GENERAL] [FIXED] - Views with a non-invertible transform (e.g. `scaleX: 0` or `scaleY: 0`) no longer receive touches on Android or iOS.

## Test Plan

### Unit tests

- `./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests 'com.facebook.react.uimanager.TouchTargetHelperTest*'`: 7/7 pass.
- iOS build-for-testing of `RNTesterUnitTests` scheme succeeds; the four new `RCTViewComponentViewTests` cases live next to the existing cases in `React/Tests/Mounting/`.
- `./gradlew ktfmtCheck`, `clang-format --dry-run -Werror`, `prettier --check`, `flow`, and `eslint` all pass.

### Manual verification (Android)

RNTester → Components → Transforms → "Zero-scale hit test (regression for #50797)".

**Variant 1: tap the `scaleY: 0` row directly.** "Last tapped:" must stay `(none)`.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/qflen/react-native/6f3799dbb597630a91f43e460437d636796dbbe7/assets/50797/before-tap-zero-scale.png" width="260"> | <img src="https://raw.githubusercontent.com/qflen/react-native/6f3799dbb597630a91f43e460437d636796dbbe7/assets/50797/after-tap-zero-scale.png" width="260"> |
| `Last tapped: zero-scale` (bug) | `Last tapped: (none)` |

**Variant 2: tap the `scaleY: 0.5` row (①), then tap the `scaleY: 0` row (②).** Without the fix, the shared `inverseMatrix` cache populated by tap ① leaks into the zero-scale hit test on tap ②. After the fix, tap ② is correctly ignored and "Last tapped" still reflects tap ①.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/qflen/react-native/6f3799dbb597630a91f43e460437d636796dbbe7/assets/50797/before-tap-zero-after-05.png" width="260"> | <img src="https://raw.githubusercontent.com/qflen/react-native/6f3799dbb597630a91f43e460437d636796dbbe7/assets/50797/after-tap-zero-after-05.png" width="260"> |
| `Last tapped: zero-scale` (stale cache) | `Last tapped: variable (scaleY=0.5)` |

iOS behaves similarly. I tried the example on iPhone 17 Pro (Simulator, iOS 26.1) and the zero-scale pressable is correctly untouchable; driving synthetic taps on the simulator wasn't scripted here, so the iOS signal is the four XCTest cases plus manual verification.