### PR TITLE
Resolve appPath in getInputFiles so "/Pods/" filter doesn't drop xcodeproj results

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
@@ -49,8 +49,13 @@ function getInputFiles(appPath /*: string */, appPkgJson /*: $FlowFixMe */) {
     return '[]';
   }
 
+  // Normalize appPath so any "Pods/.." segment is collapsed before find runs.
+  // Otherwise every find result inherits the search-root prefix containing
+  // "/Pods/" and gets dropped by the exclusion filter below.
+  const resolvedAppPath = path.resolve(appPath);
+
   const xcodeproj = String(
-    execSync(`find ${appPath} -type d -name "*.xcodeproj"`),
+    execSync(`find ${resolvedAppPath} -type d -name "*.xcodeproj"`),
   )
     .trim()
     .split('\n')
@@ -61,12 +66,12 @@ function getInputFiles(appPath /*: string */, appPkgJson /*: $FlowFixMe */) {
     )[0];
   if (!xcodeproj) {
     throw new Error(
-      `Cannot find .xcodeproj file inside ${appPath}. This is required to determine codegen spec paths relative to native project.`,
+      `Cannot find .xcodeproj file inside ${resolvedAppPath}. This is required to determine codegen spec paths relative to native project.`,
     );
   }
   const jsFiles = '-name "Native*.js" -or -name "*NativeComponent.js"';
   const tsFiles = '-name "Native*.ts" -or -name "*NativeComponent.ts"';
-  const findCommand = `find ${path.join(appPath, jsSrcsDir)} -type f -not -path "*/__mocks__/*" -and \\( ${jsFiles} -or ${tsFiles} \\)`;
+  const findCommand = `find ${path.join(resolvedAppPath, jsSrcsDir)} -type f -not -path "*/__mocks__/*" -and \\( ${jsFiles} -or ${tsFiles} \\)`;
   const list = String(execSync(findCommand))
     .trim()
     .split('\n')


### PR DESCRIPTION
## Summary:

`getInputFiles` in `generateReactCodegenPodspec.js` runs `find` against the raw `appPath` argument. When the caller passes a path containing a `Pods/..` segment (common when the script is invoked from CocoaPods, especially with a symlinked `Pods/` directory), every result returned by `find` inherits that prefix. The subsequent `!projectPath.includes('/Pods/')` filter then drops all results, and the script throws `Cannot find .xcodeproj file inside …` even though a valid project exists.

This change normalizes `appPath` via `path.resolve()` before invoking `find`, so the `Pods/..` segment is collapsed up front and the exclusion filter only catches genuine `Pods/Pods.xcodeproj` paths.

## Changelog:

[IOS] [FIXED] - Resolve `appPath` in codegen podspec generation so paths containing `Pods/..` no longer cause the `.xcodeproj` lookup to fail

## Test Plan:

1. From a project where `appPath` is passed as something like `<root>/ios/Pods/../`, run the codegen step (e.g. `pod install` triggering `generateReactCodegenPodspec`).
2. Before the fix: codegen errors with `Cannot find .xcodeproj file inside …/ios/Pods/../`.
3. After the fix: `find` is invoked against the resolved `<root>/ios/` path, the host app's `.xcodeproj` is located, and `ReactCodegen.podspec` is generated with correct `${PODS_ROOT}`-relative input file paths.
4. Sanity-check that paths without a `Pods/..` segment continue to work unchanged (`path.resolve` is a no-op on already-absolute, normalized paths).
