### PR TITLE
Remove stale disableMaintainVisibleContentPosition feature flag

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -31,7 +31,6 @@ import {
   VScrollContentViewNativeComponent,
   VScrollViewNativeComponent,
 } from '../../../src/private/components/scrollview/VScrollViewNativeComponents';
-import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 import AnimatedImplementation from '../../Animated/AnimatedImplementation';
 import FrameRateLogger from '../../Interaction/FrameRateLogger';
 import {findNodeHandle} from '../../ReactNative/RendererProxy';
@@ -1762,11 +1761,8 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
 
     const baseStyle = horizontal ? styles.baseHorizontal : styles.baseVertical;
 
-    const {
-      experimental_endDraggingSensitivityMultiplier,
-      maintainVisibleContentPosition,
-      ...otherProps
-    } = this.props;
+    const {experimental_endDraggingSensitivityMultiplier, ...otherProps} =
+      this.props;
     const props = {
       ...otherProps,
       alwaysBounceHorizontal,
@@ -1819,10 +1815,6 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
           this.props.snapToInterval != null ||
           this.props.snapToOffsets != null,
       }),
-      maintainVisibleContentPosition:
-        ReactNativeFeatureFlags.disableMaintainVisibleContentPosition()
-          ? undefined
-          : this.props.maintainVisibleContentPosition,
     };
 
     const {decelerationRate} = this.props;

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -1065,17 +1065,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    disableMaintainVisibleContentPosition: {
-      defaultValue: false,
-      metadata: {
-        dateAdded: '2025-08-26',
-        description:
-          'Disable prop maintainVisibleContentPosition in ScrollView',
-        expectedReleaseValue: false,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
     enableNativeEventTargetEventDispatching: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ec712f5528e1e06486a9c471baba631b>>
+ * @generated SignedSource<<72c610dc5a8efc1eba2121949e1c24a0>>
  * @flow strict
  * @noformat
  */
@@ -32,7 +32,6 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
   deferFlatListFocusChangeRenderUpdate: Getter<boolean>,
-  disableMaintainVisibleContentPosition: Getter<boolean>,
   enableNativeEventTargetEventDispatching: Getter<boolean>,
   externalElementInspectionEnabled: Getter<boolean>,
   fixVirtualizeListCollapseWindowSize: Getter<boolean>,
@@ -160,11 +159,6 @@ export const animatedShouldUseSingleOp: Getter<boolean> = createJavaScriptFlagGe
  * Use the deferred cell render update mechanism for focus change in FlatList.
  */
 export const deferFlatListFocusChangeRenderUpdate: Getter<boolean> = createJavaScriptFlagGetter('deferFlatListFocusChangeRenderUpdate', false);
-
-/**
- * Disable prop maintainVisibleContentPosition in ScrollView
- */
-export const disableMaintainVisibleContentPosition: Getter<boolean> = createJavaScriptFlagGetter('disableMaintainVisibleContentPosition', false);
 
 /**
  * When enabled, the React Native renderer dispatches events through the W3C EventTarget API (addEventListener/dispatchEvent) instead of the legacy plugin-based system.


### PR DESCRIPTION
Summary:
Remove the stale `disableMaintainVisibleContentPosition` feature flag which was never rolled out (defaultValue: false, expectedReleaseValue: false). This flag was intended to disable the `maintainVisibleContentPosition` prop in ScrollView but was never enabled.

Changes:
- Remove the feature flag definition from ReactNativeFeatureFlags
- Simplify ScrollView.js by removing the unnecessary destructuring of `maintainVisibleContentPosition` (now passed through via otherProps spread)
- Remove related generated code

## Changelog:
[General][Removed] - Removed the unused `disableMaintainVisibleContentPosition` feature flag from ReactNativeFeatureFlags

Differential Revision: D104195744


