### PR TITLE
[0.85] Add RCTDevSupportHeaders to React Umbrella

### DIFF
--- a/packages/react-native/scripts/ios-prebuild/templates/React-umbrella.h
+++ b/packages/react-native/scripts/ios-prebuild/templates/React-umbrella.h
@@ -88,6 +88,7 @@
 #import <React/RCTDevMenu.h>
 #import <React/RCTDevSupportHttpHeaders.h>
 #import <React/RCTDevSettings.h>
+#import <React/RCTDevSupportHttpHeaders.h>
 #import <React/RCTDevToolsRuntimeSettingsModule.h>
 #import <React/RCTDeviceInfo.h>
 #import <React/RCTDiffClampAnimatedNode.h>


### PR DESCRIPTION
## Summary

Cherry-pick of https://github.com/facebook/react-native/commit/753e0ad9b3b (#55974) from `main`.

Adds `RCTDevSupportHeaders` to the React umbrella header on iOS.

Previously picked to 0.83-stable as https://github.com/facebook/react-native/commit/cfb53288331 (#55969).

## Changelog:

[Internal]

## Test Plan

- CI

cc @cipolleschi