### PR TITLE
Remove unused websocketProxyURL property

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1845,7 +1845,6 @@ public class com/facebook/react/devsupport/DevServerHelper {
 	public fun getDevServerSplitBundleURL (Ljava/lang/String;)Ljava/lang/String;
 	public fun getSourceMapUrl (Ljava/lang/String;)Ljava/lang/String;
 	public fun getSourceUrl (Ljava/lang/String;)Ljava/lang/String;
-	public final fun getWebsocketProxyURL ()Ljava/lang/String;
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public final fun openDebugger (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun openInspectorConnection ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
@@ -78,10 +78,6 @@ public open class DevServerHelper(
     public fun customCommandHandlers(): Map<String, RequestHandler>?
   }
 
-  public val websocketProxyURL: String
-    get() =
-        "${DevSupportHttpClient.wsScheme(packagerConnectionSettings.debugServerHost)}://${packagerConnectionSettings.debugServerHost}/debugger-proxy?role=client"
-
   private enum class BundleType(val typeID: String) {
     BUNDLE("bundle"),
     MAP("map"),


### PR DESCRIPTION
Summary:
Remove `DevServerHelper.websocketProxyURL`, which constructed the URL for the legacy `/debugger-proxy` WebSocket endpoint. This property had no callers — the legacy remote JS debugging proxy has been superseded by `/inspector/device` and `/inspector/debug` endpoints (React Native DevTools CDP).

Changelog: [Android][Removed] - Remove unused `DevServerHelper.websocketProxyURL` property (legacy remote JS debugger)

Differential Revision: D104253123


