### PR TITLE
[0.81] [iOS] Backport TurboModule NSException safe-handling fix for iOS 26

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -435,7 +435,9 @@ void ObjCTurboModule::performVoidMethodInvocation(
     @try {
       [inv invokeWithTarget:strongModule];
     } @catch (NSException *exception) {
-      throw convertNSExceptionToJSError(runtime, exception, std::string{moduleName}, methodNameStr);
+      // Void methods are always async, re-throw instead of converting to
+      // JSError, same as the async branch in performMethodInvocation.
+      @throw exception;
     } @finally {
       [retainedObjectsForInvocation removeAllObjects];
     }


### PR DESCRIPTION
## Summary

Backport of #56265 (commit `4083a6ff92b0ffd4f71166848f3d7ce36172fac8`,
"Fix Hermes crash from TurboModule void method NSException handling")
from `main` to `0.81-stable`.

iOS 26 hardened TurboModule cold-start error handling. On the
unpatched 0.81 branch, ~66% of iPhones (per Apple's Feb 2026
adoption stats) crash at app launch with `EXC_BAD_ACCESS` /
`SIGABRT` inside `performVoidMethodInvocation` when any async void
TurboModule method throws an `NSException`. The unsafe path calls
`convertNSExceptionToJSError` from the native method call invoker
thread; since `jsi::Runtime` is not thread-safe, this corrupts
Hermes' heap.

The fix swaps the `throw convertNSExceptionToJSError(...)` for a
plain `@throw exception;`, mirroring how the sibling sync function
`performMethodInvocation` was already fixed in #50193 (D71619229)
back in March 2025. Since void methods are always async, there is
no JS caller to receive a converted JSError anyway — the original
JS call has already returned.

The cherry-pick from main applied cleanly (3-line single-file
change, no conflicts). This brings the fix to `0.81-stable` so the
huge install base on RN 0.81.x (Expo SDK 54 and the ecosystem
pinned to it) can ship a fix without an SDK upgrade.

## Linked issues

- Fixes #54859 ([iOS 26] App crashes on startup with TurboModule performVoidMethodInvocation - SIGABRT)
- Fixes #53960 (Runtime Exceptions in TurboModule Void Methods Crash the App)
- Related: expo/expo#44606

## Test plan

- Reproducer: https://github.com/picassomd/turbo-modules-exceptions
  (linked from #53960). On unpatched 0.81.5 the "Void Function"
  button crashes the app with `EXC_BAD_ACCESS` / `SIGABRT` inside
  `performVoidMethodInvocation` 100% of the time.
- After applying this cherry-pick the same button surfaces the
  expected RedBox / error log and the app keeps running.
- iOS 26 cold-start crash signature in #54859 matches the same
  code path (`performVoidMethodInvocation` → `convertNSExceptionToJSError`
  → Hermes heap corruption) and is resolved by this patch.
- No new tests required — the patch is a 3-line direct port of the
  upstream fix, which has full coverage on `main` (sibling test
  coverage already lives there for `performMethodInvocation`).

## Pick Request

This is a backport of a merged crash fix to a stable branch.
Marking as a pick request per RN backport conventions.