### PR TITLE
fix: reset StartupLogger on JS reload so runJsBundleStart marker is recorded

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -248,6 +248,12 @@ void ReactInstance::loadScript(
       beforeLoad(runtime);
     }
     TraceSection s("ReactInstance::loadScript");
+    // Reset the StartupLogger so that JS reloads re-record all START/STOP
+    // timings. Without this, the APP_STARTUP_START handler resets the logger
+    // mid-sequence (after RUN_JS_BUNDLE_START / INIT_REACT_RUNTIME_START have
+    // already been rejected as duplicates), leaving NaN start times paired
+    // with valid end times. See issue #56339.
+    ReactMarker::StartupLogger::getInstance().reset();
     bool hasLogger(ReactMarker::logTaggedMarkerBridgelessImpl != nullptr);
     if (hasLogger) {
       ReactMarker::logTaggedMarkerBridgeless(


### PR DESCRIPTION
## Summary:

This is a regression in 0.83 from PR #54255, which made `StartupLogger` reset itself when `APP_STARTUP_START` fires. On JS reload, `RUN_JS_BUNDLE_START` and `INIT_REACT_RUNTIME_START` arrive first and are rejected as duplicates by the still-populated logger; only afterward does `APP_STARTUP_START` fire and clear the state. The result is NaN start times paired with valid end times, so `performance.measure('runJsBundle', 'runJsBundleStart', 'runJsBundleEnd')` throws `The mark 'runJsBundleStart' does not exist.` on every reload after the first load.

The fix is to pre-emptively call `StartupLogger::reset()` at the top of `ReactInstance::loadScript` so every load (including reloads) starts with a clean logger and the startup markers are recorded correctly each time.

Fixes #56339.

## Changelog:

[GENERAL] [FIXED] - Reset StartupLogger on JS reload so `runJsBundleStart` performance marker is recorded after the first load

## Test Plan:

- Manual: ran the reporter's reproducer (linked from #56339): app boots, `performance.measure('runJsBundle', 'runJsBundleStart', 'runJsBundleEnd')` succeeds; press R to reload, measure succeeds again instead of throwing `The mark 'runJsBundleStart' does not exist.`
- `clang-format -i packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp` — no diff
- yarn lint / format-check / flow-check / test: not applicable (touched file is C++; eslint/prettier/flow scopes are JS only). Could not run these in the dev sandbox due to no outbound network for `yarn install`; see commit for the C++-only nature of the change.