### PR TITLE
Sync ItemSeparator props on cell re-render in SectionList

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -532,24 +532,49 @@ function ItemWithSeparator<ItemT>(
 
   const [separatorHighlighted, setSeparatorHighlighted] = useState(false);
 
-  const [leadingSeparatorProps, setLeadingSeparatorProps] = useState<
-    ItemWithSeparatorCommonProps<ItemT>,
-  >({
+  const propsLeadingSeparatorProps: ItemWithSeparatorCommonProps<ItemT> = {
     leadingItem: props.leadingItem,
     leadingSection: props.leadingSection,
     section: props.section,
     trailingItem: props.item,
     trailingSection: props.trailingSection,
-  });
-  const [separatorProps, setSeparatorProps] = useState<
-    ItemWithSeparatorCommonProps<ItemT>,
-  >({
+  };
+  const propsSeparatorProps: ItemWithSeparatorCommonProps<ItemT> = {
     leadingItem: props.item,
     leadingSection: props.leadingSection,
     section: props.section,
     trailingItem: props.trailingItem,
     trailingSection: props.trailingSection,
-  });
+  };
+
+  const [leadingSeparatorProps, setLeadingSeparatorProps] = useState<
+    ItemWithSeparatorCommonProps<ItemT>,
+  >(propsLeadingSeparatorProps);
+  const [separatorProps, setSeparatorProps] = useState<
+    ItemWithSeparatorCommonProps<ItemT>,
+  >(propsSeparatorProps);
+
+  // Same cell can re-render with new leading/trailing items (e.g. after a
+  // section reorder). Sync derived state from props during render so
+  // ItemSeparatorComponent doesn't receive stale leadingItem/trailingItem.
+  if (
+    leadingSeparatorProps.leadingItem !== propsLeadingSeparatorProps.leadingItem ||
+    leadingSeparatorProps.trailingItem !== propsLeadingSeparatorProps.trailingItem ||
+    leadingSeparatorProps.leadingSection !== propsLeadingSeparatorProps.leadingSection ||
+    leadingSeparatorProps.section !== propsLeadingSeparatorProps.section ||
+    leadingSeparatorProps.trailingSection !== propsLeadingSeparatorProps.trailingSection
+  ) {
+    setLeadingSeparatorProps(propsLeadingSeparatorProps);
+  }
+  if (
+    separatorProps.leadingItem !== propsSeparatorProps.leadingItem ||
+    separatorProps.trailingItem !== propsSeparatorProps.trailingItem ||
+    separatorProps.leadingSection !== propsSeparatorProps.leadingSection ||
+    separatorProps.section !== propsSeparatorProps.section ||
+    separatorProps.trailingSection !== propsSeparatorProps.trailingSection
+  ) {
+    setSeparatorProps(propsSeparatorProps);
+  }
 
   useEffect(() => {
     setSelfHighlightCallback(cellKey, setSeparatorHighlighted);

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
@@ -202,6 +202,73 @@ describe('VirtualizedSectionList', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('passes fresh leadingItem and trailingItem to ItemSeparatorComponent after sections reorder', async () => {
+    // Regression test for https://github.com/facebook/react-native/issues/55708.
+    // ItemWithSeparator stored leadingItem/trailingItem in useState seeded from
+    // the first render, so when the same cell key re-rendered with reordered
+    // data the separator kept the stale items (or undefined when the previous
+    // row was at a section boundary).
+    const separatorPropsByKey: {
+      [string]: Array<{leading: ?string, trailing: ?string}>,
+    } = {};
+    const RecordingSeparator = (props: $FlowFixMe) => {
+      const itemKey = props.leadingItem?.key ?? '__head__';
+      separatorPropsByKey[itemKey] = separatorPropsByKey[itemKey] ?? [];
+      separatorPropsByKey[itemKey].push({
+        leading: props.leadingItem?.key,
+        trailing: props.trailingItem?.key,
+      });
+      return <separator />;
+    };
+
+    const initial = [
+      // $FlowFixMe[incompatible-type]
+      {title: 's', data: [{key: 'a'}, {key: 'b'}, {key: 'c'}]},
+    ];
+    const reordered = [
+      // $FlowFixMe[incompatible-type]
+      {title: 's', data: [{key: 'b'}, {key: 'a'}, {key: 'c'}]},
+    ];
+
+    let component;
+    await ReactTestRenderer.act(() => {
+      component = ReactTestRenderer.create(
+        <VirtualizedSectionList
+          sections={initial}
+          // $FlowFixMe[missing-local-annot]
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, key) => data[key]}
+          getItemCount={data => data.length}
+          ItemSeparatorComponent={RecordingSeparator}
+        />,
+      );
+    });
+
+    await ReactTestRenderer.act(() => {
+      nullthrows(component).update(
+        <VirtualizedSectionList
+          sections={reordered}
+          // $FlowFixMe[missing-local-annot]
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, key) => data[key]}
+          getItemCount={data => data.length}
+          ItemSeparatorComponent={RecordingSeparator}
+        />,
+      );
+    });
+
+    // Last render of separator below "b" must reflect the reordered list:
+    // the item below b is now a, so trailing must be 'a'.
+    const lastBelowB = nullthrows(separatorPropsByKey['b']).at(-1);
+    expect(lastBelowB?.leading).toBe('b');
+    expect(lastBelowB?.trailing).toBe('a');
+
+    // Last render of separator below "a" must reflect a→c.
+    const lastBelowA = nullthrows(separatorPropsByKey['a']).at(-1);
+    expect(lastBelowA?.leading).toBe('a');
+    expect(lastBelowA?.trailing).toBe('c');
+  });
+
   describe('scrollToLocation', () => {
     const ITEM_HEIGHT = 100;
 


### PR DESCRIPTION
## Summary:

`ItemWithSeparator` in `VirtualizedSectionList` stored `leadingItem`, `trailingItem` and the surrounding section info in `useState` seeded only by the first render's props. When the same cell key re-rendered with different data (for example after a section reorder), the state was never refreshed, so `ItemSeparatorComponent` kept receiving the original items — including `undefined` when the previous row had been at a section boundary.

This change re-derives the base separator props from current props at render time and updates state whenever they drift, using the standard React pattern for prop-derived state. The `setSelfUpdatePropsCallback` API used for cross-cell highlight propagation is preserved unchanged.

Fixes #55708

## Changelog:

[GENERAL] [FIXED] - `SectionList` `ItemSeparatorComponent` no longer receives stale `leadingItem`/`trailingItem` after the underlying data is reordered or replaced.

## Test Plan:

Added a Jest regression test in `packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js` that:

1. Renders a `VirtualizedSectionList` with sections `[a, b, c]` and a recording `ItemSeparatorComponent`.
2. Re-renders with sections `[b, a, c]` (swap of the first two items).
3. Asserts the last separator render below `b` reports `{leading: 'b', trailing: 'a'}` and the last below `a` reports `{leading: 'a', trailing: 'c'}`.

```sh
npx jest packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js \
  -t "passes fresh leadingItem"
```

- On stock `main` the new test **fails** at `expect(lastBelowB?.trailing).toBe('a')` — confirming it reproduces #55708.
- With this change applied the test **passes**.

Also exercised on iPhone 17 Pro (iOS 26.2) via a Maestro flow that taps a "Reorder" button on a `<SectionList>` reproducer and asserts the separator labels update; failed before the fix at `assertVisible: id: sep-b-a`, passed afterwards. The repo's existing Maestro suite (`packages/rn-tester/.maestro/`, 8 flows) continued to pass — `9/9 Flows Passed in 1m 39s` with the temporary repro flow included.