### PR TITLE
Do not include an `expanded` property by default in accessibilityState (#56814)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -456,8 +456,9 @@ inline static void updateAccessibilityStateProp(
   }
 
   if (!oldState.has_value() || newState->expanded != oldState->expanded) {
-    resultState["expanded"] =
-        newState->expanded.has_value() && newState->expanded.value();
+    if (newState->expanded.has_value()) {
+      resultState["expanded"] = newState->expanded.value();
+    }
   }
 
   if (!oldState.has_value() || newState->checked != oldState->checked) {


### PR DESCRIPTION
Summary:

Any time we have a non-nullable accessibilityState prop, it appears to always set `expanded` false, which causes most Android screen readers to append or prepend "collapsed". This fixes the issue.

## Changelog
[Android][Fixed] Screen reader behavior for accessibilityState expanded

Reviewed By: javache

Differential Revision: D105035390


