### PR TITLE
Migrate RCTAlertManager to handle synchronous void method execution (#56801)

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAlertManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertManager.mm
@@ -42,11 +42,6 @@ RCT_ENUM_CONVERTER(
 
 RCT_EXPORT_MODULE()
 
-- (dispatch_queue_t)methodQueue
-{
-  return dispatch_get_main_queue();
-}
-
 - (void)invalidate
 {
   RCTExecuteOnMainQueue(^{


### PR DESCRIPTION
Summary:

In preparation for enabling `enableSyncVoidMethods` (D104331837), which makes TurboModule void methods execute synchronously on the JS thread instead of being dispatched asynchronously.

Currently, this module overrides `methodQueue` to return `dispatch_get_main_queue()` so its void methods execute on the main thread. When `enableSyncVoidMethods` is enabled, the `methodQueue` override is ignored for void methods — they execute directly on the JS thread. This causes crashes for any UI operations that must run on the main thread.

**Fix:** Remove the `methodQueue` override. The `alertWithArgs` method already dispatches UI work onto the main thread via `RCTExecuteOnMainQueue`, so it is already safe.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D104771644


