### PR TITLE
Move accessibility order + swift blur filters to canary

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2912fe4c90e3b493770bf14e70264656>>
+ * @generated SignedSource<<2c5d2f88cf7150403cbed87aeadc0239>>
  */
 
 /**
@@ -23,11 +23,15 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android : ReactN
   // We could use JNI to get the defaults from C++,
   // but that is more expensive than just duplicating the defaults here.
 
+  override fun enableAccessibilityOrder(): Boolean = true
+
   override fun enableBridgelessArchitecture(): Boolean = true
 
   override fun enableFabricRenderer(): Boolean = true
 
   override fun enableIntersectionObserverByDefault(): Boolean = true
+
+  override fun enableSwiftUIBasedFilters(): Boolean = true
 
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6a5fd95dffcab319acb765aa25a33d8d>>
+ * @generated SignedSource<<dcf277b9f00976b0e40394d1e0bd053f>>
  */
 
 /**
@@ -25,11 +25,7 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : 
 
   override fun cxxNativeAnimatedEnabled(): Boolean = true
 
-  override fun enableAccessibilityOrder(): Boolean = true
-
   override fun enableSchedulerDelegateInvalidation(): Boolean = true
-
-  override fun enableSwiftUIBasedFilters(): Boolean = true
 
   override fun preventShadowTreeCommitExhaustion(): Boolean = true
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1b2061068e0d6c9ca362ceddd97862da>>
+ * @generated SignedSource<<dab6dad91b32e837d1a303382566fc3d>>
  */
 
 /**
@@ -27,6 +27,10 @@ class ReactNativeFeatureFlagsOverridesOSSCanary : public ReactNativeFeatureFlags
  public:
     ReactNativeFeatureFlagsOverridesOSSCanary() = default;
 
+  bool enableAccessibilityOrder() override {
+    return true;
+  }
+
   bool enableBridgelessArchitecture() override {
     return true;
   }
@@ -36,6 +40,10 @@ class ReactNativeFeatureFlagsOverridesOSSCanary : public ReactNativeFeatureFlags
   }
 
   bool enableIntersectionObserverByDefault() override {
+    return true;
+  }
+
+  bool enableSwiftUIBasedFilters() override {
     return true;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<887a3ac5f8a93cc5ae5c8d01ec1d5e46>>
+ * @generated SignedSource<<44778a01f2e3f503ea31d340f89587b8>>
  */
 
 /**
@@ -31,15 +31,7 @@ class ReactNativeFeatureFlagsOverridesOSSExperimental : public ReactNativeFeatur
     return true;
   }
 
-  bool enableAccessibilityOrder() override {
-    return true;
-  }
-
   bool enableSchedulerDelegateInvalidation() override {
-    return true;
-  }
-
-  bool enableSwiftUIBasedFilters() override {
     return true;
   }
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -167,7 +167,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'experimental',
+      ossReleaseStage: 'canary',
     },
     enableAccumulatedUpdatesInRawPropsAndroid: {
       defaultValue: false,
@@ -534,7 +534,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'experimental',
+      ossReleaseStage: 'canary',
     },
     enableViewCulling: {
       defaultValue: false,


### PR DESCRIPTION
Summary:
These have been in experimental for some time and should be moved to canary. 

Changelog: [Internal]

Reviewed By: jorge-cab

Differential Revision: D104239097


