### PR TITLE
Make PODFILE_DIR build setting portable across machines

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
@@ -49,8 +49,13 @@ function getInputFiles(appPath /*: string */, appPkgJson /*: $FlowFixMe */) {
     return '[]';
   }
 
+  // Normalize appPath so any "Pods/.." segment is collapsed before find runs.
+  // Otherwise every find result inherits the search-root prefix containing
+  // "/Pods/" and gets dropped by the exclusion filter below.
+  const resolvedAppPath = path.resolve(appPath);
+
   const xcodeproj = String(
-    execSync(`find ${appPath} -type d -name "*.xcodeproj"`),
+    execSync(`find ${resolvedAppPath} -type d -name "*.xcodeproj"`),
   )
     .trim()
     .split('\n')
@@ -61,12 +66,12 @@ function getInputFiles(appPath /*: string */, appPkgJson /*: $FlowFixMe */) {
     )[0];
   if (!xcodeproj) {
     throw new Error(
-      `Cannot find .xcodeproj file inside ${appPath}. This is required to determine codegen spec paths relative to native project.`,
+      `Cannot find .xcodeproj file inside ${resolvedAppPath}. This is required to determine codegen spec paths relative to native project.`,
     );
   }
   const jsFiles = '-name "Native*.js" -or -name "*NativeComponent.js"';
   const tsFiles = '-name "Native*.ts" -or -name "*NativeComponent.ts"';
-  const findCommand = `find ${path.join(appPath, jsSrcsDir)} -type f -not -path "*/__mocks__/*" -and \\( ${jsFiles} -or ${tsFiles} \\)`;
+  const findCommand = `find ${path.join(resolvedAppPath, jsSrcsDir)} -type f -not -path "*/__mocks__/*" -and \\( ${jsFiles} -or ${tsFiles} \\)`;
   const list = String(execSync(findCommand))
     .trim()
     .split('\n')

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -539,9 +539,11 @@ def react_native_post_install(
   rn_relative_to_pods = rn_real.relative_path_from(pods_dir_real)
   ReactNativePodsUtils.set_build_setting(installer, build_setting: "REACT_NATIVE_PATH", value: File.join("${PODS_ROOT}", rn_relative_to_pods.to_s))
   # Store the Podfile directory as a build setting so that shell scripts can
-  # locate it without relying on PODS_ROOT/.. (breaks when Pods/ is a symlink).
-  # Use Xcode variable substitution per-project so the value persisted in
-  # project.pbxproj is portable across machines.
+  # locate it without hardcoding an absolute path. Use Xcode variable
+  # substitution per-project so the value persisted in project.pbxproj is
+  # portable across machines: $(SRCROOT) is the Podfile dir for user projects
+  # (also avoids the PODS_ROOT/.. traversal that breaks when Pods/ is a
+  # symlink), and $(SRCROOT)/.. for the Pods project.
   installer.aggregate_targets.map(&:user_project).uniq(&:path).each do |user_project|
     user_project.build_configurations.each do |config|
       config.build_settings['PODFILE_DIR'] = '$(SRCROOT)'

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -540,7 +540,18 @@ def react_native_post_install(
   ReactNativePodsUtils.set_build_setting(installer, build_setting: "REACT_NATIVE_PATH", value: File.join("${PODS_ROOT}", rn_relative_to_pods.to_s))
   # Store the Podfile directory as a build setting so that shell scripts can
   # locate it without relying on PODS_ROOT/.. (breaks when Pods/ is a symlink).
-  ReactNativePodsUtils.set_build_setting(installer, build_setting: "PODFILE_DIR", value: Pod::Config.instance.installation_root.to_s)
+  # Use Xcode variable substitution per-project so the value persisted in
+  # project.pbxproj is portable across machines.
+  installer.aggregate_targets.map(&:user_project).uniq(&:path).each do |user_project|
+    user_project.build_configurations.each do |config|
+      config.build_settings['PODFILE_DIR'] = '$(SRCROOT)'
+    end
+    user_project.save
+  end
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings['PODFILE_DIR'] = '$(SRCROOT)/..'
+  end
+  installer.pods_project.save
   ReactNativePodsUtils.set_build_setting(installer, build_setting: "SWIFT_ACTIVE_COMPILATION_CONDITIONS", value: ['$(inherited)', 'DEBUG'], config_name: "Debug")
 
   if (ENV['RCT_REMOVE_LEGACY_ARCH'] == '1')


### PR DESCRIPTION
## Summary:

`PODFILE_DIR` was being set to `Pod::Config.instance.installation_root.to_s`, which bakes the contributor's absolute path (e.g. `/Users/alice/Projects/MyApp/ios`) into `project.pbxproj` — every `pod install` on a different machine churns the diff, and a checked-in pbxproj points at someone else's filesystem.

Set `PODFILE_DIR` per-project via Xcode variable substitution: `$(SRCROOT)` for user projects, `$(SRCROOT)/..` for the Pods project. Resolved value is identical at build time; the persisted string is now machine-independent.

## Changelog:

[IOS] [FIXED] - Persist `PODFILE_DIR` as `$(SRCROOT)`-relative so `project.pbxproj` is portable across machines

## Test Plan:

1. `pod install`, inspect host-app and Pods `pbxproj`: `PODFILE_DIR` should be `$(SRCROOT)` and `$(SRCROOT)/..`, not an absolute path.
2. Build the app and confirm consumers of `${PODFILE_DIR}` still resolve correctly (`with-environment.sh`, codegen script phases).
