### PR TITLE
Update react-native-devtools-frontend URLs

### DIFF
--- a/packages/debugger-frontend/README.md
+++ b/packages/debugger-frontend/README.md
@@ -20,7 +20,7 @@ const frontendPath = require('@react-native/debugger-frontend');
 
 ### Source repo
 
-Source code for this package lives in the [facebook/react-native-devtools-frontend](https://github.com/facebook/react-native-devtools-frontend) repo. See below for how we build and check in changes.
+Source code for this package lives in the [react/react-native-devtools-frontend](https://github.com/react/react-native-devtools-frontend) repo. See below for how we build and check in changes.
 
 ### Updating the frontend assets
 
@@ -34,4 +34,4 @@ node scripts/debugger-frontend/sync-and-build --branch main
 node scripts/debugger-frontend/sync-and-build --branch 0.73-stable
 ```
 
-By default, this will clone and build from [facebook/react-native-devtools-frontend](https://github.com/facebook/react-native-devtools-frontend).
+By default, this will clone and build from [react/react-native-devtools-frontend](https://github.com/react/react-native-devtools-frontend).

--- a/scripts/debugger-frontend/sync-and-build.js
+++ b/scripts/debugger-frontend/sync-and-build.js
@@ -25,7 +25,7 @@ const supportsColor = require('supports-color');
 const {parseArgs, styleText} = require('util');
 
 const DEVTOOLS_FRONTEND_REPO_URL =
-  'https://github.com/facebook/react-native-devtools-frontend';
+  'https://github.com/react/react-native-devtools-frontend';
 
 const config = {
   allowPositionals: true,


### PR DESCRIPTION
Summary:
Update load-bearing `react/react-native-devtools-frontend` URLs following repo move. In particular, the `sync-and-build` script.

URLs in code comments are preserved (rely on redirect / avoid churn).

Changelog: [Internal]

Differential Revision: D105033074


