### PR TITLE
Dispatch FPS events from ACTION_SCROLL events (#56601)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -859,6 +859,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
       float hScroll = ev.getAxisValue(MotionEvent.AXIS_HSCROLL);
       if (hScroll != 0) {
         // Perform the scroll
+        enableFpsListener();
         boolean result = super.dispatchGenericMotionEvent(ev);
         // Schedule snap alignment to run after scrolling stops
         if (result
@@ -866,9 +867,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
                 || mSnapInterval != 0
                 || mSnapOffsets != null
                 || mSnapToAlignment != SNAP_ALIGNMENT_DISABLED)) {
-          // Cancel any pending runnable and reschedule
+          // Cancel any pending post-touch runnable and reschedule
           if (mPostTouchRunnable != null) {
             removeCallbacks(mPostTouchRunnable);
+            mPostTouchRunnable = null;
           }
           mPostTouchRunnable =
               new Runnable() {
@@ -882,9 +884,12 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
                     velocityX = 0;
                   }
                   flingAndSnap(velocityX);
+                  handlePostTouchScrolling(velocityX, 0);
                 }
               };
           postOnAnimationDelayed(mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
+        } else {
+          handlePostTouchScrolling(0, 0);
         }
         return result;
       }
@@ -1212,6 +1217,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
                 }
                 ReactScrollViewHelper.notifyUserDrivenScrollEnded_internal(
                     ReactHorizontalScrollView.this);
+                disableFpsListener();
               } else {
                 if (mPagingEnabled && !mSnappingToPage) {
                   // If we have pagingEnabled and we have not snapped to the page

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.java
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a0490be2c6f7eb42376e8e64abf9ce5e>>
+ * @generated SignedSource<<41d03f4948562c0fae870a660e6e1eac>>
  */
 
 /**
@@ -700,6 +700,7 @@ class ReactNestedScrollView extends NestedScrollView
       float vScroll = ev.getAxisValue(MotionEvent.AXIS_VSCROLL);
       if (vScroll != 0) {
         // Perform the scroll
+        enableFpsListener();
         boolean result = super.dispatchGenericMotionEvent(ev);
         // Schedule snap alignment to run after scrolling stops
         if (result
@@ -710,6 +711,7 @@ class ReactNestedScrollView extends NestedScrollView
           // Cancel any pending post-touch runnable and reschedule
           if (mPostTouchRunnable != null) {
             removeCallbacks(mPostTouchRunnable);
+            mPostTouchRunnable = null;
           }
           mPostTouchRunnable =
               new Runnable() {
@@ -723,9 +725,12 @@ class ReactNestedScrollView extends NestedScrollView
                     velocityY = 0;
                   }
                   flingAndSnap(velocityY);
+                  handlePostTouchScrolling(0, velocityY);
                 }
               };
           postOnAnimationDelayed(mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
+        } else {
+          handlePostTouchScrolling(0, 0);
         }
         return result;
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -692,6 +692,7 @@ public class ReactScrollView extends ScrollView
       float vScroll = ev.getAxisValue(MotionEvent.AXIS_VSCROLL);
       if (vScroll != 0) {
         // Perform the scroll
+        enableFpsListener();
         boolean result = super.dispatchGenericMotionEvent(ev);
         // Schedule snap alignment to run after scrolling stops
         if (result
@@ -702,6 +703,7 @@ public class ReactScrollView extends ScrollView
           // Cancel any pending post-touch runnable and reschedule
           if (mPostTouchRunnable != null) {
             removeCallbacks(mPostTouchRunnable);
+            mPostTouchRunnable = null;
           }
           mPostTouchRunnable =
               new Runnable() {
@@ -715,9 +717,12 @@ public class ReactScrollView extends ScrollView
                     velocityY = 0;
                   }
                   flingAndSnap(velocityY);
+                  handlePostTouchScrolling(0, velocityY);
                 }
               };
           postOnAnimationDelayed(mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
+        } else {
+          handlePostTouchScrolling(0, 0);
         }
         return result;
       }


### PR DESCRIPTION
Summary:

`ACTION_SCROLL` events (mouse wheel, trackpad, joystick) were not participating in FPS performance logging. Touch-driven scrolls already called `enableFpsListener`/`disableFpsListener` through `handlePostTouchScrolling`, which uses a stable-frames heuristic to detect when scrolling has settled (3 consecutive frames with no position change). ACTION_SCROLL events bypassed this entirely.

This adds FPS listener support to the `ACTION_SCROLL` path by calling `enableFpsListener` when a scroll event arrives, then delegating to `handlePostTouchScrolling` for lifecycle management:

- **Snapping ScrollViews (`ReactScrollView`, `ReactHorizontalScrollView`):** The existing debounce runnable calls `flingAndSnap` to animate to a snap point. After the snap, `handlePostTouchScrolling` monitors the animation via the stable-frames mechanism and disables the FPS listener once settled.
- **Non-snapping ScrollViews (`ReactScrollView`):** `handlePostTouchScrolling` is called directly. Its re-entry guard (`mPostTouchRunnable != null`) naturally deduplicates across rapid scroll events, while `onScrollChanged` keeps the monitor alive by setting `mActivelyScrolling`.

Also nulls `mPostTouchRunnable` before reassignment in the debounce cancel path to avoid stale references.

Changelog:
[Android][Fixed] - Dispatch FPS performance events for mouse wheel and trackpad scroll interactions in ScrollView

Differential Revision: D102347043


