### PR TITLE
Add scaffolding for batched animated prop updates delegate chain (#56771)

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -79,6 +79,13 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     [scheduler.delegate schedulerDidSynchronouslyUpdateViewOnUIThread:tag props:props];
   }
 
+  void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+      SurfaceId surfaceId,
+      const std::unordered_map<Tag, AnimatedProps> &updates) override
+  {
+    // Not implemented on iOS yet -- filled in by a later commit.
+  }
+
   void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) override
   {
     // Does nothing.

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -20,6 +20,7 @@
 #include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/animationbackend/AnimatedProps.h>
 #include <react/renderer/animations/LayoutAnimationDriver.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/EventBeat.h>
@@ -790,6 +791,13 @@ void FabricUIManagerBinding::schedulerShouldSynchronouslyUpdateViewOnUIThread(
   if (ReactNativeFeatureFlags::cxxNativeAnimatedEnabled() && mountingManager_) {
     mountingManager_->synchronouslyUpdateViewOnUIThread(tag, props);
   }
+}
+
+void FabricUIManagerBinding::
+    schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+        SurfaceId /*surfaceId*/,
+        const std::unordered_map<Tag, AnimatedProps>& /*updates*/) {
+  // Implemented in a follow-up.
 }
 
 void FabricUIManagerBinding::schedulerDidUpdateShadowTree(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -115,6 +115,10 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
 
   void schedulerShouldSynchronouslyUpdateViewOnUIThread(Tag tag, const folly::dynamic &props) override;
 
+  void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+      SurfaceId surfaceId,
+      const std::unordered_map<Tag, AnimatedProps> &updates) override;
+
   void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) override;
 
   void schedulerDidCaptureViewSnapshot(Tag tag, SurfaceId surfaceId) override;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -401,6 +401,15 @@ void Scheduler::uiManagerShouldSynchronouslyUpdateViewOnUIThread(
   }
 }
 
+void Scheduler::uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+    SurfaceId surfaceId,
+    const std::unordered_map<Tag, AnimatedProps>& updates) {
+  if (delegate_ != nullptr) {
+    delegate_->schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+        surfaceId, updates);
+  }
+}
+
 void Scheduler::uiManagerDidUpdateShadowTree(
     const std::unordered_map<Tag, folly::dynamic>& tagToProps) {
   if (delegate_ != nullptr) {

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -94,6 +94,9 @@ class Scheduler final : public UIManagerDelegate {
       bool isJSResponder,
       bool blockNativeResponder) override;
   void uiManagerShouldSynchronouslyUpdateViewOnUIThread(Tag tag, const folly::dynamic &props) override;
+  void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+      SurfaceId surfaceId,
+      const std::unordered_map<Tag, AnimatedProps> &updates) override;
   void uiManagerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) override;
   void uiManagerDidCaptureViewSnapshot(Tag tag, SurfaceId surfaceId) override;
   void uiManagerDidSetViewSnapshot(Tag sourceTag, Tag targetTag, SurfaceId surfaceId) override;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -8,12 +8,15 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/mounting/MountingCoordinator.h>
 #include <react/renderer/mounting/ShadowView.h>
 
 namespace facebook::react {
+
+struct AnimatedProps;
 
 /*
  * Abstract class for Scheduler's delegate.
@@ -63,6 +66,17 @@ class SchedulerDelegate {
   schedulerDidSetIsJSResponder(const ShadowView &shadowView, bool isJSResponder, bool blockNativeResponder) = 0;
 
   virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(Tag tag, const folly::dynamic &props) = 0;
+
+  /**
+   * Synchronously update animated properties for multiple views on the UI
+   * thread. Each entry maps a Tag to the AnimatedProps that should be applied
+   * to that view. Platform implementations translate AnimatedProps into the
+   * native update mechanism (e.g. buffer protocol on Android, typed props on
+   * iOS).
+   */
+  virtual void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+      SurfaceId surfaceId,
+      const std::unordered_map<Tag, AnimatedProps> &updates) = 0;
 
   virtual void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) = 0;
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -765,6 +765,15 @@ void UIManager::synchronouslyUpdateViewOnUIThread(
   }
 }
 
