### PR TITLE
Update prettier-plugin-hermes-parser in fbsource to 0.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "node-fetch": "^2.2.0",
     "nullthrows": "^1.1.1",
     "prettier": "3.6.2",
-    "prettier-plugin-hermes-parser": "0.35.0",
+    "prettier-plugin-hermes-parser": "0.36.0",
     "react": "19.2.3",
     "react-test-renderer": "19.2.3",
     "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7797,10 +7797,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier-plugin-hermes-parser@0.35.0:
-  version "0.35.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.35.0.tgz#f037f76b50669aa9fd9dcbe78ceec7b891239646"
-  integrity sha512-+qAxEwdNI6sWw/g/+OxbUp5Tt5WaiuufQpDyE95M13S+P+IO8UDmErSBUwN+QvxakcT0bGTd8sfSLJNZrfV4eg==
+prettier-plugin-hermes-parser@0.36.0:
+  version "0.36.0"
+  resolved "https://registry.facebook.net/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.36.0.tgz#8839207d3a4290b7afe1bd54fbc5154f963b8cf2"
+  integrity sha512-CtlJ5l0DC48SN3OWSht5jAEIFU92xwHSe87/Bl005/9TlHyN2aAmPa6T/A2JLiIgRT/lGsCtc6srwEMM3/5k4w==
 
 prettier@3.6.2:
   version "3.6.2"


### PR DESCRIPTION
Summary:
Bump prettier-plugin-hermes-parser to 0.36.0.

Changelog: [internal]

Differential Revision: D103107243


