### PR TITLE
Add TextEffect component and registry for custom text span effects (#56720)

### DIFF
--- a/packages/react-native/Libraries/Text/TextEffectNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextEffectNativeComponent.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {HostComponent} from '../../src/private/types/HostComponent';
+
+import * as NativeComponentRegistry from '../NativeComponent/NativeComponentRegistry';
+import * as React from 'react';
+
+type NativeTextEffectProps = Readonly<{
+  effectName?: ?string,
+  effectProps?: ?Readonly<{+[string]: unknown}>,
+  children?: React.Node,
+}>;
+
+const NativeTextEffect: HostComponent<NativeTextEffectProps> =
+  NativeComponentRegistry.get<NativeTextEffectProps>('RCTTextEffect', () => ({
+    validAttributes: {
+      effectName: true,
+      effectProps: true,
+    },
+    uiViewClassName: 'RCTTextEffect',
+  }));
+
+export default NativeTextEffect;

--- a/packages/react-native/Libraries/Text/requireNativeTextEffect.js
+++ b/packages/react-native/Libraries/Text/requireNativeTextEffect.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import Text from './Text';
+import NativeTextEffect from './TextEffectNativeComponent';
+import * as React from 'react';
+
+export default function requireNativeTextEffect<P>(
+  name: string,
+): React.ComponentType<{...P, children: React.Node}> {
+  component TextEffect(...props: {...P, children: React.Node}) {
+    const {children, ...effectProps} = props;
+    return (
+      <NativeTextEffect effectName={name} effectProps={effectProps}>
+        <Text>{children}</Text>
+      </NativeTextEffect>
+    );
+  }
+  TextEffect.displayName = `TextEffect(${name})`;
+  return TextEffect;
+}

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6141,6 +6141,7 @@ public final class com/facebook/react/views/text/TextAttributeProps {
 	public static final field TA_KEY_TEXT_DECORATION_COLOR I
 	public static final field TA_KEY_TEXT_DECORATION_LINE I
 	public static final field TA_KEY_TEXT_DECORATION_STYLE I
+	public static final field TA_KEY_TEXT_EFFECTS I
 	public static final field TA_KEY_TEXT_SHADOW_COLOR I
 	public static final field TA_KEY_TEXT_SHADOW_OFFSET_DX I
 	public static final field TA_KEY_TEXT_SHADOW_OFFSET_DY I
@@ -6207,6 +6208,9 @@ public final class com/facebook/react/views/text/TextAttributes {
 	public final fun setLineHeight (F)V
 	public final fun setMaxFontSizeMultiplier (F)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/facebook/react/views/text/TextEffectRegistry$Companion {
 }
 
 public abstract interface class com/facebook/react/views/textinput/ContentSizeWatcher {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -93,6 +93,7 @@ import com.facebook.react.uimanager.events.SynchronousEventReceiver;
 import com.facebook.react.views.text.PreparedLayout;
 import com.facebook.react.views.text.ReactTextViewManager;
 import com.facebook.react.views.text.ReactTextViewManagerCallback;
+import com.facebook.react.views.text.TextEffectRegistry;
 import com.facebook.react.views.text.TextLayoutManager;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -178,6 +179,8 @@ public class FabricUIManager
   private final FabricEventDispatcher mEventDispatcher;
   private final MountItemDispatcher mMountItemDispatcher;
   private final ViewManagerRegistry mViewManagerRegistry;
+
+  private final TextEffectRegistry mTextEffectRegistry = new TextEffectRegistry();
 
   private final BatchEventDispatchedListener mBatchEventDispatchedListener;
 
@@ -553,7 +556,8 @@ public class FabricUIManager
             PixelUtil.toPixelFromDIP(height),
             textViewManager instanceof ReactTextViewManagerCallback
                 ? (ReactTextViewManagerCallback) textViewManager
-                : null);
+                : null,
+            mTextEffectRegistry);
   }
 
   public int getColor(int surfaceId, String[] resourcePaths) {
@@ -641,7 +645,8 @@ public class FabricUIManager
         textViewManager instanceof ReactTextViewManagerCallback
             ? (ReactTextViewManagerCallback) textViewManager
             : null,
-        attachmentsPositions);
+        attachmentsPositions,
+        mTextEffectRegistry);
   }
 
   @AnyThread
@@ -666,7 +671,8 @@ public class FabricUIManager
         getYogaMeasureMode(minHeight, maxHeight),
         textViewManager instanceof ReactTextViewManagerCallback
             ? (ReactTextViewManagerCallback) textViewManager
-            : null);
+            : null,
+        mTextEffectRegistry);
   }
 
   @AnyThread
@@ -698,6 +704,11 @@ public class FabricUIManager
         getYogaMeasureMode(minWidth, maxWidth),
         getYogaSize(minHeight, maxHeight),
         getYogaMeasureMode(minHeight, maxHeight));
+  }
+
+  @UnstableReactNativeAPI
+  public TextEffectRegistry getTextEffectRegistry() {
+    return mTextEffectRegistry;
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -20,6 +20,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewParent
 import androidx.annotation.ColorInt
 import androidx.annotation.DoNotInline
 import androidx.annotation.RequiresApi
@@ -28,6 +29,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.uimanager.BackgroundStyleApplicator
 import com.facebook.react.uimanager.ReactCompoundView
+import com.facebook.react.uimanager.RootView
 import com.facebook.react.uimanager.style.Overflow
 import com.facebook.react.views.text.internal.span.AnimatedEffectSpan
 import com.facebook.react.views.text.internal.span.CanvasEffectSpan
@@ -260,6 +262,13 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
       val layoutX = event.x - paddingLeft
       val layoutY = event.y - paddingTop - (preparedLayout?.verticalOffset ?: 0f)
       if (touchableSpan.onTouchEvent(action, layoutX, layoutY)) {
+        if (action == MotionEvent.ACTION_DOWN) {
+          // Returning true from onTouchEvent stops Android's onClickListener path on parents,
+          // but RN's gesture responder runs at the JS layer and would still let an ancestor
+          // <Pressable> fire onPress on this gesture. Tell the React root we're taking over so
+          // it cancels in-flight JS responder tracking — same hook ScrollView uses on intercept.
+          findRootView()?.onChildStartedNativeGesture(this, event)
+        }
         invalidate()
         return true
       }
@@ -288,6 +297,15 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
     }
 
     return true
