### PR TITLE
Upgrade lodash 4.17.21 → 4.18.1 (CVE-2026-4800)

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "react-is": "19.2.3",
     "on-headers": "1.1.0",
     "compression": "1.8.1",
-    "@microsoft/api-extractor/minimatch": "3.1.4"
+    "@microsoft/api-extractor/minimatch": "3.1.4",
+    "lodash": "4.18.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6506,10 +6506,10 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
-lodash@^4.17.11, lodash@^4.17.19, lodash@^4.17.21, lodash@~4.17.15:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.18.1, lodash@^4.17.11, lodash@^4.17.19, lodash@^4.17.21, lodash@~4.17.15:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Summary:
Upgrade transitive dependency lodash from 4.17.21 to 4.18.1 to remediate CVE-2026-4800 (Improper Control of Generation of Code / Code Injection).

- Added `"lodash": "4.18.1"` to `resolutions` in package.json to force all lodash ranges (including `~4.17.15`) to resolve to 4.18.1
- Updated yarn.lock entry to resolve all lodash ranges to 4.18.1

Without the resolution override, the `~4.17.15` range would stay at 4.17.21 (vulnerable) since `~` only allows patch-level updates and 4.18.1 is a minor bump.

Changelog: [Internal]

Differential Revision: D102273666


