### PR TITLE
Fix (android): show payload preview for FormData and one-shot uploads in DevTools (#55764)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
-
 package com.facebook.react.modules.network
 
 import android.os.Bundle
@@ -238,7 +236,7 @@ internal object NetworkEventUtil {
   @JvmStatic
   fun okHttpHeadersToMap(headers: Headers): Map<String, String> {
     val responseHeaders = mutableMapOf<String, String>()
-    for (i in 0 until headers.size()) {
+    for (i in 0 until headers.size) {
       val headerName = headers.name(i)
       // multiple values for the same header
       if (responseHeaders.containsKey(headerName)) {
@@ -260,22 +258,23 @@ internal object NetworkEventUtil {
     val body = (requestBody as? ProgressRequestBody)?.innerBody() ?: requestBody
 
     if (body.isOneShot()) {
-      // Fallback - body cannot be read twice
-      return "[Preview unavailable]"
+      // Reading would drain the underlying stream and break the real upload,
+      // so fall back to a placeholder that includes the byte count when known.
+      return binaryPartLabel(body)
     }
 
     // MultipartBody does not propagate isOneShot() from its parts, so check each
     // part explicitly. Reading a one-shot part here would drain the underlying
     // stream and cause the real request to fail.
-    if (body is MultipartBody && body.parts().any { it.body().isOneShot() }) {
-      return "[Preview unavailable]"
+    if (body is MultipartBody && body.parts.any { it.body.isOneShot() }) {
+      return previewMultipartWithBinaryParts(body)
     }
 
     return try {
       val buffer = Buffer()
       body.writeTo(buffer)
 
-      val size = buffer.size()
+      val size = buffer.size
       if (size <= MAX_BODY_PREVIEW_SIZE) {
         buffer.readUtf8()
       } else {
@@ -284,5 +283,54 @@ internal object NetworkEventUtil {
     } catch (e: IOException) {
       "[Preview unavailable]"
     }
+  }
+
+  private fun previewMultipartWithBinaryParts(body: MultipartBody): String {
+    val boundary = body.boundary
+    val out = StringBuilder()
+
+    for (part in body.parts) {
+      out.append("--").append(boundary).append("\r\n")
+
+      part.headers?.let { headers ->
+        for (i in 0 until headers.size) {
+          out.append(headers.name(i)).append(": ").append(headers.value(i)).append("\r\n")
+        }
+      }
+      val partBody = part.body
+      partBody.contentType()?.let { out.append("Content-Type: ").append(it).append("\r\n") }
+      out.append("\r\n")
+
+      if (partBody.isOneShot()) {
+        out.append(binaryPartLabel(partBody))
+      } else {
+        try {
+          val partBuffer = Buffer()
+          partBody.writeTo(partBuffer)
+          out.append(partBuffer.readUtf8())
+        } catch (e: IOException) {
+          out.append("[Preview unavailable]")
+        }
+      }
+      out.append("\r\n")
+    }
+    out.append("--").append(boundary).append("--\r\n")
+
+    return if (out.length <= MAX_BODY_PREVIEW_SIZE) {
+      out.toString()
+    } else {
+      out.substring(0, MAX_BODY_PREVIEW_SIZE) + "... (truncated, ${out.length} bytes total)"
+    }
+  }
+
+  /** Placeholder for a one-shot body, including the byte count when known. */
+  private fun binaryPartLabel(body: RequestBody): String {
+    val length =
+        try {
+          body.contentLength()
+        } catch (e: IOException) {
+          -1L
+        }
+    return if (length >= 0) "[Binary data, $length bytes]" else "[Binary data]"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+
 package com.facebook.react.modules.network
 
 import android.os.Bundle
@@ -236,7 +238,7 @@ internal object NetworkEventUtil {
   @JvmStatic
   fun okHttpHeadersToMap(headers: Headers): Map<String, String> {
     val responseHeaders = mutableMapOf<String, String>()
-    for (i in 0 until headers.size) {
+    for (i in 0 until headers.size()) {
       val headerName = headers.name(i)
       // multiple values for the same header
       if (responseHeaders.containsKey(headerName)) {
@@ -259,14 +261,14 @@ internal object NetworkEventUtil {
 
     if (body.isOneShot()) {
       // Reading would drain the underlying stream and break the real upload,
-      // so fall back to a placeholder that includes the byte count when known.
+      // so fall back to a placeholder that includes the byte count when known
       return binaryPartLabel(body)
     }
 
     // MultipartBody does not propagate isOneShot() from its parts, so check each
     // part explicitly. Reading a one-shot part here would drain the underlying
     // stream and cause the real request to fail.
-    if (body is MultipartBody && body.parts.any { it.body.isOneShot() }) {
+    if (body is MultipartBody && body.parts().any { it.body().isOneShot() }) {
       return previewMultipartWithBinaryParts(body)
     }
 
@@ -274,7 +276,7 @@ internal object NetworkEventUtil {
       val buffer = Buffer()
       body.writeTo(buffer)
 
-      val size = buffer.size
+      val size = buffer.size()
       if (size <= MAX_BODY_PREVIEW_SIZE) {
         buffer.readUtf8()
       } else {
@@ -286,18 +288,18 @@ internal object NetworkEventUtil {
   }
 
   private fun previewMultipartWithBinaryParts(body: MultipartBody): String {
-    val boundary = body.boundary
+    val boundary = body.boundary()
     val out = StringBuilder()
 
-    for (part in body.parts) {
+    for (part in body.parts()) {
       out.append("--").append(boundary).append("\r\n")
 
-      part.headers?.let { headers ->
-        for (i in 0 until headers.size) {
+      part.headers()?.let { headers ->
+        for (i in 0 until headers.size()) {
           out.append(headers.name(i)).append(": ").append(headers.value(i)).append("\r\n")
         }
       }
-      val partBody = part.body
+      val partBody = part.body()
       partBody.contentType()?.let { out.append("Content-Type: ").append(it).append("\r\n") }
       out.append("\r\n")
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+
 package com.facebook.react.modules.network
 
 import com.facebook.react.bridge.Arguments
@@ -15,7 +17,13 @@ import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsDefaults
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.testutils.shadows.ShadowArguments
+import java.io.ByteArrayInputStream
 import java.net.SocketTimeoutException
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -290,6 +298,84 @@ class NetworkEventUtilTest {
     assertThat(args.getInt(1)).isEqualTo(statusCode)
     assertThat(args.getMap(2)).isEqualTo(expectedHeadersMap)
     assertThat(args.getString(3)).isEqualTo(url)
+  }
+
+  @Test
+  fun testGetRequestBodyPreviewReturnsNullForNullBody() {
+    assertThat(NetworkEventUtil.getRequestBodyPreview(null)).isNull()
+  }
+
+  @Test
+  fun testGetRequestBodyPreviewReturnsBodyForStringRequest() {
+    val payload = """{"key":"value"}"""
+    val body = payload.toRequestBody("application/json".toMediaTypeOrNull())
+
+    assertThat(NetworkEventUtil.getRequestBodyPreview(body)).isEqualTo(payload)
+  }
+
+  @Test
+  fun testGetRequestBodyPreviewUnwrapsProgressRequestBody() {
+    val payload = "hello world"
+    val inner = payload.toRequestBody("text/plain".toMediaTypeOrNull())
+    val wrapped = ProgressRequestBody(inner) { _, _, _ -> }
+
+    assertThat(NetworkEventUtil.getRequestBodyPreview(wrapped)).isEqualTo(payload)
+  }
+
+  @Test
+  fun testGetRequestBodyPreviewMultipartWithTextParts() {
+    val body =
+        MultipartBody.Builder("test-boundary")
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("field1", "value1")
+            .addFormDataPart("field2", "value2")
+            .build()
+
+    val preview = NetworkEventUtil.getRequestBodyPreview(body)
+
+    assertThat(preview).isNotNull()
+    assertThat(preview).contains("--test-boundary")
+    assertThat(preview).contains("--test-boundary--")
+    assertThat(preview).contains("name=\"field1\"")
+    assertThat(preview).contains("value1")
+    assertThat(preview).contains("name=\"field2\"")
+    assertThat(preview).contains("value2")
+    assertThat(preview).doesNotContain("[Preview unavailable]")
+  }
+
+  @Test
+  fun testGetRequestBodyPreviewMultipartWithFilePartReplacesBinaryContent() {
+    val fileBytes = ByteArray(2048) { it.toByte() }
+    val streamingPart =
+        RequestBodyUtil.create(MediaType.parse("application/octet-stream"), ByteArrayInputStream(fileBytes))
+    val body =
+        MultipartBody.Builder("test-boundary")
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("description", "an image")
+            .addFormDataPart("file", "photo.jpg", streamingPart)
+            .build()
+
+    val preview = NetworkEventUtil.getRequestBodyPreview(body)
+
+    assertThat(preview).isNotNull()
+    assertThat(preview).contains("--test-boundary")
+    assertThat(preview).contains("name=\"description\"")
+    assertThat(preview).contains("an image")
+    assertThat(preview).contains("name=\"file\"")
+    assertThat(preview).contains("filename=\"photo.jpg\"")
+    assertThat(preview).contains("[Binary data, 2048 bytes]")
+    assertThat(preview).doesNotContain("[Preview unavailable]")
+  }
+
+  @Test
+  fun testGetRequestBodyPreviewSingleOneShotBodyShowsPlaceholder() {
+    val fileBytes = ByteArray(512) { it.toByte() }
+    val body =
+        RequestBodyUtil.create(MediaType.parse("application/octet-stream"), ByteArrayInputStream(fileBytes))
+
+    val preview = NetworkEventUtil.getRequestBodyPreview(body)
+
+    assertThat(preview).isEqualTo("[Binary data, 512 bytes]")
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
@@ -379,6 +379,40 @@ class NetworkEventUtilTest {
   }
 
   @Test
+  fun testGetRequestBodyPreviewDoesNotConsumeMultipartOneShotStream() {
+    // Regression guard: previewMultipartWithBinaryParts must not call writeTo() on a
+    // one-shot part. If it ever does, the underlying stream will be drained and the
+    // real upload will fail at request time.
+    val fileBytes = ByteArray(2048) { it.toByte() }
+    val stream = ByteArrayInputStream(fileBytes)
+    val streamingPart =
+        RequestBodyUtil.create(MediaType.parse("application/octet-stream"), stream)
+    val body =
+        MultipartBody.Builder("test-boundary")
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("description", "an image")
+            .addFormDataPart("file", "photo.jpg", streamingPart)
+            .build()
+
+    NetworkEventUtil.getRequestBodyPreview(body)
+
+    assertThat(stream.available()).isEqualTo(fileBytes.size)
+  }
+
+  @Test
+  fun testGetRequestBodyPreviewDoesNotConsumeSingleOneShotStream() {
+    // Regression guard for the top-level one-shot branch: getRequestBodyPreview must
+    // only read contentLength() / contentType() on a one-shot body, never writeTo().
+    val fileBytes = ByteArray(512) { it.toByte() }
+    val stream = ByteArrayInputStream(fileBytes)
+    val body = RequestBodyUtil.create(MediaType.parse("application/octet-stream"), stream)
+
+    NetworkEventUtil.getRequestBodyPreview(body)
+
+    assertThat(stream.available()).isEqualTo(fileBytes.size)
+  }
+
+  @Test
   fun testNullReactContext() {
     val url = "http://example.com"
 


### PR DESCRIPTION
## Summary:

Follow-up to #56406. After that PR landed, NetworkEventUtil.getRequestBodyPreview still returns the literal string "[Preview unavailable]" in two cases:

The top-level RequestBody.isOneShot() is true (e.g. a single URI/file upload).
The body is a MultipartBody whose parts include any one-shot stream (the common case for FormData with files on Android).
Both branches exist for a good reason — calling writeTo() on a one-shot stream would drain it and break the real upload. This PR keeps that invariant but replaces the two return sites with structured previews:

Single one-shot body → [Binary data, N bytes] (or [Binary data] if contentLength() is unknown).
MultipartBody with one-shot parts → a multipart envelope using the request's actual boundary, with text parts inlined and one-shot parts replaced by [Binary data, N bytes]. The result parses cleanly against the on-the-wire Content-Type: multipart/form-data; boundary=..., so DevTools renders it the same way it renders any other multipart payload.
Net result: issue #55764 (no payload preview for FormData / file uploads in the React Native DevTools Network tab) is closed, with no change to what gets sent on the wire.

## Changelog:

NetworkEventUtil.kt: replace the two "[Preview unavailable]" returns with binaryPartLabel(body) and a new previewMultipartWithBinaryParts(body) helper. No change to the existing all-text path.

NetworkEventUtilTest.kt: 6 new tests covering null body, plain string body, ProgressRequestBody unwrapping, multipart with text parts, multipart with a file part, and a single one-shot body.

[ANDROID] [FIXED] - Show request body preview for FormData and file uploads in DevTools Network tab

## Test Plan:

1) `` ./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests "com.facebook.react.modules.network.*"`` — 16/16 pass in NetworkEventUtilTest, full network suite green.

2) Manual: in RN-Tester debug build, POST a FormData with a file using fetch → DevTools Network → Payload tab now shows the multipart envelope with [Binary data, N bytes] instead of [Preview unavailable].

3) Manual: POST a single-file RequestBody from a URI → preview now shows [Binary data, N bytes].

Stream safety
The whole point of #56406's bail-outs was to avoid draining one-shot streams. This PR preserves that: it never calls writeTo() on a body whose isOneShot() is true. The only RequestBody methods invoked on one-shot bodies are contentType() and contentLength(), both of which are pure getters per the OkHttp docs.

Refs #55764, follows up on #56406.
