### PR TITLE
clear up props registry in shared backend on js thread (#56677)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -275,10 +275,6 @@ ShadowTree::Unique UIManager::stopSurface(SurfaceId surfaceId) const {
   // Stop any ongoing layout animations.
   stopSurfaceForAnimationDelegate(surfaceId);
 
-  if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-    animationBackend_->clearRegistryOnSurfaceStop(surfaceId);
-  }
-
   // Waiting for all concurrent commits to be finished and unregistering the
   // `ShadowTree`.
   auto shadowTree = getShadowTreeRegistry().remove(surfaceId);
@@ -295,6 +291,18 @@ ShadowTree::Unique UIManager::stopSurface(SurfaceId surfaceId) const {
       leakChecker_->stopSurface(surfaceId);
     }
   }
+
+  if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+    runtimeExecutor_(
+        [surfaceId,
+         animationBackendWeak = std::weak_ptr<UIManagerAnimationBackend>(
+             animationBackend_)](jsi::Runtime& /*runtime*/) {
+          if (auto animationBackend = animationBackendWeak.lock()) {
+            animationBackend->clearRegistryOnSurfaceStop(surfaceId);
+          }
+        });
+  }
+
   return shadowTree;
 }
 


### PR DESCRIPTION
Summary:

## Changelog:

[Internal] [Fixed] - clear up props registry in shared backend on js thread

stopSurface is usually called from main thread, but `animatedPropsRegistry_->getMap` in animationBackendCommitHook is called from js thread. Removing the surface props entry on ui thread can cause race condition (getMap() result on js thread becomes undefined) 

https://www.internalfb.com/code/fbsource/[26d70084020e]/xplat/js/react-native-github/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.cpp?lines=26-31

Reviewed By: christophpurrer

Differential Revision: D103752709


