### PR TITLE
Return actual loaded bundle URL from SourceCodeModule

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/devsupport/SourceCodeModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/SourceCodeModule.cpp
@@ -7,17 +7,10 @@
 
 #include "SourceCodeModule.h"
 
-#include <react/devsupport/DevServerHelper.h>
-#include <string>
-
 namespace facebook::react {
 
 SourceCodeConstants SourceCodeModule::getConstants(jsi::Runtime& /*rt*/) {
-  std::string scriptURL;
-  if (auto devServerHelper = devServerHelper_.lock()) {
-    scriptURL = devServerHelper->getBundleUrl();
-  }
-  return SourceCodeConstants{.scriptURL = scriptURL};
+  return SourceCodeConstants{.scriptURL = sourceURL_};
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/devsupport/SourceCodeModule.h
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/SourceCodeModule.h
@@ -13,8 +13,6 @@
 
 namespace facebook::react {
 
-class DevServerHelper;
-
 using SourceCodeConstants = NativeSourceCodeSourceCodeConstants<std::string>;
 
 template <>
@@ -22,17 +20,15 @@ struct Bridging<SourceCodeConstants> : NativeSourceCodeSourceCodeConstantsBridgi
 
 class SourceCodeModule : public NativeSourceCodeCxxSpec<SourceCodeModule> {
  public:
-  explicit SourceCodeModule(
-      std::shared_ptr<CallInvoker> jsInvoker,
-      std::shared_ptr<DevServerHelper> devServerHelper = nullptr)
-      : NativeSourceCodeCxxSpec(jsInvoker), devServerHelper_(devServerHelper)
+  explicit SourceCodeModule(std::shared_ptr<CallInvoker> jsInvoker, std::string sourceURL = "")
+      : NativeSourceCodeCxxSpec(jsInvoker), sourceURL_(std::move(sourceURL))
   {
   }
 
   SourceCodeConstants getConstants(jsi::Runtime &rt);
 
  private:
-  std::weak_ptr<DevServerHelper> devServerHelper_;
+  std::string sourceURL_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactCxxTurboModuleProvider.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactCxxTurboModuleProvider.cpp
@@ -38,7 +38,8 @@ ReactCxxTurboModuleProvider::ReactCxxTurboModuleProvider(
     std::shared_ptr<SurfaceDelegate> logBoxSurfaceDelegate,
     HttpClientFactory httpClientFactory,
     WebSocketClientFactory webSocketClientFactory,
-    std::function<void()> liveReloadCallback)
+    std::function<void()> liveReloadCallback,
+    std::shared_ptr<std::string> sourceURL)
     : turboModuleProviders_(std::move(turboModuleProviders)),
       jsInvoker_(std::move(jsInvoker)),
       onJsError_(std::move(onJsError)),
@@ -48,7 +49,8 @@ ReactCxxTurboModuleProvider::ReactCxxTurboModuleProvider(
       logBoxSurfaceDelegate_(std::move(logBoxSurfaceDelegate)),
       httpClientFactory_(std::move(httpClientFactory)),
       webSocketClientFactory_(std::move(webSocketClientFactory)),
-      liveReloadCallback_(std::move(liveReloadCallback)) {}
+      liveReloadCallback_(std::move(liveReloadCallback)),
+      sourceURL_(std::move(sourceURL)) {}
 
 std::shared_ptr<TurboModule> ReactCxxTurboModuleProvider::operator()(
     const std::string& name) const {
@@ -82,7 +84,8 @@ std::shared_ptr<TurboModule> ReactCxxTurboModuleProvider::operator()(
   } else if (name == ImageLoaderModule::kModuleName) {
     return std::make_shared<ImageLoaderModule>(jsInvoker_);
   } else if (name == SourceCodeModule::kModuleName) {
-    return std::make_shared<SourceCodeModule>(jsInvoker_, devServerHelper_);
+    return std::make_shared<SourceCodeModule>(
+        jsInvoker_, sourceURL_ ? *sourceURL_ : "");
   } else if (name == WebSocketModule::kModuleName) {
     return std::make_shared<WebSocketModule>(
         jsInvoker_, webSocketClientFactory_);

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactCxxTurboModuleProvider.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactCxxTurboModuleProvider.h
@@ -33,7 +33,8 @@ class ReactCxxTurboModuleProvider final {
       std::shared_ptr<SurfaceDelegate> logBoxSurfaceDelegate = nullptr,
       HttpClientFactory httpClientFactory = nullptr,
       WebSocketClientFactory webSocketClientFactory = nullptr,
-      std::function<void()> liveReloadCallback = nullptr);
+      std::function<void()> liveReloadCallback = nullptr,
+      std::shared_ptr<std::string> sourceURL = nullptr);
 
   std::shared_ptr<TurboModule> operator()(const std::string &name) const;
 
@@ -48,6 +49,7 @@ class ReactCxxTurboModuleProvider final {
   HttpClientFactory httpClientFactory_;
   WebSocketClientFactory webSocketClientFactory_;
   std::function<void()> liveReloadCallback_;
+  std::shared_ptr<std::string> sourceURL_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -261,7 +261,8 @@ void ReactHost::createReactInstance() {
       reactInstanceData_->logBoxSurfaceDelegate,
       httpClientFactory,
       webSocketClientFactory,
-      std::move(liveReloadCallback));
+      std::move(liveReloadCallback),
+      sourceURL_);
 
   reactInstance_->initializeRuntime(
       {
@@ -392,6 +393,7 @@ bool ReactHost::loadScriptFromDevServer() {
                 })
             .get();
     auto script = std::make_unique<JSBigStdString>(std::move(response));
+    *sourceURL_ = bundleUrl;
     reactInstance_->loadScript(std::move(script), bundleUrl);
     devServerHelper_->setupHMRClient();
     return true;
@@ -408,6 +410,7 @@ bool ReactHost::loadScriptFromBundlePath(const std::string& bundlePath) {
   try {
     LOG(INFO) << "Loading JS bundle from bundle path: " << bundlePath;
     auto script = ResourceLoader::getFileContents(bundlePath);
+    *sourceURL_ = "";
     reactInstance_->loadScript(std::move(script), bundlePath);
     LOG(INFO) << "Loaded JS bundle from bundle path: " << bundlePath;
     return true;

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.h
@@ -110,6 +110,7 @@ class ReactHost {
   std::unique_ptr<SurfaceManager> surfaceManager_;
 
   std::shared_ptr<DevServerHelper> devServerHelper_;
+  std::shared_ptr<std::string> sourceURL_ = std::make_shared<std::string>();
   std::shared_ptr<Inspector> inspector_;
   std::unique_ptr<PackagerConnection> packagerConnection_;
 


### PR DESCRIPTION
Summary:
The C++ `SourceCodeModule` (ReactCxxPlatform) always derived `scriptURL` from `DevServerHelper::getBundleUrl()`, coupling the module to dev infrastructure. This diff replaces that dependency with a simple `std::string` parameter passed at construction time.

`ReactHost` and `FoxReactHost` store the source URL in a `shared_ptr<string>` that is updated on each successful dev-server bundle load. When `SourceCodeModule` is instantiated (lazily, after the bundle is loaded), the TurboModule provider dereferences the current value and passes it through as a plain string. For file-based bundle loading the URL is cleared, matching the previous behavior.

This decouples `SourceCodeModule` from `DevServerHelper` without introducing lambdas, context container lookups, or shared mutable state in the module itself.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D102669868


