### PR TITLE
Fix Image.getSize returning downsampled dimensions on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
@@ -17,6 +17,7 @@ import com.facebook.datasource.DataSource
 import com.facebook.datasource.DataSubscriber
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.fbreact.specs.NativeImageLoaderAndroidSpec
+import com.facebook.imagepipeline.common.RotationOptions
 import com.facebook.imagepipeline.core.ImagePipeline
 import com.facebook.imagepipeline.image.EncodedImage
 import com.facebook.imagepipeline.request.ImageRequest
@@ -83,7 +84,10 @@ internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventL
       return
     }
     val source = ImageSource(reactApplicationContext, uriString)
-    val request: ImageRequest = ImageRequestBuilder.newBuilderWithSource(source.uri).build()
+    val request: ImageRequest =
+        ImageRequestBuilder.newBuilderWithSource(source.uri)
+            .setRotationOptions(RotationOptions.disableRotation())
+            .build()
     val dataSource: DataSource<CloseableReference<PooledByteBuffer>> =
         this.imagePipeline.fetchEncodedImage(request, this.callerContext)
     dataSource.subscribe(createSizeSubscriber(promise), CallerThreadExecutor.getInstance())
@@ -106,6 +110,7 @@ internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventL
     val source = ImageSource(reactApplicationContext, uriString)
     val imageRequestBuilder: ImageRequestBuilder =
         ImageRequestBuilder.newBuilderWithSource(source.uri)
+            .setRotationOptions(RotationOptions.disableRotation())
     val request: ImageRequest =
         ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, headers)
     val dataSource: DataSource<CloseableReference<PooledByteBuffer>> =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.modules.image
 
+import android.media.ExifInterface
 import android.net.Uri
 import android.util.SparseArray
 import com.facebook.common.executors.CallerThreadExecutor
@@ -131,9 +132,14 @@ internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventL
             var encodedImage: EncodedImage? = null
             try {
               encodedImage = EncodedImage(ref)
-              // Swap width and height when the image is rotated 90 or 270 degrees so the
-              // values reflect the visible dimensions, matching iOS behavior.
-              val rotated = encodedImage.rotationAngle == 90 || encodedImage.rotationAngle == 270
+              // Swap width and height when the image's EXIF orientation swaps the X/Y axes
+              // (90°/270° rotations, or transpose/transverse), so the values reflect the
+              // visible dimensions, matching iOS behavior.
+              val rotated =
+                  encodedImage.rotationAngle == 90 ||
+                      encodedImage.rotationAngle == 270 ||
+                      encodedImage.exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+                      encodedImage.exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
               val width = if (rotated) encodedImage.height else encodedImage.width
               val height = if (rotated) encodedImage.width else encodedImage.height
               if (width < 0 || height < 0) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
@@ -10,6 +10,7 @@ package com.facebook.react.modules.image
 import android.net.Uri
 import android.util.SparseArray
 import com.facebook.common.executors.CallerThreadExecutor
+import com.facebook.common.memory.PooledByteBuffer
 import com.facebook.common.references.CloseableReference
 import com.facebook.datasource.BaseDataSubscriber
 import com.facebook.datasource.DataSource
@@ -17,7 +18,7 @@ import com.facebook.datasource.DataSubscriber
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.fbreact.specs.NativeImageLoaderAndroidSpec
 import com.facebook.imagepipeline.core.ImagePipeline
-import com.facebook.imagepipeline.image.CloseableImage
+import com.facebook.imagepipeline.image.EncodedImage
 import com.facebook.imagepipeline.request.ImageRequest
 import com.facebook.imagepipeline.request.ImageRequestBuilder
 import com.facebook.react.bridge.GuardedAsyncTask
@@ -83,38 +84,9 @@ internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventL
     }
     val source = ImageSource(reactApplicationContext, uriString)
     val request: ImageRequest = ImageRequestBuilder.newBuilderWithSource(source.uri).build()
