### PR TITLE
Use MutableIntObjectMap for SurfaceMountingManager view registry (#56646)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
@@ -15,6 +15,7 @@ import android.view.ViewGroup
 import android.view.ViewParent
 import androidx.annotation.AnyThread
 import androidx.annotation.UiThread
+import androidx.collection.MutableIntObjectMap
 import androidx.collection.SparseArrayCompat
 import androidx.core.graphics.drawable.toDrawable
 import com.facebook.common.logging.FLog
@@ -56,7 +57,10 @@ import java.util.ArrayDeque
 import java.util.LinkedList
 import java.util.Queue
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.Volatile
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 /** Returns true if the collection contains [key]. */
 private operator fun <T> SparseArrayCompat<T>.contains(key: Int): Boolean = containsKey(key)
@@ -84,7 +88,20 @@ internal constructor(
   public var context: ThemedReactContext? = reactContext
     private set
 
-  private val tagToViewState: ConcurrentHashMap<Int, ViewState> = ConcurrentHashMap() // any thread
+  private val tagToViewState: ConcurrentHashMap<Int, ViewState>?
+  private val optimizedTagToViewState: MutableIntObjectMap<ViewState>?
+  private val registryLock = ReentrantReadWriteLock()
+
+  init {
+    if (ReactNativeFeatureFlags.useOptimizedViewRegistryOnAndroid()) {
+      tagToViewState = null
+      optimizedTagToViewState = MutableIntObjectMap()
+    } else {
+      tagToViewState = ConcurrentHashMap()
+      optimizedTagToViewState = null
+    }
+  }
+
   private val onViewAttachMountItems: Queue<MountItem> = ArrayDeque()
 
   // These are all non-null, until StopSurface is called
@@ -126,7 +143,7 @@ internal constructor(
       return
     }
 
-    tagToViewState[surfaceId] = ViewState(surfaceId, rootView, rootViewManager, true)
+    registryPut(surfaceId, ViewState(surfaceId, rootView, rootViewManager, true))
 
     val runnable: Runnable =
         object : GuardedRunnable(checkNotNull(context)) {
@@ -190,7 +207,7 @@ internal constructor(
     if (tagSetForStoppedSurface?.containsKey(tag) == true) {
       return true
     }
-    return tagToViewState.containsKey(tag)
+    return registryContains(tag)
   }
 
   @UiThread
@@ -236,7 +253,7 @@ internal constructor(
     // Reset all StateWrapper objects
     // Since this can happen on any thread, is it possible to race between StateWrapper destruction
     // and some accesses from View classes in the UI thread?
-    for (viewState in tagToViewState.values) {
+    registryForEachValue { viewState ->
       viewState.stateWrapper?.destroyState()
       viewState.stateWrapper = null
 
@@ -248,15 +265,30 @@ internal constructor(
       if (ReactNativeFeatureFlags.enableViewRecycling()) {
         viewManagerRegistry?.onSurfaceStopped(surfaceId)
       }
-      val tagSetForStoppedSurface =
-          SparseArrayCompat<Any>().also { this.tagSetForStoppedSurface = it }
-      for ((key, value) in tagToViewState) {
-        // Using this as a placeholder value in the map. We're using SparseArrayCompat
-        // since it can efficiently represent the list of pending tags
-        tagSetForStoppedSurface[key] = this
 
-        // We must call `onDropViewInstance` on all remaining Views
-        onViewStateDeleted(value)
+      if (optimizedTagToViewState != null) {
+        val viewStatesToDelete: ArrayList<ViewState>
+        registryLock.write {
+          val tagSetForStoppedSurface =
+              SparseArrayCompat<Any>().also { this.tagSetForStoppedSurface = it }
+          viewStatesToDelete = ArrayList(optimizedTagToViewState.size)
+          optimizedTagToViewState.forEach { key, value ->
+            tagSetForStoppedSurface[key] = this@SurfaceMountingManager
+            viewStatesToDelete.add(value)
+          }
+          optimizedTagToViewState.clear()
+        }
+        for (viewState in viewStatesToDelete) {
+          onViewStateDeleted(viewState)
+        }
+      } else {
+        val tagSetForStoppedSurface =
+            SparseArrayCompat<Any>().also { this.tagSetForStoppedSurface = it }
+        for ((key, value) in tagToViewState!!) {
+          tagSetForStoppedSurface[key] = this
+          onViewStateDeleted(value)
+        }
+        tagToViewState!!.clear()
       }
 
       // Evict all views from cache and memory
@@ -264,7 +296,6 @@ internal constructor(
       rootViewManager = null
       mountItemExecutor = null
       context = null
-      tagToViewState.clear()
       onViewAttachMountItems.clear()
       tagToSynchronousMountProps.clear()
       FLog.e(TAG, "Surface [$surfaceId] was stopped on SurfaceMountingManager.")
@@ -572,7 +603,7 @@ internal constructor(
             this.stateWrapper = stateWrapper
             this.eventEmitter = eventEmitterWrapper
           }
-      tagToViewState[reactTag] = viewState
+      registryPut(reactTag, viewState)
 
       if (isLayoutable) {
         @Suppress("UNCHECKED_CAST")
@@ -921,13 +952,19 @@ internal constructor(
       return
     }
 
-    var viewState = tagToViewState[reactTag]
-    if (viewState == null) {
-      // TODO T62717437 - Use a flag to determine that these event emitters belong to virtual nodes
-      // only.
-      viewState = ViewState(reactTag)
-      tagToViewState[reactTag] = viewState
-    }
+    // TODO T62717437 - Use a flag to determine that these event emitters belong to virtual nodes
+    // only.
+    val viewState: ViewState =
+        if (optimizedTagToViewState != null) {
+          registryLock.write { optimizedTagToViewState.getOrPut(reactTag) { ViewState(reactTag) } }
+        } else {
+          var vs = tagToViewState!![reactTag]
+          if (vs == null) {
+            vs = ViewState(reactTag)
+            tagToViewState!![reactTag] = vs
+          }
+          vs
+        }
     val previousEventEmitterWrapper = viewState.eventEmitter
     viewState.eventEmitter = eventEmitter
 
@@ -1039,7 +1076,7 @@ internal constructor(
       // To delete we simply remove the tag from the registry.
       // We want to rely on the correct set of MountInstructions being sent to the platform,
       // or StopSurface being called, so we do not handle deleting descendants of the View.
-      tagToViewState.remove(reactTag)
+      registryRemove(reactTag)
 
       onViewStateDeleted(viewState)
     }
@@ -1084,12 +1121,52 @@ internal constructor(
   }
 
   private fun getViewState(reactTag: Int): ViewState =
-      tagToViewState[reactTag]
+      registryGet(reactTag)
           ?: throw RetryableMountingLayerException(
               "Unable to find viewState for tag $reactTag. Surface stopped: $isStopped"
           )
 
-  private fun getNullableViewState(reactTag: Int): ViewState? = tagToViewState[reactTag]
+  private fun getNullableViewState(reactTag: Int): ViewState? = registryGet(reactTag)
+
+  private fun registryGet(tag: Int): ViewState? {
+    return if (optimizedTagToViewState != null) {
+      registryLock.read { optimizedTagToViewState[tag] }
+    } else {
+      tagToViewState!![tag]
+    }
+  }
+
+  private fun registryPut(tag: Int, state: ViewState) {
+    if (optimizedTagToViewState != null) {
+      registryLock.write { optimizedTagToViewState[tag] = state }
+    } else {
+      tagToViewState!![tag] = state
+    }
+  }
+
+  private fun registryRemove(tag: Int) {
+    if (optimizedTagToViewState != null) {
+      registryLock.write { optimizedTagToViewState.remove(tag) }
+    } else {
+      tagToViewState!!.remove(tag)
+    }
+  }
+
+  private fun registryContains(tag: Int): Boolean {
+    return if (optimizedTagToViewState != null) {
+      registryLock.read { optimizedTagToViewState.containsKey(tag) }
+    } else {
+      tagToViewState!!.containsKey(tag)
+    }
+  }
+
+  private inline fun registryForEachValue(action: (ViewState) -> Unit) {
+    if (optimizedTagToViewState != null) {
+      registryLock.read { optimizedTagToViewState.forEachValue(action) }
+    } else {
+      tagToViewState!!.values.forEach(action)
+    }
+  }
 
   /** Applies a bitmap as the background of the view with the given tag, if it exists. */
   @UiThread
@@ -1100,7 +1177,7 @@ internal constructor(
 
   public fun printSurfaceState(): Unit {
     FLog.e(TAG, "Views created for surface $surfaceId:")
-    for (viewState in tagToViewState.values) {
+    registryForEachValue { viewState ->
       val viewManagerName = viewState.viewManager?.name
       val view = viewState.view
       val parent = if (view != null) view.parent as View? else null
@@ -1142,7 +1219,7 @@ internal constructor(
   ): Unit {
     // When the surface stopped we will reset the view state map. We are not going to enqueue
     // pending events as they are not expected to be dispatched anyways.
-    val viewState = tagToViewState[reactTag]
+    val viewState = registryGet(reactTag)
 
     if (viewState == null) {
       // Cannot queue event without view state. Do nothing here.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cd8218c8b8588f3317bf63ce8d608548>>
+ * @generated SignedSource<<6ad566ffaa8330c696fa2088ff696a2b>>
  */
 
 /**
@@ -533,6 +533,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useNestedScrollViewAndroid(): Boolean = accessor.useNestedScrollViewAndroid()
+
+  /**
+   * Use MutableIntObjectMap with ReadWriteLock instead of ConcurrentHashMap for the view registry in SurfaceMountingManager to reduce memory overhead and GC pressure.
+   */
+  @JvmStatic
+  public fun useOptimizedViewRegistryOnAndroid(): Boolean = accessor.useOptimizedViewRegistryOnAndroid()
 
   /**
    * Use shared animation backend in C++ Animated

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4f9f5c1c46217ed6802abd5f786aac19>>
+ * @generated SignedSource<<ff84a26e3306cc438fead82ad766ce53>>
  */
 
 /**
@@ -104,6 +104,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var useLISAlgorithmInDifferentiatorCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
   private var useNestedScrollViewAndroidCache: Boolean? = null
+  private var useOptimizedViewRegistryOnAndroidCache: Boolean? = null
   private var useSharedAnimatedBackendCache: Boolean? = null
   private var useTraitHiddenOnAndroidCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
@@ -865,6 +866,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useNestedScrollViewAndroid()
       useNestedScrollViewAndroidCache = cached
+    }
+    return cached
+  }
+
+  override fun useOptimizedViewRegistryOnAndroid(): Boolean {
+    var cached = useOptimizedViewRegistryOnAndroidCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.useOptimizedViewRegistryOnAndroid()
+      useOptimizedViewRegistryOnAndroidCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8916e9f4a938a69ff175c806db9835d4>>
+ * @generated SignedSource<<817790c7ceb9112376b4ab4ee338ff43>>
  */
 
 /**
@@ -195,6 +195,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun useNativeViewConfigsInBridgelessMode(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useNestedScrollViewAndroid(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun useOptimizedViewRegistryOnAndroid(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useSharedAnimatedBackend(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a9a8ce443fa160a7494fc1c9e7baa02f>>
+ * @generated SignedSource<<1d764e41252e2709e574da5e0ac64bd7>>
  */
 
 /**
@@ -190,6 +190,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = false
 
   override fun useNestedScrollViewAndroid(): Boolean = false
+
+  override fun useOptimizedViewRegistryOnAndroid(): Boolean = false
 
   override fun useSharedAnimatedBackend(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cbe90c2bf8ba9d34804d97c31edfd31a>>
+ * @generated SignedSource<<299507458fe84339ddf816dd58671fd3>>
  */
 
 /**
@@ -108,6 +108,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var useLISAlgorithmInDifferentiatorCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
   private var useNestedScrollViewAndroidCache: Boolean? = null
+  private var useOptimizedViewRegistryOnAndroidCache: Boolean? = null
   private var useSharedAnimatedBackendCache: Boolean? = null
   private var useTraitHiddenOnAndroidCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
@@ -953,6 +954,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.useNestedScrollViewAndroid()
       accessedFeatureFlags.add("useNestedScrollViewAndroid")
       useNestedScrollViewAndroidCache = cached
+    }
+    return cached
+  }
+
+  override fun useOptimizedViewRegistryOnAndroid(): Boolean {
+    var cached = useOptimizedViewRegistryOnAndroidCache
+    if (cached == null) {
+      cached = currentProvider.useOptimizedViewRegistryOnAndroid()
+      accessedFeatureFlags.add("useOptimizedViewRegistryOnAndroid")
+      useOptimizedViewRegistryOnAndroidCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<536a5156deea17740dd24782bf79feb4>>
+ * @generated SignedSource<<8f887fb839df553b23886a61537e6991>>
  */
 
 /**
@@ -190,6 +190,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun useNativeViewConfigsInBridgelessMode(): Boolean
 
   @DoNotStrip public fun useNestedScrollViewAndroid(): Boolean
+
+  @DoNotStrip public fun useOptimizedViewRegistryOnAndroid(): Boolean
 
   @DoNotStrip public fun useSharedAnimatedBackend(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b99eaffc2d11a08a6efe32b2e2732965>>
+ * @generated SignedSource<<5cd1b7223dd852a97280f6dd9bd3e559>>
  */
 
 /**
@@ -543,6 +543,12 @@ class ReactNativeFeatureFlagsJavaProvider
     return method(javaProvider_);
   }
 
+  bool useOptimizedViewRegistryOnAndroid() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useOptimizedViewRegistryOnAndroid");
+    return method(javaProvider_);
+  }
+
   bool useSharedAnimatedBackend() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useSharedAnimatedBackend");
@@ -1015,6 +1021,11 @@ bool JReactNativeFeatureFlagsCxxInterop::useNestedScrollViewAndroid(
   return ReactNativeFeatureFlags::useNestedScrollViewAndroid();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::useOptimizedViewRegistryOnAndroid(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::useOptimizedViewRegistryOnAndroid();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::useSharedAnimatedBackend(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useSharedAnimatedBackend();
@@ -1338,6 +1349,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useNestedScrollViewAndroid",
         JReactNativeFeatureFlagsCxxInterop::useNestedScrollViewAndroid),
+      makeNativeMethod(
+        "useOptimizedViewRegistryOnAndroid",
+        JReactNativeFeatureFlagsCxxInterop::useOptimizedViewRegistryOnAndroid),
       makeNativeMethod(
         "useSharedAnimatedBackend",
         JReactNativeFeatureFlagsCxxInterop::useSharedAnimatedBackend),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4be32bad403baeca1a28f19ad181c42c>>
+ * @generated SignedSource<<b738c6cd756294b4d2a79f3a058a20b8>>
  */
 
 /**
@@ -280,6 +280,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useNestedScrollViewAndroid(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool useOptimizedViewRegistryOnAndroid(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useSharedAnimatedBackend(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b55a79c9f84947fa4c12b04f15cfeefb>>
+ * @generated SignedSource<<13f834a8abe75fd71b75aa7d94a40303>>
  */
 
 /**
@@ -360,6 +360,10 @@ bool ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode() {
 
 bool ReactNativeFeatureFlags::useNestedScrollViewAndroid() {
   return getAccessor().useNestedScrollViewAndroid();
+}
+
+bool ReactNativeFeatureFlags::useOptimizedViewRegistryOnAndroid() {
+  return getAccessor().useOptimizedViewRegistryOnAndroid();
 }
 
 bool ReactNativeFeatureFlags::useSharedAnimatedBackend() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8e9b09843bf4a0312b254559a975f612>>
+ * @generated SignedSource<<e516c670626478b1cc1a139fe52cae21>>
  */
 
 /**
@@ -458,6 +458,11 @@ class ReactNativeFeatureFlags {
    * When enabled, ReactScrollView will extend NestedScrollView instead of ScrollView on Android for improved nested scrolling support.
    */
   RN_EXPORT static bool useNestedScrollViewAndroid();
+
+  /**
+   * Use MutableIntObjectMap with ReadWriteLock instead of ConcurrentHashMap for the view registry in SurfaceMountingManager to reduce memory overhead and GC pressure.
+   */
+  RN_EXPORT static bool useOptimizedViewRegistryOnAndroid();
 
   /**
    * Use shared animation backend in C++ Animated

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ac0901d62505522c1c6f7e251e845871>>
+ * @generated SignedSource<<631de9950d2702721e0f926967e77a3e>>
  */
 
 /**
@@ -1541,6 +1541,24 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::useOptimizedViewRegistryOnAndroid() {
+  auto flagValue = useOptimizedViewRegistryOnAndroid_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(84, "useOptimizedViewRegistryOnAndroid");
+
+    flagValue = currentProvider_->useOptimizedViewRegistryOnAndroid();
+    useOptimizedViewRegistryOnAndroid_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
   auto flagValue = useSharedAnimatedBackend_.load();
 
@@ -1550,7 +1568,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "useSharedAnimatedBackend");
+    markFlagAsAccessed(85, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1568,7 +1586,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(86, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1586,7 +1604,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "useTurboModuleInterop");
+    markFlagAsAccessed(87, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1604,7 +1622,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(87, "useTurboModules");
+    markFlagAsAccessed(88, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;
@@ -1622,7 +1640,7 @@ bool ReactNativeFeatureFlagsAccessor::useUnorderedMapInDifferentiator() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(88, "useUnorderedMapInDifferentiator");
+    markFlagAsAccessed(89, "useUnorderedMapInDifferentiator");
 
     flagValue = currentProvider_->useUnorderedMapInDifferentiator();
     useUnorderedMapInDifferentiator_ = flagValue;
@@ -1640,7 +1658,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(89, "viewCullingOutsetRatio");
+    markFlagAsAccessed(90, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1658,7 +1676,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(90, "viewTransitionEnabled");
+    markFlagAsAccessed(91, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1676,7 +1694,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(91, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(92, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9334675799ea378311b8c675ed419b1d>>
+ * @generated SignedSource<<fb0e613a671d6bae0c7b5af15597058f>>
  */
 
 /**
@@ -116,6 +116,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool useLISAlgorithmInDifferentiator();
   bool useNativeViewConfigsInBridgelessMode();
   bool useNestedScrollViewAndroid();
+  bool useOptimizedViewRegistryOnAndroid();
   bool useSharedAnimatedBackend();
   bool useTraitHiddenOnAndroid();
   bool useTurboModuleInterop();
@@ -135,7 +136,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 92> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 93> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -221,6 +222,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> useLISAlgorithmInDifferentiator_;
   std::atomic<std::optional<bool>> useNativeViewConfigsInBridgelessMode_;
   std::atomic<std::optional<bool>> useNestedScrollViewAndroid_;
+  std::atomic<std::optional<bool>> useOptimizedViewRegistryOnAndroid_;
   std::atomic<std::optional<bool>> useSharedAnimatedBackend_;
   std::atomic<std::optional<bool>> useTraitHiddenOnAndroid_;
   std::atomic<std::optional<bool>> useTurboModuleInterop_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d987528598996fc7b1bf3c872f51e2ed>>
+ * @generated SignedSource<<278c24a1e5dc5fc24f9f9349fe6d09b4>>
  */
 
 /**
@@ -360,6 +360,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool useNestedScrollViewAndroid() override {
+    return false;
+  }
+
+  bool useOptimizedViewRegistryOnAndroid() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7853bedb8a11b20a633eb6579257b4bc>>
+ * @generated SignedSource<<30df75f444340e662066500c20e3614f>>
  */
 
 /**
@@ -799,6 +799,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::useNestedScrollViewAndroid();
+  }
+
+  bool useOptimizedViewRegistryOnAndroid() override {
+    auto value = values_["useOptimizedViewRegistryOnAndroid"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::useOptimizedViewRegistryOnAndroid();
   }
 
   bool useSharedAnimatedBackend() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e2bc4c6058c873605e7030d74fa2901d>>
+ * @generated SignedSource<<2262c1ed8ff7983caf65dc2975d52642>>
  */
 
 /**
@@ -109,6 +109,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useLISAlgorithmInDifferentiator() = 0;
   virtual bool useNativeViewConfigsInBridgelessMode() = 0;
   virtual bool useNestedScrollViewAndroid() = 0;
+  virtual bool useOptimizedViewRegistryOnAndroid() = 0;
   virtual bool useSharedAnimatedBackend() = 0;
   virtual bool useTraitHiddenOnAndroid() = 0;
   virtual bool useTurboModuleInterop() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d93bf6a3c6f32af3071b7f81568d3e8d>>
+ * @generated SignedSource<<0d2290e74b0e522d15403896a40955cc>>
  */
 
 /**
@@ -462,6 +462,11 @@ bool NativeReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode(
 bool NativeReactNativeFeatureFlags::useNestedScrollViewAndroid(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useNestedScrollViewAndroid();
+}
+
+bool NativeReactNativeFeatureFlags::useOptimizedViewRegistryOnAndroid(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::useOptimizedViewRegistryOnAndroid();
 }
 
 bool NativeReactNativeFeatureFlags::useSharedAnimatedBackend(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3f44b628a681f0d005827f51f4ad885e>>
+ * @generated SignedSource<<0afa249e55277f5029eec0a740ad00b2>>
  */
 
 /**
@@ -203,6 +203,8 @@ class NativeReactNativeFeatureFlags
   bool useNativeViewConfigsInBridgelessMode(jsi::Runtime& runtime);
 
   bool useNestedScrollViewAndroid(jsi::Runtime& runtime);
+
+  bool useOptimizedViewRegistryOnAndroid(jsi::Runtime& runtime);
 
   bool useSharedAnimatedBackend(jsi::Runtime& runtime);
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -945,6 +945,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    useOptimizedViewRegistryOnAndroid: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2026-04-28',
+        description:
+          'Use MutableIntObjectMap with ReadWriteLock instead of ConcurrentHashMap for the view registry in SurfaceMountingManager to reduce memory overhead and GC pressure.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     useSharedAnimatedBackend: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1dd51a152bb30c0e2073a14566c8368d>>
+ * @generated SignedSource<<01348c36a6888d3ca4863a37ca70d150>>
  * @flow strict
  * @noformat
  */
@@ -131,6 +131,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   useLISAlgorithmInDifferentiator: Getter<boolean>,
   useNativeViewConfigsInBridgelessMode: Getter<boolean>,
   useNestedScrollViewAndroid: Getter<boolean>,
+  useOptimizedViewRegistryOnAndroid: Getter<boolean>,
   useSharedAnimatedBackend: Getter<boolean>,
   useTraitHiddenOnAndroid: Getter<boolean>,
   useTurboModuleInterop: Getter<boolean>,
@@ -541,6 +542,10 @@ export const useNativeViewConfigsInBridgelessMode: Getter<boolean> = createNativ
  * When enabled, ReactScrollView will extend NestedScrollView instead of ScrollView on Android for improved nested scrolling support.
  */
 export const useNestedScrollViewAndroid: Getter<boolean> = createNativeFlagGetter('useNestedScrollViewAndroid', false);
+/**
+ * Use MutableIntObjectMap with ReadWriteLock instead of ConcurrentHashMap for the view registry in SurfaceMountingManager to reduce memory overhead and GC pressure.
+ */
+export const useOptimizedViewRegistryOnAndroid: Getter<boolean> = createNativeFlagGetter('useOptimizedViewRegistryOnAndroid', false);
 /**
  * Use shared animation backend in C++ Animated
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5ab72b9af228bc7e591bc0addaf6150e>>
+ * @generated SignedSource<<68f7919d416dce9a9b6bc0959bfc259b>>
  * @flow strict
  * @noformat
  */
@@ -109,6 +109,7 @@ export interface Spec extends TurboModule {
   +useLISAlgorithmInDifferentiator?: () => boolean;
   +useNativeViewConfigsInBridgelessMode?: () => boolean;
   +useNestedScrollViewAndroid?: () => boolean;
+  +useOptimizedViewRegistryOnAndroid?: () => boolean;
   +useSharedAnimatedBackend?: () => boolean;
   +useTraitHiddenOnAndroid?: () => boolean;
   +useTurboModuleInterop?: () => boolean;


### PR DESCRIPTION
Summary:

Replace `ConcurrentHashMap<Int, ViewState>` with `MutableIntObjectMap<ViewState>` + `ReentrantReadWriteLock` in `SurfaceMountingManager`, behind the `useOptimizedViewRegistryOnAndroid` feature flag.

`ConcurrentHashMap<Int, ViewState>` boxes every `Int` key to `java.lang.Integer` (16 bytes) and allocates a `Node` object per entry (~32 bytes). `MutableIntObjectMap` from `androidx.collection` uses a Swiss Table layout with primitive `IntArray` keys — ~9 bytes/entry vs ~56-64 bytes, a ~6x reduction in map overhead. For a complex surface with 2000+ views, this saves ~90KB per surface in map overhead alone, plus reduced GC pressure from eliminating `Integer` boxing.

The `ReentrantReadWriteLock` replaces CHM's built-in concurrency. This matches the access pattern: reads from any thread (`getEventEmitter`, `enqueuePendingEvent`), writes almost exclusively from the UI thread. Readers never block each other. `stopSurface` snapshots entries under the write lock and processes `onViewStateDeleted` outside the lock to minimize reader blocking.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D102797904


