### PR TITLE
Skip prebuilds for DynamicFrameworks CI jobs

### DIFF
--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -33,7 +33,10 @@ runs:
       if: ${{ inputs.use-hermes-nightly == 'true' }}
       shell: bash
       run: |
-        node ./scripts/releases/use-hermes-nightly.js
+        HERMES_VERSION=$(sed -n 's/^HERMES_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
+        if [ "$HERMES_VERSION" == "1000.0.0" ]; then
+          node ./scripts/releases/use-hermes-nightly.js
+        fi
     - name: Run yarn install again, with the correct hermes version
       if: ${{ inputs.use-hermes-nightly == 'true' }}
       uses: ./.github/actions/yarn-install

--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -38,19 +38,23 @@ runs:
       if: ${{ inputs.use-hermes-nightly == 'true' }}
       uses: ./.github/actions/yarn-install
     - name: Download ReactNativeDependencies
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       uses: actions/download-artifact@v4
       with:
         name: ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/third-party
     - name: Print third-party folder
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       shell: bash
       run: ls -lR /tmp/third-party
     - name: Download React Native Prebuilds
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       uses: actions/download-artifact@v4
       with:
         name: ReactCore${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/ReactCore
     - name: Print ReactCore folder
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       shell: bash
       run: ls -lR /tmp/ReactCore
     - name: Install iOS dependencies - Configuration ${{ inputs.flavor }};
@@ -61,10 +65,10 @@ runs:
 
         if [[ ${{ inputs.use-frameworks }} == "DynamicFrameworks" ]]; then
           args+=(--frameworks dynamic)
+        else
+          export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
+          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ inputs.flavor }}.xcframework.tar.gz"
         fi
-
-        export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
-        export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ inputs.flavor }}.xcframework.tar.gz"
 
         yarn bootstrap ios "${args[@]}" | cat
 

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -41,7 +41,10 @@ runs:
       if: ${{ inputs.use-hermes-nightly == 'true' }}
       shell: bash
       run: |
-        node ./scripts/releases/use-hermes-nightly.js
+        HERMES_VERSION=$(sed -n 's/^HERMES_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
+        if [ "$HERMES_VERSION" == "1000.0.0" ]; then
+          node ./scripts/releases/use-hermes-nightly.js
+        fi
     - name: Run yarn install again, with the correct hermes version
       if: ${{ inputs.use-hermes-nightly == 'true' }}
       uses: ./.github/actions/yarn-install

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -49,29 +49,33 @@ runs:
       if: ${{ inputs.run-unit-tests == 'true' }}
       uses: ./.github/actions/prepare-ios-tests
     - name: Download ReactNativeDependencies
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       uses: actions/download-artifact@v4
       with:
         name: ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/third-party/
     - name: Print third-party folder
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       shell: bash
       run: ls -lR /tmp/third-party
     - name: Download React Native Prebuilds
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       uses: actions/download-artifact@v4
       with:
         name: ReactCore${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/ReactCore
     - name: Print ReactCore folder
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       shell: bash
       run: ls -lR /tmp/ReactCore
     - name: Install CocoaPods dependencies
       shell: bash
       run: |
-        export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
-        export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ inputs.flavor }}.xcframework.tar.gz"
-
         if [[ ${{ inputs.use-frameworks }} == "DynamicFrameworks" ]]; then
           export USE_FRAMEWORKS=dynamic
+        else
+          export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
+          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ inputs.flavor }}.xcframework.tar.gz"
         fi
 
         cd packages/rn-tester

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -49,10 +49,9 @@ jobs:
       - name: Set Hermes version
         shell: bash
         run: |
-          if [ "${{ inputs.use-hermes-nightly }}" == "true" ]; then
+          HERMES_VERSION=$(sed -n 's/^HERMES_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
+          if [ "$HERMES_VERSION" == "1000.0.0" ]; then
             HERMES_VERSION="nightly"
-          else
-            HERMES_VERSION=$(sed -n 's/^HERMES_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
           fi
           echo "Using Hermes version: $HERMES_VERSION"
           echo "HERMES_VERSION=$HERMES_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- DynamicFrameworks CI jobs on `0.83-stable` were incorrectly downloading and using prebuilds (ReactNativeDependencies + ReactCore xcframeworks), which could mask CocoaPods misconfigurations when running with `use_frameworks`.
- Both `test-ios-rntester` and `test-ios-helloworld` composite actions now conditionally skip prebuild downloads and env vars when `use-frameworks` is set to `DynamicFrameworks`, ensuring these jobs always build from source.
- This aligns the behavior with how the same jobs are configured on `main`.

## Changelog:
[INTERNAL] - Skip prebuilds for DynamicFrameworks CI jobs to always build from source

## Test plan
CI should pass — StaticLibraries jobs still use prebuilds as before; DynamicFrameworks jobs will now build from source.