### PR TITLE
fix: use Gradle 9 compatible Foojay resolver on 0.83-stable

### DIFF
--- a/packages/gradle-plugin/settings.gradle.kts
+++ b/packages/gradle-plugin/settings.gradle.kts
@@ -13,7 +13,7 @@ pluginManagement {
   }
 }
 
-plugins { id("org.gradle.toolchains.foojay-resolver-convention").version("0.5.0") }
+plugins { id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0") }
 
 include(
     ":react-native-gradle-plugin",


### PR DESCRIPTION
## Summary

Backports the Foojay resolver upgrade to `0.83-stable` by changing `foojay-resolver-convention` from `0.5.0` to `1.0.0`.

This is backwards compatible for existing projects and fixes Gradle 9 builds where Foojay 0.5.0 crashes because it references the removed `JvmVendorSpec.IBM_SEMERU` field.

## Why

React Native `main` already contains the same effective fix via #56210, but the published 0.83 line still ships `0.5.0`. Expo SDK 55 / RN 0.83 users hit this during Android builds with Gradle 9.

Refs:
- #55781
- #56210
- gradle/foojay-toolchains#151

## Changelog:

[Android] [Fixed] - Use Gradle 9 compatible Foojay resolver convention plugin in the 0.83 Gradle plugin.

## Test Plan

- `git diff --check`
- Verified `@react-native/gradle-plugin@0.83.x` ships Foojay `0.5.0` and React Native `main` uses `1.0.0`.