+  }
+
+  private fun findRootView(): RootView? {
+    var p: ViewParent? = parent
+    while (p != null) {
+      if (p is RootView) return p
+      p = p.parent
+    }
+    return null
   }
 
   private fun <T> getSpanInCoords(x: Int, y: Int, clazz: Class<T>): T? {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
@@ -160,6 +160,7 @@ public constructor(
             view.context.assets,
             attributedString,
             reactTextViewManagerCallback,
+            TextEffectRegistry.current,
         )
     view.setSpanned(spanned)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.kt
@@ -100,6 +100,11 @@ public class TextAttributeProps private constructor() {
   public var role: ReactAccessibilityDelegate.Role? = null
     private set
 
+  internal data class TextEffectEntry(val name: String, val props: String?)
+
+  internal var textEffects: List<TextEffectEntry> = emptyList()
+    private set
+
   public var fontStyle: Int = ReactConstants.UNSET
     private set
 
@@ -375,6 +380,9 @@ public class TextAttributeProps private constructor() {
     public const val TA_KEY_ROLE: Int = 26
     public const val TA_KEY_TEXT_TRANSFORM: Int = 27
     public const val TA_KEY_MAX_FONT_SIZE_MULTIPLIER: Int = 29
+    public const val TA_KEY_TEXT_EFFECTS: Int = 30
+    private const val TE_KEY_NAME: Int = 0
+    private const val TE_KEY_PROPS: Int = 1
 
     public const val UNSET: Int = -1
 
@@ -429,6 +437,22 @@ public class TextAttributeProps private constructor() {
           TA_KEY_TEXT_TRANSFORM -> result.setTextTransform(entry.stringValue)
           TA_KEY_MAX_FONT_SIZE_MULTIPLIER ->
               result.maxFontSizeMultiplier = entry.doubleValue.toFloat()
+          TA_KEY_TEXT_EFFECTS -> {
+            val effectsMap = entry.mapBufferValue
+            val list = mutableListOf<TextEffectEntry>()
+            for (j in 0 until effectsMap.count) {
+              val effectMap = effectsMap.getMapBuffer(j)
+              list.add(
+                  TextEffectEntry(
+                      name = effectMap.getString(TE_KEY_NAME),
+                      props =
+                          if (effectMap.contains(TE_KEY_PROPS)) effectMap.getString(TE_KEY_PROPS)
+                          else null,
+                  )
+              )
+            }
+            result.textEffects = list
+          }
         }
       }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextEffectRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextEffectRegistry.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text
+
+import com.facebook.common.logging.FLog
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.views.text.internal.span.TextEffectSpan
+import java.util.concurrent.ConcurrentHashMap
+
+@UnstableReactNativeAPI
+public class TextEffectRegistry {
+  private val factories = ConcurrentHashMap<String, TextEffectSpanFactory>()
+
+  public fun register(name: String, factory: TextEffectSpanFactory) {
+    factories[name] = factory
+    current = this
+  }
+
+  public fun unregister(name: String) {
+    factories.remove(name)
+  }
+
+  internal fun createSpan(name: String, props: ReadableMap?): TextEffectSpan? {
+    val factory = factories[name] ?: return null
+    return try {
+      factory.createSpan(props)
+    } catch (t: Throwable) {
+      // A throwing factory (e.g. invalid color prop) must not break the entire text render path
+      // for an unrelated paragraph or for subsequent renders. Skip this span and keep going.
+      FLog.e(TAG, "TextEffectSpanFactory '$name' threw — skipping span", t)
+      null
+    }
+  }
+
+  public companion object {
+    private const val TAG = "TextEffectRegistry"
+    @JvmField @Volatile public var current: TextEffectRegistry? = null
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextEffectSpanFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextEffectSpanFactory.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text
+
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.views.text.internal.span.TextEffectSpan
+
+@UnstableReactNativeAPI
+public fun interface TextEffectSpanFactory {
+  public fun createSpan(props: ReadableMap?): TextEffectSpan
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -26,8 +26,12 @@ import android.view.Gravity
 import android.view.View
 import com.facebook.common.logging.FLog
 import com.facebook.infer.annotation.Assertions
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.common.ReactConstants
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.mapbuffer.MapBuffer
 import com.facebook.react.common.mapbuffer.ReadableMapBuffer
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
@@ -60,6 +64,8 @@ import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
+import org.json.JSONArray
+import org.json.JSONObject
 
 /** Class responsible of creating [Spanned] object for the JS representation of Text */
 internal object TextLayoutManager {
@@ -229,13 +235,20 @@ internal object TextLayoutManager {
     }
   }
 
+  @OptIn(UnstableReactNativeAPI::class)
   private fun buildSpannableFromFragments(
       assets: AssetManager,
       fragments: MapBuffer,
       sb: SpannableStringBuilder,
       ops: MutableList<SetSpanOperation>,
       outputReactTags: IntArray?,
+      textEffectRegistry: TextEffectRegistry?,
   ) {
+    // Track pending text effects to coalesce consecutive fragments with the same effects into
+    // single spans, avoiding duplicate draws (e.g. multiple accent marks in HighlighterTextSpan).
+    var pendingEffects: List<TextAttributeProps.TextEffectEntry> = emptyList()
+    var pendingEffectStart = 0
+
     for (i in 0 until fragments.count) {
       val fragment = fragments.getMapBuffer(i)
       val start = sb.length
@@ -352,6 +365,34 @@ internal object TextLayoutManager {
           ops.add(SetSpanOperation(start, end, ReactTagSpan(reactTag)))
         }
       }
+
+      // Coalesce consecutive fragments with the same text effects into single spans.
+      val effects = textAttributes.textEffects
+      if (effects != pendingEffects) {
+        // Flush the previous pending effects
+        if (pendingEffects.isNotEmpty() && textEffectRegistry != null) {
+          for (effect in pendingEffects) {
+            val effectProps = jsonStringToReadableMap(effect.props)
+            val span = textEffectRegistry.createSpan(effect.name, effectProps)
+            if (span != null) {
+              ops.add(SetSpanOperation(pendingEffectStart, start, span))
+            }
+          }
+        }
+        pendingEffects = effects
+        pendingEffectStart = start
+      }
+    }
+
+    // Flush any remaining pending effects after the last fragment
+    if (pendingEffects.isNotEmpty() && textEffectRegistry != null) {
+      for (effect in pendingEffects) {
+        val effectProps = jsonStringToReadableMap(effect.props)
+        val span = textEffectRegistry.createSpan(effect.name, effectProps)
+        if (span != null) {
+          ops.add(SetSpanOperation(pendingEffectStart, sb.length, span))
+        }
+      }
     }
   }
 
@@ -364,10 +405,12 @@ internal object TextLayoutManager {
       val height: Double,
   )
 
+  @OptIn(UnstableReactNativeAPI::class)
   private fun buildSpannableFromFragmentsOptimized(
       assets: AssetManager,
       fragments: MapBuffer,
       outputReactTags: IntArray?,
+      textEffectRegistry: TextEffectRegistry?,
   ): Spannable {
     val text = StringBuilder()
     val parsedFragments = ArrayList<FragmentAttributes>(fragments.count)
@@ -407,6 +450,11 @@ internal object TextLayoutManager {
     }
 
     val spannable = SpannableString(text)
+
+    // Track pending text effects to coalesce consecutive fragments with the same effects into
+    // single spans, avoiding duplicate draws (e.g. multiple accent marks in HighlighterTextSpan).
+    var pendingEffects: List<TextAttributeProps.TextEffectEntry> = emptyList()
+    var pendingEffectStart = 0
 
     var start = 0
     for ((i, fragment) in parsedFragments.withIndex()) {
@@ -534,16 +582,53 @@ internal object TextLayoutManager {
         }
       }
 
+      // Coalesce consecutive fragments with the same text effects into single spans.
+      val effects = fragment.props.textEffects
+      if (effects != pendingEffects) {
+        if (pendingEffects.isNotEmpty() && textEffectRegistry != null) {
+          for (effect in pendingEffects) {
+            val effectProps = jsonStringToReadableMap(effect.props)
+            val span = textEffectRegistry.createSpan(effect.name, effectProps)
+            if (span != null) {
+              spannable.setSpan(span, pendingEffectStart, start, Spannable.SPAN_EXCLUSIVE_INCLUSIVE)
+            }
+          }
+        }
+        pendingEffects = effects
+        pendingEffectStart = start
+      }
+
       start = end
+    }
+
+    // Flush any remaining pending effects after the last fragment
+    if (pendingEffects.isNotEmpty() && textEffectRegistry != null) {
+      for (effect in pendingEffects) {
+        val effectProps = jsonStringToReadableMap(effect.props)
+        val span = textEffectRegistry.createSpan(effect.name, effectProps)
+        if (span != null) {
+          spannable.setSpan(span, pendingEffectStart, start, Spannable.SPAN_EXCLUSIVE_INCLUSIVE)
+        }
+      }
     }
 
     return spannable
   }
 
+  @OptIn(UnstableReactNativeAPI::class)
   fun getOrCreateSpannableForText(
       assets: AssetManager,
       attributedString: MapBuffer,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
+  ): Spannable =
+      getOrCreateSpannableForText(assets, attributedString, reactTextViewManagerCallback, null)
+
+  @OptIn(UnstableReactNativeAPI::class)
+  internal fun getOrCreateSpannableForText(
+      assets: AssetManager,
+      attributedString: MapBuffer,
+      reactTextViewManagerCallback: ReactTextViewManagerCallback?,
+      textEffectRegistry: TextEffectRegistry?,
   ): Spannable {
     var text: Spannable?
     if (attributedString.contains(AS_KEY_CACHE_ID)) {
@@ -556,20 +641,29 @@ internal object TextLayoutManager {
               attributedString.getMapBuffer(AS_KEY_FRAGMENTS),
               reactTextViewManagerCallback,
               null,
+              textEffectRegistry,
           )
     }
 
     return text
   }
 
+  @OptIn(UnstableReactNativeAPI::class)
   private fun createSpannableFromAttributedString(
       assets: AssetManager,
       fragments: MapBuffer,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
       outputReactTags: IntArray?,
+      textEffectRegistry: TextEffectRegistry? = null,
   ): Spannable {
     if (ReactNativeFeatureFlags.enableAndroidTextMeasurementOptimizations()) {
-      val spannable = buildSpannableFromFragmentsOptimized(assets, fragments, outputReactTags)
+      val spannable =
+          buildSpannableFromFragmentsOptimized(
+              assets,
+              fragments,
+              outputReactTags,
+              textEffectRegistry,
+          )
 
       reactTextViewManagerCallback?.onPostProcessSpannable(spannable)
       return spannable
@@ -581,7 +675,7 @@ internal object TextLayoutManager {
       // a new spannable will be wiped out
       val ops: MutableList<SetSpanOperation> = ArrayList()
 
-      buildSpannableFromFragments(assets, fragments, sb, ops, outputReactTags)
+      buildSpannableFromFragments(assets, fragments, sb, ops, outputReactTags, textEffectRegistry)
 
       // TODO T31905686: add support for inline Images
       // While setting the Spans on the final text, we also check whether any of them are images.
@@ -759,6 +853,7 @@ internal object TextLayoutManager {
     return paint
   }
 
+  @OptIn(UnstableReactNativeAPI::class)
   private fun createLayoutForMeasurement(
       assets: AssetManager,
       attributedString: MapBuffer,
@@ -768,8 +863,15 @@ internal object TextLayoutManager {
       height: Float,
       heightYogaMeasureMode: YogaMeasureMode,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
+      textEffectRegistry: TextEffectRegistry? = null,
   ): Layout {
-    val text = getOrCreateSpannableForText(assets, attributedString, reactTextViewManagerCallback)
+    val text =
+        getOrCreateSpannableForText(
+            assets,
+            attributedString,
+            reactTextViewManagerCallback,
+            textEffectRegistry,
+        )
 
     val paint: TextPaint
     if (attributedString.contains(AS_KEY_CACHE_ID)) {
@@ -881,6 +983,7 @@ internal object TextLayoutManager {
   }
 
   @JvmStatic
+  @OptIn(UnstableReactNativeAPI::class)
   fun createPreparedLayout(
       assets: AssetManager,
       attributedString: ReadableMapBuffer,
@@ -890,6 +993,7 @@ internal object TextLayoutManager {
       height: Float,
       heightYogaMeasureMode: YogaMeasureMode,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
+      textEffectRegistry: TextEffectRegistry? = null,
   ): PreparedLayout {
     val fragments = attributedString.getMapBuffer(AS_KEY_FRAGMENTS)
     val reactTags = IntArray(fragments.count)
@@ -899,6 +1003,7 @@ internal object TextLayoutManager {
             fragments,
             reactTextViewManagerCallback,
             reactTags,
+            textEffectRegistry,
         )
     val baseTextAttributes =
         TextAttributeProps.fromMapBuffer(attributedString.getMapBuffer(AS_KEY_BASE_ATTRIBUTES))
@@ -1044,6 +1149,7 @@ internal object TextLayoutManager {
   }
 
   @JvmStatic
+  @OptIn(UnstableReactNativeAPI::class)
   fun measureText(
       assets: AssetManager,
       attributedString: MapBuffer,
@@ -1054,6 +1160,7 @@ internal object TextLayoutManager {
       heightYogaMeasureMode: YogaMeasureMode,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
       attachmentsPositions: FloatArray?,
+      textEffectRegistry: TextEffectRegistry? = null,
   ): Long {
     // TODO(5578671): Handle text direction (see View#getTextDirectionHeuristic)
     val layout =
@@ -1066,6 +1173,7 @@ internal object TextLayoutManager {
             height,
             heightYogaMeasureMode,
             reactTextViewManagerCallback,
+            textEffectRegistry,
         )
 
     val maximumNumberOfLines =
@@ -1314,6 +1422,7 @@ internal object TextLayoutManager {
   }
 
   @JvmStatic
+  @OptIn(UnstableReactNativeAPI::class)
   fun measureLines(
       assetManager: AssetManager,
       attributedString: MapBuffer,
@@ -1321,6 +1430,7 @@ internal object TextLayoutManager {
       width: Float,
       height: Float,
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
+      textEffectRegistry: TextEffectRegistry? = null,
   ): WritableArray {
     val layout =
         createLayoutForMeasurement(
@@ -1332,6 +1442,7 @@ internal object TextLayoutManager {
             height,
             YogaMeasureMode.EXACTLY,
             reactTextViewManagerCallback,
+            textEffectRegistry,
         )
     return FontMetricsUtil.getFontMetrics(
         layout.text,
@@ -1371,5 +1482,64 @@ internal object TextLayoutManager {
     var left: Float = 0f
     var width: Float = 0f
     var height: Float = 0f
+  }
+
+  private fun jsonStringToReadableMap(json: String?): ReadableMap? {
+    if (json == null) return null
+    return try {
+      jsonObjectToReadableMap(JSONObject(json))
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private fun jsonObjectToReadableMap(jsonObject: JSONObject): JavaOnlyMap {
+    val map = JavaOnlyMap()
+    val keys = jsonObject.keys()
+    while (keys.hasNext()) {
+      val key = keys.next()
+      putJsonValue(map, key, jsonObject.get(key))
+    }
+    return map
+  }
+
+  private fun jsonArrayToReadableArray(jsonArray: JSONArray): JavaOnlyArray {
+    val array = JavaOnlyArray()
+    for (i in 0 until jsonArray.length()) {
+      pushJsonValue(array, jsonArray.get(i))
+    }
+    return array
+  }
+
+  private fun putJsonValue(map: JavaOnlyMap, key: String, value: Any) {
+    when (value) {
+      JSONObject.NULL -> map.putNull(key)
+      is Boolean -> map.putBoolean(key, value)
+      is Number -> map.putDouble(key, value.toDouble())
+      is String -> map.putString(key, value)
+      is JSONObject -> map.putMap(key, jsonObjectToReadableMap(value))
+      is JSONArray -> map.putArray(key, jsonArrayToReadableArray(value))
+      else ->
+          FLog.w(
+              ReactConstants.TAG,
+              "Unsupported text effect prop type for key $key: ${value.javaClass.name}",
+          )
+    }
+  }
+
+  private fun pushJsonValue(array: JavaOnlyArray, value: Any) {
+    when (value) {
+      JSONObject.NULL -> array.pushNull()
+      is Boolean -> array.pushBoolean(value)
+      is Number -> array.pushDouble(value.toDouble())
+      is String -> array.pushString(value)
+      is JSONObject -> array.pushMap(jsonObjectToReadableMap(value))
+      is JSONArray -> array.pushArray(jsonArrayToReadableArray(value))
+      else ->
+          FLog.w(
+              ReactConstants.TAG,
+              "Unsupported text effect prop type: ${value.javaClass.name}",
+          )
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CanvasEffectSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CanvasEffectSpan.kt
@@ -14,7 +14,7 @@ import android.text.Layout
  * A span which draws a static effect on top of text. [onPreDraw] and [onDraw] hooks are called
  * during [PreparedLayoutTextView] drawing, providing glyph layout information for custom rendering.
  */
-public abstract class CanvasEffectSpan {
+public abstract class CanvasEffectSpan : TextEffectSpan {
   /**
    * Called before the text is drawn. This happens after the Paragraph component has drawn its
    * background, but may be called before text spans with their own background color are drawn.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/SetSpanOperation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/SetSpanOperation.kt
@@ -16,7 +16,7 @@ import kotlin.math.max
 internal class SetSpanOperation(
     private val start: Int,
     private val end: Int,
-    @JvmField val what: ReactSpan,
+    @JvmField val what: Any,
 ) {
   /**
    * @param builder Spannable string builder

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/StatefulSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/StatefulSpan.kt
@@ -15,7 +15,7 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
  * spannable so that each view gets independent state even when layouts are shared from a cache.
  */
 @UnstableReactNativeAPI
-public interface StatefulSpan {
+public interface StatefulSpan : TextEffectSpan {
   /** Returns a fresh instance with the same configuration but independent mutable state. */
   public fun clone(): StatefulSpan
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextEffectSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextEffectSpan.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text.internal.span
+
+/**
+ * Marker interface implemented by every span that may be returned from a
+ * [com.facebook.react.views.text.TextEffectSpanFactory]. Constraining the factory's return type to
+ * this interface means a `List` (or any other non-span value) is rejected at compile time, which
+ * was previously possible because the contract was typed as `Any`.
+ *
+ * Built-in span families ([CanvasEffectSpan], [StatefulSpan], including [AnimatedEffectSpan])
+ * implement this directly so that user spans extending them satisfy the contract automatically.
+ */
+public interface TextEffectSpan

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
@@ -21,6 +21,7 @@
 #include <react/renderer/components/text/RawTextComponentDescriptor.h>
 #include <react/renderer/components/text/SelectableParagraphComponentDescriptor.h>
 #include <react/renderer/components/text/TextComponentDescriptor.h>
+#include <react/renderer/components/text/TextEffectComponentDescriptor.h>
 #include <react/renderer/components/view/LayoutConformanceComponentDescriptor.h>
 #include <react/renderer/components/view/ViewComponentDescriptor.h>
 #include <react/renderer/components/virtualview/VirtualViewComponentDescriptor.h>
@@ -61,6 +62,8 @@ void addCoreComponents(
       concreteComponentDescriptorProvider<SafeAreaViewComponentDescriptor>());
   providerRegistry->add(
       concreteComponentDescriptorProvider<TextComponentDescriptor>());
+  providerRegistry->add(
+      concreteComponentDescriptorProvider<TextEffectComponentDescriptor>());
   providerRegistry->add(
       concreteComponentDescriptorProvider<RawTextComponentDescriptor>());
   providerRegistry->add(

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -114,6 +114,8 @@ void TextAttributes::apply(TextAttributes textAttributes) {
       ? textAttributes.accessibilityRole
       : accessibilityRole;
   role = textAttributes.role.has_value() ? textAttributes.role : role;
+  textEffects = !textAttributes.textEffects.empty() ? textAttributes.textEffects
+                                                    : textEffects;
 }
 
 #pragma mark - Operators
@@ -141,7 +143,8 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
              layoutDirection,
              accessibilityRole,
              role,
-             textTransform) ==
+             textTransform,
+             textEffects) ==
       std::tie(
              rhs.foregroundColor,
              rhs.backgroundColor,
@@ -164,7 +167,8 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
              rhs.layoutDirection,
              rhs.accessibilityRole,
              rhs.role,
-             rhs.textTransform) &&
+             rhs.textTransform,
+             rhs.textEffects) &&
       floatEquality(maxFontSizeMultiplier, rhs.maxFontSizeMultiplier) &&
       floatEquality(opacity, rhs.opacity) &&
       floatEquality(fontSize, rhs.fontSize) &&

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -10,7 +10,9 @@
 #include <functional>
 #include <limits>
 #include <optional>
+#include <vector>
 
+#include <folly/dynamic.h>
 #include <react/renderer/attributedstring/primitives.h>
 #include <react/renderer/components/view/AccessibilityPrimitives.h>
 #include <react/renderer/core/LayoutPrimitives.h>
@@ -22,6 +24,12 @@
 #include <react/utils/hash_combine.h>
 
 namespace facebook::react {
+
+struct TextEffectInfo {
+  std::string name;
+  folly::dynamic props;
+  bool operator==(const TextEffectInfo &) const = default;
+};
 
 class TextAttributes;
 
@@ -86,6 +94,9 @@ class TextAttributes : public DebugStringConvertible {
   std::optional<AccessibilityRole> accessibilityRole{};
   std::optional<Role> role{};
 
+  // Text Effects (ordered by nesting depth: index 0 = outermost = drawn first)
+  std::vector<TextEffectInfo> textEffects{};
+
 #pragma mark - Operations
 
   void apply(TextAttributes textAttributes);
@@ -106,9 +117,21 @@ class TextAttributes : public DebugStringConvertible {
 namespace std {
 
 template <>
+struct hash<facebook::react::TextEffectInfo> {
+  size_t operator()(const facebook::react::TextEffectInfo &info) const
+  {
+    return facebook::react::hash_combine(info.name, info.props);
+  }
+};
+
+template <>
 struct hash<facebook::react::TextAttributes> {
   size_t operator()(const facebook::react::TextAttributes &textAttributes) const
   {
+    size_t textEffectsHash = 0;
+    for (const auto &effect : textAttributes.textEffects) {
+      facebook::react::hash_combine(textEffectsHash, effect);
+    }
     return facebook::react::hash_combine(
         textAttributes.foregroundColor,
         textAttributes.backgroundColor,
@@ -138,7 +161,8 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.isPressable,
         textAttributes.layoutDirection,
         textAttributes.accessibilityRole,
-        textAttributes.role);
+        textAttributes.role,
+        textEffectsHash);
   }
 };
 } // namespace std

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -26,6 +26,7 @@
 #include <unordered_map>
 
 #ifdef RN_SERIALIZABLE_STATE
+#include <folly/json.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
@@ -1128,6 +1129,11 @@ constexpr static MapBuffer::Key TA_KEY_ROLE = 26;
 constexpr static MapBuffer::Key TA_KEY_TEXT_TRANSFORM = 27;
 constexpr static MapBuffer::Key TA_KEY_ALIGNMENT_VERTICAL = 28;
 constexpr static MapBuffer::Key TA_KEY_MAX_FONT_SIZE_MULTIPLIER = 29;
+constexpr static MapBuffer::Key TA_KEY_TEXT_EFFECTS = 30;
+
+// Keys within each text effect entry MapBuffer
+constexpr static MapBuffer::Key TE_KEY_NAME = 0;
+constexpr static MapBuffer::Key TE_KEY_PROPS = 1;
 
 // constants for ParagraphAttributes serialization
 constexpr static MapBuffer::Key PA_KEY_MAX_NUMBER_OF_LINES = 0;
@@ -1331,6 +1337,16 @@ inline MapBuffer toMapBuffer(const TextAttributes &textAttributes)
   }
   if (textAttributes.role.has_value()) {
     builder.putInt(TA_KEY_ROLE, static_cast<int32_t>(*textAttributes.role));
+  }
+  if (!textAttributes.textEffects.empty()) {
+    auto effectsBuilder = MapBufferBuilder();
+    for (size_t i = 0; i < textAttributes.textEffects.size(); i++) {
+      auto effectBuilder = MapBufferBuilder();
+      effectBuilder.putString(TE_KEY_NAME, textAttributes.textEffects[i].name);
+      effectBuilder.putString(TE_KEY_PROPS, folly::toJson(textAttributes.textEffects[i].props));
+      effectsBuilder.putMapBuffer(i, effectBuilder.build());
+    }
+    builder.putMapBuffer(TA_KEY_TEXT_EFFECTS, effectsBuilder.build());
   }
   return builder.build();
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
@@ -9,6 +9,7 @@
 
 #include <react/renderer/components/text/RawTextProps.h>
 #include <react/renderer/components/text/RawTextShadowNode.h>
+#include <react/renderer/components/text/TextEffectShadowNode.h>
 #include <react/renderer/components/text/TextProps.h>
 #include <react/renderer/components/text/TextShadowNode.h>
 #include <react/renderer/mounting/ShadowView.h>
@@ -65,6 +66,24 @@ void BaseTextShadowNode::buildAttributedString(
       buildAttributedString(
           localTextAttributes,
           *textShadowNode,
+          outAttributedString,
+          outAttachments);
+      continue;
+    }
+
+    // TextEffectShadowNode
+    auto textEffectNode =
+        dynamic_cast<const TextEffectShadowNode*>(childNode.get());
+    if (textEffectNode != nullptr) {
+      auto localTextAttributes = baseTextAttributes;
+      const auto& effectProps = textEffectNode->getConcreteProps();
+      localTextAttributes.textEffects.push_back(
+          TextEffectInfo{
+              .name = effectProps.effectName,
+              .props = effectProps.effectProps});
+      buildAttributedString(
+          localTextAttributes,
+          *textEffectNode,
           outAttributedString,
           outAttachments);
       continue;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectComponentDescriptor.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/text/TextEffectShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook::react {
+
+using TextEffectComponentDescriptor = ConcreteComponentDescriptor<TextEffectShadowNode>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectProps.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "TextEffectProps.h"
+
+#include <react/renderer/core/propsConversions.h>
+
+namespace facebook::react {
+
+TextEffectProps::TextEffectProps(
+    const PropsParserContext& context,
+    const TextEffectProps& sourceProps,
+    const RawProps& rawProps)
+    : Props(context, sourceProps, rawProps),
+      effectName(convertRawProp(
+          context,
+          rawProps,
+          "effectName",
+          sourceProps.effectName,
+          std::string{})),
+      effectProps(convertRawProp(
+          context,
+          rawProps,
+          "effectProps",
+          sourceProps.effectProps,
+          folly::dynamic(nullptr))) {}
+
+#ifdef RN_SERIALIZABLE_STATE
+
+ComponentName TextEffectProps::getDiffPropsImplementationTarget() const {
+  return "TextEffect";
+}
+
+folly::dynamic TextEffectProps::getDiffProps(const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  static const auto defaultProps = TextEffectProps();
+
+  const TextEffectProps* oldProps = prevProps == nullptr
+      ? &defaultProps
+      : static_cast<const TextEffectProps*>(prevProps);
+
+  if (effectName != oldProps->effectName) {
+    result["effectName"] = effectName;
+  }
+  if (effectProps != oldProps->effectProps) {
+    result["effectProps"] = effectProps;
+  }
+
+  return result;
+}
+
+#endif
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectProps.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsParserContext.h>
+
+namespace facebook::react {
+
+class TextEffectProps : public Props {
+ public:
+  TextEffectProps() = default;
+  TextEffectProps(const PropsParserContext &context, const TextEffectProps &sourceProps, const RawProps &rawProps);
+
+  std::string effectName;
+  folly::dynamic effectProps;
+
+#ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+  folly::dynamic getDiffProps(const Props *prevProps) const override;
+#endif
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectShadowNode.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "TextEffectShadowNode.h"
+
+namespace facebook::react {
+
+extern const char TextEffectComponentName[] = "TextEffect";
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectShadowNode.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/text/TextEffectProps.h>
+#include <react/renderer/components/view/ViewEventEmitter.h>
+#include <react/renderer/core/ConcreteShadowNode.h>
+
+namespace facebook::react {
+
+extern const char TextEffectComponentName[];
+
+using TextEffectEventEmitter = TouchEventEmitter;
+
+class TextEffectShadowNode
+    : public ConcreteShadowNode<TextEffectComponentName, ShadowNode, TextEffectProps, TextEffectEventEmitter> {
+ public:
+  using ConcreteShadowNode::ConcreteShadowNode;
+};
+
+} // namespace facebook::react

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -456,6 +456,7 @@ const char facebook::react::RuntimeSchedulerKey[];
 const char facebook::react::SafeAreaViewComponentName[];
 const char facebook::react::ScrollViewComponentName[];
 const char facebook::react::TextComponentName[];
+const char facebook::react::TextEffectComponentName[];
 const char facebook::react::UnimplementedViewComponentName[];
 const char facebook::react::ViewComponentName[];
 const facebook::react::EventTag facebook::react::EMPTY_EVENT_TAG;
@@ -521,11 +522,14 @@ static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_ROLE;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_DECORATION_COLOR;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_DECORATION_LINE;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_DECORATION_STYLE;
+static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_EFFECTS;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_SHADOW_COLOR;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_SHADOW_OFFSET_DX;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_SHADOW_OFFSET_DY;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_SHADOW_RADIUS;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_TRANSFORM;
+static constexpr facebook::react::MapBuffer::Key facebook::react::TE_KEY_NAME;
+static constexpr facebook::react::MapBuffer::Key facebook::react::TE_KEY_PROPS;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TX_STATE_KEY_ATTRIBUTED_STRING;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TX_STATE_KEY_HASH;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TX_STATE_KEY_MOST_RECENT_EVENT_COUNT;
@@ -691,6 +695,8 @@ using facebook::react::TelemetryClock = std::chrono::steady_clock;
 using facebook::react::TelemetryDuration = std::chrono::nanoseconds;
 using facebook::react::TelemetryTimePoint = facebook::react::TelemetryClock::time_point;
 using facebook::react::TextComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextShadowNode>;
+using facebook::react::TextEffectComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextEffectShadowNode>;
+using facebook::react::TextEffectEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextLayoutManagerExtended = facebook::react::detail::TextLayoutManagerExtended<facebook::react::TextLayoutManager>;
 using facebook::react::TextMeasureCache = facebook::react::SimpleThreadSafeCache<facebook::react::TextMeasureCacheKey, facebook::react::TextMeasurement, facebook::react::kSimpleThreadSafeCacheSizeCap>;
@@ -4950,7 +4956,20 @@ class facebook::react::TextAttributes : public facebook::react::DebugStringConve
   public std::optional<facebook::react::TextTransform> textTransform;
   public std::optional<facebook::react::WritingDirection> baseWritingDirection;
   public std::string fontFamily;
+  public std::vector<facebook::react::TextEffectInfo> textEffects;
   public void apply(facebook::react::TextAttributes textAttributes);
+}
+
+class facebook::react::TextEffectProps : public facebook::react::Props {
+  public TextEffectProps() = default;
+  public TextEffectProps(const facebook::react::PropsParserContext& context, const facebook::react::TextEffectProps& sourceProps, const facebook::react::RawProps& rawProps);
+  public folly::dynamic effectProps;
+  public std::string effectName;
+  public virtual facebook::react::ComponentName getDiffPropsImplementationTarget() const override;
+  public virtual folly::dynamic getDiffProps(const facebook::react::Props* prevProps) const override;
+}
+
+class facebook::react::TextEffectShadowNode : public facebook::react::ConcreteShadowNode<facebook::react::TextEffectComponentName, facebook::react::ShadowNode, facebook::react::TextEffectProps, facebook::react::TextEffectEventEmitter> {
 }
 
 class facebook::react::TextInputEventEmitter : public facebook::react::BaseViewEventEmitter {
@@ -7898,6 +7917,12 @@ struct facebook::react::SystraceSection : public facebook::react::DummyTraceSect
 struct facebook::react::Task : public facebook::jsi::NativeState {
   public Task(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback, facebook::react::HighResTimeStamp expirationTime);
   public Task(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback, facebook::react::HighResTimeStamp expirationTime);
+}
+
+struct facebook::react::TextEffectInfo {
+  public bool operator==(const facebook::react::TextEffectInfo&) const = default;
+  public folly::dynamic props;
+  public std::string name;
 }
 
 struct facebook::react::TextLayoutContext {
@@ -13630,6 +13655,10 @@ struct std::hash<facebook::react::Size> {
 
 struct std::hash<facebook::react::TextAttributes> {
   public size_t operator()(const facebook::react::TextAttributes& textAttributes) const;
+}
+
+struct std::hash<facebook::react::TextEffectInfo> {
+  public size_t operator()(const facebook::react::TextEffectInfo& info) const;
 }
 
 struct std::hash<facebook::react::TextMeasureCacheKey> {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -456,6 +456,7 @@ const char facebook::react::RuntimeSchedulerKey[];
 const char facebook::react::SafeAreaViewComponentName[];
 const char facebook::react::ScrollViewComponentName[];
 const char facebook::react::TextComponentName[];
+const char facebook::react::TextEffectComponentName[];
 const char facebook::react::UnimplementedViewComponentName[];
 const char facebook::react::ViewComponentName[];
 const facebook::react::EventTag facebook::react::EMPTY_EVENT_TAG;
@@ -521,11 +522,14 @@ static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_ROLE;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_DECORATION_COLOR;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_DECORATION_LINE;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_DECORATION_STYLE;
+static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_EFFECTS;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_SHADOW_COLOR;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_SHADOW_OFFSET_DX;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_SHADOW_OFFSET_DY;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_SHADOW_RADIUS;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TA_KEY_TEXT_TRANSFORM;
+static constexpr facebook::react::MapBuffer::Key facebook::react::TE_KEY_NAME;
+static constexpr facebook::react::MapBuffer::Key facebook::react::TE_KEY_PROPS;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TX_STATE_KEY_ATTRIBUTED_STRING;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TX_STATE_KEY_HASH;
 static constexpr facebook::react::MapBuffer::Key facebook::react::TX_STATE_KEY_MOST_RECENT_EVENT_COUNT;
@@ -691,6 +695,8 @@ using facebook::react::TelemetryClock = std::chrono::steady_clock;
 using facebook::react::TelemetryDuration = std::chrono::nanoseconds;
 using facebook::react::TelemetryTimePoint = facebook::react::TelemetryClock::time_point;
 using facebook::react::TextComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextShadowNode>;
+using facebook::react::TextEffectComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextEffectShadowNode>;
+using facebook::react::TextEffectEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextLayoutManagerExtended = facebook::react::detail::TextLayoutManagerExtended<facebook::react::TextLayoutManager>;
 using facebook::react::TextMeasureCache = facebook::react::SimpleThreadSafeCache<facebook::react::TextMeasureCacheKey, facebook::react::TextMeasurement, facebook::react::kSimpleThreadSafeCacheSizeCap>;
@@ -4941,7 +4947,20 @@ class facebook::react::TextAttributes : public facebook::react::DebugStringConve
   public std::optional<facebook::react::TextTransform> textTransform;
   public std::optional<facebook::react::WritingDirection> baseWritingDirection;
   public std::string fontFamily;
+  public std::vector<facebook::react::TextEffectInfo> textEffects;
   public void apply(facebook::react::TextAttributes textAttributes);
+}
+
+class facebook::react::TextEffectProps : public facebook::react::Props {
+  public TextEffectProps() = default;
+  public TextEffectProps(const facebook::react::PropsParserContext& context, const facebook::react::TextEffectProps& sourceProps, const facebook::react::RawProps& rawProps);
+  public folly::dynamic effectProps;
+  public std::string effectName;
+  public virtual facebook::react::ComponentName getDiffPropsImplementationTarget() const override;
+  public virtual folly::dynamic getDiffProps(const facebook::react::Props* prevProps) const override;
+}
+
+class facebook::react::TextEffectShadowNode : public facebook::react::ConcreteShadowNode<facebook::react::TextEffectComponentName, facebook::react::ShadowNode, facebook::react::TextEffectProps, facebook::react::TextEffectEventEmitter> {
 }
 
 class facebook::react::TextInputEventEmitter : public facebook::react::BaseViewEventEmitter {
@@ -7889,6 +7908,12 @@ struct facebook::react::SystraceSection : public facebook::react::DummyTraceSect
 struct facebook::react::Task : public facebook::jsi::NativeState {
   public Task(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback, facebook::react::HighResTimeStamp expirationTime);
   public Task(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback, facebook::react::HighResTimeStamp expirationTime);
+}
+
+struct facebook::react::TextEffectInfo {
+  public bool operator==(const facebook::react::TextEffectInfo&) const = default;
+  public folly::dynamic props;
+  public std::string name;
 }
 
 struct facebook::react::TextLayoutContext {
@@ -13486,6 +13511,10 @@ struct std::hash<facebook::react::Size> {
 
 struct std::hash<facebook::react::TextAttributes> {
   public size_t operator()(const facebook::react::TextAttributes& textAttributes) const;
+}
+
+struct std::hash<facebook::react::TextEffectInfo> {
+  public size_t operator()(const facebook::react::TextEffectInfo& info) const;
 }
 
 struct std::hash<facebook::react::TextMeasureCacheKey> {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -3735,6 +3735,7 @@ const char facebook::react::RuntimeSchedulerKey[];
 const char facebook::react::SafeAreaViewComponentName[];
 const char facebook::react::ScrollViewComponentName[];
 const char facebook::react::TextComponentName[];
+const char facebook::react::TextEffectComponentName[];
 const char facebook::react::TextInputComponentName[];
 const char facebook::react::UnimplementedViewComponentName[];
 const char facebook::react::ViewComponentName[];
@@ -3914,6 +3915,8 @@ using facebook::react::TelemetryClock = std::chrono::steady_clock;
 using facebook::react::TelemetryDuration = std::chrono::nanoseconds;
 using facebook::react::TelemetryTimePoint = facebook::react::TelemetryClock::time_point;
 using facebook::react::TextComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextShadowNode>;
+using facebook::react::TextEffectComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextEffectShadowNode>;
+using facebook::react::TextEffectEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextLayoutManagerExtended = facebook::react::detail::TextLayoutManagerExtended<facebook::react::TextLayoutManager>;
 using facebook::react::TextMeasureCache = facebook::react::SimpleThreadSafeCache<facebook::react::TextMeasureCacheKey, facebook::react::TextMeasurement, facebook::react::kSimpleThreadSafeCacheSizeCap>;
@@ -7511,7 +7514,18 @@ class facebook::react::TextAttributes : public facebook::react::DebugStringConve
   public std::optional<facebook::react::TextTransform> textTransform;
   public std::optional<facebook::react::WritingDirection> baseWritingDirection;
   public std::string fontFamily;
+  public std::vector<facebook::react::TextEffectInfo> textEffects;
   public void apply(facebook::react::TextAttributes textAttributes);
+}
+
+class facebook::react::TextEffectProps : public facebook::react::Props {
+  public TextEffectProps() = default;
+  public TextEffectProps(const facebook::react::PropsParserContext& context, const facebook::react::TextEffectProps& sourceProps, const facebook::react::RawProps& rawProps);
+  public folly::dynamic effectProps;
+  public std::string effectName;
+}
+
+class facebook::react::TextEffectShadowNode : public facebook::react::ConcreteShadowNode<facebook::react::TextEffectComponentName, facebook::react::ShadowNode, facebook::react::TextEffectProps, facebook::react::TextEffectEventEmitter> {
 }
 
 class facebook::react::TextInputComponentDescriptor : public facebook::react::ConcreteComponentDescriptor<facebook::react::TextInputShadowNode> {
@@ -10309,6 +10323,12 @@ struct facebook::react::SystraceSection : public facebook::react::DummyTraceSect
 struct facebook::react::Task : public facebook::jsi::NativeState {
   public Task(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback, facebook::react::HighResTimeStamp expirationTime);
   public Task(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback, facebook::react::HighResTimeStamp expirationTime);
+}
+
+struct facebook::react::TextEffectInfo {
+  public bool operator==(const facebook::react::TextEffectInfo&) const = default;
+  public folly::dynamic props;
+  public std::string name;
 }
 
 struct facebook::react::TextLayoutContext {
@@ -16163,6 +16183,10 @@ struct std::hash<facebook::react::Size> {
 
 struct std::hash<facebook::react::TextAttributes> {
   public size_t operator()(const facebook::react::TextAttributes& textAttributes) const;
+}
+
+struct std::hash<facebook::react::TextEffectInfo> {
+  public size_t operator()(const facebook::react::TextEffectInfo& info) const;
 }
 
 struct std::hash<facebook::react::TextMeasureCacheKey> {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -3735,6 +3735,7 @@ const char facebook::react::RuntimeSchedulerKey[];
 const char facebook::react::SafeAreaViewComponentName[];
 const char facebook::react::ScrollViewComponentName[];
 const char facebook::react::TextComponentName[];
+const char facebook::react::TextEffectComponentName[];
 const char facebook::react::TextInputComponentName[];
 const char facebook::react::UnimplementedViewComponentName[];
 const char facebook::react::ViewComponentName[];
@@ -3914,6 +3915,8 @@ using facebook::react::TelemetryClock = std::chrono::steady_clock;
 using facebook::react::TelemetryDuration = std::chrono::nanoseconds;
 using facebook::react::TelemetryTimePoint = facebook::react::TelemetryClock::time_point;
 using facebook::react::TextComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextShadowNode>;
+using facebook::react::TextEffectComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextEffectShadowNode>;
+using facebook::react::TextEffectEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextLayoutManagerExtended = facebook::react::detail::TextLayoutManagerExtended<facebook::react::TextLayoutManager>;
 using facebook::react::TextMeasureCache = facebook::react::SimpleThreadSafeCache<facebook::react::TextMeasureCacheKey, facebook::react::TextMeasurement, facebook::react::kSimpleThreadSafeCacheSizeCap>;
@@ -7502,7 +7505,18 @@ class facebook::react::TextAttributes : public facebook::react::DebugStringConve
   public std::optional<facebook::react::TextTransform> textTransform;
   public std::optional<facebook::react::WritingDirection> baseWritingDirection;
   public std::string fontFamily;
+  public std::vector<facebook::react::TextEffectInfo> textEffects;
   public void apply(facebook::react::TextAttributes textAttributes);
+}
+
+class facebook::react::TextEffectProps : public facebook::react::Props {
+  public TextEffectProps() = default;
+  public TextEffectProps(const facebook::react::PropsParserContext& context, const facebook::react::TextEffectProps& sourceProps, const facebook::react::RawProps& rawProps);
+  public folly::dynamic effectProps;
+  public std::string effectName;
+}
+
+class facebook::react::TextEffectShadowNode : public facebook::react::ConcreteShadowNode<facebook::react::TextEffectComponentName, facebook::react::ShadowNode, facebook::react::TextEffectProps, facebook::react::TextEffectEventEmitter> {
 }
 
 class facebook::react::TextInputComponentDescriptor : public facebook::react::ConcreteComponentDescriptor<facebook::react::TextInputShadowNode> {
@@ -10300,6 +10314,12 @@ struct facebook::react::SystraceSection : public facebook::react::DummyTraceSect
 struct facebook::react::Task : public facebook::jsi::NativeState {
   public Task(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback, facebook::react::HighResTimeStamp expirationTime);
   public Task(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback, facebook::react::HighResTimeStamp expirationTime);
+}
+
+struct facebook::react::TextEffectInfo {
+  public bool operator==(const facebook::react::TextEffectInfo&) const = default;
+  public folly::dynamic props;
+  public std::string name;
 }
 
 struct facebook::react::TextLayoutContext {
@@ -16029,6 +16049,10 @@ struct std::hash<facebook::react::Size> {
 
 struct std::hash<facebook::react::TextAttributes> {
   public size_t operator()(const facebook::react::TextAttributes& textAttributes) const;
+}
+
+struct std::hash<facebook::react::TextEffectInfo> {
+  public size_t operator()(const facebook::react::TextEffectInfo& info) const;
 }
 
 struct std::hash<facebook::react::TextMeasureCacheKey> {

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -153,6 +153,7 @@ const char facebook::react::RuntimeSchedulerKey[];
 const char facebook::react::SafeAreaViewComponentName[];
 const char facebook::react::ScrollViewComponentName[];
 const char facebook::react::TextComponentName[];
+const char facebook::react::TextEffectComponentName[];
 const char facebook::react::UnimplementedViewComponentName[];
 const char facebook::react::ViewComponentName[];
 const facebook::react::EventTag facebook::react::EMPTY_EVENT_TAG;
@@ -315,6 +316,8 @@ using facebook::react::TelemetryClock = std::chrono::steady_clock;
 using facebook::react::TelemetryDuration = std::chrono::nanoseconds;
 using facebook::react::TelemetryTimePoint = facebook::react::TelemetryClock::time_point;
 using facebook::react::TextComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextShadowNode>;
+using facebook::react::TextEffectComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextEffectShadowNode>;
+using facebook::react::TextEffectEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextLayoutManagerExtended = facebook::react::detail::TextLayoutManagerExtended<TextLayoutManager>;
 using facebook::react::TextMeasureCache = facebook::react::SimpleThreadSafeCache<facebook::react::TextMeasureCacheKey, facebook::react::TextMeasurement, facebook::react::kSimpleThreadSafeCacheSizeCap>;
@@ -3465,7 +3468,18 @@ class facebook::react::TextAttributes : public facebook::react::DebugStringConve
   public std::optional<facebook::react::TextTransform> textTransform;
   public std::optional<facebook::react::WritingDirection> baseWritingDirection;
   public std::string fontFamily;
+  public std::vector<facebook::react::TextEffectInfo> textEffects;
   public void apply(facebook::react::TextAttributes textAttributes);
+}
+
+class facebook::react::TextEffectProps : public facebook::react::Props {
+  public TextEffectProps() = default;
+  public TextEffectProps(const facebook::react::PropsParserContext& context, const facebook::react::TextEffectProps& sourceProps, const facebook::react::RawProps& rawProps);
+  public folly::dynamic effectProps;
+  public std::string effectName;
+}
+
+class facebook::react::TextEffectShadowNode : public facebook::react::ConcreteShadowNode<facebook::react::TextEffectComponentName, facebook::react::ShadowNode, facebook::react::TextEffectProps, facebook::react::TextEffectEventEmitter> {
 }
 
 class facebook::react::TextInputEventEmitter : public facebook::react::BaseViewEventEmitter {
@@ -6047,6 +6061,12 @@ struct facebook::react::SystraceSection : public facebook::react::DummyTraceSect
 struct facebook::react::Task : public facebook::jsi::NativeState {
   public Task(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback, facebook::react::HighResTimeStamp expirationTime);
   public Task(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback, facebook::react::HighResTimeStamp expirationTime);
+}
+
+struct facebook::react::TextEffectInfo {
+  public bool operator==(const facebook::react::TextEffectInfo&) const = default;
+  public folly::dynamic props;
+  public std::string name;
 }
 
 struct facebook::react::TextLayoutContext {
@@ -10577,6 +10597,10 @@ struct std::hash<facebook::react::Size> {
 
 struct std::hash<facebook::react::TextAttributes> {
   public size_t operator()(const facebook::react::TextAttributes& textAttributes) const;
+}
+
+struct std::hash<facebook::react::TextEffectInfo> {
+  public size_t operator()(const facebook::react::TextEffectInfo& info) const;
 }
 
 struct std::hash<facebook::react::TextMeasureCacheKey> {

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -153,6 +153,7 @@ const char facebook::react::RuntimeSchedulerKey[];
 const char facebook::react::SafeAreaViewComponentName[];
 const char facebook::react::ScrollViewComponentName[];
 const char facebook::react::TextComponentName[];
+const char facebook::react::TextEffectComponentName[];
 const char facebook::react::UnimplementedViewComponentName[];
 const char facebook::react::ViewComponentName[];
 const facebook::react::EventTag facebook::react::EMPTY_EVENT_TAG;
@@ -315,6 +316,8 @@ using facebook::react::TelemetryClock = std::chrono::steady_clock;
 using facebook::react::TelemetryDuration = std::chrono::nanoseconds;
 using facebook::react::TelemetryTimePoint = facebook::react::TelemetryClock::time_point;
 using facebook::react::TextComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextShadowNode>;
+using facebook::react::TextEffectComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::TextEffectShadowNode>;
+using facebook::react::TextEffectEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextEventEmitter = facebook::react::TouchEventEmitter;
 using facebook::react::TextLayoutManagerExtended = facebook::react::detail::TextLayoutManagerExtended<TextLayoutManager>;
 using facebook::react::TextMeasureCache = facebook::react::SimpleThreadSafeCache<facebook::react::TextMeasureCacheKey, facebook::react::TextMeasurement, facebook::react::kSimpleThreadSafeCacheSizeCap>;
@@ -3456,7 +3459,18 @@ class facebook::react::TextAttributes : public facebook::react::DebugStringConve
   public std::optional<facebook::react::TextTransform> textTransform;
   public std::optional<facebook::react::WritingDirection> baseWritingDirection;
   public std::string fontFamily;
+  public std::vector<facebook::react::TextEffectInfo> textEffects;
   public void apply(facebook::react::TextAttributes textAttributes);
+}
+
+class facebook::react::TextEffectProps : public facebook::react::Props {
+  public TextEffectProps() = default;
+  public TextEffectProps(const facebook::react::PropsParserContext& context, const facebook::react::TextEffectProps& sourceProps, const facebook::react::RawProps& rawProps);
+  public folly::dynamic effectProps;
+  public std::string effectName;
+}
+
+class facebook::react::TextEffectShadowNode : public facebook::react::ConcreteShadowNode<facebook::react::TextEffectComponentName, facebook::react::ShadowNode, facebook::react::TextEffectProps, facebook::react::TextEffectEventEmitter> {
 }
 
 class facebook::react::TextInputEventEmitter : public facebook::react::BaseViewEventEmitter {
@@ -6038,6 +6052,12 @@ struct facebook::react::SystraceSection : public facebook::react::DummyTraceSect
 struct facebook::react::Task : public facebook::jsi::NativeState {
   public Task(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback, facebook::react::HighResTimeStamp expirationTime);
   public Task(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback, facebook::react::HighResTimeStamp expirationTime);
+}
+
+struct facebook::react::TextEffectInfo {
+  public bool operator==(const facebook::react::TextEffectInfo&) const = default;
+  public folly::dynamic props;
+  public std::string name;
 }
 
 struct facebook::react::TextLayoutContext {
@@ -10568,6 +10588,10 @@ struct std::hash<facebook::react::Size> {
 
 struct std::hash<facebook::react::TextAttributes> {
   public size_t operator()(const facebook::react::TextAttributes& textAttributes) const;
+}
+
+struct std::hash<facebook::react::TextEffectInfo> {
+  public size_t operator()(const facebook::react::TextEffectInfo& info) const;
 }
 
 struct std::hash<facebook::react::TextMeasureCacheKey> {


### PR DESCRIPTION
Summary:

Introduces a generic TextEffect system that lets apps register custom text
span effects without modifying React Native core. This can serve for use cases like `react-native-live-markdown`, or product specific effects.

The implementation is pretty dumb right now. It's just a marker, where we can add some JSON serializable data, to be serialized during Spannable creation on JS side MapBuffer. 

**JS API:**
```js
import requireNativeTextEffect from 'react-native/Libraries/Text/requireNativeTextEffect';
const Spoiler = requireNativeTextEffect<{}>('RCTSpoiler');

<Text>Normal <Spoiler>hidden text</Spoiler></Text>
```

**Android registration** (via FabricUIManager):
```kotlin
val fabricUIManager = UIManagerHelper.getUIManager(
    context, UIManagerType.FABRIC) as? FabricUIManager
fabricUIManager?.textEffectRegistry?.register("RCTSpoiler") { props ->
    MyCustomSpan()
}
```

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D98812222