+void UIManager::synchronouslyUpdateAnimatedPropsOnUIThread(
+    SurfaceId surfaceId,
+    const std::unordered_map<Tag, AnimatedProps>& updates) {
+  if (delegate_ != nullptr) {
+    delegate_->uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+        surfaceId, updates);
+  }
+}
+
 #pragma mark ContextContainer
 
 std::shared_ptr<const ContextContainer> UIManager::getContextContainer() const {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -85,6 +85,10 @@ class UIManager final : public ShadowTreeDelegate {
 
   void synchronouslyUpdateViewOnUIThread(Tag tag, const folly::dynamic &props);
 
+  void synchronouslyUpdateAnimatedPropsOnUIThread(
+      SurfaceId surfaceId,
+      const std::unordered_map<Tag, AnimatedProps> &updates);
+
   /*
    * Provides access to a UIManagerBinding.
    * The `callback` methods will not be called if the internal pointer to

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
@@ -15,6 +15,7 @@
 
 namespace facebook::react {
 
+struct AnimatedProps;
 struct AnimationMutations;
 
 using AnimationTimestamp = std::chrono::duration<double, std::milli>;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -7,12 +7,16 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/mounting/MountingCoordinator.h>
 #include <react/renderer/mounting/ShadowTree.h>
 
 namespace facebook::react {
+
+struct AnimatedProps;
 
 /*
  * Abstract class for UIManager's delegate.
@@ -63,6 +67,13 @@ class UIManagerDelegate {
    * Synchronous view update.
    */
   virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(Tag tag, const folly::dynamic &props) = 0;
+
+  /*
+   * Synchronously update animated properties on the UI thread.
+   */
+  virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+      SurfaceId surfaceId,
+      const std::unordered_map<Tag, AnimatedProps> &updates) = 0;
 
   /*
    * Called after updateShadowTree is invoked.

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.cpp
@@ -71,6 +71,13 @@ void SchedulerDelegateImpl::schedulerShouldSynchronouslyUpdateViewOnUIThread(
   mountingManager_->synchronouslyUpdateViewOnUIThread(tag, props);
 }
 
+void SchedulerDelegateImpl::
+    schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+        SurfaceId /*surfaceId*/,
+        const std::unordered_map<Tag, AnimatedProps>& /*updates*/) {
+  // Not implemented on CxxPlatform.
+}
+
 void SchedulerDelegateImpl::schedulerDidUpdateShadowTree(
     const std::unordered_map<Tag, folly::dynamic>& tagToProps) {
   mountingManager_->onUpdateShadowTree(tagToProps);

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.h
@@ -49,6 +49,10 @@ class SchedulerDelegateImpl : public SchedulerDelegate {
 
   void schedulerShouldSynchronouslyUpdateViewOnUIThread(Tag tag, const folly::dynamic &props) override;
 
+  void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(
+      SurfaceId surfaceId,
+      const std::unordered_map<Tag, AnimatedProps> &updates) override;
+
   void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) override;
 
   void schedulerDidCaptureViewSnapshot(Tag tag, SurfaceId surfaceId) override;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -4479,6 +4479,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) final;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) final;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) override;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) override;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) override;
   public void addEventListener(std::shared_ptr<const facebook::react::EventListener> listener);
   public void animationTick() const;
@@ -4502,6 +4503,7 @@ class facebook::react::SchedulerDelegate {
   public virtual void schedulerDidUpdateShadowTree(const std::unordered_map<facebook::react::Tag, folly::dynamic>& tagToProps) = 0;
   public virtual void schedulerShouldMergeReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerShouldRenderTransactions(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
+  public virtual void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~SchedulerDelegate() noexcept = default;
 }
@@ -5216,6 +5218,7 @@ class facebook::react::UIManager : public facebook::react::ShadowTreeDelegate {
   public void startEmptySurface(facebook::react::ShadowTree::Unique&& shadowTree) const noexcept;
   public void startSurface(facebook::react::ShadowTree::Unique&& shadowTree, const std::string& moduleName, const folly::dynamic& props, facebook::react::DisplayMode displayMode) const noexcept;
   public void stopSurfaceForAnimationDelegate(facebook::react::SurfaceId surfaceId) const;
+  public void synchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates);
   public void synchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props);
   public void unregisterCommitHook(facebook::react::UIManagerCommitHook& commitHook);
   public void unregisterMountHook(facebook::react::UIManagerMountHook& mountHook);
@@ -5283,6 +5286,7 @@ class facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) = 0;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) = 0;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) = 0;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~UIManagerDelegate() noexcept = default;
 }

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -4476,6 +4476,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) final;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) final;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) override;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) override;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) override;
   public void addEventListener(std::shared_ptr<const facebook::react::EventListener> listener);
   public void animationTick() const;
