### PR TITLE
Add null guard for changedTouches in ResponderTouchHistoryStore.recordTouchTrack

### DIFF
--- a/packages/react-native/src/private/renderer/events/ResponderTouchHistoryStore.js
+++ b/packages/react-native/src/private/renderer/events/ResponderTouchHistoryStore.js
@@ -221,11 +221,20 @@ const ResponderTouchHistoryStore = {
       instrumentationCallback(topLevelType, nativeEvent);
     }
 
+    if (nativeEvent.changedTouches == null) {
+      console.error(
+        'Touch event "%s" received with no changedTouches. This is likely ' +
+          'a bug in the native touch handling system.',
+        topLevelType,
+      );
+      return;
+    }
+
     if (isMoveish(topLevelType)) {
       nativeEvent.changedTouches.forEach(recordTouchMove);
     } else if (isStartish(topLevelType)) {
       nativeEvent.changedTouches.forEach(recordTouchStart);
-      touchHistory.numberActiveTouches = nativeEvent.touches.length;
+      touchHistory.numberActiveTouches = nativeEvent.touches?.length ?? 0;
       if (touchHistory.numberActiveTouches === 1) {
         touchHistory.indexOfSingleActiveTouch =
           // $FlowFixMe[incompatible-type] might be null according to type
@@ -233,7 +242,7 @@ const ResponderTouchHistoryStore = {
       }
     } else if (isEndish(topLevelType)) {
       nativeEvent.changedTouches.forEach(recordTouchEnd);
-      touchHistory.numberActiveTouches = nativeEvent.touches.length;
+      touchHistory.numberActiveTouches = nativeEvent.touches?.length ?? 0;
       if (touchHistory.numberActiveTouches === 1) {
         for (let i = 0; i < touchBank.length; i++) {
           const touchTrackToCheck = touchBank[i];


### PR DESCRIPTION
Summary:
The native iOS touch system can occasionally dispatch touch events to JavaScript where `nativeEvent.changedTouches` is undefined due to inconsistencies between local and UIKit touch registries. This causes a TypeError crash in `ResponderTouchHistoryStore.recordTouchTrack` when it unconditionally calls `.forEach()` on `changedTouches`.

The fix adds a defensive null check: if `changedTouches` is null/undefined, we log a DEV warning and bail out early from `recordTouchTrack`. Additionally, `nativeEvent.touches` accesses use optional chaining to prevent secondary crashes.

Changelog: [iOS][Fixed] - Fix TypeError crash in ResponderTouchHistoryStore when changedTouches is undefined

Reviewed By: fkgozali

Differential Revision: D105023000


