### PR TITLE
Fix ccache being silently bypassed on iOS builds

### DIFF
--- a/packages/react-native/scripts/xcode/ccache-clang++.sh
+++ b/packages/react-native/scripts/xcode/ccache-clang++.sh
@@ -11,4 +11,13 @@ REACT_NATIVE_CCACHE_CONFIGPATH=$SCRIPT_DIR/ccache.conf
 # Provide our config file if none is already provided
 export CCACHE_CONFIGPATH="${CCACHE_CONFIGPATH:-$REACT_NATIVE_CCACHE_CONFIGPATH}"
 
-exec $CCACHE_BINARY clang++ "$@"
+# Xcode does not export user-defined build settings as environment variables
+# for invoked scripts, so $CCACHE_BINARY may be empty even when set in the
+# project. Fall back to a PATH lookup so ccache is still used.
+CCACHE_BINARY="${CCACHE_BINARY:-$(command -v ccache)}"
+
+if [ -n "$CCACHE_BINARY" ]; then
+    exec "$CCACHE_BINARY" clang++ "$@"
+fi
+
+exec clang++ "$@"

--- a/packages/react-native/scripts/xcode/ccache-clang.sh
+++ b/packages/react-native/scripts/xcode/ccache-clang.sh
@@ -11,4 +11,13 @@ REACT_NATIVE_CCACHE_CONFIGPATH=$SCRIPT_DIR/ccache.conf
 # Provide our config file if none is already provided
 export CCACHE_CONFIGPATH="${CCACHE_CONFIGPATH:-$REACT_NATIVE_CCACHE_CONFIGPATH}"
 
-exec $CCACHE_BINARY clang "$@"
+# Xcode does not export user-defined build settings as environment variables
+# for invoked scripts, so $CCACHE_BINARY may be empty even when set in the
+# project. Fall back to a PATH lookup so ccache is still used.
+CCACHE_BINARY="${CCACHE_BINARY:-$(command -v ccache)}"
+
+if [ -n "$CCACHE_BINARY" ]; then
+    exec "$CCACHE_BINARY" clang "$@"
+fi
+
+exec clang "$@"


### PR DESCRIPTION
## Summary:

When ccache is enabled for an iOS build via `react_native_post_install` (or `USE_CCACHE=1`), `packages/react-native/scripts/cocoapods/utils.rb` wires up `ccache-clang.sh` / `ccache-clang++.sh` as `CC` / `CXX` and writes the resolved ccache path to a `CCACHE_BINARY` Xcode build setting. The shell wrappers then run `exec $CCACHE_BINARY clang "$@"`.

The problem: as of recent Xcode versions (confirmed at least on Xcode 26.2 by the issue reporter, and reproducible by inspection — Xcode does not export user-defined build settings as environment variables for invoked scripts), `$CCACHE_BINARY` is empty when the wrapper runs. Because the variable was unquoted, the empty value collapsed and the line silently became `exec clang "$@"` — so **ccache was never invoked**, even though everything else was set up correctly.

This change makes the wrappers fall back to `command -v ccache` when `CCACHE_BINARY` is unset, and only prepends ccache when an executable is actually available so projects without ccache installed still build.

Fixes #55381

## Changelog:

[IOS] [FIXED] - ccache is no longer silently bypassed on iOS builds when Xcode does not propagate the `CCACHE_BINARY` user-defined build setting to scripts.

## Test Plan:

Smoke-tested the modified wrappers under four scenarios with a fake `ccache` on `PATH`:

1. **`CCACHE_BINARY` set explicitly** — ccache is invoked. ✅
2. **`CCACHE_BINARY` unset, `ccache` on `PATH`** (the bug case) — wrapper now finds and invokes ccache via the PATH fallback. ✅
3. **C++ wrapper with `CCACHE_BINARY` unset, `ccache` on `PATH`** — same behaviour for `ccache-clang++.sh`. ✅
4. **No ccache anywhere** — wrapper falls through to direct `clang`/`clang++` invocation, so projects without ccache still build (no regression vs. previous silent-bypass behaviour, just no longer a build error). ✅

```sh
# Reproducing T2 (the bug case):
env -i PATH="/path/with/ccache:/usr/bin:/bin" /bin/sh \
  packages/react-native/scripts/xcode/ccache-clang.sh --version
# Before this PR: ran clang directly, no ccache
# After this PR:  routes through ccache as expected
```

`shellcheck` is clean on both files.