### PR TITLE
Remove --version spawn from debugger shell preparation

### DIFF
--- a/packages/debugger-shell/src/node/index.flow.js
+++ b/packages/debugger-shell/src/node/index.flow.js
@@ -8,10 +8,7 @@
  * @format
  */
 
-import {
-  prepareDebuggerShellFromDotSlashFile,
-  spawnAndGetStderr,
-} from './private/LaunchUtils';
+import {prepareDebuggerShellFromDotSlashFile} from './private/LaunchUtils';
 
 const {spawn} = require('cross-spawn');
 const debug = require('debug')('Metro:DebuggerShell');
@@ -174,20 +171,6 @@ async function unstable_prepareDebuggerShell({
         throw new Error(`Unknown flavor: ${flavor}`);
     }
 
-    const [binaryPath, baseArgs] = getShellBinaryAndArgs(
-      flavor,
-      prebuiltBinaryPath,
-    );
-    const {code, stderr} = await spawnAndGetStderr(binaryPath, [
-      ...baseArgs,
-      '--version',
-    ]);
-    if (code !== 0) {
-      return {
-        code: 'unexpected_error',
-        verboseInfo: stderr,
-      };
-    }
     return {code: 'success'};
   } catch (e) {
     return {

--- a/packages/debugger-shell/src/node/private/LaunchUtils.js
+++ b/packages/debugger-shell/src/node/private/LaunchUtils.js
@@ -95,4 +95,4 @@ async function prepareDebuggerShellFromDotSlashFile(
   };
 }
 
-export {spawnAndGetStderr, prepareDebuggerShellFromDotSlashFile};
+export {prepareDebuggerShellFromDotSlashFile};


### PR DESCRIPTION
Summary:
Addresses an issue where on macOS, we briefly flashed the RNDT app icon in the Dock. (This has been raised to us recently by Expo.)

**More info**

The `unstable_prepareDebuggerShell` health check was spawning the Electron binary with `--version` after a successful `dotslash fetch`. Invoking the native binary causes the app icon flash.

- I couldn't find an Electron-side way to eliminate this (e.g. headless).
- DotSlash already performs mandatory verification of every fetched artifact. The additional `--version` spawn was therefore redundant/overkill.

Changelog:
[General][Fixed] - React Native DevTools will no longer briefly flash in the system dock/taskbar when starting Metro

Differential Revision: D104061238


