### PR TITLE
fix(android): preserve cursor position when centered TextInput is cleared

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -36,6 +36,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityNodeInfo
+import android.view.inputmethod.BaseInputConnection
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputMethodManager
@@ -679,9 +680,19 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     disableTextDiffing = true
 
     // On some devices, when the text is cleared, buggy keyboards will not clear the composing
-    // text so, we have to set text to null, which will clear the currently composing text.
+    // text. We remove composing spans explicitly and clear the text via replace() on the existing
+    // Editable rather than setText(null), which would recreate the buffer and cause the cursor
+    // to lose its gravity-based positioning (e.g. jumping to the right for centered text).
     if (reactTextUpdate.text.length == 0) {
-      text = null
+      val currentText = editableText
+      if (currentText != null) {
+        BaseInputConnection.removeComposingSpans(currentText)
+        if (currentText.isNotEmpty()) {
+          currentText.replace(0, currentText.length, "")
+        }
+      } else {
+        text = null
+      }
     } else {
       // When we update text, we trigger onChangeText code that will
       // try to update state if the wrapper is available. Temporarily disable

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
@@ -17,6 +17,7 @@ import android.text.InputFilter
 import android.text.InputFilter.AllCaps
 import android.text.InputType
 import android.text.Layout
+import android.text.SpannableStringBuilder
 import android.util.DisplayMetrics
 import android.view.Gravity
 import android.view.View
@@ -32,6 +33,7 @@ import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.text.DefaultStyleValuesUtil.getDefaultTextColorHint
+import com.facebook.react.views.text.ReactTextUpdate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -471,6 +473,35 @@ class ReactTextInputPropertyTest {
     manager.updateProperties(view, buildStyles("textAlign", null, "textAlignVertical", null))
     assertThat(view.gravity).isEqualTo(defaultGravity)
     // endregion
+  }
+
+  @Test
+  fun testClearingTextPreservesEditableBufferAndGravity() {
+    // Regression test for #55457. Clearing a centered TextInput must not recreate the
+    // underlying Editable buffer, otherwise the EditText loses its gravity-based caret
+    // positioning and the cursor jumps to the right edge.
+    manager.updateProperties(view, buildStyles("textAlign", "center"))
+    assertThat(view.gravity and Gravity.HORIZONTAL_GRAVITY_MASK)
+        .isEqualTo(Gravity.CENTER_HORIZONTAL)
+
+    manager.updateExtraData(
+        view,
+        ReactTextUpdate(SpannableStringBuilder("hello"), 0, Gravity.CENTER_HORIZONTAL, 0, 0))
+    val bufferBeforeClear = view.editableText
+    assertThat(view.text.toString()).isEqualTo("hello")
+    assertThat(bufferBeforeClear).isNotNull()
+
+    manager.updateExtraData(
+        view, ReactTextUpdate(SpannableStringBuilder(""), 0, Gravity.CENTER_HORIZONTAL, 0, 0))
+
+    // Behavioral guarantee of the fix: the Editable instance is reused via replace(),
+    // not swapped out via setText(null). This is what keeps the cursor centered.
+    assertThat(view.editableText).isSameAs(bufferBeforeClear)
+    assertThat(view.text.toString()).isEmpty()
+    assertThat(view.gravity and Gravity.HORIZONTAL_GRAVITY_MASK)
+        .isEqualTo(Gravity.CENTER_HORIZONTAL)
+    assertThat(view.selectionStart).isEqualTo(0)
+    assertThat(view.selectionEnd).isEqualTo(0)
   }
 
   @Test


### PR DESCRIPTION
## Summary:

On Android, clearing a `TextInput` with `textAlign: "center"` caused the cursor to jump to the right edge of the field instead of staying centered. iOS was not affected. See #55457 for a video reproduction.

The cause is `setText(null)` in `ReactEditText.maybeSetText`. On `AppCompatEditText`, that call replaces the underlying `Editable` buffer with a freshly constructed one, and the new buffer doesn't carry forward the gravity-based caret positioning that `Gravity.CENTER_HORIZONTAL` relies on. The cursor then snaps to the layout's natural edge — the right side for LTR centered text — until the user taps the field again.

This PR fixes the issue by clearing the text **in place** on the existing `Editable` rather than swapping the buffer:

- `BaseInputConnection.removeComposingSpans(currentText)` — preserves the original "some buggy keyboards don't clear the composing text on their own" intent that motivated the original `setText(null)`.
- `currentText.replace(0, currentText.length, "")` — empties the buffer without re-creating it.

This mirrors the approach already used a few lines below for the non-empty branch (`checkNotNull(text).replace(0, length(), spannableStringBuilder)`), so the empty-text path is now consistent with the non-empty path. Gravity is preserved on the same `Editable`, so the cursor stays centered (or right-aligned for RTL) after clearing.

Fixes #55457.

## Changelog:

[ANDROID] [FIXED] - Cursor no longer jumps to the right edge when a centered `TextInput` is cleared

## Test Plan:

Added a Robolectric regression test `ReactTextInputPropertyTest.testClearingTextPreservesEditableBufferAndGravity` that:

1. Applies `textAlign: "center"` and asserts gravity is `Gravity.CENTER_HORIZONTAL`.
2. Sets the text to `"hello"` via `ReactTextUpdate` and captures `view.editableText` as `bufferBeforeClear`.
3. Clears the text via another `ReactTextUpdate` with an empty string.
4. Asserts `view.editableText` **is the same instance** as `bufferBeforeClear` — this is the discriminating behavioral guarantee of the fix vs. `setText(null)`, which would replace the buffer.
5. Asserts the text is empty, gravity is still centered, and `selectionStart`/`selectionEnd` are both `0`.

The test is a true regression test:

- Passes against the fix.
- Fails against the original `text = null` code with `Expecting actual: hello and actual: "" to refer to the same object`.

Ran:

```
./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest \
  --tests "com.facebook.react.views.textinput.ReactTextInputPropertyTest"
```

Result:

```
BUILD SUCCESSFUL
tests=23 skipped=0 failures=0 errors=0
```

All 22 pre-existing tests in the class continue to pass, so no behavior is regressed by the fix.