### PR TITLE
Remove getWindowDisplayMetrics from DisplayMetricsHolder

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3284,13 +3284,10 @@ public abstract class com/facebook/react/uimanager/BaseViewManagerDelegate : com
 
 public final class com/facebook/react/uimanager/DisplayMetricsHolder {
 	public static final field INSTANCE Lcom/facebook/react/uimanager/DisplayMetricsHolder;
-	public static final fun getDisplayMetricsWritableMap (D)Lcom/facebook/react/bridge/WritableMap;
 	public static final fun getScreenDisplayMetrics ()Landroid/util/DisplayMetrics;
-	public static final fun getWindowDisplayMetrics ()Landroid/util/DisplayMetrics;
 	public static final fun initDisplayMetrics (Landroid/content/Context;)V
 	public static final fun initDisplayMetricsIfNotInitialized (Landroid/content/Context;)V
 	public static final fun setScreenDisplayMetrics (Landroid/util/DisplayMetrics;)V
-	public static final fun setWindowDisplayMetrics (Landroid/util/DisplayMetrics;)V
 }
 
 public final class com/facebook/react/uimanager/FloatUtil {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -14,8 +14,6 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 
 /**
@@ -26,22 +24,7 @@ public object DisplayMetricsHolder {
   private const val INITIALIZATION_MISSING_MESSAGE =
       "DisplayMetricsHolder must be initialized with initDisplayMetricsIfNotInitialized or initDisplayMetrics"
 
-  @JvmStatic private var windowDisplayMetrics: DisplayMetrics? = null
   @JvmStatic private var screenDisplayMetrics: DisplayMetrics? = null
-
-  // TODO(0.87): Remove once we are out of the non-breaking window (see 8d21ffda60)
-  /** The metrics of the window associated to the Context used to initialize ReactNative */
-  @JvmStatic
-  public fun getWindowDisplayMetrics(): DisplayMetrics {
-    checkNotNull(windowDisplayMetrics) { INITIALIZATION_MISSING_MESSAGE }
-    return windowDisplayMetrics as DisplayMetrics
-  }
-
-  // TODO(0.87): Remove once we are out of the non-breaking window (see 8d21ffda60)
-  @JvmStatic
-  public fun setWindowDisplayMetrics(displayMetrics: DisplayMetrics?) {
-    windowDisplayMetrics = displayMetrics
-  }
 
   /** Screen metrics returns the metrics of the default screen on the device. */
   @JvmStatic
@@ -64,11 +47,10 @@ public object DisplayMetricsHolder {
   }
 
   @JvmStatic
-  @SuppressLint("DeprecatedMethod") // for Andriod Lint
+  @SuppressLint("DeprecatedMethod") // for Android Lint
   @Suppress("DEPRECATION") // for Kotlin compiler
   public fun initDisplayMetrics(context: Context) {
     val displayMetrics = context.resources.displayMetrics
-    windowDisplayMetrics = displayMetrics
     val screenDisplayMetrics = DisplayMetrics()
     screenDisplayMetrics.setTo(displayMetrics)
     try {
@@ -85,36 +67,6 @@ public object DisplayMetricsHolder {
     screenDisplayMetrics.scaledDensity = displayMetrics.scaledDensity
     DisplayMetricsHolder.screenDisplayMetrics = screenDisplayMetrics
   }
-
-  // TODO(0.87): Remove once we are out of the non-breaking window (see 8d21ffda60)
-  @JvmStatic
-  public fun getDisplayMetricsWritableMap(fontScale: Double): WritableMap {
-    checkNotNull(windowDisplayMetrics) { INITIALIZATION_MISSING_MESSAGE }
-    checkNotNull(screenDisplayMetrics) { INITIALIZATION_MISSING_MESSAGE }
-
-    return WritableNativeMap().apply {
-      putMap(
-          "windowPhysicalPixels",
-          getPhysicalPixelsWritableMap(windowDisplayMetrics as DisplayMetrics, fontScale),
-      )
-      putMap(
-          "screenPhysicalPixels",
-          getPhysicalPixelsWritableMap(screenDisplayMetrics as DisplayMetrics, fontScale),
-      )
-    }
-  }
-
-  private fun getPhysicalPixelsWritableMap(
-      displayMetrics: DisplayMetrics,
-      fontScale: Double,
-  ): WritableMap =
-      WritableNativeMap().apply {
-        putInt("width", displayMetrics.widthPixels)
-        putInt("height", displayMetrics.heightPixels)
-        putDouble("scale", displayMetrics.density.toDouble())
-        putDouble("fontScale", fontScale)
-        putDouble("densityDpi", displayMetrics.densityDpi.toDouble())
-      }
 
   internal fun getStatusBarHeightPx(activity: Activity?): Int {
     val windowInsets = activity?.window?.decorView?.let(ViewCompat::getRootWindowInsets) ?: return 0

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -1333,7 +1333,7 @@ internal object TextLayoutManager {
     return FontMetricsUtil.getFontMetrics(
         layout.text,
         layout,
-        DisplayMetricsHolder.getWindowDisplayMetrics(),
+        DisplayMetricsHolder.getScreenDisplayMetrics(),
     )
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/DisplayMetricsHolderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/DisplayMetricsHolderTest.kt
@@ -17,7 +17,6 @@ import android.view.View
 import android.view.Window
 import android.view.WindowInsets
 import androidx.annotation.RequiresApi
-import com.facebook.react.bridge.WritableMap
 import com.facebook.testutils.shadows.ShadowNativeLoader
 import com.facebook.testutils.shadows.ShadowNativeMap
 import com.facebook.testutils.shadows.ShadowReadableNativeMap
@@ -55,31 +54,17 @@ class DisplayMetricsHolderTest {
   fun setUp() {
     context = RuntimeEnvironment.getApplication()
     displayMetrics = context.resources.displayMetrics
-    DisplayMetricsHolder.setWindowDisplayMetrics(null)
     DisplayMetricsHolder.setScreenDisplayMetrics(null)
   }
 
   @After
   fun tearDown() {
-    DisplayMetricsHolder.setWindowDisplayMetrics(null)
     DisplayMetricsHolder.setScreenDisplayMetrics(null)
-  }
-
-  @Test(expected = IllegalStateException::class)
-  fun getWindowDisplayMetrics_failsIfDisplayMetricsIsNotInitialized() {
-    DisplayMetricsHolder.getWindowDisplayMetrics()
   }
 
   @Test(expected = IllegalStateException::class)
   fun getScreenDisplayMetrics_failsIfDisplayMetricsIsNotInitialized() {
     DisplayMetricsHolder.getScreenDisplayMetrics()
-  }
-
-  @Test
-  fun setAndGetWindowDisplayMetrics_returnsSetValue() {
-    DisplayMetricsHolder.setWindowDisplayMetrics(displayMetrics)
-    val result = DisplayMetricsHolder.getWindowDisplayMetrics()
-    assertThat(result).isEqualTo(displayMetrics)
   }
 
   @Test
@@ -92,44 +77,17 @@ class DisplayMetricsHolderTest {
   @Test
   fun initDisplayMetrics_setsMetrics() {
     DisplayMetricsHolder.initDisplayMetrics(context)
-    assertThat(DisplayMetricsHolder.getWindowDisplayMetrics()).isNotNull()
     assertThat(DisplayMetricsHolder.getScreenDisplayMetrics()).isNotNull()
   }
 
   @Test
   fun initDisplayMetricsIfNotInitialized_onlyInitializesOnce() {
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(context)
-    val firstWindow = DisplayMetricsHolder.getWindowDisplayMetrics()
     val firstScreen = DisplayMetricsHolder.getScreenDisplayMetrics()
     // Should not reinitialize
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(context)
-    val secondWindow = DisplayMetricsHolder.getWindowDisplayMetrics()
     val secondScreen = DisplayMetricsHolder.getScreenDisplayMetrics()
-    assertThat(secondWindow).isEqualTo(firstWindow)
     assertThat(secondScreen).isEqualTo(firstScreen)
-  }
-
-  @Test(expected = IllegalStateException::class)
-  fun getDisplayMetricsWritableMap_failsIfNotInitialized() {
-    DisplayMetricsHolder.getDisplayMetricsWritableMap(1.0)
-  }
-
-  @Test
-  fun getDisplayMetricsWritableMap_returnsCorrectMap() {
-    // Use the official initialization method to ensure both metrics are set
-    DisplayMetricsHolder.initDisplayMetrics(context)
-    val map: WritableMap = DisplayMetricsHolder.getDisplayMetricsWritableMap(1.0)
-    assertThat(map.hasKey("windowPhysicalPixels")).isTrue()
-    assertThat(map.hasKey("screenPhysicalPixels")).isTrue()
-    val windowMap = map.getMap("windowPhysicalPixels")
-    val screenMap = map.getMap("screenPhysicalPixels")
-    checkNotNull(windowMap)
-    checkNotNull(screenMap)
-    assertThat(windowMap.hasKey("width")).isTrue()
-    assertThat(windowMap.hasKey("height")).isTrue()
-    assertThat(windowMap.hasKey("scale")).isTrue()
-    assertThat(windowMap.hasKey("fontScale")).isTrue()
-    assertThat(windowMap.hasKey("densityDpi")).isTrue()
   }
 
   @Test
@@ -204,7 +162,6 @@ class DisplayMetricsHolderTest {
     DisplayMetricsHolder.initDisplayMetrics(mockContext)
 
     // Metrics should still be set from resource display metrics
-    assertThat(DisplayMetricsHolder.getWindowDisplayMetrics()).isNotNull()
     assertThat(DisplayMetricsHolder.getScreenDisplayMetrics()).isNotNull()
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/PixelUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/PixelUtilTest.kt
@@ -37,13 +37,11 @@ class PixelUtilTest {
   @Before
   fun setUp() {
     context = RuntimeEnvironment.getApplication()
-    DisplayMetricsHolder.setWindowDisplayMetrics(null)
     DisplayMetricsHolder.setScreenDisplayMetrics(null)
   }
 
   @After
   fun tearDown() {
-    DisplayMetricsHolder.setWindowDisplayMetrics(null)
     DisplayMetricsHolder.setScreenDisplayMetrics(null)
   }
 
@@ -57,7 +55,6 @@ class PixelUtilTest {
     displayMetrics.heightPixels = 1920
     displayMetrics.densityDpi = DisplayMetrics.DENSITY_XXHIGH
 
-    DisplayMetricsHolder.setWindowDisplayMetrics(displayMetrics)
     DisplayMetricsHolder.setScreenDisplayMetrics(displayMetrics)
 
     // Test that toPixelFromSP respects fontScale < 1.0
@@ -80,7 +77,6 @@ class PixelUtilTest {
     displayMetrics.heightPixels = 1920
     displayMetrics.densityDpi = DisplayMetrics.DENSITY_XXHIGH
 
-    DisplayMetricsHolder.setWindowDisplayMetrics(displayMetrics)
     DisplayMetricsHolder.setScreenDisplayMetrics(displayMetrics)
 
     // Test that toPixelFromSP respects fontScale > 1.0
@@ -103,7 +99,6 @@ class PixelUtilTest {
     displayMetrics.heightPixels = 1920
     displayMetrics.densityDpi = DisplayMetrics.DENSITY_XXHIGH
 
-    DisplayMetricsHolder.setWindowDisplayMetrics(displayMetrics)
     DisplayMetricsHolder.setScreenDisplayMetrics(displayMetrics)
 
     // Test that maxFontScale limits the scaling
@@ -128,7 +123,6 @@ class PixelUtilTest {
     displayMetrics.heightPixels = 1920
     displayMetrics.densityDpi = DisplayMetrics.DENSITY_XXHIGH
 
-    DisplayMetricsHolder.setWindowDisplayMetrics(displayMetrics)
     DisplayMetricsHolder.setScreenDisplayMetrics(displayMetrics)
 
     // Test that maxFontScale doesn't prevent scaling down


### PR DESCRIPTION
## Summary:

Following https://github.com/facebook/react-native/pull/53254

Removes the deprecated `getWindowDisplayMetrics` / `setWindowDisplayMetrics` / `getDisplayMetricsWritableMap` APIs from `DisplayMetricsHolder`. These were marked `TODO(0.87)` for removal once the non-breaking window closed.

## Changelog:

[ANDROID] [REMOVED] - Remove `DisplayMetricsHolder.getWindowDisplayMetrics`, `setWindowDisplayMetrics`, and `getDisplayMetricsWritableMap`

## Test Plan:

- `./gradlew :packages:react-native:ReactAndroid:test` passes (removed `DisplayMetricsHolderTest` window-metrics cases and the `PixelUtilTest` references)
