### PR TITLE
[0.83] Fix React-CoreModules missing React-featureflags header path under use_frameworks!

### DIFF
--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/CoreModulesHeaders", version
   s.dependency "React-RCTImage", version
   s.dependency "React-jsi", version
-  s.dependency "React-featureflags"
+  add_dependency(s, "React-featureflags")
   s.dependency 'React-RCTBlob'
   add_dependency(s, "React-debug")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])


### PR DESCRIPTION
## Summary:

Companion to #56591 (main). Same one-line fix, cherry-picked cleanly — `React-CoreModules.podspec` is byte-identical between `main` and `0.83-stable`.

`React/CoreModules/RCTRedBox.mm` imports `<react/featureflags/ReactNativeFeatureFlags.h>` (added in #56574). Under `use_frameworks!` this fails to build on 0.83.7:

    RCTRedBox.mm:19:9: 'react/featureflags/ReactNativeFeatureFlags.h' file not found

`React-CoreModules.podspec` uses plain `s.dependency "React-featureflags"`, which doesn't add the framework's Headers dir to `HEADER_SEARCH_PATHS`. Switching to `add_dependency(s, "React-featureflags")` does — matching every neighboring dep (`React-debug`, `React-runtimeexecutor`, `React-jsinspector*`, etc.) in the same file.

On `main` the symptom is masked by the `update_search_paths` post-install hook (#55679 added a global entry for `React-featureflags`), which was never backported to `0.83-stable` — which is why the bug surfaces here and not on `main`. Landing this directly on `0.83-stable` unblocks 0.83.7 `use_frameworks!` users without waiting for a main → stable cherry-pick.

## Changelog:

[IOS] [FIXED] - Fix `<react/featureflags/ReactNativeFeatureFlags.h>` not found in `RCTRedBox.mm` when building with `use_frameworks!`

## Test Plan:

RN 0.83.7 consumer app with `use_frameworks! :linkage => :static`, `RCT_USE_RN_DEP=1`: fails before, builds end-to-end after. Generated `React-CoreModules.debug.xcconfig` now includes `\${PODS_CONFIGURATION_BUILD_DIR}/React-featureflags/React_featureflags.framework/Headers`.