### PR TITLE
Remove unused ivars from React Native (RCTAnimation, RCTBlob, RCTNetworking)

### DIFF
--- a/packages/react-native/Libraries/Blob/RCTBlobManager.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobManager.mm
@@ -42,7 +42,6 @@ static NSString *const kBlobURIScheme = @"blob";
   std::mutex _blobsMutex;
 
   NSOperationQueue *_queue;
-  dispatch_queue_t _processingQueue;
 }
 
 RCT_EXPORT_MODULE(BlobModule)

--- a/packages/react-native/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.mm
+++ b/packages/react-native/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.mm
@@ -80,8 +80,6 @@ NSString *RCTInterpolateString(
   RCTInterpolationOutputType _outputType;
   id _Nullable _outputvalue;
   NSString *_Nullable _outputPattern;
-
-  NSArray<NSTextCheckingResult *> *_matches;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag config:(NSDictionary<NSString *, id> *)config

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -162,7 +162,6 @@ static NSString *RCTGenerateFormBoundary()
   NSMutableArray<id<RCTNetworkingRequestHandler>> *_requestHandlers;
   NSMutableArray<id<RCTNetworkingResponseHandler>> *_responseHandlers;
   NSMutableArray<id<RCTNetworkingTextResponseHandler>> *_textResponseHandlers;
-  dispatch_queue_t _requestQueue;
 }
 
 @synthesize methodQueue = _methodQueue;


### PR DESCRIPTION
Summary:
Changelog:

[iOS][Fixed] - Removing unused ivars

Reviewed By: Murf-o

Differential Revision: D102315121


