### PR TITLE
Fix ScrollView touch events ignored in contentInset area on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -523,7 +523,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     }
   }
 
-  return isPointInside ? self : nil;
+  return isPointInside ? _scrollView : nil;
 }
 
 /*


### PR DESCRIPTION
## Summary:

Fixes #54123

In RN 0.80, `betterHitTest:withEvent:` in `RCTScrollViewComponentView` was added, which returns `self` (the `RCTScrollViewComponentView` wrapper view) when a touch point falls inside the scroll view's bounds. This causes touches in the contentInset area — where no content is rendered — to be absorbed by the wrapper rather than forwarded to the underlying UIScrollView, making scroll gestures in that region completely non-functional.

The fix returns `_scrollView` instead of `self`, so hit-tested touches are correctly attributed to the `UIScrollView` and scrolling works throughout the full bounds, including the inset area.

## Changelog:

[IOS] [FIXED] - Fix ScrollView touch events ignored in contentInset area on Fabric

## Test Plan:

Couldn't use the snack-repro from #54123 since this requires a native change. But using the `ScrollViewSimpleExample` from the RNTester, and removing a lot of the items demonstrates the behaviour change.

The two videos show attempted dragging from the region below the ScrollView content.

### Before: Dragging in the inset area does nothing — scroll view does not respond
https://github.com/user-attachments/assets/55468ca8-78a7-4034-9e34-0191d55f7da1

### After: Dragging in the inset area scrolls the content correctly
https://github.com/user-attachments/assets/d1f10729-9b41-4a55-8738-16faf27031d7