### PR TITLE
Guard against OTA mismatch in NativeAnimatedHelper queue

### DIFF
--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -98,7 +98,8 @@ function createNativeOperations(): NonNullable<typeof NativeAnimatedModule> {
   if (
     ReactNativeFeatureFlags.cxxNativeAnimatedEnabled() &&
     //eslint-disable-next-line
-    ReactNativeFeatureFlags.useSharedAnimatedBackend()
+    ReactNativeFeatureFlags.useSharedAnimatedBackend() &&
+    NativeAnimatedModule?.connectAnimatedNodeToShadowNodeFamily != null
   ) {
     methodNames.push('connectAnimatedNodeToShadowNodeFamily');
   }


### PR DESCRIPTION
Summary:
When MobileConfig flags (`cxxNativeAnimatedEnabled` and `useSharedAnimatedBackend`) are enabled server-side, `connectAnimatedNodeToShadowNodeFamily` is added to the method names list in `createNativeOperations()`. However, MobileConfig values and what is available in the AnimatedModule on the client can mismatch due to OTA updates — the JS bundle may have the flag enabled while the native module on the device does not yet implement the method. In this case, `nullthrows(NativeAnimatedModule)[methodName]` returns `undefined`, which gets queued as `() => undefined(...args)` and throws TypeError when the queue is flushed.

This fix adds a runtime check that `NativeAnimatedModule?.connectAnimatedNodeToShadowNodeFamily != null` before including the method in the list, preventing the mismatch from surfacing. The specific guard at the registration site is sufficient — if the method is not available on the native module, it will never be registered, so the general null guard in the method wrapper is unnecessary.

Fixes T270861607.

Changelog: [Internal]

Reviewed By: zeyap

Differential Revision: D104775294


