### PR TITLE
Add useTraitHiddenOnIOS feature flag

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cd8218c8b8588f3317bf63ce8d608548>>
+ * @generated SignedSource<<89627a52825452c8f6c0dd3725f61175>>
  */
 
 /**
@@ -545,6 +545,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useTraitHiddenOnAndroid(): Boolean = accessor.useTraitHiddenOnAndroid()
+
+  /**
+   * Use Trait::hidden slice-skip on iOS. When false, Hidden subtrees stay mounted and hide via UIView.hidden = YES (the path in UIView+ComponentViewProtocol since 2018) instead of REMOVE + DELETE.
+   */
+  @JvmStatic
+  public fun useTraitHiddenOnIOS(): Boolean = accessor.useTraitHiddenOnIOS()
 
   /**
    * In Bridgeless mode, should legacy NativeModules use the TurboModule system?

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4f9f5c1c46217ed6802abd5f786aac19>>
+ * @generated SignedSource<<e2704fec486263b5f74ab909f9d2f533>>
  */
 
 /**
@@ -106,6 +106,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var useNestedScrollViewAndroidCache: Boolean? = null
   private var useSharedAnimatedBackendCache: Boolean? = null
   private var useTraitHiddenOnAndroidCache: Boolean? = null
+  private var useTraitHiddenOnIOSCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
   private var useTurboModulesCache: Boolean? = null
   private var useUnorderedMapInDifferentiatorCache: Boolean? = null
@@ -883,6 +884,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useTraitHiddenOnAndroid()
       useTraitHiddenOnAndroidCache = cached
+    }
+    return cached
+  }
+
+  override fun useTraitHiddenOnIOS(): Boolean {
+    var cached = useTraitHiddenOnIOSCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.useTraitHiddenOnIOS()
+      useTraitHiddenOnIOSCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8916e9f4a938a69ff175c806db9835d4>>
+ * @generated SignedSource<<9a216ce4f720f39e338ba9eb40e3503d>>
  */
 
 /**
@@ -199,6 +199,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun useSharedAnimatedBackend(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useTraitHiddenOnAndroid(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun useTraitHiddenOnIOS(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useTurboModuleInterop(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d2b14345bf627e35562530912b3aae1f>>
+ * @generated SignedSource<<d047393d9b77ab6bdf610f272ec376cd>>
  */
 
 /**
@@ -194,6 +194,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun useSharedAnimatedBackend(): Boolean = false
 
   override fun useTraitHiddenOnAndroid(): Boolean = false
+
+  override fun useTraitHiddenOnIOS(): Boolean = true
 
   override fun useTurboModuleInterop(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cbe90c2bf8ba9d34804d97c31edfd31a>>
+ * @generated SignedSource<<e23bcf89e2a15139f6a1511ebb7d6fc8>>
  */
 
 /**
@@ -110,6 +110,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var useNestedScrollViewAndroidCache: Boolean? = null
   private var useSharedAnimatedBackendCache: Boolean? = null
   private var useTraitHiddenOnAndroidCache: Boolean? = null
+  private var useTraitHiddenOnIOSCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
   private var useTurboModulesCache: Boolean? = null
   private var useUnorderedMapInDifferentiatorCache: Boolean? = null
@@ -973,6 +974,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.useTraitHiddenOnAndroid()
       accessedFeatureFlags.add("useTraitHiddenOnAndroid")
       useTraitHiddenOnAndroidCache = cached
+    }
+    return cached
+  }
+
+  override fun useTraitHiddenOnIOS(): Boolean {
+    var cached = useTraitHiddenOnIOSCache
+    if (cached == null) {
+      cached = currentProvider.useTraitHiddenOnIOS()
+      accessedFeatureFlags.add("useTraitHiddenOnIOS")
+      useTraitHiddenOnIOSCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<536a5156deea17740dd24782bf79feb4>>
+ * @generated SignedSource<<4ba890681ce63a02ddcd443223515323>>
  */
 
 /**
@@ -194,6 +194,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun useSharedAnimatedBackend(): Boolean
 
   @DoNotStrip public fun useTraitHiddenOnAndroid(): Boolean
+
+  @DoNotStrip public fun useTraitHiddenOnIOS(): Boolean
 
   @DoNotStrip public fun useTurboModuleInterop(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b99eaffc2d11a08a6efe32b2e2732965>>
+ * @generated SignedSource<<592d2f00a3b2ff81533cf74f27068819>>
  */
 
 /**
@@ -555,6 +555,12 @@ class ReactNativeFeatureFlagsJavaProvider
     return method(javaProvider_);
   }
 
+  bool useTraitHiddenOnIOS() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useTraitHiddenOnIOS");
+    return method(javaProvider_);
+  }
+
   bool useTurboModuleInterop() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useTurboModuleInterop");
@@ -1025,6 +1031,11 @@ bool JReactNativeFeatureFlagsCxxInterop::useTraitHiddenOnAndroid(
   return ReactNativeFeatureFlags::useTraitHiddenOnAndroid();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::useTraitHiddenOnIOS(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::useTraitHiddenOnIOS();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::useTurboModuleInterop(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useTurboModuleInterop();
@@ -1344,6 +1355,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useTraitHiddenOnAndroid",
         JReactNativeFeatureFlagsCxxInterop::useTraitHiddenOnAndroid),
+      makeNativeMethod(
+        "useTraitHiddenOnIOS",
+        JReactNativeFeatureFlagsCxxInterop::useTraitHiddenOnIOS),
       makeNativeMethod(
         "useTurboModuleInterop",
         JReactNativeFeatureFlagsCxxInterop::useTurboModuleInterop),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4be32bad403baeca1a28f19ad181c42c>>
+ * @generated SignedSource<<23eef56b233a38a30476600370621264>>
  */
 
 /**
@@ -286,6 +286,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useTraitHiddenOnAndroid(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool useTraitHiddenOnIOS(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useTurboModuleInterop(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b55a79c9f84947fa4c12b04f15cfeefb>>
+ * @generated SignedSource<<05ffdb0ed4ce2b2f2eed475127ff170a>>
  */
 
 /**
@@ -368,6 +368,10 @@ bool ReactNativeFeatureFlags::useSharedAnimatedBackend() {
 
 bool ReactNativeFeatureFlags::useTraitHiddenOnAndroid() {
   return getAccessor().useTraitHiddenOnAndroid();
+}
+
+bool ReactNativeFeatureFlags::useTraitHiddenOnIOS() {
+  return getAccessor().useTraitHiddenOnIOS();
 }
 
 bool ReactNativeFeatureFlags::useTurboModuleInterop() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8e9b09843bf4a0312b254559a975f612>>
+ * @generated SignedSource<<21d1871f9323c4adc17695dcc141a60d>>
  */
 
 /**
@@ -468,6 +468,11 @@ class ReactNativeFeatureFlags {
    * Use Trait::hidden on Android
    */
   RN_EXPORT static bool useTraitHiddenOnAndroid();