@@ -4499,6 +4500,7 @@ class facebook::react::SchedulerDelegate {
   public virtual void schedulerDidUpdateShadowTree(const std::unordered_map<facebook::react::Tag, folly::dynamic>& tagToProps) = 0;
   public virtual void schedulerShouldMergeReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerShouldRenderTransactions(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
+  public virtual void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~SchedulerDelegate() noexcept = default;
 }
@@ -5207,6 +5209,7 @@ class facebook::react::UIManager : public facebook::react::ShadowTreeDelegate {
   public void startEmptySurface(facebook::react::ShadowTree::Unique&& shadowTree) const noexcept;
   public void startSurface(facebook::react::ShadowTree::Unique&& shadowTree, const std::string& moduleName, const folly::dynamic& props, facebook::react::DisplayMode displayMode) const noexcept;
   public void stopSurfaceForAnimationDelegate(facebook::react::SurfaceId surfaceId) const;
+  public void synchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates);
   public void synchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props);
   public void unregisterCommitHook(facebook::react::UIManagerCommitHook& commitHook);
   public void unregisterMountHook(facebook::react::UIManagerMountHook& mountHook);
@@ -5274,6 +5277,7 @@ class facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) = 0;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) = 0;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) = 0;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~UIManagerDelegate() noexcept = default;
 }

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -7060,6 +7060,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) final;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) final;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) override;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) override;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) override;
   public void addEventListener(std::shared_ptr<const facebook::react::EventListener> listener);
   public void animationTick() const;
@@ -7083,6 +7084,7 @@ class facebook::react::SchedulerDelegate {
   public virtual void schedulerDidUpdateShadowTree(const std::unordered_map<facebook::react::Tag, folly::dynamic>& tagToProps) = 0;
   public virtual void schedulerShouldMergeReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerShouldRenderTransactions(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
+  public virtual void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~SchedulerDelegate() noexcept = default;
 }
@@ -7780,6 +7782,7 @@ class facebook::react::UIManager : public facebook::react::ShadowTreeDelegate {
   public void startEmptySurface(facebook::react::ShadowTree::Unique&& shadowTree) const noexcept;
   public void startSurface(facebook::react::ShadowTree::Unique&& shadowTree, const std::string& moduleName, const folly::dynamic& props, facebook::react::DisplayMode displayMode) const noexcept;
   public void stopSurfaceForAnimationDelegate(facebook::react::SurfaceId surfaceId) const;
+  public void synchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates);
   public void synchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props);
   public void unregisterCommitHook(facebook::react::UIManagerCommitHook& commitHook);
   public void unregisterMountHook(facebook::react::UIManagerMountHook& mountHook);
@@ -7847,6 +7850,7 @@ class facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) = 0;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) = 0;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) = 0;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~UIManagerDelegate() noexcept = default;
 }

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -7057,6 +7057,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) final;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) final;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) override;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) override;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) override;
   public void addEventListener(std::shared_ptr<const facebook::react::EventListener> listener);
   public void animationTick() const;
@@ -7080,6 +7081,7 @@ class facebook::react::SchedulerDelegate {
   public virtual void schedulerDidUpdateShadowTree(const std::unordered_map<facebook::react::Tag, folly::dynamic>& tagToProps) = 0;
   public virtual void schedulerShouldMergeReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerShouldRenderTransactions(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
+  public virtual void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~SchedulerDelegate() noexcept = default;
 }
@@ -7771,6 +7773,7 @@ class facebook::react::UIManager : public facebook::react::ShadowTreeDelegate {
   public void startEmptySurface(facebook::react::ShadowTree::Unique&& shadowTree) const noexcept;
   public void startSurface(facebook::react::ShadowTree::Unique&& shadowTree, const std::string& moduleName, const folly::dynamic& props, facebook::react::DisplayMode displayMode) const noexcept;
   public void stopSurfaceForAnimationDelegate(facebook::react::SurfaceId surfaceId) const;
+  public void synchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates);
   public void synchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props);
   public void unregisterCommitHook(facebook::react::UIManagerCommitHook& commitHook);
   public void unregisterMountHook(facebook::react::UIManagerMountHook& mountHook);
@@ -7838,6 +7841,7 @@ class facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) = 0;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) = 0;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) = 0;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~UIManagerDelegate() noexcept = default;
 }

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -3041,6 +3041,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) final;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) final;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) override;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) override;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) override;
   public void addEventListener(std::shared_ptr<const facebook::react::EventListener> listener);
   public void animationTick() const;
