### PR TITLE
Fix UBSan float-cast-overflow in BridgingTest.numberTest (#56693)

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -69,11 +69,6 @@ TEST_F(BridgingTest, numberTest) {
       -42,
       static_cast<uint32_t>(
           bridging::toJs(rt, static_cast<uint32_t>(-42)).asNumber()));
-
-  EXPECT_FALSE(
-      -42 ==
-      static_cast<int32_t>(
-          bridging::toJs(rt, static_cast<uint32_t>(-42)).asNumber()));
 }
 
 TEST_F(BridgingTest, stringTest) {


### PR DESCRIPTION
Summary:

Changelog:
[Internal] - Remove UB-relying assertion from BridgingTest.numberTest

Reviewed By: shwanton

Differential Revision: D103954447