+
+  /**
+   * Use Trait::hidden slice-skip on iOS. When false, Hidden subtrees stay mounted and hide via UIView.hidden = YES (the path in UIView+ComponentViewProtocol since 2018) instead of REMOVE + DELETE.
+   */
+  RN_EXPORT static bool useTraitHiddenOnIOS();
 
   /**
    * In Bridgeless mode, should legacy NativeModules use the TurboModule system?

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ac0901d62505522c1c6f7e251e845871>>
+ * @generated SignedSource<<6c5ecdf9466d74d3a4c66a7bacfc7043>>
  */
 
 /**
@@ -1577,6 +1577,24 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnIOS() {
+  auto flagValue = useTraitHiddenOnIOS_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(86, "useTraitHiddenOnIOS");
+
+    flagValue = currentProvider_->useTraitHiddenOnIOS();
+    useTraitHiddenOnIOS_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
   auto flagValue = useTurboModuleInterop_.load();
 
@@ -1586,7 +1604,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "useTurboModuleInterop");
+    markFlagAsAccessed(87, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1604,7 +1622,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(87, "useTurboModules");
+    markFlagAsAccessed(88, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;
@@ -1622,7 +1640,7 @@ bool ReactNativeFeatureFlagsAccessor::useUnorderedMapInDifferentiator() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(88, "useUnorderedMapInDifferentiator");
+    markFlagAsAccessed(89, "useUnorderedMapInDifferentiator");
 
     flagValue = currentProvider_->useUnorderedMapInDifferentiator();
     useUnorderedMapInDifferentiator_ = flagValue;
@@ -1640,7 +1658,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(89, "viewCullingOutsetRatio");
+    markFlagAsAccessed(90, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1658,7 +1676,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(90, "viewTransitionEnabled");
+    markFlagAsAccessed(91, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1676,7 +1694,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(91, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(92, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9334675799ea378311b8c675ed419b1d>>
+ * @generated SignedSource<<d34324172201668ef16dd273f62a65c7>>
  */
 
 /**
@@ -118,6 +118,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool useNestedScrollViewAndroid();
   bool useSharedAnimatedBackend();
   bool useTraitHiddenOnAndroid();
+  bool useTraitHiddenOnIOS();
   bool useTurboModuleInterop();
   bool useTurboModules();
   bool useUnorderedMapInDifferentiator();
@@ -135,7 +136,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 92> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 93> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -223,6 +224,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> useNestedScrollViewAndroid_;
   std::atomic<std::optional<bool>> useSharedAnimatedBackend_;
   std::atomic<std::optional<bool>> useTraitHiddenOnAndroid_;
+  std::atomic<std::optional<bool>> useTraitHiddenOnIOS_;
   std::atomic<std::optional<bool>> useTurboModuleInterop_;
   std::atomic<std::optional<bool>> useTurboModules_;
   std::atomic<std::optional<bool>> useUnorderedMapInDifferentiator_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4a2fd61cbcdb28042f09ccb03c970674>>
+ * @generated SignedSource<<7861725f5c1354b87caba6b7c0e406a7>>
  */
 
 /**
@@ -369,6 +369,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
 
   bool useTraitHiddenOnAndroid() override {
     return false;
+  }
+
+  bool useTraitHiddenOnIOS() override {
+    return true;
   }
 
   bool useTurboModuleInterop() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7853bedb8a11b20a633eb6579257b4bc>>
+ * @generated SignedSource<<d2bff249236ed8e2ec0139cc3afb0241>>
  */
 
 /**
@@ -817,6 +817,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::useTraitHiddenOnAndroid();
+  }
+
+  bool useTraitHiddenOnIOS() override {
+    auto value = values_["useTraitHiddenOnIOS"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::useTraitHiddenOnIOS();
   }
 
   bool useTurboModuleInterop() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e2bc4c6058c873605e7030d74fa2901d>>
+ * @generated SignedSource<<b2c5cfbae7d9854967f8e219f88f696b>>
  */
 
 /**
@@ -111,6 +111,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useNestedScrollViewAndroid() = 0;
   virtual bool useSharedAnimatedBackend() = 0;
   virtual bool useTraitHiddenOnAndroid() = 0;
+  virtual bool useTraitHiddenOnIOS() = 0;
   virtual bool useTurboModuleInterop() = 0;
   virtual bool useTurboModules() = 0;
   virtual bool useUnorderedMapInDifferentiator() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d93bf6a3c6f32af3071b7f81568d3e8d>>
+ * @generated SignedSource<<a27cde35e65dec75d74ab9e4521bbe7a>>
  */
 
 /**
@@ -472,6 +472,11 @@ bool NativeReactNativeFeatureFlags::useSharedAnimatedBackend(
 bool NativeReactNativeFeatureFlags::useTraitHiddenOnAndroid(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useTraitHiddenOnAndroid();
+}
+
+bool NativeReactNativeFeatureFlags::useTraitHiddenOnIOS(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::useTraitHiddenOnIOS();
 }
 
 bool NativeReactNativeFeatureFlags::useTurboModuleInterop(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3f44b628a681f0d005827f51f4ad885e>>
+ * @generated SignedSource<<85c7f4be002fb6edd73b11d3876abbd6>>
  */
 
 /**
@@ -207,6 +207,8 @@ class NativeReactNativeFeatureFlags
   bool useSharedAnimatedBackend(jsi::Runtime& runtime);
 
   bool useTraitHiddenOnAndroid(jsi::Runtime& runtime);
+
+  bool useTraitHiddenOnIOS(jsi::Runtime& runtime);
 
   bool useTurboModuleInterop(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp
@@ -58,9 +58,20 @@ static void sliceChildShadowNodeViewPairsRecursively(
     auto& childShadowNode = *sharedChildShadowNode;
     // T153547836: Disabled on Android because the mounting infrastructure
     // is not fully ready yet.
+    //
+    // On iOS, the Trait::Hidden slice-skip destroys host views via REMOVE +
+    // DELETE on every `display: none` toggle. Apps that mutate native state
+    // imperatively via Fabric Commands lose that state silently, because
+    // Commands have no prop-shape for React to replay onto the new instance.
+    // `useTraitHiddenOnIOS` lets such apps opt out and fall back to the
+    // hide-via-`UIView.hidden` path that has been in
+    // `UIView+ComponentViewProtocol.updateLayoutMetrics:` since 2018
+    // (D8460108). Defaults to `true` so existing behaviour is preserved.
     if (
 #ifdef ANDROID
         ReactNativeFeatureFlags::useTraitHiddenOnAndroid() &&
+#elif defined(__APPLE__)
+        ReactNativeFeatureFlags::useTraitHiddenOnIOS() &&
 #endif
         childShadowNode.getTraits().check(ShadowNodeTraits::Trait::Hidden)) {
       continue;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -21,6 +21,9 @@
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <react/renderer/mounting/stubs/stubs.h>
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
+
 namespace facebook::react {
 
 class StackingContextTest : public ::testing::Test {
@@ -974,5 +977,64 @@ TEST_F(StackingContextTest, zIndexAndFlattenedNodes) {
     EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, 3);
 #endif
   });
+}
+
+namespace {
+
+// Override that flips the iOS slice-skip flag off so that Hidden subtrees
+// stay in the mount slice and are hidden via UIView.hidden = YES (the path
+// in UIView+ComponentViewProtocol since 2018) instead of being torn down
+// via REMOVE + DELETE.
+class UseTraitHiddenOnIOSDisabledOverride
+    : public ReactNativeFeatureFlagsDefaults {
+ public:
+  bool useTraitHiddenOnIOS() override {
+    return false;
+  }
+};
+
+} // namespace
+
+// Companion to the `display: none` assertions above. The default-flag
+// case (current iOS behaviour: views removed) is already covered there.
+// This test pins the opt-out: with `useTraitHiddenOnIOS = false`, an iOS
+// `display: none` subtree must stay in the mount slice — i.e. the view
+// tree should match what Android already produces with
+// `useTraitHiddenOnAndroid = false` (its default).
+//
+// Skipped on Android: the `useTraitHiddenOnIOS` gate is unreachable
+// there because the surrounding block is `#ifdef ANDROID && useTraitHiddenOnAndroid()`.
+TEST_F(
+    StackingContextTest,
+    displayNoneRespectsUseTraitHiddenOnIOSOptOut) {
+#ifdef ANDROID
+  GTEST_SKIP() << "useTraitHiddenOnIOS gate is unreachable on Android";
+#else
+  ReactNativeFeatureFlags::override(
+      std::make_unique<UseTraitHiddenOnIOSDisabledOverride>());
+
+  mutateViewShadowNodeProps_(nodeBB_, [](ViewProps& props) {
+    auto& yogaStyle = props.yogaStyle;
+    yogaStyle.setDisplay(yoga::Display::None);
+  });
+
+  testViewTree_([](const StubViewTree& viewTree) {
+    // With useTraitHiddenOnIOS = false, the Hidden subtree stays in the
+    // mount slice. These expectations mirror the existing `#ifdef ANDROID`
+    // assertion in `zIndexAndFlattenedNodes` for the same display:none
+    // mutation.
+    EXPECT_EQ(viewTree.size(), 8);
+
+    // nodeBB_ (tag 6) forms a stacking context and is present.
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 5);
+
+    // The root view subviews are [6, 10, 9, 5, 3].
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, 6);
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, 10);
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, 9);
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.at(4)->tag, 3);
+  });
+#endif
 }
 } // namespace facebook::react

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -965,6 +965,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    useTraitHiddenOnIOS: {
+      defaultValue: true,
+      metadata: {
+        dateAdded: '2026-04-30',
+        description:
+          'Use Trait::hidden slice-skip on iOS. When false, Hidden subtrees stay mounted and hide via UIView.hidden = YES (the path in UIView+ComponentViewProtocol since 2018) instead of REMOVE + DELETE.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     useTurboModuleInterop: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<aa202d346e68c3dd641d557306964ebe>>
+ * @generated SignedSource<<133adf1c55824bb238caf569f94829ca>>
  * @flow strict
  * @noformat
  */
