### PR TITLE
 Re-enabled VirtualizedList "retains batch render region when an item is appended" test

### DIFF
--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -1836,8 +1836,7 @@ it('retains initial render region when an item is appended', async () => {
   expect(component).toMatchSnapshot();
 });
 
-// TODO: Revisit this test case after upgrading to React 19.
-skipTestSilenceLinter(
+it(
   'retains batch render region when an item is appended',
   async () => {
     const items = generateItems(10);
@@ -1860,12 +1859,9 @@ skipTestSilenceLinter(
         viewport: {width: 10, height: 50},
         content: {width: 10, height: 100},
       });
-      performAllBatches();
     });
 
-    await act(async () => {
-      await jest.runAllTimersAsync();
-    });
+    await advanceUntilLastCellIndexRendered(component, items.length - 1);
 
     await act(() => {
       component.update(
@@ -2639,11 +2635,28 @@ async function advanceUntilRenderAreaChanged(component) {
     }
 
     await act(() => {
-      jest.advanceTimersToNextTimer(1);
+      performNextBatch();
     });
   }
 
   throw new Error(`Render area did not change`);
+}
+
+async function advanceUntilLastCellIndexRendered(component, targetLastIndex) {
+  const instance = component.getInstance();
+  const MAX_TIMER_STEPS = 20;
+
+  for (let step = 0; step < MAX_TIMER_STEPS; step++) {
+    if (instance.state.cellsAroundViewport.last === targetLastIndex) {
+      return;
+    }
+
+    await act(() => {
+      performNextBatch();
+    });
+  }
+
+  throw new Error(`Target last index ${targetLastIndex} not rendered`);
 }
 
 function performAllBatches() {

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -1836,52 +1836,49 @@ it('retains initial render region when an item is appended', async () => {
   expect(component).toMatchSnapshot();
 });
 
-it(
-  'retains batch render region when an item is appended',
-  async () => {
-    const items = generateItems(10);
-    const ITEM_HEIGHT = 10;
+it('retains batch render region when an item is appended', async () => {
+  const items = generateItems(10);
+  const ITEM_HEIGHT = 10;
 
-    let component;
-    await act(() => {
-      component = create(
-        <VirtualizedList
-          initialNumToRender={1}
-          maxToRenderPerBatch={1}
-          {...baseItemProps(items)}
-          {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-        />,
-      );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialNumToRender={1}
+        maxToRenderPerBatch={1}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
+
+  await act(() => {
+    simulateLayout(component, {
+      viewport: {width: 10, height: 50},
+      content: {width: 10, height: 100},
     });
+  });
 
-    await act(() => {
-      simulateLayout(component, {
-        viewport: {width: 10, height: 50},
-        content: {width: 10, height: 100},
-      });
-    });
+  await advanceUntilLastCellIndexRendered(component, items.length - 1);
 
-    await advanceUntilLastCellIndexRendered(component, items.length - 1);
+  await act(() => {
+    component.update(
+      <VirtualizedList
+        initialNumToRender={1}
+        maxToRenderPerBatch={1}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+        data={generateItems(11)}
+      />,
+    );
+  });
 
-    await act(() => {
-      component.update(
-        <VirtualizedList
-          initialNumToRender={1}
-          maxToRenderPerBatch={1}
-          {...baseItemProps(items)}
-          {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-          data={generateItems(11)}
-        />,
-      );
-    });
-
-    // Adding an item to the list after batch render should keep the existing
-    // rendered items rendered. We batch render 10 items, then add an 11th. Expect
-    // the first ten items to be present, with a spacer for the 11th until the
-    // next batch render.
-    expect(component).toMatchSnapshot();
-  },
-);
+  // Adding an item to the list after batch render should keep the existing
+  // rendered items rendered. We batch render 10 items, then add an 11th. Expect
+  // the first ten items to be present, with a spacer for the 11th until the
+  // next batch render.
+  expect(component).toMatchSnapshot();
+});
 
 it('constrains batch render region when an item is removed', async () => {
   const items = generateItems(10);


### PR DESCRIPTION
## Summary:

This PR is a follow-up of #56358, in order to improve and VirtualizedList tests. 
I re-enabled the skipped test `retains batch render region when an item is appended`.
With React 19, the previous approach that was using `jest.runAllTimersAsync` in this test path was unstable because the pre-update render region could still be processing updates.
I adopted the same approach used in #56358 by introducing a small helper function, `advanceUntilLastCellIndexRendered`, which advances timers one step at a time and stops when the expected state is reached: `cellsAroundViewport.last === items.length - 1`.

As part of this follow-up, I also aligned `advanceUntilRenderAreaChanged` to use performNextBatch for consistent stepwise timer advancement.

## Changelog:

[GENERAL][FIXED] - Re-enabled VirtualizedList "retains batch render region when an item is appended" tes

## Test Plan:

- Ran the VirtualizedList-test.js and verified all test cases passed.
- Verified test modification correctness by intentionally breaking the related snapshot and check that it is breaking/it is failing.
