### PR TITLE
Fix crash on reload

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -313,9 +313,6 @@ void ReactHost::destroyReactInstance() {
 
   reactInstanceData_->contextContainer->erase(RuntimeSchedulerKey);
   reactInstanceData_->mountingManager->setSchedulerTaskExecutor(nullptr);
-  reactInstanceData_->mountingManager = nullptr;
-  reactInstanceData_->contextContainer = nullptr;
-  reactInstanceData_->turboModuleProviders.clear();
   reactInstance_ = nullptr;
   reactInstanceData_->messageQueueThread = nullptr;
 }


### PR DESCRIPTION
Revert crash on reload caused by https://github.com/facebook/react-native/commit/45b4817414928c9bfa0b055bb09533ac177cada6#diff-99e9fee4dbe9d329e2f7df16035fb871fa583c92028a48fefb1c48e405638944R314-R316

## Summary:

@j-piasecki your change that seems redundant for the destructor case (reactInstanceData_ is a unique pointer and will be destroyed anyway) and breaks the reload case (by setting `contextContainer` to `nullptr`, which is then immediately accessed by `createReactInstance`, causing a crash)

## Changelog:

[GENERAL] [FIXED] - Fixed a regression that causes crashes on reload for `ReactCxxPlatform`'s `ReactHost`

## Test Plan:

Reload the development server
