### PR TITLE
Add TypeScript types for TextEncoder and TextDecoder globals

### DIFF
--- a/packages/react-native/src/types/globals.d.ts
+++ b/packages/react-native/src/types/globals.d.ts
@@ -521,6 +521,59 @@ declare global {
     ): URLSearchParams;
   };
 
+  interface TextEncoderEncodeIntoResult {
+    read: number;
+    written: number;
+  }
+
+  /**
+   * Encodes strings to bytes using UTF-8.
+   * Available in Hermes since React Native 0.74.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextEncoder)
+   */
+  interface TextEncoder {
+    /** Always `"utf-8"`. */
+    readonly encoding: string;
+    encode(input?: string): Uint8Array;
+    encodeInto(
+      source: string,
+      destination: Uint8Array,
+    ): TextEncoderEncodeIntoResult;
+  }
+
+  var TextEncoder: {
+    prototype: TextEncoder;
+    new (): TextEncoder;
+  };
+
+  interface TextDecoderOptions {
+    fatal?: boolean;
+    ignoreBOM?: boolean;
+  }
+
+  interface TextDecodeOptions {
+    stream?: boolean;
+  }
+
+  /**
+   * Decodes bytes to strings. Supports UTF-8 and several legacy encodings.
+   * Available in Hermes since React Native 0.85.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextDecoder)
+   */
+  interface TextDecoder {
+    readonly encoding: string;
+    readonly fatal: boolean;
+    readonly ignoreBOM: boolean;
+    decode(input?: BufferSource, options?: TextDecodeOptions): string;
+  }
+
+  var TextDecoder: {
+    prototype: TextDecoder;
+    new (label?: string, options?: TextDecoderOptions): TextDecoder;
+  };
+
   interface WebSocketMessageEvent extends Event {
     data?: any | undefined;
   }

--- a/packages/react-native/types/__typetests__/globals.tsx
+++ b/packages/react-native/types/__typetests__/globals.tsx
@@ -216,3 +216,22 @@ const formData = new FormData();
 formData.append('file', { fileName: 'example' });
 console.log(formData.getParts());
 console.log(formData.getAll('username'));
+
+const textEncoder = new TextEncoder();
+const encodingValue: string = textEncoder.encoding;
+const encoded: Uint8Array = textEncoder.encode();
+const encoded2: Uint8Array = textEncoder.encode('hello');
+const encodeIntoResult = textEncoder.encodeInto('hello', new Uint8Array(10));
+const readCount: number = encodeIntoResult.read;
+const writtenCount: number = encodeIntoResult.written;
+
+const textDecoder = new TextDecoder();
+const textDecoderWithLabel = new TextDecoder('utf-8');
+const textDecoderWithOptions = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false });
+const decoderEncoding: string = textDecoder.encoding;
+const decoderFatal: boolean = textDecoder.fatal;
+const decoderIgnoreBOM: boolean = textDecoder.ignoreBOM;
+const decoded: string = textDecoder.decode();
+const decoded2: string = textDecoder.decode(new Uint8Array([72, 101, 108, 108, 111]));
+const decoded3: string = textDecoder.decode(new Uint8Array([72, 101, 108, 108, 111]), { stream: true });
+const decoded4: string = textDecoder.decode(new ArrayBuffer(5));


### PR DESCRIPTION
## Summary:

Both `TextEncoder` and `TextDecoder` are now natively available in Hermes, but neither is declared in React Native's TypeScript globals (`packages/react-native/src/types/globals.d.ts`), so TypeScript users have to cast through `any`, pull in `lib: ["dom"]`, or add their own declarations to use these APIs without type errors.

- `TextEncoder` has been in Hermes since React Native 0.74 (facebook/hermes#948)
- `TextDecoder` landed in Hermes in December 2025 (facebook/hermes#1855) and ships with React Native 0.85

This PR adds the missing type declarations, matching the Hermes implementation:

- `TextEncoder`: `new TextEncoder()`, `encoding` (readonly, always `"utf-8"`), `encode(input?)`, `encodeInto(source, destination)`
- `TextDecoder`: `new TextDecoder(label?, { fatal?, ignoreBOM? })`, `encoding`, `fatal`, `ignoreBOM`, `decode(input?, { stream? })`

Fixes #56325

## Changelog:

[GENERAL] [ADDED] - Add TypeScript types for `TextEncoder` and `TextDecoder` globals

## Test Plan:

- Ran `yarn test-typescript` (`tsc -p packages/react-native/types/tsconfig.json`) — no new errors introduced; the same pre-existing unrelated errors appear before and after this change.
- Added typetests in `packages/react-native/types/__typetests__/globals.tsx` exercising constructors, readonly properties, and every method/overload with the expected argument and return types.
- Verified the declarations match the API surface installed by Hermes in `API/hermes/extensions/10-TextEncoder.js` and `API/hermes/extensions/20-TextDecoder.js` (including the `stream`, `fatal`, `ignoreBOM` options parsed by `TextDecoder.cpp`).