### PR TITLE
Guard LogBox dialog dismiss against detached window

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
@@ -76,7 +76,7 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
   }
 
   override fun hide() {
-    if (isShowing()) {
+    if (isShowing() && dialog?.window?.decorView?.isAttachedToWindow == true) {
       dialog?.dismiss()
     }
     (reactRootView?.parent as ViewGroup?)?.removeView(reactRootView)


### PR DESCRIPTION
Summary:
`LogBoxDialogSurfaceDelegate.hide()` calls `dialog.dismiss()` whenever
`dialog.isShowing` is true, but the host Activity's window can be torn
down between the dispatch of `LogBoxModule.hide()` and the Handler
callback that runs `hide()`. When that race hits, `Dialog.dismiss()`
routes to `WindowManagerImpl.removeViewImmediate`, which throws
`IllegalArgumentException: View ... not attached to window manager`
and crashes the process.

Add an `isAttachedToWindow` check on the dialog's DecorView so the
dismiss is skipped once the host window is gone. The dialog reference
is still nulled and `destroyContentView()` still runs, so React state
is cleaned up correctly.

Changelog:
[Android][Fixed] - Avoid IllegalArgumentException when LogBox dismisses after the host Activity is destroyed

Differential Revision: D104391294


