### PR TITLE
Fix React-CoreModules missing React-featureflags header path under use_frameworks!

### DIFF
--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/CoreModulesHeaders", version
   s.dependency "React-RCTImage", version
   s.dependency "React-jsi", version
-  s.dependency "React-featureflags"
+  add_dependency(s, "React-featureflags")
   s.dependency 'React-RCTBlob'
   add_dependency(s, "React-debug")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])


### PR DESCRIPTION
## Summary:

`React/CoreModules/RCTRedBox.mm` imports `<react/featureflags/ReactNativeFeatureFlags.h>` (added in #56574). Under `use_frameworks!` this fails to build:

    RCTRedBox.mm:19:9: 'react/featureflags/ReactNativeFeatureFlags.h' file not found
    Did not find header 'featureflags/ReactNativeFeatureFlags.h' in framework 'react'

`React-CoreModules.podspec` uses plain `s.dependency "React-featureflags"`, which does not add the framework's Headers dir to `HEADER_SEARCH_PATHS`. Switching to `add_dependency(s, "React-featureflags")` preserves the same pod dependency and also adds the dependency header path, matching every neighboring dep (`React-debug`, `React-runtimeexecutor`, `React-jsinspector*`, etc.) in the same file.

On `main`, this missing podspec-level header path is currently likely masked by the global `update_search_paths` entry added in #55679, which injects `React_featureflags.framework/Headers` into inherited header search paths for `use_frameworks!` builds. `0.83-stable` does not have that global entry, so the same podspec issue surfaces as a build regression in 0.83.7.

This change fixes the dependency at the target that directly imports the header, so `React-CoreModules` no longer relies on a broad inherited header path. A cherry-pick to `0.83-stable` would fix the regression in 0.83.7.

## Changelog:

[IOS] [FIXED] - Fix React-CoreModules failing to compile with `use_frameworks!` due to missing React-featureflags header path

## Test Plan:

RN 0.83.7 consumer app with `use_frameworks! :linkage => :static`, `RCT_USE_RN_DEP=1`: fails before this change. After the fix, `pod install` regenerates `React-CoreModules.debug.xcconfig` so `HEADER_SEARCH_PATHS` includes:

    ${PODS_CONFIGURATION_BUILD_DIR}/React-featureflags/React_featureflags.framework/Headers

Verified locally that the `React-CoreModules` pod target builds after the fix:

    xcodebuild -project ios/Pods/Pods.xcodeproj \
      -scheme React-CoreModules \
      -configuration Debug \
      -sdk iphonesimulator \
      -derivedDataPath /tmp/rncoremodules-test \
      CODE_SIGNING_ALLOWED=NO build