### PR TITLE
Make IRuntime public

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -680,7 +680,6 @@ class JSI_EXPORT IRuntime : public ICast {
   /// property of a JS string.
   virtual size_t length(const String& str) = 0;
 
- protected:
   virtual ~IRuntime() = default;
 };
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -11859,7 +11859,6 @@ class facebook::jsi::HostObject {
 }
 
 class facebook::jsi::IRuntime : public facebook::jsi::ICast {
-  protected virtual ~IRuntime() = default;
   public static constexpr facebook::jsi::UUID uuid;
   public virtual ScopeState* pushScope() = 0;
   public virtual bool bigintIsInt64(const facebook::jsi::BigInt&) = 0;
@@ -11969,6 +11968,7 @@ class facebook::jsi::IRuntime : public facebook::jsi::ICast {
   public virtual void setRuntimeData(const facebook::jsi::UUID& dataUUID, const std::shared_ptr<void>& data) = 0;
   public virtual void setRuntimeDataImpl(const facebook::jsi::UUID& dataUUID, const void* data, void(*)(const void* data) deleter) = 0;
   public virtual void setValueAtIndexImpl(const facebook::jsi::Array&, size_t i, const facebook::jsi::Value& value) = 0;
+  public virtual ~IRuntime() = default;
 }
 
 struct facebook::jsi::IRuntime::PointerValue {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -11715,7 +11715,6 @@ class facebook::jsi::HostObject {
 }
 
 class facebook::jsi::IRuntime : public facebook::jsi::ICast {
-  protected virtual ~IRuntime() = default;
   public static constexpr facebook::jsi::UUID uuid;
   public virtual ScopeState* pushScope() = 0;
   public virtual bool bigintIsInt64(const facebook::jsi::BigInt&) = 0;
@@ -11825,6 +11824,7 @@ class facebook::jsi::IRuntime : public facebook::jsi::ICast {
   public virtual void setRuntimeData(const facebook::jsi::UUID& dataUUID, const std::shared_ptr<void>& data) = 0;
   public virtual void setRuntimeDataImpl(const facebook::jsi::UUID& dataUUID, const void* data, void(*)(const void* data) deleter) = 0;
   public virtual void setValueAtIndexImpl(const facebook::jsi::Array&, size_t i, const facebook::jsi::Value& value) = 0;
+  public virtual ~IRuntime() = default;
 }
 
 struct facebook::jsi::IRuntime::PointerValue {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -14077,7 +14077,6 @@ class facebook::jsi::HostObject {
 }
 
 class facebook::jsi::IRuntime : public facebook::jsi::ICast {
-  protected virtual ~IRuntime() = default;
   public static constexpr facebook::jsi::UUID uuid;
   public virtual ScopeState* pushScope() = 0;
   public virtual bool bigintIsInt64(const facebook::jsi::BigInt&) = 0;
@@ -14187,6 +14186,7 @@ class facebook::jsi::IRuntime : public facebook::jsi::ICast {
   public virtual void setRuntimeData(const facebook::jsi::UUID& dataUUID, const std::shared_ptr<void>& data) = 0;
   public virtual void setRuntimeDataImpl(const facebook::jsi::UUID& dataUUID, const void* data, void(*)(const void* data) deleter) = 0;
   public virtual void setValueAtIndexImpl(const facebook::jsi::Array&, size_t i, const facebook::jsi::Value& value) = 0;
+  public virtual ~IRuntime() = default;
 }
 
 struct facebook::jsi::IRuntime::PointerValue {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -13943,7 +13943,6 @@ class facebook::jsi::HostObject {
 }
 
 class facebook::jsi::IRuntime : public facebook::jsi::ICast {
-  protected virtual ~IRuntime() = default;
   public static constexpr facebook::jsi::UUID uuid;
   public virtual ScopeState* pushScope() = 0;
   public virtual bool bigintIsInt64(const facebook::jsi::BigInt&) = 0;
@@ -14053,6 +14052,7 @@ class facebook::jsi::IRuntime : public facebook::jsi::ICast {
   public virtual void setRuntimeData(const facebook::jsi::UUID& dataUUID, const std::shared_ptr<void>& data) = 0;
   public virtual void setRuntimeDataImpl(const facebook::jsi::UUID& dataUUID, const void* data, void(*)(const void* data) deleter) = 0;
   public virtual void setValueAtIndexImpl(const facebook::jsi::Array&, size_t i, const facebook::jsi::Value& value) = 0;
+  public virtual ~IRuntime() = default;
 }
 
 struct facebook::jsi::IRuntime::PointerValue {

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -8894,7 +8894,6 @@ class facebook::jsi::HostObject {
 }
 
 class facebook::jsi::IRuntime : public facebook::jsi::ICast {
-  protected virtual ~IRuntime() = default;
   public static constexpr facebook::jsi::UUID uuid;
   public virtual ScopeState* pushScope() = 0;
   public virtual bool bigintIsInt64(const facebook::jsi::BigInt&) = 0;
@@ -9004,6 +9003,7 @@ class facebook::jsi::IRuntime : public facebook::jsi::ICast {
   public virtual void setRuntimeData(const facebook::jsi::UUID& dataUUID, const std::shared_ptr<void>& data) = 0;
   public virtual void setRuntimeDataImpl(const facebook::jsi::UUID& dataUUID, const void* data, void(*)(const void* data) deleter) = 0;
   public virtual void setValueAtIndexImpl(const facebook::jsi::Array&, size_t i, const facebook::jsi::Value& value) = 0;
+  public virtual ~IRuntime() = default;
 }
 
 struct facebook::jsi::IRuntime::PointerValue {

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -8885,7 +8885,6 @@ class facebook::jsi::HostObject {
 }
 
 class facebook::jsi::IRuntime : public facebook::jsi::ICast {
-  protected virtual ~IRuntime() = default;
   public static constexpr facebook::jsi::UUID uuid;
   public virtual ScopeState* pushScope() = 0;
   public virtual bool bigintIsInt64(const facebook::jsi::BigInt&) = 0;
@@ -8995,6 +8994,7 @@ class facebook::jsi::IRuntime : public facebook::jsi::ICast {
   public virtual void setRuntimeData(const facebook::jsi::UUID& dataUUID, const std::shared_ptr<void>& data) = 0;
   public virtual void setRuntimeDataImpl(const facebook::jsi::UUID& dataUUID, const void* data, void(*)(const void* data) deleter) = 0;
   public virtual void setValueAtIndexImpl(const facebook::jsi::Array&, size_t i, const facebook::jsi::Value& value) = 0;
+  public virtual ~IRuntime() = default;
 }
 
 struct facebook::jsi::IRuntime::PointerValue {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

`jsi::IRuntime`'s destructor is declared `protected:`. Swift's C++ interop requires an accessible destructor before it will import a class, and that check runs before APINotes, so `SwiftImportAs: reference` cannot rescue the type, and every method taking `IRuntime&` (`Value::getString`, `String::createFromUtf8`, `PropNameID::forUtf8`, `IRuntime::global`, …) is unreachable from Swift.

Without this change, ExpoModulesJSI (Expo's Swift/C++ JSI wrapper, used by every Expo SDK module on Apple platforms) fails to build against RN 0.86.

Moving `virtual ~IRuntime() = default;` from `protected:` to `public:` is enough: it's already virtual, so there's no ABI or vtable change and `Runtime`'s `override` stays valid — the destructor just becomes reachable, which is what Swift's importer needs.

## Changelog:

[GENERAL] [CHANGED] - Make `jsi::IRuntime`'s destructor public so the type is importable from Swift via C++ interop

## Test Plan:

- Built `react-native` on iOS — no ABI/vtable change since the destructor was already virtual, and `Runtime`'s `override` still compiles.
- Built ExpoModulesJSI against this change: Swift can now import `IRuntime` and call methods that take `IRuntime&` (previously rejected by Swift's C++ importer due to the inaccessible destructor).
