### PR TITLE
[iOS] Account for contentInset in Fabric maintainVisibleContentPosition autoscroll

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -1096,13 +1096,14 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   if (horizontal) {
     CGFloat deltaX = _firstVisibleView.frame.origin.x - _prevFirstVisibleFrame.origin.x;
     if (ABS(deltaX) > 0.5) {
-      CGFloat x = _scrollView.contentOffset.x;
+      CGFloat leftInset = [self isInverted] ? _scrollView.contentInset.right : _scrollView.contentInset.left;
+      CGFloat x = _scrollView.contentOffset.x + leftInset;
       [self _forceDispatchNextScrollEvent];
       _scrollView.contentOffset = CGPointMake(_scrollView.contentOffset.x + deltaX, _scrollView.contentOffset.y);
       if (autoscrollThreshold) {
         // If the offset WAS within the threshold of the start, animate to the start.
         if (x <= autoscrollThreshold.value()) {
-          [self scrollToOffset:CGPointMake(0, _scrollView.contentOffset.y) animated:YES];
+          [self scrollToOffset:CGPointMake(-leftInset, _scrollView.contentOffset.y) animated:YES];
         }
       }
     }
@@ -1110,13 +1111,14 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     CGRect newFrame = _firstVisibleView.frame;
     CGFloat deltaY = newFrame.origin.y - _prevFirstVisibleFrame.origin.y;
     if (ABS(deltaY) > 0.5) {
-      CGFloat y = _scrollView.contentOffset.y;
+      CGFloat bottomInset = [self isInverted] ? _scrollView.contentInset.top : _scrollView.contentInset.bottom;
+      CGFloat y = _scrollView.contentOffset.y + bottomInset;
       [self _forceDispatchNextScrollEvent];
       _scrollView.contentOffset = CGPointMake(_scrollView.contentOffset.x, _scrollView.contentOffset.y + deltaY);
       if (autoscrollThreshold) {
         // If the offset WAS within the threshold of the start, animate to the start.
         if (y <= autoscrollThreshold.value()) {
-          [self scrollToOffset:CGPointMake(_scrollView.contentOffset.x, 0) animated:YES];
+          [self scrollToOffset:CGPointMake(_scrollView.contentOffset.x, -bottomInset) animated:YES];
         }
       }
     }


### PR DESCRIPTION
## Summary

The Fabric implementation of `_adjustForMaintainVisibleContentPosition` in `RCTScrollViewComponentView.mm` does not account for `contentInset` when computing the autoscroll threshold comparison or the scroll target position. The Paper implementation (`RCTScrollView.m`) already handles this correctly via `bottomInset`/`leftInset` variables. The Fabric port simply missed carrying this logic over.

### Root cause

**Vertical (before):**
```objc
CGFloat y = _scrollView.contentOffset.y;              // ignores contentInset
[self scrollToOffset:CGPointMake(..., 0) animated:YES]; // wrong target
```
**Vertical (after, matching Paper):**
```objc
CGFloat bottomInset = [self isInverted] ? _scrollView.contentInset.top : _scrollView.contentInset.bottom;
CGFloat y = _scrollView.contentOffset.y + bottomInset; // inset-adjusted
[self scrollToOffset:CGPointMake(..., -bottomInset) animated:YES]; // correct target
```

Same pattern for the horizontal branch with `leftInset`.

### Visible symptoms

On a scroll view with a non-zero `contentInset`:

1. **Wrong threshold firing**: The autoscroll threshold comparison uses raw `contentOffset` instead of the inset-adjusted value, causing autoscroll to fire when it should not (or fail to fire when it should).
2. **Wrong scroll target**: When autoscroll fires, `scrollToOffset` is called with `0` instead of `-inset`, causing the scroll view to jump to the wrong position.

The same scroll view behaves correctly on Paper (Old Architecture) since `RCTScrollView.m` already accounts for `contentInset`.

No behavior change when `contentInset` is zero.

## Changelog:
[iOS] [Fixed] - Account for contentInset in Fabric ScrollView maintainVisibleContentPosition autoscroll threshold and target

## Test Plan

- [ ] **Non-inverted vertical**, `contentInset={{ bottom: 100 }}`, `autoscrollToTopThreshold: 10`: insert item at index 0 while at the bottom → stays at correct position, does not jump to `y=0`
- [ ] **Inverted vertical**, `contentInset={{ top: 100 }}`, `autoscrollToTopThreshold: 10`: insert item at index 0 while at the bottom → stays at `contentOffset.y = -100`, does not jump to `y=0`
- [ ] Both cases, scrolled past the threshold: insert item → no autoscroll fires
- [ ] **Non-inverted horizontal**, `contentInset={{ left: 100 }}`: equivalent checks
- [ ] **Inverted horizontal**, `contentInset={{ right: 100 }}`: equivalent checks
- [ ] All cases with `contentInset` all zeros: existing behavior unchanged
- [ ] Run existing ScrollView tests: `yarn jest packages/react-native/Libraries/Components/ScrollView`