### PR TITLE
Use pinned Hermes version when version.properties is not 1000.0.0

### DIFF
--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -26,7 +26,10 @@ runs:
     - name: Set nightly Hermes versions
       shell: bash
       run: |
-        node ./scripts/releases/use-hermes-nightly.js
+        HERMES_VERSION=$(sed -n 's/^HERMES_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
+        if [ "$HERMES_VERSION" == "1000.0.0" ]; then
+          node ./scripts/releases/use-hermes-nightly.js
+        fi
     - name: Run yarn install again, with the correct hermes version
       uses: ./.github/actions/yarn-install
     - name: Download ReactNativeDependencies

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -35,7 +35,10 @@ runs:
     - name: Set nightly Hermes versions
       shell: bash
       run: |
-        node ./scripts/releases/use-hermes-nightly.js
+        HERMES_VERSION=$(sed -n 's/^HERMES_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
+        if [ "$HERMES_VERSION" == "1000.0.0" ]; then
+          node ./scripts/releases/use-hermes-nightly.js
+        fi
     - name: Run yarn install again, with the correct hermes version
       uses: ./.github/actions/yarn-install
     - name: Prepare IOS Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,6 @@ jobs:
   prebuild_react_native_core:
     uses: ./.github/workflows/prebuild-ios-core.yml
     with:
-      use-hermes-nightly: true
       version-type: nightly
     secrets: inherit
     needs: [prebuild_apple_dependencies]

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -45,8 +45,6 @@ jobs:
           HERMES_VERSION=$(sed -n 's/^HERMES_V1_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
           if [ "$HERMES_VERSION" == "1000.0.0" ]; then
             HERMES_VERSION="latest-v1"
-          else
-            HERMES_VERSION="hermes-v${HERMES_VERSION}"
           fi
           echo "Using Hermes version: $HERMES_VERSION"
           echo "HERMES_VERSION=$HERMES_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -8,11 +8,6 @@ on:
         type: string
         required: false
         default: ''
-      use-hermes-nightly:
-        description: 'Whether to use the hermes nightly build or read the version from the versions.properties file'
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   build-rn-slice:

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -45,6 +45,8 @@ jobs:
           HERMES_VERSION=$(sed -n 's/^HERMES_V1_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
           if [ "$HERMES_VERSION" == "1000.0.0" ]; then
             HERMES_VERSION="latest-v1"
+          else
+            HERMES_VERSION="hermes-v${HERMES_VERSION}"
           fi
           echo "Using Hermes version: $HERMES_VERSION"
           echo "HERMES_VERSION=$HERMES_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -47,12 +47,9 @@ jobs:
       - name: Set Hermes version
         shell: bash
         run: |
-          if [ "${{ inputs.use-hermes-nightly }}" == "true" ]; then
-            # We are not publishing nightly versions of Hermes V1 yet.
-            # For now, we can use the latest version of Hermes V1 published on maven and npm.
+          HERMES_VERSION=$(sed -n 's/^HERMES_V1_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
+          if [ "$HERMES_VERSION" == "1000.0.0" ]; then
             HERMES_VERSION="latest-v1"
-          else
-            HERMES_VERSION=$(sed -n 's/^HERMES_V1_VERSION_NAME=//p' packages/react-native/sdks/hermes-engine/version.properties)
           fi
           echo "Using Hermes version: $HERMES_VERSION"
           echo "HERMES_VERSION=$HERMES_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -96,8 +96,6 @@ jobs:
 
   prebuild_react_native_core:
     uses: ./.github/workflows/prebuild-ios-core.yml
-    with:
-      use-hermes-nightly: ${{ !endsWith(github.ref_name, '-stable') }}
     secrets: inherit
     needs: [prebuild_apple_dependencies]
 


### PR DESCRIPTION
## Summary
- Reads `HERMES_VERSION_NAME` / `HERMES_V1_VERSION_NAME` from `version.properties` to decide whether to use nightly Hermes, instead of relying on the branch name.
- Only runs `use-hermes-nightly.js` or sets `latest-v1` when the version is `1000.0.0` (the development placeholder).
- Fixes incorrect nightly Hermes usage on PR branches targeting stable.

This is the 0.85-stable backport of the same fix applied to 0.83-stable.

## Changelog:
[Internal] - Fix CI

## Test plan
- CI should pass on this PR with the pinned Hermes version from `version.properties` rather than falling back to nightly.