### PR TITLE
Add rn-tester example exercising every batched-animated prop

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d4e81be344e15b275d015651b4fa824d>>
+ * @generated SignedSource<<9fa8df8bd4c6ef4efeddff62e8518472>>
  */
 
 /**
@@ -413,6 +413,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun hideOffscreenVirtualViewsOnIOS(): Boolean = accessor.hideOffscreenVirtualViewsOnIOS()
+
+  /**
+   * When enabled, uses optimized platform-specific paths to apply animated props synchronously. On Android, this uses a batched int/double buffer protocol with a single JNI call. On iOS, this passes AnimatedProps directly through the delegate chain and applies them via cloneProps, avoiding the folly::dynamic round-trip.
+   */
+  @JvmStatic
+  public fun optimizedAnimatedPropUpdates(): Boolean = accessor.optimizedAnimatedPropUpdates()
 
   /**
    * Override props at mounting with synchronously mounted (i.e. direct manipulation) props from Native Animated.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<189cc2dd3b42cd736191f13b442e7317>>
+ * @generated SignedSource<<ef125427b8daa352919a846435008cad>>
  */
 
 /**
@@ -84,6 +84,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var fuseboxNetworkInspectionEnabledCache: Boolean? = null
   private var fuseboxScreenshotCaptureEnabledCache: Boolean? = null
   private var hideOffscreenVirtualViewsOnIOSCache: Boolean? = null
+  private var optimizedAnimatedPropUpdatesCache: Boolean? = null
   private var overrideBySynchronousMountPropsAtMountingAndroidCache: Boolean? = null
   private var perfIssuesEnabledCache: Boolean? = null
   private var perfMonitorV2EnabledCache: Boolean? = null
@@ -685,6 +686,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.hideOffscreenVirtualViewsOnIOS()
       hideOffscreenVirtualViewsOnIOSCache = cached
+    }
+    return cached
+  }
+
+  override fun optimizedAnimatedPropUpdates(): Boolean {
+    var cached = optimizedAnimatedPropUpdatesCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.optimizedAnimatedPropUpdates()
+      optimizedAnimatedPropUpdatesCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<81c6672ae539af203fae7e0f9cf541a6>>
+ * @generated SignedSource<<ebe28a896847fe54affddc0007733ee9>>
  */
 
 /**
@@ -155,6 +155,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun fuseboxScreenshotCaptureEnabled(): Boolean
 
   @DoNotStrip @JvmStatic public external fun hideOffscreenVirtualViewsOnIOS(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun optimizedAnimatedPropUpdates(): Boolean
 
   @DoNotStrip @JvmStatic public external fun overrideBySynchronousMountPropsAtMountingAndroid(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<053d67947ccd1a3556c8f6e1b6af5a14>>
+ * @generated SignedSource<<008cbcccd695935f1d4ca17e69bce718>>
  */
 
 /**
@@ -150,6 +150,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun fuseboxScreenshotCaptureEnabled(): Boolean = false
 
   override fun hideOffscreenVirtualViewsOnIOS(): Boolean = false
+
+  override fun optimizedAnimatedPropUpdates(): Boolean = false
 
   override fun overrideBySynchronousMountPropsAtMountingAndroid(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<24972f077ba738a8191a2956be61b491>>
+ * @generated SignedSource<<0d50d159540c35fa0ae015093a483442>>
  */
 
 /**
@@ -88,6 +88,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var fuseboxNetworkInspectionEnabledCache: Boolean? = null
   private var fuseboxScreenshotCaptureEnabledCache: Boolean? = null
   private var hideOffscreenVirtualViewsOnIOSCache: Boolean? = null
+  private var optimizedAnimatedPropUpdatesCache: Boolean? = null
   private var overrideBySynchronousMountPropsAtMountingAndroidCache: Boolean? = null
   private var perfIssuesEnabledCache: Boolean? = null
   private var perfMonitorV2EnabledCache: Boolean? = null
@@ -753,6 +754,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.hideOffscreenVirtualViewsOnIOS()
       accessedFeatureFlags.add("hideOffscreenVirtualViewsOnIOS")
       hideOffscreenVirtualViewsOnIOSCache = cached
+    }
+    return cached
+  }
+
+  override fun optimizedAnimatedPropUpdates(): Boolean {
+    var cached = optimizedAnimatedPropUpdatesCache
+    if (cached == null) {
+      cached = currentProvider.optimizedAnimatedPropUpdates()
+      accessedFeatureFlags.add("optimizedAnimatedPropUpdates")
+      optimizedAnimatedPropUpdatesCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a7c69ce7e10faeb5328412c5e29552cf>>
+ * @generated SignedSource<<0c9e61dd9a6102da81fa394d8a6401e2>>
  */
 
 /**
@@ -150,6 +150,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun fuseboxScreenshotCaptureEnabled(): Boolean
 
   @DoNotStrip public fun hideOffscreenVirtualViewsOnIOS(): Boolean
+
+  @DoNotStrip public fun optimizedAnimatedPropUpdates(): Boolean
 
   @DoNotStrip public fun overrideBySynchronousMountPropsAtMountingAndroid(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74f0602ce337a86730efe638ab8e966d>>
+ * @generated SignedSource<<1f63c355480af133d9245dad20da704c>>
  */
 
 /**
@@ -420,6 +420,12 @@ class ReactNativeFeatureFlagsJavaProvider
   bool hideOffscreenVirtualViewsOnIOS() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("hideOffscreenVirtualViewsOnIOS");
+    return method(javaProvider_);
+  }
+
+  bool optimizedAnimatedPropUpdates() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("optimizedAnimatedPropUpdates");
     return method(javaProvider_);
   }
 
@@ -915,6 +921,11 @@ bool JReactNativeFeatureFlagsCxxInterop::hideOffscreenVirtualViewsOnIOS(
   return ReactNativeFeatureFlags::hideOffscreenVirtualViewsOnIOS();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::optimizedAnimatedPropUpdates(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::optimizedAnimatedPropUpdates();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::overrideBySynchronousMountPropsAtMountingAndroid(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::overrideBySynchronousMountPropsAtMountingAndroid();
@@ -1278,6 +1289,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "hideOffscreenVirtualViewsOnIOS",
         JReactNativeFeatureFlagsCxxInterop::hideOffscreenVirtualViewsOnIOS),
+      makeNativeMethod(
+        "optimizedAnimatedPropUpdates",
+        JReactNativeFeatureFlagsCxxInterop::optimizedAnimatedPropUpdates),
       makeNativeMethod(
         "overrideBySynchronousMountPropsAtMountingAndroid",
         JReactNativeFeatureFlagsCxxInterop::overrideBySynchronousMountPropsAtMountingAndroid),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2e867941f693c14c0c52475d790cfed4>>
+ * @generated SignedSource<<fbc1ffa6b9806e600b1e956f949eec3d>>
  */
 
 /**
@@ -220,6 +220,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool hideOffscreenVirtualViewsOnIOS(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool optimizedAnimatedPropUpdates(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool overrideBySynchronousMountPropsAtMountingAndroid(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9c49f2931ab219997bc29969de95805d>>
+ * @generated SignedSource<<b6d127d91bedd52101dae5761a9322b0>>
  */
 
 /**
@@ -280,6 +280,10 @@ bool ReactNativeFeatureFlags::fuseboxScreenshotCaptureEnabled() {
 
 bool ReactNativeFeatureFlags::hideOffscreenVirtualViewsOnIOS() {
   return getAccessor().hideOffscreenVirtualViewsOnIOS();
+}
+
+bool ReactNativeFeatureFlags::optimizedAnimatedPropUpdates() {
+  return getAccessor().optimizedAnimatedPropUpdates();
 }
 
 bool ReactNativeFeatureFlags::overrideBySynchronousMountPropsAtMountingAndroid() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d15e79bbfac17a32fd7981538afc3683>>
+ * @generated SignedSource<<58cb57cd6fc7d708db8f496744608f53>>
  */
 
 /**
@@ -358,6 +358,11 @@ class ReactNativeFeatureFlags {
    * Hides offscreen VirtualViews on iOS by setting hidden = YES to avoid extra cost of views
    */
   RN_EXPORT static bool hideOffscreenVirtualViewsOnIOS();
