### PR TITLE
[0.85] Skip prebuilds for DynamicFrameworks CI jobs

### DIFF
--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -33,19 +33,23 @@ runs:
     - name: Run yarn install again, with the correct hermes version
       uses: ./.github/actions/yarn-install
     - name: Download ReactNativeDependencies
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       uses: actions/download-artifact@v7
       with:
         name: ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/third-party
     - name: Print third-party folder
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       shell: bash
       run: ls -lR /tmp/third-party
     - name: Download React Native Prebuilds
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       uses: actions/download-artifact@v7
       with:
         name: ReactCore${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/ReactCore
     - name: Print ReactCore folder
+      if: ${{ inputs.use-frameworks != 'DynamicFrameworks' }}
       shell: bash
       run: ls -lR /tmp/ReactCore
     - name: Install iOS dependencies - Configuration ${{ inputs.flavor }};
@@ -56,10 +60,10 @@ runs:
 
         if [[ ${{ inputs.use-frameworks }} == "DynamicFrameworks" ]]; then
           args+=(--frameworks dynamic)
+        else
+          export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
+          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ inputs.flavor }}.xcframework.tar.gz"
         fi
-
-        export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
-        export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ inputs.flavor }}.xcframework.tar.gz"
 
         yarn bootstrap ios "${args[@]}" | cat
 


### PR DESCRIPTION
## Summary

Adapted cherry-pick of https://github.com/facebook/react-native/commit/3770421e960 (#56593) from `0.83-stable`.

Adds `if: != DynamicFrameworks` guards to the prebuild download steps in the helloworld CI action, and moves the prebuild env var exports into the `else` branch so they are only set when not using DynamicFrameworks.

On 0.85, the rntester action already has stricter guards (`== false`), and the prebuild workflow already uses the version.properties-based Hermes detection pattern, so only the helloworld action needed changes.

This commit does not exist on `main` — it may need a separate forward-port there. See notes in the pick request.

## Changelog:

[Internal]

## Test Plan

- CI

cc @cipolleschi