### PR TITLE
Handle OutOfMemoryError in NetworkingModule response processing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -773,6 +773,14 @@ public class NetworkingModule(
                       e.message,
                       e,
                   )
+                } catch (e: OutOfMemoryError) {
+                  NetworkEventUtil.onRequestError(
+                      reactApplicationContext,
+                      requestId,
+                      devToolsRequestId,
+                      "Out of memory while processing network response",
+                      null,
+                  )
                 }
               }
             }


### PR DESCRIPTION
Summary:
Catch `OutOfMemoryError` in the `onResponse` callback's response processing try-catch block in `NetworkingModule.kt`. Previously, only `IOException` was caught — `OutOfMemoryError` (which extends `Error`, not `Exception`) would propagate uncaught and crash the app.

When the Java heap is near its limit (e.g., 256MB with <1% free), any allocation during response processing (buffer creation in `readWithProgress`, `responseBody.bytes()`, `responseBody.string()`) can trigger OOM. The fix converts this to a network request error event sent to JS, allowing the app to handle the failure gracefully (retry, show error message) instead of crashing.

**Crash:** `android_crash:java.lang.OutOfMemoryError:com.oculus.igvr`
**MID:** `024a57cfb70eef9a61af42d845c981a1` — 246 crashes in 7 days
**Task:** T212267841

Logview link: [024a57cfb70eef9a61af42d845c981a1](https://www.internalfb.com/logview/system_vros_crashes/024a57cfb70eef9a61af42d845c981a1)
Changelog: [Android][Fixed] - Catch OutOfMemoryError in NetworkingModule response processing to prevent app crashes

Reviewed By: cortinico

Differential Revision: D102236869