-    val dataSource: DataSource<CloseableReference<CloseableImage>> =
-        this.imagePipeline.fetchDecodedImage(request, this.callerContext)
-    val dataSubscriber: DataSubscriber<CloseableReference<CloseableImage>> =
-        object : BaseDataSubscriber<CloseableReference<CloseableImage>>() {
-          override fun onNewResultImpl(dataSource: DataSource<CloseableReference<CloseableImage>>) {
-            if (!dataSource.isFinished) {
-              return
-            }
-            val ref = dataSource.result
-            if (ref != null) {
-              try {
-                val image: CloseableImage = ref.get()
-                val sizes = buildReadableMap {
-                  put("width", image.width)
-                  put("height", image.height)
-                }
-                promise.resolve(sizes)
-              } catch (e: Exception) {
-                promise.reject(ERROR_GET_SIZE_FAILURE, e)
-              } finally {
-                CloseableReference.closeSafely(ref)
-              }
-            } else {
-              promise.reject(ERROR_GET_SIZE_FAILURE, "Failed to get the size of the image")
-            }
-          }
-
-          override fun onFailureImpl(dataSource: DataSource<CloseableReference<CloseableImage>>) {
-            promise.reject(ERROR_GET_SIZE_FAILURE, dataSource.failureCause)
-          }
-        }
-    dataSource.subscribe(dataSubscriber, CallerThreadExecutor.getInstance())
+    val dataSource: DataSource<CloseableReference<PooledByteBuffer>> =
+        this.imagePipeline.fetchEncodedImage(request, this.callerContext)
+    dataSource.subscribe(createSizeSubscriber(promise), CallerThreadExecutor.getInstance())
   }
 
   /**
@@ -136,39 +108,53 @@ internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventL
         ImageRequestBuilder.newBuilderWithSource(source.uri)
     val request: ImageRequest =
         ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, headers)
-    val dataSource: DataSource<CloseableReference<CloseableImage>> =
-        this.imagePipeline.fetchDecodedImage(request, this.callerContext)
-    val dataSubscriber: DataSubscriber<CloseableReference<CloseableImage>> =
-        object : BaseDataSubscriber<CloseableReference<CloseableImage>>() {
-          override fun onNewResultImpl(dataSource: DataSource<CloseableReference<CloseableImage>>) {
-            if (!dataSource.isFinished) {
-              return
-            }
-            val ref = dataSource.result
-            if (ref != null) {
-              try {
-                val image: CloseableImage = ref.get()
-                val sizes = buildReadableMap {
-                  put("width", image.width)
-                  put("height", image.height)
-                }
-                promise.resolve(sizes)
-              } catch (e: Exception) {
-                promise.reject(ERROR_GET_SIZE_FAILURE, e)
-              } finally {
-                CloseableReference.closeSafely(ref)
-              }
-            } else {
-              promise.reject(ERROR_GET_SIZE_FAILURE, "Failed to get the size of the image")
-            }
-          }
+    val dataSource: DataSource<CloseableReference<PooledByteBuffer>> =
+        this.imagePipeline.fetchEncodedImage(request, this.callerContext)
+    dataSource.subscribe(createSizeSubscriber(promise), CallerThreadExecutor.getInstance())
+  }
 
-          override fun onFailureImpl(dataSource: DataSource<CloseableReference<CloseableImage>>) {
-            promise.reject(ERROR_GET_SIZE_FAILURE, dataSource.failureCause)
+  private fun createSizeSubscriber(
+      promise: Promise
+  ): DataSubscriber<CloseableReference<PooledByteBuffer>> =
+      object : BaseDataSubscriber<CloseableReference<PooledByteBuffer>>() {
+        override fun onNewResultImpl(dataSource: DataSource<CloseableReference<PooledByteBuffer>>) {
+          if (!dataSource.isFinished) {
+            return
+          }
+          val ref = dataSource.result
+          if (ref != null) {
+            var encodedImage: EncodedImage? = null
+            try {
+              encodedImage = EncodedImage(ref)
+              // Swap width and height when the image is rotated 90 or 270 degrees so the
+              // values reflect the visible dimensions, matching iOS behavior.
+              val rotated = encodedImage.rotationAngle == 90 || encodedImage.rotationAngle == 270
+              val width = if (rotated) encodedImage.height else encodedImage.width
+              val height = if (rotated) encodedImage.width else encodedImage.height
+              if (width < 0 || height < 0) {
+                promise.reject(ERROR_GET_SIZE_FAILURE, "Failed to get the size of the image")
+                return
+              }
+              val sizes = buildReadableMap {
+                put("width", width)
+                put("height", height)
+              }
+              promise.resolve(sizes)
+            } catch (e: Exception) {
+              promise.reject(ERROR_GET_SIZE_FAILURE, e)
+            } finally {
+              encodedImage?.close()
+              CloseableReference.closeSafely(ref)
+            }
+          } else {
+            promise.reject(ERROR_GET_SIZE_FAILURE, "Failed to get the size of the image")
           }
         }
-    dataSource.subscribe(dataSubscriber, CallerThreadExecutor.getInstance())
-  }
+
+        override fun onFailureImpl(dataSource: DataSource<CloseableReference<PooledByteBuffer>>) {
+          promise.reject(ERROR_GET_SIZE_FAILURE, dataSource.failureCause)
+        }
+      }
 
   /**
    * Prefetches the given image to the Fresco image disk cache.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

`Image.getSize` and `getSizeWithHeaders` call Fresco's `fetchDecodedImage`, which returns a `CloseableImage` whose width / height reflect the bitmap after Fresco's automatic downsampling (typically capped at the screen size).

For sources larger than the screen this returned the wrong dimensions. ex: a 4000x3000 image on a 1920x1080 device came back as 1920x1440.

Switch to `fetchEncodedImage` and read the dimensions from the parsed image metadata (JPEG / PNG / WebP / HEIF headers), so the values are the true source dimensions. Swap width / height for 90°/270° EXIF rotation to match the iOS behavior in `RCTImageLoader`.

Fixes #33498
Closes facebook/fresco#2236

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - `Image.getSize` and `Image.getSizeWithHeaders` now return the true source dimensions instead of Fresco's downsampled values

## Test Plan:

In the RNTester app, add:

```ts
useEffect(() => {
  Image.getSize(
    'https://images.pexels.com/photos/842711/pexels-photo-842711.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
    (width, height) => {
      console.log({width, height});
    },
  );
}, []);
```

### Before

<img width="811" height="467" alt="before" src="https://github.com/user-attachments/assets/6fb401ed-cf5a-4496-bcc1-4cfd243bc0b7" />

### After

<img width="811" height="467" alt="after" src="https://github.com/user-attachments/assets/dc809d5f-c554-45d6-a3a3-7712bf39ac44" />