### PR TITLE
Add animationBackend_ nullcheck before calling clearRegistry() (#56679)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -210,7 +210,8 @@ void UIManager::completeSurface(
     // after we commit a specific one.
     lazyShadowTreeRevisionConsistencyManager_->updateCurrentRevision(surfaceId);
 
-    if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+    if (ReactNativeFeatureFlags::useSharedAnimatedBackend() &&
+        animationBackend_) {
       animationBackend_->clearRegistry(surfaceId);
     }
   }

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -275,10 +275,6 @@ ShadowTree::Unique UIManager::stopSurface(SurfaceId surfaceId) const {
   // Stop any ongoing layout animations.
   stopSurfaceForAnimationDelegate(surfaceId);
 
-  if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-    animationBackend_->clearRegistryOnSurfaceStop(surfaceId);
-  }
-
   // Waiting for all concurrent commits to be finished and unregistering the
   // `ShadowTree`.
   auto shadowTree = getShadowTreeRegistry().remove(surfaceId);
@@ -295,6 +291,18 @@ ShadowTree::Unique UIManager::stopSurface(SurfaceId surfaceId) const {
       leakChecker_->stopSurface(surfaceId);
     }
   }
+
+  if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+    runtimeExecutor_(
+        [surfaceId,
+         animationBackendWeak = std::weak_ptr<UIManagerAnimationBackend>(
+             animationBackend_)](jsi::Runtime& /*runtime*/) {
+          if (auto animationBackend = animationBackendWeak.lock()) {
+            animationBackend->clearRegistryOnSurfaceStop(surfaceId);
+          }
+        });
+  }
+
   return shadowTree;
 }
 


### PR DESCRIPTION
Summary:

## Changelog:

[Internal] [Fixed] - Add animationBackend_ nullcheck before calling clearRegistry()

Reviewed By: christophpurrer

Differential Revision: D103759679


