### PR TITLE
 Enable `overrideBySynchronousMountPropsAtMountingAndroid` by default on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d2b14345bf627e35562530912b3aae1f>>
+ * @generated SignedSource<<a9a8ce443fa160a7494fc1c9e7baa02f>>
  */
 
 /**
@@ -153,7 +153,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun hideOffscreenVirtualViewsOnIOS(): Boolean = false
 
-  override fun overrideBySynchronousMountPropsAtMountingAndroid(): Boolean = false
+  override fun overrideBySynchronousMountPropsAtMountingAndroid(): Boolean = true
 
   override fun perfIssuesEnabled(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4a2fd61cbcdb28042f09ccb03c970674>>
+ * @generated SignedSource<<d987528598996fc7b1bf3c872f51e2ed>>
  */
 
 /**
@@ -288,7 +288,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool overrideBySynchronousMountPropsAtMountingAndroid() override {
-    return false;
+    return true;
   }
 
   bool perfIssuesEnabled() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -743,7 +743,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     overrideBySynchronousMountPropsAtMountingAndroid: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2025-09-04',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<aa202d346e68c3dd641d557306964ebe>>
+ * @generated SignedSource<<1dd51a152bb30c0e2073a14566c8368d>>
  * @flow strict
  * @noformat
  */
@@ -468,7 +468,7 @@ export const hideOffscreenVirtualViewsOnIOS: Getter<boolean> = createNativeFlagG
 /**
  * Override props at mounting with synchronously mounted (i.e. direct manipulation) props from Native Animated.
  */
-export const overrideBySynchronousMountPropsAtMountingAndroid: Getter<boolean> = createNativeFlagGetter('overrideBySynchronousMountPropsAtMountingAndroid', false);
+export const overrideBySynchronousMountPropsAtMountingAndroid: Getter<boolean> = createNativeFlagGetter('overrideBySynchronousMountPropsAtMountingAndroid', true);
 /**
  * Enable reporting Performance Issues (`detail.devtools.performanceIssue`). Displayed in the V2 Performance Monitor and the "Performance Issues" sub-panel in DevTools.
  */


### PR DESCRIPTION
Enable `overrideBySynchronousMountPropsAtMountingAndroid` by default on Android.

This flag was added to prevent regular Fabric mount updates from overriding newer props that were already applied synchronously by Native Animated direct manipulation. Without this path enabled, Android can still hit a race where:

1. Native Animated applies `transform` props synchronously on the UI thread.
2. A regular Fabric mount update for the same view is already in flight with older props.
3. That regular mount update reaches `SurfaceMountingManager.updateProps()` later and overwrites the newer synchronous animated value.
4. The view visibly jumps/flickers during the animation.

This is not just theoretical. I spent about a week debugging this from a real Android flickering issue, and the final repro is intentionally very small. The visual impact is clear in the README videos, and I am attaching the same videos here as well.

Minimal repro:
https://github.com/jingjing2222/fix-react-native-android-flickering

The repro uses React Native 0.85.2 with Android Fabric. The JS only runs `Animated.timing(..., {useNativeDriver: true})` for `translateX` and `translateY`.

## As-is

https://github.com/user-attachments/assets/64882c09-1580-4209-a4aa-aa62bcf58287

With the current default, flickering is visible during the animation.

## To-be

https://github.com/user-attachments/assets/fa929562-36b3-4930-98b5-754098e571e3

With `overrideBySynchronousMountPropsAtMountingAndroid` enabled, the flickering is gone.

The existing mounting-layer flag fixes this by storing the latest synchronous mount props and reapplying them when regular mount props are processed. This makes the final mounted props preserve the latest Native Animated direct manipulation value.

Because this can happen with a simple native-driver transform animation, enabling this default should prevent other Android users from spending time debugging the same race condition.

### Why Android only?

iOS Fabric already tracks props managed by NativeAnimated on the component view. When NativeAnimated synchronously updates props such as `transform` or `opacity`, iOS records those prop keys and prevents later normal Fabric updates from re-applying stale values for those props.

Android Fabric has a similar mechanism through `tagToSynchronousMountProps`, but it was gated behind `overrideBySynchronousMountPropsAtMountingAndroid`, which defaults to false. Therefore, NativeAnimated could synchronously apply the final transform to the view, and a later normal Fabric props update could re-apply stale transform props, causing a transient flicker.

This change makes Android preserve synchronously mounted NativeAnimated props across later Fabric prop updates, matching the ownership behavior already present on iOS.

## Changelog:

[ANDROID] [FIXED] - Prevent stale Fabric mount updates from overriding newer Native Animated synchronous prop updates.

## Test Plan:

- Ran `yarn featureflags --update`
- Ran `git diff --check`
- Verified generated feature flag defaults were updated for Android, C++, and JS.
- Verified the minimal repro with the README videos attached above:
  - as-is/current default: flickering is visible during `translateX`/`translateY` native-driver animation
  - to-be/flag enabled: flickering is not visible