### PR TITLE
Clarify Android AppState background API docs

### DIFF
--- a/packages/react-native/Libraries/AppState/AppState.d.ts
+++ b/packages/react-native/Libraries/AppState/AppState.d.ts
@@ -23,7 +23,10 @@ import {NativeEventSubscription} from '../EventEmitter/RCTNativeAppEventEmitter'
  *
  * App States
  *      active - The app is running in the foreground
- *      background - The app is running in the background. The user is either in another app or on the home screen
+ *      background - The app is running in the background. The user is either in another app,
+ *      on the home screen
+ *      [Android only] on another Activity, including temporary system
+ *      activities such as autofill credential pickers (even if launched by your app or the system)
  *      inactive [iOS] - This is a transition state that happens when the app launches, is asking for permissions or when a call or SMS message is received.
  *      unknown [iOS] - Initial value until the current app state is determined
  *      extension [iOS] - The app is running as an app extension

--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -19,7 +19,8 @@ import NativeAppState from './NativeAppState';
  * background - The app is running in the background. The user is either:
  *   - in another app
  *   - on the home screen
- *   - @platform android - on another Activity (even if it was launched by your app)
+ *   - [Android only] on another Activity, including temporary system activities such
+ *     as autofill credential pickers (even if launched by your app or the system)
  * @platform ios - inactive - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
  */
 export type AppStateStatus =


### PR DESCRIPTION
## Summary:

Syncs the in-package AppState API documentation with the Android AppState clarification added in facebook/react-native-website#5079.

Android AppState `background` was already documented as including another `Activity`. This clarifies that temporary system activities, such as autofill credential pickers, are included too.

## Changelog:

[GENERAL] [CHANGED] - Clarify Android AppState background API documentation.

## Test Plan:

Documentation-only change.

Verified with:
- `git diff --check`
- `prettier --check packages/react-native/Libraries/AppState/AppState.js packages/react-native/Libraries/AppState/AppState.d.ts`