+
+  /**
+   * When enabled, uses optimized platform-specific paths to apply animated props synchronously. On Android, this uses a batched int/double buffer protocol with a single JNI call. On iOS, this passes AnimatedProps directly through the delegate chain and applies them via cloneProps, avoiding the folly::dynamic round-trip.
+   */
+  RN_EXPORT static bool optimizedAnimatedPropUpdates();
 
   /**
    * Override props at mounting with synchronously mounted (i.e. direct manipulation) props from Native Animated.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<51ffddd6283069a1846336c65d40338c>>
+ * @generated SignedSource<<3c16a4403b6b202ef32dcf57c8da4cf6>>
  */
 
 /**
@@ -1181,6 +1181,24 @@ bool ReactNativeFeatureFlagsAccessor::hideOffscreenVirtualViewsOnIOS() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::optimizedAnimatedPropUpdates() {
+  auto flagValue = optimizedAnimatedPropUpdates_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(64, "optimizedAnimatedPropUpdates");
+
+    flagValue = currentProvider_->optimizedAnimatedPropUpdates();
+    optimizedAnimatedPropUpdates_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::overrideBySynchronousMountPropsAtMountingAndroid() {
   auto flagValue = overrideBySynchronousMountPropsAtMountingAndroid_.load();
 
@@ -1190,7 +1208,7 @@ bool ReactNativeFeatureFlagsAccessor::overrideBySynchronousMountPropsAtMountingA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(64, "overrideBySynchronousMountPropsAtMountingAndroid");
+    markFlagAsAccessed(65, "overrideBySynchronousMountPropsAtMountingAndroid");
 
     flagValue = currentProvider_->overrideBySynchronousMountPropsAtMountingAndroid();
     overrideBySynchronousMountPropsAtMountingAndroid_ = flagValue;
@@ -1208,7 +1226,7 @@ bool ReactNativeFeatureFlagsAccessor::perfIssuesEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(65, "perfIssuesEnabled");
+    markFlagAsAccessed(66, "perfIssuesEnabled");
 
     flagValue = currentProvider_->perfIssuesEnabled();
     perfIssuesEnabled_ = flagValue;
@@ -1226,7 +1244,7 @@ bool ReactNativeFeatureFlagsAccessor::perfMonitorV2Enabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(66, "perfMonitorV2Enabled");
+    markFlagAsAccessed(67, "perfMonitorV2Enabled");
 
     flagValue = currentProvider_->perfMonitorV2Enabled();
     perfMonitorV2Enabled_ = flagValue;
@@ -1244,7 +1262,7 @@ double ReactNativeFeatureFlagsAccessor::preparedTextCacheSize() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(67, "preparedTextCacheSize");
+    markFlagAsAccessed(68, "preparedTextCacheSize");
 
     flagValue = currentProvider_->preparedTextCacheSize();
     preparedTextCacheSize_ = flagValue;
@@ -1262,7 +1280,7 @@ bool ReactNativeFeatureFlagsAccessor::preventShadowTreeCommitExhaustion() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(68, "preventShadowTreeCommitExhaustion");
+    markFlagAsAccessed(69, "preventShadowTreeCommitExhaustion");
 
     flagValue = currentProvider_->preventShadowTreeCommitExhaustion();
     preventShadowTreeCommitExhaustion_ = flagValue;
@@ -1280,7 +1298,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2Android() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(69, "redBoxV2Android");
+    markFlagAsAccessed(70, "redBoxV2Android");
 
     flagValue = currentProvider_->redBoxV2Android();
     redBoxV2Android_ = flagValue;
@@ -1298,7 +1316,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2IOS() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(70, "redBoxV2IOS");
+    markFlagAsAccessed(71, "redBoxV2IOS");
 
     flagValue = currentProvider_->redBoxV2IOS();
     redBoxV2IOS_ = flagValue;
@@ -1316,7 +1334,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldPressibilityUseW3CPointerEventsForHo
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(71, "shouldPressibilityUseW3CPointerEventsForHover");
+    markFlagAsAccessed(72, "shouldPressibilityUseW3CPointerEventsForHover");
 
     flagValue = currentProvider_->shouldPressibilityUseW3CPointerEventsForHover();
     shouldPressibilityUseW3CPointerEventsForHover_ = flagValue;
@@ -1334,7 +1352,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldTriggerResponderTransferOnScrollAndr
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(72, "shouldTriggerResponderTransferOnScrollAndroid");
+    markFlagAsAccessed(73, "shouldTriggerResponderTransferOnScrollAndroid");
 
     flagValue = currentProvider_->shouldTriggerResponderTransferOnScrollAndroid();
     shouldTriggerResponderTransferOnScrollAndroid_ = flagValue;
@@ -1352,7 +1370,7 @@ bool ReactNativeFeatureFlagsAccessor::skipActivityIdentityAssertionOnHostPause()
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(73, "skipActivityIdentityAssertionOnHostPause");
+    markFlagAsAccessed(74, "skipActivityIdentityAssertionOnHostPause");
 
     flagValue = currentProvider_->skipActivityIdentityAssertionOnHostPause();
     skipActivityIdentityAssertionOnHostPause_ = flagValue;
@@ -1370,7 +1388,7 @@ bool ReactNativeFeatureFlagsAccessor::syncAndroidClipBoundsWithOverflow() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(74, "syncAndroidClipBoundsWithOverflow");
+    markFlagAsAccessed(75, "syncAndroidClipBoundsWithOverflow");
 
     flagValue = currentProvider_->syncAndroidClipBoundsWithOverflow();
     syncAndroidClipBoundsWithOverflow_ = flagValue;
@@ -1388,7 +1406,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(75, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(76, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -1406,7 +1424,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommit(
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(76, "updateRuntimeShadowNodeReferencesOnCommit");
+    markFlagAsAccessed(77, "updateRuntimeShadowNodeReferencesOnCommit");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommit();
     updateRuntimeShadowNodeReferencesOnCommit_ = flagValue;
@@ -1424,7 +1442,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommitT
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(77, "updateRuntimeShadowNodeReferencesOnCommitThread");
+    markFlagAsAccessed(78, "updateRuntimeShadowNodeReferencesOnCommitThread");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommitThread();
     updateRuntimeShadowNodeReferencesOnCommitThread_ = flagValue;
@@ -1442,7 +1460,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(78, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(79, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -1460,7 +1478,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(79, "useFabricInterop");
+    markFlagAsAccessed(80, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -1478,7 +1496,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(80, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(81, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -1496,7 +1514,7 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useNestedScrollViewAndroid");
+    markFlagAsAccessed(82, "useNestedScrollViewAndroid");
 
     flagValue = currentProvider_->useNestedScrollViewAndroid();
     useNestedScrollViewAndroid_ = flagValue;
@@ -1514,7 +1532,7 @@ bool ReactNativeFeatureFlagsAccessor::useOptimizedViewRegistryOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "useOptimizedViewRegistryOnAndroid");
+    markFlagAsAccessed(83, "useOptimizedViewRegistryOnAndroid");
 
     flagValue = currentProvider_->useOptimizedViewRegistryOnAndroid();
     useOptimizedViewRegistryOnAndroid_ = flagValue;
@@ -1532,7 +1550,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "useSharedAnimatedBackend");
+    markFlagAsAccessed(84, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1550,7 +1568,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(85, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1568,7 +1586,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "useTurboModuleInterop");
+    markFlagAsAccessed(86, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1586,7 +1604,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "useTurboModules");
+    markFlagAsAccessed(87, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;
@@ -1604,7 +1622,7 @@ bool ReactNativeFeatureFlagsAccessor::useUnorderedMapInDifferentiator() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(87, "useUnorderedMapInDifferentiator");
+    markFlagAsAccessed(88, "useUnorderedMapInDifferentiator");
 
     flagValue = currentProvider_->useUnorderedMapInDifferentiator();
     useUnorderedMapInDifferentiator_ = flagValue;
@@ -1622,7 +1640,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(88, "viewCullingOutsetRatio");
+    markFlagAsAccessed(89, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1640,7 +1658,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(89, "viewTransitionEnabled");
+    markFlagAsAccessed(90, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1658,7 +1676,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionUseHardwareBitmapAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(90, "viewTransitionUseHardwareBitmapAndroid");
+    markFlagAsAccessed(91, "viewTransitionUseHardwareBitmapAndroid");
 
     flagValue = currentProvider_->viewTransitionUseHardwareBitmapAndroid();
     viewTransitionUseHardwareBitmapAndroid_ = flagValue;
@@ -1676,7 +1694,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(91, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(92, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<46d2d87deec97afaa3d5b89d22fc9ff7>>
+ * @generated SignedSource<<da9a6ad6f33deada0a3949f07d667b80>>
  */
 
 /**
@@ -96,6 +96,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool fuseboxNetworkInspectionEnabled();
   bool fuseboxScreenshotCaptureEnabled();
   bool hideOffscreenVirtualViewsOnIOS();
+  bool optimizedAnimatedPropUpdates();
   bool overrideBySynchronousMountPropsAtMountingAndroid();
   bool perfIssuesEnabled();
   bool perfMonitorV2Enabled();
@@ -135,7 +136,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 92> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 93> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -201,6 +202,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> fuseboxNetworkInspectionEnabled_;
   std::atomic<std::optional<bool>> fuseboxScreenshotCaptureEnabled_;
   std::atomic<std::optional<bool>> hideOffscreenVirtualViewsOnIOS_;
+  std::atomic<std::optional<bool>> optimizedAnimatedPropUpdates_;
   std::atomic<std::optional<bool>> overrideBySynchronousMountPropsAtMountingAndroid_;
   std::atomic<std::optional<bool>> perfIssuesEnabled_;
   std::atomic<std::optional<bool>> perfMonitorV2Enabled_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3e3db9d13a20d62c9cfb80330de6b4e0>>
+ * @generated SignedSource<<631d9805d5deb3b9d8fa721c25f41f75>>
  */
 
 /**
@@ -280,6 +280,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool hideOffscreenVirtualViewsOnIOS() override {
+    return false;
+  }
+
+  bool optimizedAnimatedPropUpdates() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<963ea85be18e1df973142b74addf3b16>>
+ * @generated SignedSource<<27b6f1fcb4de7d5338b72043f16c6a54>>
  */
 
 /**
@@ -619,6 +619,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::hideOffscreenVirtualViewsOnIOS();
+  }
+
+  bool optimizedAnimatedPropUpdates() override {
+    auto value = values_["optimizedAnimatedPropUpdates"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::optimizedAnimatedPropUpdates();
   }
 
   bool overrideBySynchronousMountPropsAtMountingAndroid() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d2f0e5328454ab9080743fe15f2dc229>>
+ * @generated SignedSource<<193caba6826abcb01603ae7a96faf434>>
  */
 
 /**
@@ -89,6 +89,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool fuseboxNetworkInspectionEnabled() = 0;
   virtual bool fuseboxScreenshotCaptureEnabled() = 0;
   virtual bool hideOffscreenVirtualViewsOnIOS() = 0;
+  virtual bool optimizedAnimatedPropUpdates() = 0;
   virtual bool overrideBySynchronousMountPropsAtMountingAndroid() = 0;
   virtual bool perfIssuesEnabled() = 0;
   virtual bool perfMonitorV2Enabled() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9061422bb5437e737602f33e74453779>>
+ * @generated SignedSource<<82af9618cc1a09d5e5c93c9a6cacfcb2>>
  */
 
 /**
@@ -362,6 +362,11 @@ bool NativeReactNativeFeatureFlags::fuseboxScreenshotCaptureEnabled(
 bool NativeReactNativeFeatureFlags::hideOffscreenVirtualViewsOnIOS(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::hideOffscreenVirtualViewsOnIOS();
+}
+
+bool NativeReactNativeFeatureFlags::optimizedAnimatedPropUpdates(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::optimizedAnimatedPropUpdates();
 }
 
 bool NativeReactNativeFeatureFlags::overrideBySynchronousMountPropsAtMountingAndroid(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<295f75a120dcf079af2846c5cabb8bb4>>
+ * @generated SignedSource<<9ad664ffda3606d894339dd64e364374>>
  */
 
 /**
@@ -163,6 +163,8 @@ class NativeReactNativeFeatureFlags
   bool fuseboxScreenshotCaptureEnabled(jsi::Runtime& runtime);
 
   bool hideOffscreenVirtualViewsOnIOS(jsi::Runtime& runtime);
+
+  bool optimizedAnimatedPropUpdates(jsi::Runtime& runtime);
 
   bool overrideBySynchronousMountPropsAtMountingAndroid(jsi::Runtime& runtime);
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -731,6 +731,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    optimizedAnimatedPropUpdates: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2026-04-07',
+        description:
+          'When enabled, uses optimized platform-specific paths to apply animated props synchronously. On Android, this uses a batched int/double buffer protocol with a single JNI call. On iOS, this passes AnimatedProps directly through the delegate chain and applies them via cloneProps, avoiding the folly::dynamic round-trip.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     overrideBySynchronousMountPropsAtMountingAndroid: {
       defaultValue: true,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<72c610dc5a8efc1eba2121949e1c24a0>>
+ * @generated SignedSource<<34db44248449a69453a4d0cad69b051d>>
  * @flow strict
  * @noformat
  */