@@ -133,6 +133,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   useNestedScrollViewAndroid: Getter<boolean>,
   useSharedAnimatedBackend: Getter<boolean>,
   useTraitHiddenOnAndroid: Getter<boolean>,
+  useTraitHiddenOnIOS: Getter<boolean>,
   useTurboModuleInterop: Getter<boolean>,
   useTurboModules: Getter<boolean>,
   useUnorderedMapInDifferentiator: Getter<boolean>,
@@ -549,6 +550,10 @@ export const useSharedAnimatedBackend: Getter<boolean> = createNativeFlagGetter(
  * Use Trait::hidden on Android
  */
 export const useTraitHiddenOnAndroid: Getter<boolean> = createNativeFlagGetter('useTraitHiddenOnAndroid', false);
+/**
+ * Use Trait::hidden slice-skip on iOS. When false, Hidden subtrees stay mounted and hide via UIView.hidden = YES (the path in UIView+ComponentViewProtocol since 2018) instead of REMOVE + DELETE.
+ */
+export const useTraitHiddenOnIOS: Getter<boolean> = createNativeFlagGetter('useTraitHiddenOnIOS', true);
 /**
  * In Bridgeless mode, should legacy NativeModules use the TurboModule system?
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5ab72b9af228bc7e591bc0addaf6150e>>
+ * @generated SignedSource<<4832bd4ef65113e677d266f15200ec37>>
  * @flow strict
  * @noformat
  */
@@ -111,6 +111,7 @@ export interface Spec extends TurboModule {
   +useNestedScrollViewAndroid?: () => boolean;
   +useSharedAnimatedBackend?: () => boolean;
   +useTraitHiddenOnAndroid?: () => boolean;
+  +useTraitHiddenOnIOS?: () => boolean;
   +useTurboModuleInterop?: () => boolean;
   +useTurboModules?: () => boolean;
   +useUnorderedMapInDifferentiator?: () => boolean;


### PR DESCRIPTION
Closes #56656.

## Summary:

Adds `useTraitHiddenOnIOS`, the iOS twin of [`useTraitHiddenOnAndroid`](https://github.com/facebook/react-native/pull/54112). Defaults to `true` so iOS behaviour is unchanged.

Set it to `false` and `Trait::Hidden` subtrees stay mounted and get hidden via [`UIView.hidden = YES`](https://github.com/facebook/react-native/blob/795d9022707d543540217c72bf05d4e5893ecfe2/packages/react-native/React/Fabric/Mounting/UIView%2BComponentViewProtocol.mm#L117-L119) instead of being torn down via [`REMOVE + DELETE`](https://github.com/facebook/react-native/blob/795d9022707d543540217c72bf05d4e5893ecfe2/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp#L353-L361). That hide path has been in the codebase since 2018 — the [2020 slice-skip](https://github.com/facebook/react-native/blob/795d9022707d543540217c72bf05d4e5893ecfe2/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp#L62-L67) just makes it unreachable on iOS by default.

### Why does this matter?

Custom Fabric components that mutate native state via Commands (the same way `RCTTextInput.focus()` and `RCTScrollView.scrollTo()` do) lose that state silently every time an ancestor toggles `display: none`. Commands have no prop-shape, so React can't replay them onto the freshly-built instance. And [`<Suspense>` flips `display: none`](https://github.com/facebook/react/blob/f4e0d4ed0cb44f5f106579d20824f49ec41247f3/packages/react-native-renderer/src/ReactFiberConfigFabric.js#L535-L550) every time it suspends — so anything below a Suspense boundary that holds Command-set state is exposed today.

10-second, 3-tap reproducer: https://github.com/SudoPlz/reproducer-react-native.

### Why a flag instead of just flipping the default?

Same approach as #54112 — the existing platform behaviour stays the default, apps opt out if they need to. No surprises for anyone not actively reaching for it.

## Changelog:

[IOS] [ADDED] - `useTraitHiddenOnIOS` feature flag (defaults to `true`)

## Test Plan:

- `zIndexAndFlattenedNodes` in `StackingContextTest.cpp` already exercises `display: none` and asserts the iOS arm via `#ifdef ANDROID / #else`. With the flag at its default `true` that assertion still holds, so existing-behaviour coverage is free.
- New `displayNoneRespectsUseTraitHiddenOnIOSOptOut` overrides the flag to `false` and asserts the inverse: Hidden subtree stays mounted, mirroring what the Android arm already says. Skipped on Android via `GTEST_SKIP` because the iOS gate is unreachable there.
- Smoke-tested on iOS Simulator against the reproducer above: bug repros with default flag; view survives the toggle with the override.
