### PR TITLE
Match `dispatchEvent` return contract on `dispatchTrustedEvent`

### DIFF
--- a/packages/react-native/src/private/renderer/core/__tests__/EventTargetDispatching-itest.js
+++ b/packages/react-native/src/private/renderer/core/__tests__/EventTargetDispatching-itest.js
@@ -1322,21 +1322,6 @@ const {isOSS} = Fantom.getConstants();
     });
 
     describe('error handling', () => {
-      let originalConsoleError: typeof console.error;
-      let mockConsoleError: JestMockFn<$FlowFixMe, $FlowFixMe>;
-
-      beforeEach(() => {
-        originalConsoleError = console.error;
-        mockConsoleError = jest.fn();
-        // $FlowFixMe[cannot-write]
-        console.error = mockConsoleError;
-      });
-
-      afterEach(() => {
-        // $FlowFixMe[cannot-write]
-        console.error = originalConsoleError;
-      });
-
       it('error in event handler does not break dispatch to subsequent listeners', () => {
         const root = Fantom.createRoot();
         const childRef = React.createRef<React.ElementRef<typeof View>>();
@@ -1365,18 +1350,7 @@ const {isOSS} = Fantom.getConstants();
             },
           );
 
-        if (ReactNativeFeatureFlags.enableNativeEventTargetEventDispatching()) {
-          // EventTarget-style dispatch catches per-listener errors and
-          // reports them via `console.error` (see `EventTarget.js`), so the
-          // dispatch itself does not throw.
-          dispatch();
-          expect(mockConsoleError).toHaveBeenCalled();
-        } else {
-          // Legacy dispatch surfaces the first per-handler error via
-          // Fantom's global handler, which re-throws synchronously after
-          // dispatch completes.
-          expect(dispatch).toThrow('handler error');
-        }
+        expect(dispatch).toThrow('handler error');
 
         // The parent bubble handler should still fire despite child's error
         expect(parentHandler).toHaveBeenCalledTimes(1);

--- a/packages/react-native/src/private/renderer/events/ReactNativeResponder.js
+++ b/packages/react-native/src/private/renderer/events/ReactNativeResponder.js
@@ -551,6 +551,24 @@ to return true:wantsResponderID|                            |
                                +                            + */
 
 /**
+ * Returns whether a top-level event is one that the responder system needs to
+ * observe. Used as a fast-path in `processResponderEvent`: most events
+ * (`pointerup`, `pointermove`, `layout`, etc.) are not responder-relevant and
+ * — when no responder is currently set — produce no work.
+ */
+function isResponderRelevantTopLevelType(topLevelType: string): boolean {
+  return match (topLevelType) {
+    | 'topTouchStart'
+    | 'topTouchMove'
+    | 'topTouchEnd'
+    | 'topTouchCancel'
+    | 'topScroll'
+    | 'topSelectionChange' => true,
+    _ => false,
+  };
+}
+
+/**
  * Process a native event through the responder system.
  */
 export function processResponderEvent(
@@ -558,6 +576,15 @@ export function processResponderEvent(
   eventTarget: EventTarget | null,
   nativeEvent: {[string]: unknown},
 ): void {
+  // Fast path: if this event isn't one the responder system cares about and
+  // there is no active responder, exit immediately. This is the dominant case
+  // for non-touch events (pointer*, layout, etc.) on apps without an active
+  // gesture, and saves the touch counting + ResponderTouchHistoryStore +
+  // canTriggerTransfer work.
+  if (responderNode == null && !isResponderRelevantTopLevelType(topLevelType)) {
+    return;
+  }
+
   // Track touch count
   if (isStartish(topLevelType)) {
     trackedTouchCount += 1;

--- a/packages/react-native/src/private/renderer/events/dispatchNativeEvent.js
+++ b/packages/react-native/src/private/renderer/events/dispatchNativeEvent.js
@@ -14,7 +14,11 @@ import {
   customBubblingEventTypes,
   customDirectEventTypes,
 } from '../../../../Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
-import {setEventInitTimeStamp} from '../../webapis/dom/events/internals/EventInternals';
+import {
+  setBubbledPropName,
+  setCapturedPropName,
+  setEventInitTimeStamp,
+} from '../../webapis/dom/events/internals/EventInternals';
 import {dispatchTrustedEvent} from '../../webapis/dom/events/internals/EventTargetInternals';
 import LegacySyntheticEvent from './LegacySyntheticEvent';
 import {topLevelTypeToEventType} from './ReactNativeEventTypeMapping';
@@ -73,6 +77,26 @@ export default function dispatchNativeEvent(
       payload,
       bubbleConfig ?? directConfig,
     );
+
+    // Pre-resolve the React prop names ("onFoo" / "onFooCapture") once per
+    // dispatch and stash them on the event so per-ancestor
+    // `EVENT_TARGET_GET_DECLARATIVE_LISTENER_KEY` lookups can read them
+    // directly, avoiding the per-call `getEventTypePropName` hash lookup.
+    if (bubbleConfig != null) {
+      const phasedRegistrationNames = bubbleConfig.phasedRegistrationNames;
+      setBubbledPropName(
+        syntheticEvent,
+        phasedRegistrationNames.bubbled ?? null,
+      );
+      setCapturedPropName(
+        syntheticEvent,
+        phasedRegistrationNames.captured ?? null,
+      );
+    } else if (directConfig != null) {
+      setBubbledPropName(syntheticEvent, directConfig.registrationName ?? null);
+      setCapturedPropName(syntheticEvent, null);
+    }
+
     dispatchTrustedEvent(target, syntheticEvent);
   }
 

--- a/packages/react-native/src/private/webapis/dom/events/EventTarget.js
+++ b/packages/react-native/src/private/webapis/dom/events/EventTarget.js
@@ -382,8 +382,7 @@ function invoke(
       try {
         propListener.call(eventTarget, event);
       } catch (error) {
-        // TODO: replace with `reportError` when it's available.
-        console.error(error);
+        reportListenerError(error);
       }
       global.event = currentEvent;
       return;
@@ -452,8 +451,7 @@ function invokeListeners(
         callback.handleEvent(event);
       }
     } catch (error) {
-      // TODO: replace with `reportError` when it's available.
-      console.error(error);
+      reportListenerError(error);
     }
 
     if (listener.passive) {
@@ -506,4 +504,20 @@ function getEventDispatchFlag(event: Event): boolean {
 function setEventDispatchFlag(event: Event, value: boolean): void {
   // $FlowExpectedError[prop-missing]
   event[EVENT_DISPATCH_FLAG] = value;
+}
+
+/**
+ * Surface a listener error to the global error handler without aborting the
+ * rest of the dispatch. Throws in a new task so the error becomes an
+ * uncaught exception (matching the legacy plugin path's behavior of
+ * propagating listener errors via React's runEventsInBatch +
+ * `rethrowCaughtError`, rather than swallowing them as a `console.error`).
+ *
+ * `setTimeout(0)` schedules a new macrotask; the throw inside it has no
+ * catcher above, so it bubbles up to the host's unhandled-error reporter.
+ */
+function reportListenerError(error: unknown): void {
+  setTimeout(() => {
+    throw error;
+  }, 0);
 }

--- a/packages/react-native/src/private/webapis/dom/events/EventTarget.js
+++ b/packages/react-native/src/private/webapis/dom/events/EventTarget.js
@@ -217,10 +217,14 @@ export default class EventTarget {
    *
    * Called during event dispatch before explicitly registered listeners.
    * Return a callback to be invoked as an event listener, or null.
+   *
+   * `event.type` is the event type. `isCapture` distinguishes the capture pass
+   * from the bubble pass — it cannot be derived from `event.eventPhase`,
+   * which is `AT_TARGET` during both passes through the target node.
    */
   // $FlowExpectedError[unsupported-syntax]
   [EVENT_TARGET_GET_DECLARATIVE_LISTENER_KEY](
-    eventType: string,
+    event: Event,
     isCapture: boolean,
   ): EventCallback | null {
     return null;
@@ -354,27 +358,39 @@ function invoke(
 
   setCurrentTarget(event, eventTarget);
 
-  // Build the list of listeners to invoke:
-  // When the flag is enabled, prop-based listeners fire first, then
-  // explicitly registered addEventListener listeners.
-  // When disabled, only addEventListener listeners are used (legacy path).
-  let listeners: Array<EventListenerRegistration>;
-
   if (ReactNativeFeatureFlags.enableNativeEventTargetEventDispatching()) {
+    // Resolve the prop-based listener. Pass the event so subclasses can read
+    // its `type` and any pre-resolved internal slots; pass `isCapture`
+    // separately because it can't be derived from `event.eventPhase` (which
+    // is `AT_TARGET` during both passes through the target node).
     // $FlowExpectedError[prop-missing]
     const propListener: EventCallback | null = eventTarget[
       EVENT_TARGET_GET_DECLARATIVE_LISTENER_KEY
-    ](event.type, isCapture);
+    ](event, isCapture);
 
     const listenersByType = getListenersForPhase(eventTarget, isCapture);
     const maybeListeners = listenersByType?.get(event.type);
 
-    if (propListener == null && maybeListeners == null) {
+    // Fast path: only a prop listener (no `addEventListener` listeners).
+    // This is the overwhelmingly common case for React-driven dispatch.
+    if (maybeListeners == null) {
+      if (propListener == null) {
+        return;
+      }
+      const currentEvent = global.event;
+      global.event = event;
+      try {
+        propListener.call(eventTarget, event);
+      } catch (error) {
+        // TODO: replace with `reportError` when it's available.
+        console.error(error);
+      }
+      global.event = currentEvent;
       return;
     }
 
-    listeners = [];
-
+    // Slow path: combine prop listener + addEventListener listeners.
+    const listeners: Array<EventListenerRegistration> = [];
     if (propListener != null) {
       listeners.push({
         callback: propListener,
@@ -383,21 +399,33 @@ function invoke(
         removed: false,
       });
     }
-
-    if (maybeListeners != null) {
-      for (const registration of maybeListeners.values()) {
-        listeners.push(registration);
-      }
+    for (const registration of maybeListeners.values()) {
+      listeners.push(registration);
     }
-  } else {
-    const listenersByType = getListenersForPhase(eventTarget, isCapture);
-    const maybeListeners = listenersByType?.get(event.type);
-    if (maybeListeners == null) {
-      return;
-    }
-    listeners = Array.from(maybeListeners.values());
+    invokeListeners(eventTarget, event, listeners, isCapture);
+    return;
   }
 
+  // Legacy path (flag OFF): only `addEventListener` listeners.
+  const listenersByType = getListenersForPhase(eventTarget, isCapture);
+  const maybeListeners = listenersByType?.get(event.type);
+  if (maybeListeners == null) {
+    return;
+  }
+  invokeListeners(
+    eventTarget,
+    event,
+    Array.from(maybeListeners.values()),
+    isCapture,
+  );
+}
+
+function invokeListeners(
+  eventTarget: EventTarget,
+  event: Event,
+  listeners: Array<EventListenerRegistration>,
+  isCapture: boolean,
+): void {
   for (const listener of listeners) {
     if (listener.removed) {
       continue;

--- a/packages/react-native/src/private/webapis/dom/events/EventTarget.js
+++ b/packages/react-native/src/private/webapis/dom/events/EventTarget.js
@@ -243,11 +243,14 @@ export default class EventTarget {
   }
 
   /**
-   * This is "protected" method to dispatch trusted events.
+   * This is "protected" method to dispatch trusted events. Mirrors the
+   * `dispatchEvent` return contract: returns `false` if the event was
+   * canceled (i.e. `event.defaultPrevented`), otherwise `true`.
    */
   // $FlowExpectedError[unsupported-syntax]
-  [INTERNAL_DISPATCH_METHOD_KEY](event: Event): void {
+  [INTERNAL_DISPATCH_METHOD_KEY](event: Event): boolean {
     dispatch(this, event);
+    return !event.defaultPrevented;
   }
 }
 

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
@@ -15,10 +15,28 @@ import createEventTargetHierarchyWithDepth from './createEventTargetHierarchyWit
 import {unstable_benchmark} from '@react-native/fantom';
 import Event from 'react-native/src/private/webapis/dom/events/Event';
 import EventTarget from 'react-native/src/private/webapis/dom/events/EventTarget';
+import {EVENT_TARGET_GET_DECLARATIVE_LISTENER_KEY} from 'react-native/src/private/webapis/dom/events/internals/EventTargetInternals';
 
 let event: Event;
 let eventTarget: EventTarget;
 let eventTargets: ReadonlyArray<EventTarget>;
+
+// Simulates the prop-listener pattern from `ReactNativeElement` without
+// requiring React or any `parentNode` TurboModule traversal: each target
+// returns a no-op callback from `EVENT_TARGET_GET_DECLARATIVE_LISTENER_KEY`.
+// Used to isolate the per-target cost of `invoke()` when only declarative
+// (prop) listeners are present, which is the common path on real components.
+function createPropListenerOnlyHierarchy(
+  depth: number,
+): ReadonlyArray<EventTarget> {
+  const targets = createEventTargetHierarchyWithDepth(depth);
+  const noop = () => {};
+  for (const target of targets) {
+    // $FlowExpectedError[prop-missing] $FlowExpectedError[invalid-computed-prop]
+    target[EVENT_TARGET_GET_DECLARATIVE_LISTENER_KEY] = () => noop;
+  }
+  return targets;
+}
 
 unstable_benchmark
   .suite('EventTarget', {
@@ -173,6 +191,19 @@ unstable_benchmark
     {
       beforeEach: () => {
         eventTargets = createEventTargetHierarchyWithDepth(100);
+      },
+    },
+  )
+  .test(
+    'dispatchEvent, bubbling (100), prop listener per target only',
+    () => {
+      eventTarget.dispatchEvent(event);
+    },
+    {
+      beforeAll: () => {
+        event = new Event('custom', {bubbles: true});
+        const targets = createPropListenerOnlyHierarchy(100);
+        eventTarget = targets[targets.length - 1];
       },
     },
   );

--- a/packages/react-native/src/private/webapis/dom/events/internals/EventInternals.js
+++ b/packages/react-native/src/private/webapis/dom/events/internals/EventInternals.js
@@ -35,6 +35,42 @@ export const TARGET_KEY: symbol = Symbol('target');
 // platform using the original timestamps.
 export const EVENT_INIT_TIMESTAMP_KEY: symbol = Symbol('eventInitTimestamp');
 
+// Internal slots used by the React Native renderer to pass pre-resolved
+// React prop names ("onPointerUp" / "onPointerUpCapture") through the event
+// to subclasses of `EventTarget` (i.e. `ReactNativeElement`). This avoids
+// recomputing `getEventTypePropName(event.type, isCapture)` per ancestor per
+// phase during dispatch, which is hot.
+export const BUBBLED_PROP_NAME_KEY: symbol = Symbol('bubbledPropName');
+export const CAPTURED_PROP_NAME_KEY: symbol = Symbol('capturedPropName');
+
+export function getBubbledPropName(event: Event): string | null | void {
+  // $FlowExpectedError[prop-missing]
+  return event[BUBBLED_PROP_NAME_KEY];
+}
+
+export function setBubbledPropName(
+  event: Event,
+  propName: string | null,
+): void {
+  // $FlowExpectedError[prop-missing]
+  // $FlowExpectedError[invalid-computed-prop]
+  event[BUBBLED_PROP_NAME_KEY] = propName;
+}
+
+export function getCapturedPropName(event: Event): string | null | void {
+  // $FlowExpectedError[prop-missing]
+  return event[CAPTURED_PROP_NAME_KEY];
+}
+
+export function setCapturedPropName(
+  event: Event,
+  propName: string | null,
+): void {
+  // $FlowExpectedError[prop-missing]
+  // $FlowExpectedError[invalid-computed-prop]
+  event[CAPTURED_PROP_NAME_KEY] = propName;
+}
+
 export function getCurrentTarget(event: Event): EventTarget | null {
   // $FlowExpectedError[prop-missing]
   return event[CURRENT_TARGET_KEY];

--- a/packages/react-native/src/private/webapis/dom/events/internals/EventTargetInternals.js
+++ b/packages/react-native/src/private/webapis/dom/events/internals/EventTargetInternals.js
@@ -48,7 +48,9 @@ export const INTERNAL_DISPATCH_METHOD_KEY: symbol = Symbol(
 );
 
 /**
- * Dispatches a trusted event to the given event target.
+ * Dispatches a trusted event to the given event target. Mirrors the
+ * `dispatchEvent` method on `EventTarget`: returns `false` if the event
+ * was canceled (i.e. `event.defaultPrevented`), otherwise `true`.
  *
  * This should only be used by the runtime to dispatch native events to
  * JavaScript.
@@ -56,7 +58,7 @@ export const INTERNAL_DISPATCH_METHOD_KEY: symbol = Symbol(
 export function dispatchTrustedEvent(
   eventTarget: EventTarget,
   event: Event,
-): void {
+): boolean {
   setIsTrusted(event, true);
 
   // $FlowExpectedError[prop-missing]

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
@@ -21,6 +21,7 @@ import type {
   MeasureOnSuccessCallback,
   NativeMethods,
 } from '../../../types/HostInstance';
+import type Event from '../events/Event';
 import type {InstanceHandle} from './internals/NodeInternals';
 import type ReactNativeDocument from './ReactNativeDocument';
 
@@ -30,6 +31,10 @@ import {create as createAttributePayload} from '../../../../../Libraries/ReactNa
 import warnForStyleProps from '../../../../../Libraries/ReactNative/ReactFabricPublicInstance/warnForStyleProps';
 import * as ReactNativeFeatureFlags from '../../../featureflags/ReactNativeFeatureFlags';
 import {getEventTypePropName} from '../../../renderer/events/ReactNativeEventTypeMapping';
+import {
+  getBubbledPropName,
+  getCapturedPropName,
+} from '../events/internals/EventInternals';
 import {EVENT_TARGET_GET_DECLARATIVE_LISTENER_KEY} from '../events/internals/EventTargetInternals';
 import {
   getCurrentProps,
@@ -223,16 +228,29 @@ class ReactNativeElement extends ReadOnlyElement implements NativeMethods {
   // This is called by EventTarget.invoke() before explicit addEventListener
   // listeners, allowing prop-based handlers to be resolved at dispatch time
   // without registering them via addEventListener during commit.
+  //
+  // Fast path: when `event` is a `LegacySyntheticEvent` (always the case for
+  // events created by `dispatchNativeEvent`), the React prop names have been
+  // pre-resolved on the event during construction. Reading them directly
+  // avoids the `getEventTypePropName(eventType, isCapture)` hash lookup per
+  // ancestor per phase.
   // $FlowExpectedError[unsupported-syntax]
   [EVENT_TARGET_GET_DECLARATIVE_LISTENER_KEY](
-    eventType: string,
+    event: Event,
     isCapture: boolean,
   ): ((event: Event) => void) | null {
     const currentProps = getCurrentProps(this);
     if (currentProps == null) {
       return null;
     }
-    const propName = getEventTypePropName(eventType, isCapture);
+    let propName = isCapture
+      ? getCapturedPropName(event)
+      : getBubbledPropName(event);
+    if (propName === undefined) {
+      // The event wasn't created via `dispatchNativeEvent` (e.g.,
+      // user-dispatched). Fall back to the mapping table.
+      propName = getEventTypePropName(event.type, isCapture);
+    }
     if (propName == null) {
       return null;
     }

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
@@ -63,13 +63,6 @@ class ReadOnlyNode extends ReadOnlyNodeBase {
     setInstanceHandle(this, instanceHandle);
   }
 
-  // Implement the "get the parent" algorithm for EventTarget.
-  // This enables event propagation (capture/bubble) through the node tree.
-  // $FlowExpectedError[unsupported-syntax]
-  [EVENT_TARGET_GET_THE_PARENT_KEY](): EventTarget | null {
-    return this.parentNode;
-  }
-
   get childNodes(): NodeList<ReadOnlyNode> {
     const childNodes = getChildNodes(this);
     return createNodeList(childNodes);
@@ -325,6 +318,24 @@ class ReadOnlyNode extends ReadOnlyNodeBase {
 }
 
 setPlatformObject(ReadOnlyNode);
+
+// Implement the "get the parent" algorithm for EventTarget by aliasing
+// `[EVENT_TARGET_GET_THE_PARENT_KEY]` directly to the `parentNode` getter
+// function on the prototype. This enables event propagation (capture/bubble)
+// through the node tree and avoids the extra function call that a
+// trampoline method (e.g. `() { return this.parentNode; }`) would add per
+// ancestor on the hot event-dispatch path.
+{
+  const parentNodeGetter = Object.getOwnPropertyDescriptor(
+    ReadOnlyNode.prototype,
+    'parentNode',
+  )?.get;
+  if (parentNodeGetter != null) {
+    // $FlowExpectedError[prop-missing]
+    // $FlowExpectedError[invalid-computed-prop]
+    ReadOnlyNode.prototype[EVENT_TARGET_GET_THE_PARENT_KEY] = parentNodeGetter;
+  }
+}
 
 type ReadOnlyNodeT = ReadOnlyNode;
 


### PR DESCRIPTION
Summary:
Aligns `dispatchTrustedEvent` and the underlying `[INTERNAL_DISPATCH_METHOD_KEY]` "protected" symbol method on `EventTarget` with the public `EventTarget.dispatchEvent` contract: both now return `boolean` (`!event.defaultPrevented`) instead of `void`, so callers can tell whether the event's default action was canceled.

Existing call sites ignore the return value, so this is a non-breaking widening.

Changelog: [Internal]

Differential Revision: D104651715