@@ -110,6 +110,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   fuseboxNetworkInspectionEnabled: Getter<boolean>,
   fuseboxScreenshotCaptureEnabled: Getter<boolean>,
   hideOffscreenVirtualViewsOnIOS: Getter<boolean>,
+  optimizedAnimatedPropUpdates: Getter<boolean>,
   overrideBySynchronousMountPropsAtMountingAndroid: Getter<boolean>,
   perfIssuesEnabled: Getter<boolean>,
   perfMonitorV2Enabled: Getter<boolean>,
@@ -455,6 +456,10 @@ export const fuseboxScreenshotCaptureEnabled: Getter<boolean> = createNativeFlag
  * Hides offscreen VirtualViews on iOS by setting hidden = YES to avoid extra cost of views
  */
 export const hideOffscreenVirtualViewsOnIOS: Getter<boolean> = createNativeFlagGetter('hideOffscreenVirtualViewsOnIOS', false);
+/**
+ * When enabled, uses optimized platform-specific paths to apply animated props synchronously. On Android, this uses a batched int/double buffer protocol with a single JNI call. On iOS, this passes AnimatedProps directly through the delegate chain and applies them via cloneProps, avoiding the folly::dynamic round-trip.
+ */
+export const optimizedAnimatedPropUpdates: Getter<boolean> = createNativeFlagGetter('optimizedAnimatedPropUpdates', false);
 /**
  * Override props at mounting with synchronously mounted (i.e. direct manipulation) props from Native Animated.
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<198728d86480c873bf44fc0d8d1633ef>>
+ * @generated SignedSource<<c87ff9009e001b7cf7e8d04c75117dd3>>
  * @flow strict
  * @noformat
  */