@@ -3064,6 +3065,7 @@ class facebook::react::SchedulerDelegate {
   public virtual void schedulerDidUpdateShadowTree(const std::unordered_map<facebook::react::Tag, folly::dynamic>& tagToProps) = 0;
   public virtual void schedulerShouldMergeReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerShouldRenderTransactions(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
+  public virtual void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~SchedulerDelegate() noexcept = default;
 }
@@ -3677,6 +3679,7 @@ class facebook::react::UIManager : public facebook::react::ShadowTreeDelegate {
   public void startEmptySurface(facebook::react::ShadowTree::Unique&& shadowTree) const noexcept;
   public void startSurface(facebook::react::ShadowTree::Unique&& shadowTree, const std::string& moduleName, const folly::dynamic& props, facebook::react::DisplayMode displayMode) const noexcept;
   public void stopSurfaceForAnimationDelegate(facebook::react::SurfaceId surfaceId) const;
+  public void synchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates);
   public void synchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props);
   public void unregisterCommitHook(facebook::react::UIManagerCommitHook& commitHook);
   public void unregisterMountHook(facebook::react::UIManagerMountHook& mountHook);
@@ -3744,6 +3747,7 @@ class facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) = 0;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) = 0;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) = 0;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~UIManagerDelegate() noexcept = default;
 }

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -3038,6 +3038,7 @@ class facebook::react::Scheduler : public facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) final;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) final;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) override;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) override;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) override;
   public void addEventListener(std::shared_ptr<const facebook::react::EventListener> listener);
   public void animationTick() const;
@@ -3061,6 +3062,7 @@ class facebook::react::SchedulerDelegate {
   public virtual void schedulerDidUpdateShadowTree(const std::unordered_map<facebook::react::Tag, folly::dynamic>& tagToProps) = 0;
   public virtual void schedulerShouldMergeReactRevision(facebook::react::SurfaceId surfaceId) = 0;
   public virtual void schedulerShouldRenderTransactions(const std::shared_ptr<const facebook::react::MountingCoordinator>& mountingCoordinator) = 0;
+  public virtual void schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~SchedulerDelegate() noexcept = default;
 }
@@ -3668,6 +3670,7 @@ class facebook::react::UIManager : public facebook::react::ShadowTreeDelegate {
   public void startEmptySurface(facebook::react::ShadowTree::Unique&& shadowTree) const noexcept;
   public void startSurface(facebook::react::ShadowTree::Unique&& shadowTree, const std::string& moduleName, const folly::dynamic& props, facebook::react::DisplayMode displayMode) const noexcept;
   public void stopSurfaceForAnimationDelegate(facebook::react::SurfaceId surfaceId) const;
+  public void synchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates);
   public void synchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props);
   public void unregisterCommitHook(facebook::react::UIManagerCommitHook& commitHook);
   public void unregisterMountHook(facebook::react::UIManagerMountHook& mountHook);
@@ -3735,6 +3738,7 @@ class facebook::react::UIManagerDelegate {
   public virtual void uiManagerShouldAddEventListener(std::shared_ptr<const facebook::react::EventListener> listener) = 0;
   public virtual void uiManagerShouldRemoveEventListener(const std::shared_ptr<const facebook::react::EventListener>& listener) = 0;
   public virtual void uiManagerShouldSetOnSurfaceStartCallback(facebook::react::UIManagerDelegate::OnSurfaceStartCallback&& callback) = 0;
+  public virtual void uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread(facebook::react::SurfaceId surfaceId, const std::unordered_map<facebook::react::Tag, facebook::react::AnimatedProps>& updates) = 0;
   public virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic& props) = 0;
   public virtual ~UIManagerDelegate() noexcept = default;
 }


### PR DESCRIPTION
Summary:

Introduces the cross-platform delegate chain for batched animated property updates without any platform implementation:

- Adds `schedulerShouldSynchronouslyUpdateAnimatedPropsOnUIThread` to `SchedulerDelegate` and forwards from `Scheduler`.
- Adds `uiManagerShouldSynchronouslyUpdateAnimatedPropsOnUIThread` to `UIManagerDelegate` and `synchronouslyUpdateAnimatedPropsOnUIThread` to `UIManager`.
- Adds no-op stubs in iOS (`RCTScheduler.mm`), macOS (`RCTScheduler.mm`), Windows (`FabricUIManagerModule`) and CxxPlatform (`SchedulerDelegateImpl`).

No behavioural impact; Android implementation lands in a follow-up.

Changelog:
[Internal]

Differential Revision: D104672455