@@ -89,6 +89,7 @@ export interface Spec extends TurboModule {
   +fuseboxNetworkInspectionEnabled?: () => boolean;
   +fuseboxScreenshotCaptureEnabled?: () => boolean;
   +hideOffscreenVirtualViewsOnIOS?: () => boolean;
+  +optimizedAnimatedPropUpdates?: () => boolean;
   +overrideBySynchronousMountPropsAtMountingAndroid?: () => boolean;
   +perfIssuesEnabled?: () => boolean;
   +perfMonitorV2Enabled?: () => boolean;

--- a/packages/rn-tester/js/examples/AnimationBackend/AllAnimatedPropsExample.js
+++ b/packages/rn-tester/js/examples/AnimationBackend/AllAnimatedPropsExample.js
@@ -1,0 +1,367 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
+import * as React from 'react';
+import {useMemo} from 'react';
+import {
+  Animated,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  useAnimatedValue,
+} from 'react-native';
+import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
+
+const optimizedAnimatedPropUpdatesEnabled =
+  ReactNativeFeatureFlags.optimizedAnimatedPropUpdates();
+
+// 1x1 white PNG embedded as a data URI so the `tintColor` row works without
+// network access.
+const TINT_SOURCE = {
+  uri: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+};
+
+function useLoop(): Animated.Value {
+  const value = useAnimatedValue(0);
+
+  React.useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(value, {
+          toValue: 1,
+          duration: 1500,
+          useNativeDriver: true,
+        }),
+        Animated.timing(value, {
+          toValue: 0,
+          duration: 1500,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+    return () => {
+      animation.stop();
+    };
+  }, [value]);
+
+  return value;
+}
+
+function Row({
+  label,
+  children,
+}: {
+  label: string,
+  children: React.Node,
+}): React.Node {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.label} numberOfLines={2}>
+        {label}
+      </Text>
+      <View style={styles.demo}>{children}</View>
+    </View>
+  );
+}
+
+function SectionHeader({title}: {title: string}): React.Node {
+  return <Text style={styles.section}>{title}</Text>;
+}
+
+function FlagIndicator(): React.Node {
+  return (
+    <View style={styles.flagRow}>
+      <Text style={styles.flagLabel}>optimizedAnimatedPropUpdates:</Text>
+      <Text
+        style={[
+          styles.flagValue,
+          optimizedAnimatedPropUpdatesEnabled ? styles.flagOn : styles.flagOff,
+        ]}>
+        {optimizedAnimatedPropUpdatesEnabled ? 'ON' : 'OFF'}
+      </Text>
+    </View>
+  );
+}
+
+function AllAnimatedPropsExample(): React.Node {
+  const t = useLoop();
+
+  // All interpolators are derived from a single shared driver. Building them
+  // in a useMemo keeps the underlying Animated nodes stable across renders.
+  const rows = useMemo(() => {
+    const num = (a: number, b: number) =>
+      t.interpolate({inputRange: [0, 1], outputRange: [a, b]});
+
+    const color = (a: string, b: string) =>
+      t.interpolate({inputRange: [0, 1], outputRange: [a, b]});
+
+    // NOTE: percent-based interpolators (outputRange like ["0%", "50%"]) are
+    // intentionally omitted. InterpolationAnimatedNode in the C++ renderer
+    // doesn't parse string outputRange entries with unit suffixes (it crashes
+    // on `asDouble()` for values like "50%"), so the wire-side
+    // CMD_UNIT_PERCENT path can't be exercised end-to-end from this example
+    // until that's fixed. See InterpolationAnimatedNode.cpp:50.
+
+    const deg = (a: number, b: number) =>
+      t.interpolate({
+        inputRange: [0, 1],
+        outputRange: [`${a}deg`, `${b}deg`],
+      });
+
+    const rad = (a: number, b: number) =>
+      t.interpolate({
+        inputRange: [0, 1],
+        outputRange: [`${a}rad`, `${b}rad`],
+      });
+
+    // Top-level numeric props (decoded as CMD_OPACITY..CMD_SHADOW_RADIUS).
+    const numeric = [
+      {label: 'opacity', style: {opacity: num(0.2, 1)}},
+      {label: 'elevation (Android)', style: {elevation: num(0, 16)}},
+      {label: 'zIndex', style: {zIndex: num(0, 10)}},
+      {label: 'shadowOpacity (iOS)', style: {shadowOpacity: num(0, 1)}},
+      {label: 'shadowRadius (iOS)', style: {shadowRadius: num(0, 12)}},
+    ];
+
+    // Color props (decoded as CMD_BACKGROUND_COLOR..CMD_TINT_COLOR and
+    // CMD_BORDER_COLOR..CMD_BORDER_END_COLOR). `color` and `tintColor` are
+    // rendered separately because they need Text and Image, respectively.
+    const colorRows = [
+      {
+        label: 'backgroundColor',
+        style: {backgroundColor: color('#fda4af', '#22c55e')},
+      },
+      {label: 'borderColor', style: {borderColor: color('red', 'blue')}},
+      {label: 'borderTopColor', style: {borderTopColor: color('red', 'blue')}},
+      {
+        label: 'borderBottomColor',
+        style: {borderBottomColor: color('red', 'blue')},
+      },
+      {
+        label: 'borderLeftColor',
+        style: {borderLeftColor: color('red', 'blue')},
+      },
+      {
+        label: 'borderRightColor',
+        style: {borderRightColor: color('red', 'blue')},
+      },
+      {
+        label: 'borderStartColor',
+        style: {borderStartColor: color('red', 'blue')},
+      },
+      {label: 'borderEndColor', style: {borderEndColor: color('red', 'blue')}},
+    ];
+
+    // Border radii (decoded as CMD_BORDER_RADIUS..CMD_BORDER_END_END_RADIUS).
+    // Only the px unit path is exercised here; see note above for why the
+    // percent path is currently disabled.
+    const r = () => num(0, 24);
+    const radiusPx = [
+      {label: 'borderRadius (px)', style: {borderRadius: r()}},
+      {label: 'borderTopLeftRadius (px)', style: {borderTopLeftRadius: r()}},
+      {label: 'borderTopRightRadius (px)', style: {borderTopRightRadius: r()}},
+      {label: 'borderTopStartRadius (px)', style: {borderTopStartRadius: r()}},
+      {label: 'borderTopEndRadius (px)', style: {borderTopEndRadius: r()}},
+      {
+        label: 'borderBottomLeftRadius (px)',
+        style: {borderBottomLeftRadius: r()},
+      },
+      {
+        label: 'borderBottomRightRadius (px)',
+        style: {borderBottomRightRadius: r()},
+      },
+      {
+        label: 'borderBottomStartRadius (px)',
+        style: {borderBottomStartRadius: r()},
+      },
+      {
+        label: 'borderBottomEndRadius (px)',
+        style: {borderBottomEndRadius: r()},
+      },
+      {
+        label: 'borderStartStartRadius (px)',
+        style: {borderStartStartRadius: r()},
+      },
+      {
+        label: 'borderStartEndRadius (px)',
+        style: {borderStartEndRadius: r()},
+      },
+      {
+        label: 'borderEndStartRadius (px)',
+        style: {borderEndStartRadius: r()},
+      },
+      {label: 'borderEndEndRadius (px)', style: {borderEndEndRadius: r()}},
+    ];
+
+    // Transforms (decoded under CMD_START_OF_TRANSFORM). Rotations cover both
+    // CMD_UNIT_DEG and CMD_UNIT_RAD; translations cover CMD_UNIT_PX. The
+    // CMD_UNIT_PERCENT path for translations is currently disabled (see note
+    // above).
+    const transforms = [
+      {label: 'translateX (px)', transform: [{translateX: num(-30, 30)}]},
+      {label: 'translateY (px)', transform: [{translateY: num(-15, 15)}]},
+      {label: 'scale', transform: [{scale: num(0.5, 1.5)}]},
+      {label: 'scaleX', transform: [{scaleX: num(0.5, 1.5)}]},
+      {label: 'scaleY', transform: [{scaleY: num(0.5, 1.5)}]},
+      {label: 'rotate (deg)', transform: [{rotate: deg(0, 360)}]},
+      {label: 'rotate (rad)', transform: [{rotate: rad(0, Math.PI * 2)}]},
+      {label: 'rotateX (deg)', transform: [{rotateX: deg(0, 360)}]},
+      {label: 'rotateY (deg)', transform: [{rotateY: deg(0, 360)}]},
+      {label: 'rotateZ (deg)', transform: [{rotateZ: deg(0, 360)}]},
+      {label: 'skewX (deg)', transform: [{skewX: deg(0, 30)}]},
+      {label: 'skewY (deg)', transform: [{skewY: deg(0, 30)}]},
+      {
+        label: 'perspective + rotateY',
+        transform: [{perspective: num(200, 800)}, {rotateY: deg(0, 360)}],
+      },
+    ];
+
+    return {
+      numeric,
+      textColor: color('red', 'blue'),
+      tintColor: color('red', 'blue'),
+      colorRows,
+      radiusPx,
+      transforms,
+    };
+  }, [t]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <FlagIndicator />
+      <SectionHeader title="Top-level numeric props" />
+      {rows.numeric.map(({label, style}) => (
+        <Row key={label} label={label}>
+          <Animated.View style={[styles.box, styles.colored, style]} />
+        </Row>
+      ))}
+
+      <SectionHeader title="Color props" />
+      {rows.colorRows.map(({label, style}) => (
+        <Row key={label} label={label}>
+          <Animated.View style={[styles.box, styles.thickBorder, style]} />
+        </Row>
+      ))}
+      <Row label="color (Text)">
+        <Animated.Text style={[styles.text, {color: rows.textColor}]}>
+          Animated text color
+        </Animated.Text>
+      </Row>
+      <Row label="tintColor (Image)">
+        <Animated.Image
+          source={TINT_SOURCE}
+          style={[styles.tintImage, {tintColor: rows.tintColor}]}
+        />
+      </Row>
+
+      <SectionHeader title="Border radius (px)" />
+      {rows.radiusPx.map(({label, style}) => (
+        <Row key={label} label={label}>
+          <Animated.View style={[styles.box, styles.colored, style]} />
+        </Row>
+      ))}
+
+      <SectionHeader title="Transforms" />
+      {rows.transforms.map(({label, transform}) => (
+        <Row key={label} label={label}>
+          <Animated.View style={[styles.box, styles.colored, {transform}]} />
+        </Row>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 8,
+  },
+  section: {
+    fontWeight: 'bold',
+    fontSize: 14,
+    marginTop: 16,
+    marginBottom: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    minHeight: 70,
+  },
+  label: {
+    width: 170,
+    fontSize: 12,
+    paddingRight: 8,
+  },
+  demo: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 70,
+  },
+  box: {
+    width: 50,
+    height: 50,
+  },
+  colored: {
+    backgroundColor: '#3b82f6',
+  },
+  thickBorder: {
+    borderWidth: 4,
+    borderColor: 'red',
+    backgroundColor: '#e5e7eb',
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  tintImage: {
+    width: 40,
+    height: 40,
+  },
+  flagRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    marginBottom: 4,
+    backgroundColor: '#f3f4f6',
+    borderRadius: 4,
+  },
+  flagLabel: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    marginRight: 8,
+  },
+  flagValue: {
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  flagOn: {
+    color: '#16a34a',
+  },
+  flagOff: {
+    color: '#dc2626',
+  },
+});
+
+export default {
+  title: 'All Animated Props',
+  name: 'allAnimatedProps',
+  description:
+    'Runs an animation per each property handled by BatchedAnimatedPropsMountItem (opacity, elevation, colors, border radii, transforms, etc.).',
+  render: (): React.Node => <AllAnimatedPropsExample />,
+} as RNTesterModuleExample;

--- a/packages/rn-tester/js/examples/AnimationBackend/AnimationBackendIndex.js
+++ b/packages/rn-tester/js/examples/AnimationBackend/AnimationBackendIndex.js
@@ -11,6 +11,7 @@
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
 import PlaygroundExample from './ChessboardExample';
+import PerformanceTestExample from './PerformanceTestExample';
 import SwipeableListExample from './SwipeableListExample';
 import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
 
@@ -25,5 +26,7 @@ export default {
   category: 'UI',
   description: `Examples demonstrating the Animation Backend for layout-updating animations. ${canUseBackend ? '' : 'You need to enable c++ Animated and the Animation Backend to see these examples.'}`,
   showIndividualExamples: true,
-  examples: canUseBackend ? [PlaygroundExample, SwipeableListExample] : [],
+  examples: canUseBackend
+    ? [PlaygroundExample, SwipeableListExample, PerformanceTestExample]
+    : [],
 } as RNTesterModule;

--- a/packages/rn-tester/js/examples/AnimationBackend/AnimationBackendIndex.js
+++ b/packages/rn-tester/js/examples/AnimationBackend/AnimationBackendIndex.js
@@ -10,6 +10,7 @@
 
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
+import AllAnimatedPropsExample from './AllAnimatedPropsExample';
 import PlaygroundExample from './ChessboardExample';
 import PerformanceTestExample from './PerformanceTestExample';
 import SwipeableListExample from './SwipeableListExample';
@@ -27,6 +28,11 @@ export default {
   description: `Examples demonstrating the Animation Backend for layout-updating animations. ${canUseBackend ? '' : 'You need to enable c++ Animated and the Animation Backend to see these examples.'}`,
   showIndividualExamples: true,
   examples: canUseBackend
-    ? [PlaygroundExample, SwipeableListExample, PerformanceTestExample]
+    ? [
+        AllAnimatedPropsExample,
+        PlaygroundExample,
+        SwipeableListExample,
+        PerformanceTestExample,
+      ]
     : [],
 } as RNTesterModule;

--- a/packages/rn-tester/js/examples/AnimationBackend/PerformanceTestExample.js
+++ b/packages/rn-tester/js/examples/AnimationBackend/PerformanceTestExample.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
+import * as React from 'react';
+import {Animated, StyleSheet, Text, View} from 'react-native';
+import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
+
+const optimizedAnimatedPropUpdatesEnabled =
+  ReactNativeFeatureFlags.optimizedAnimatedPropUpdates();
+
+function FlagIndicator(): React.Node {
+  return (
+    <View style={styles.flagRow}>
+      <Text style={styles.flagLabel}>optimizedAnimatedPropUpdates:</Text>
+      <Text
+        style={[
+          styles.flagValue,
+          optimizedAnimatedPropUpdatesEnabled ? styles.flagOn : styles.flagOff,
+        ]}>
+        {optimizedAnimatedPropUpdatesEnabled ? 'ON' : 'OFF'}
+      </Text>
+    </View>
+  );
+}
+
+const ROWS = 20;
+const COLS = 10;
+const SIZE = 35;
+
+function PerformanceTest() {
+  const animatedValue = React.useRef(new Animated.Value(0)).current;
+
+  React.useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(animatedValue, {
+          toValue: 1,
+          duration: 500,
+          useNativeDriver: true,
+        }),
+        Animated.timing(animatedValue, {
+          toValue: 0,
+          duration: 500,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [animatedValue]);
+
+  const backgroundColor = animatedValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['red', 'lime'],
+  });
+
+  const borderRadius = animatedValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, 25],
+  });
+
+  // Approximation of Math.pow(2, sv * 3 + 4.5) with piecewise linear interpolation
+  const perspective = animatedValue.interpolate({
+    inputRange: [0, 0.25, 0.5, 0.75, 1],
+    outputRange: [22.63, 38.05, 64, 107.63, 181.02],
+  });
+
+  const animatedStyle = {
+    borderRadius,
+    backgroundColor,
+    transform: [{perspective}, {rotateY: '45deg'}],
+  };
+
+  return (
+    <View style={styles.container}>
+      <FlagIndicator />
+      {new Array<void>(ROWS).fill().map((_row, i) => (
+        <View key={i} style={styles.row}>
+          {new Array<void>(COLS).fill().map((_col, j) => (
+            <Animated.View key={j} style={[styles.box, animatedStyle]} />
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  box: {
+    backgroundColor: 'navy',
+    borderColor: 'pink',
+    borderWidth: 1,
+    width: SIZE,
+    height: SIZE,
+  },
+  flagRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    marginBottom: 4,
+    backgroundColor: '#f3f4f6',
+    borderRadius: 4,
+  },
+  flagLabel: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    marginRight: 8,
+  },
+  flagValue: {
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  flagOn: {
+    color: '#16a34a',
+  },
+  flagOff: {
+    color: '#dc2626',
+  },
+});
+
+export default {
+  title: 'Performance Test',
+  name: 'performance-test',
+  description: 'Test out new features and ideas.',
+  render: (): React.Node => <PerformanceTest />,
+} as RNTesterModuleExample;


### PR DESCRIPTION
Summary:
Adds a new RNTester example under the Animation Backend section that runs a looping animation per each property handled by BatchedAnimatedPropsMountItem:

- Top-level numeric props: opacity, elevation, zIndex, shadowOpacity, shadowRadius
- Color props: backgroundColor, color (Text), tintColor (Image), and all
  borderColor / borderTopColor / borderBottomColor / borderLeftColor /
  borderRightColor / borderStartColor / borderEndColor variants
- All 13 border-radius props (borderRadius and per-corner) in px units, plus
  borderRadius in percent units
- All transforms: translateX/Y in px and percent, scale/scaleX/scaleY,
  rotate/rotateX/rotateY/rotateZ in deg and rad, skewX/skewY, perspective

Each row exercises one distinct command id from the buffer protocol decoded by BatchedAnimatedPropsMountItem, making it easy to visually verify that every supported animated prop survives the C++ to Java buffer round-trip.

Changelog:
[General][Added] - Add All Animated Props example to the rn-tester Animation Backend section

Differential Revision: D102800169
