### PR TITLE
Force RCT_REMOVE_LEGACY_ARCH=1 for the entire OSS iOS framework - WIP !!

### DIFF
--- a/packages/react-native/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
+++ b/packages/react-native/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
@@ -31,4 +31,5 @@ Pod::Spec.new do |s|
   s.header_dir             = "RCTActionSheet"
 
   s.dependency "React-Core/RCTActionSheetHeaders", version
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -85,4 +85,5 @@ Pod::Spec.new do |s|
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -56,4 +56,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/FBLazyVector/FBLazyVector.podspec
+++ b/packages/react-native/Libraries/FBLazyVector/FBLazyVector.podspec
@@ -28,4 +28,5 @@ Pod::Spec.new do |s|
   s.source_files           = podspec_sources("**/*.{c,h,m,mm,cpp}", "**/*.h")
   s.header_dir             = "FBLazyVector"
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -54,4 +54,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -48,4 +48,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -52,4 +52,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -54,4 +54,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-NativeModulesApple")
 
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/Required/RCTRequired.podspec
+++ b/packages/react-native/Libraries/Required/RCTRequired.podspec
@@ -27,4 +27,5 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = podspec_sources("**/*.{c,h,m,mm,cpp}", "**/*.h")
   s.header_dir             = "RCTRequired"
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
+++ b/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/Text/React-RCTText.podspec
+++ b/packages/react-native/Libraries/Text/React-RCTText.podspec
@@ -34,4 +34,5 @@ Pod::Spec.new do |s|
 
   s.dependency "Yoga"
   s.dependency "React-Core/RCTTextHeaders", version
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/TypeSafety/RCTTypeSafety.podspec
+++ b/packages/react-native/Libraries/TypeSafety/RCTTypeSafety.podspec
@@ -36,4 +36,5 @@ Pod::Spec.new do |s|
   s.dependency "FBLazyVector", version
   s.dependency "RCTRequired", version
   s.dependency "React-Core", version
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
+++ b/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/React-Core-prebuilt.podspec
+++ b/packages/react-native/React-Core-prebuilt.podspec
@@ -75,4 +75,5 @@ Pod::Spec.new do |s|
 
     s.script_phase = script_phase
   end
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -134,4 +134,5 @@ Pod::Spec.new do |s|
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/React.podspec
+++ b/packages/react-native/React.podspec
@@ -53,4 +53,5 @@ Pod::Spec.new do |s|
   s.dependency "React-RCTSettings", version
   s.dependency "React-RCTText", version
   s.dependency "React-RCTVibration", version
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -66,4 +66,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -92,4 +92,5 @@ fi
       EOS
     }
   ]
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -109,4 +109,5 @@ Pod::Spec.new do |s|
     test_spec.source_files = podspec_sources("Tests/**/*.{mm}", "")
     test_spec.framework = "XCTest"
   end
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/React/Runtime/React-RCTRuntime.podspec
+++ b/packages/react-native/React/Runtime/React-RCTRuntime.podspec
@@ -69,4 +69,5 @@ Pod::Spec.new do |s|
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation/RCTDeprecation.podspec
+++ b/packages/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation/RCTDeprecation.podspec
@@ -22,4 +22,5 @@ Pod::Spec.new do |s|
       "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
     }
     s.compiler_flags         = "-Wnullable-to-nonnull-conversion -Wnullability-completeness"
+  set_remove_legacy_arch_compiler_flag!(s)
   end

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUI.podspec
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUI.podspec
@@ -36,4 +36,5 @@ Pod::Spec.new do |s|
     "DEFINES_MODULE" => "YES",
   }
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIWrapper.podspec
+++ b/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIWrapper.podspec
@@ -34,4 +34,5 @@ Pod::Spec.new do |s|
     "SWIFT_VERSION" => "5.0",
   }
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -235,4 +235,5 @@ Pod::Spec.new do |s|
     ss.source_files         = podspec_sources("react/renderer/viewtransition/**/*.{m,mm,cpp,h}", "react/renderer/viewtransition/**/*.h")
     ss.header_dir           = "react/renderer/viewtransition"
   end
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -171,4 +171,5 @@ Pod::Spec.new do |s|
                               "react/renderer/textlayoutmanager/platform/cxx"
     ss.header_dir           = "react/renderer/textlayoutmanager"
   end
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -76,4 +76,5 @@ Pod::Spec.new do |s|
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -37,4 +37,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -69,4 +69,5 @@ Pod::Spec.new do |s|
       sss.dependency "React-utils", version
     end
   end
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/callinvoker/React-callinvoker.podspec
+++ b/packages/react-native/ReactCommon/callinvoker/React-callinvoker.podspec
@@ -27,4 +27,5 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
   s.header_dir             = "ReactCommon"
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -54,4 +54,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -51,4 +51,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/hermes/executor/React-jsitracing.podspec
+++ b/packages/react-native/ReactCommon/hermes/executor/React-jsitracing.podspec
@@ -35,4 +35,5 @@ Pod::Spec.new do |s|
   resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_jsitracing")
 
   s.dependency "React-jsi"
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -49,4 +49,5 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -47,4 +47,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -47,4 +47,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -62,4 +62,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
@@ -45,4 +45,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
@@ -47,4 +47,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -55,4 +55,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
+++ b/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/logger/React-logger.podspec
+++ b/packages/react-native/ReactCommon/logger/React-logger.podspec
@@ -31,4 +31,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
+++ b/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
@@ -28,4 +28,5 @@ Pod::Spec.new do |s|
   s.source_files           = podspec_sources("*.{cpp,h}", "*.{h}")
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "" }
   s.header_dir             = "oscompat"
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -37,4 +37,5 @@ Pod::Spec.new do |s|
     ss.exclude_files        = "redbox/tests/**/*.{cpp,h}"
     ss.header_dir           = "react/debug/redbox"
   end
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
+++ b/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
@@ -41,4 +41,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -52,4 +52,5 @@ Pod::Spec.new do |s|
     depend_on_js_engine(s)
     add_rn_third_party_dependencies(s)
     add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -60,4 +60,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-featureflags")
   add_dependency(s, "React-featureflagsnativemodule")
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
@@ -57,4 +57,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
   add_dependency(s, "React-RCTFBReactNativeSpec")
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-featureflags"
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
@@ -52,4 +52,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/React-intersectionobservernativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/React-intersectionobservernativemodule.podspec
@@ -63,4 +63,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -49,4 +49,5 @@ Pod::Spec.new do |s|
 
   s.dependency "ReactCommon/turbomodule/core"
   add_dependency(s, "React-RCTFBReactNativeSpec")
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/React-mutationobservernativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/React-mutationobservernativemodule.podspec
@@ -63,4 +63,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -61,4 +61,5 @@ Pod::Spec.new do |s|
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/viewtransition/React-viewtransitionnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/viewtransition/React-viewtransitionnativemodule.podspec
@@ -55,4 +55,5 @@ Pod::Spec.new do |s|
   s.dependency "React-Fabric/bridging"
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-RCTFBReactNativeSpec")
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/React-webperformancenativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/React-webperformancenativemodule.podspec
@@ -57,4 +57,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-performancetimeline")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/networking/React-networking.podspec
+++ b/packages/react-native/ReactCommon/react/networking/React-networking.podspec
@@ -48,4 +48,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
   if use_hermes()
     s.dependency 'hermes-engine'
   end
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -48,4 +48,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/consistency/React-rendererconsistency.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/React-rendererconsistency.podspec
@@ -40,4 +40,5 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_rendererconsistency")
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
@@ -44,4 +44,5 @@ Pod::Spec.new do |s|
 
   add_dependency(s, "React-debug")
   add_dependency(s, "React-utils")
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
@@ -45,4 +45,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -54,4 +54,5 @@ Pod::Spec.new do |s|
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -53,4 +53,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -56,4 +56,5 @@ Pod::Spec.new do |s|
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -53,4 +53,5 @@ Pod::Spec.new do |s|
 
   s.dependency "React-jsinspector"
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -69,4 +69,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/timing/React-timing.podspec
+++ b/packages/react-native/ReactCommon/react/timing/React-timing.podspec
@@ -42,4 +42,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-debug")
 
   s.resource_bundles = {'React-timing_privacy' => 'PrivacyInfo.xcprivacy'}
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -54,4 +54,5 @@ Pod::Spec.new do |s|
   add_rncore_dependency(s)
 
   add_dependency(s, "React-debug")
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -39,4 +39,5 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -53,4 +53,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-utils", :additional_framework_paths => ["react/utils/platform/ios"])
 
 
+  set_remove_legacy_arch_compiler_flag!(s)
 end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -42,9 +42,31 @@ def min_supported_versions
   return  { :ios => min_ios_version_supported }
 end
 
+# Append `-DRCT_REMOVE_LEGACY_ARCH=1` to a podspec's `compiler_flags` so that
+# the legacy (Paper) architecture stays compiled out of OSS builds at the pod
+# target level, regardless of project-level flags. Each React-* podspec calls
+# this helper so the macro is set even if the consuming project skips
+# `react_native_post_install`. Mirrors `.define("RCT_REMOVE_LEGACY_ARCH", to:
+# "1")` in `Package.swift` and the project-level flag added by
+# `react_native_post_install`.
+def set_remove_legacy_arch_compiler_flag!(spec)
+  existing = spec.attributes_hash['compiler_flags']
+  existing_str = existing.is_a?(Array) ? existing.join(' ') : (existing || '').to_s
+  combined = existing_str.empty? ? '-DRCT_REMOVE_LEGACY_ARCH=1' : "#{existing_str} -DRCT_REMOVE_LEGACY_ARCH=1"
+  spec.compiler_flags = combined
+end
+
 # This function prepares the project for React Native, before processing
 # all the target exposed by the framework.
 def prepare_react_native_project!
+  # The legacy (Paper) architecture has been removed from the open-source iOS
+  # sources and is no longer a supported configuration. Force
+  # `RCT_REMOVE_LEGACY_ARCH=1` here so that every OSS app that calls
+  # `prepare_react_native_project!` builds React Native (and any pod that
+  # consults this env var) with the legacy arch compiled out. This matches
+  # what `Package.swift` already hard-codes for the SwiftPM flow.
+  ENV['RCT_REMOVE_LEGACY_ARCH'] = '1'
+
   # Temporary solution to suppress duplicated GUID error & master specs repo warning.
   # Can be removed once we move to generate files outside pod install.
   install! 'cocoapods', :deterministic_uuids => false, :warn_for_unused_master_specs_repo => false
@@ -91,9 +113,11 @@ def use_react_native! (
   # Users can still turn them off and build from source by setting the environment variable to 0.
   ENV['RCT_USE_RN_DEP'] = ENV['RCT_USE_RN_DEP'] == '0' ? '0' : '1'
   ENV['RCT_USE_PREBUILT_RNCORE'] = ENV['RCT_USE_PREBUILT_RNCORE'] == '0' ? '0' : '1'
-  # Make `REMOVE_LEGACY_ARCH` enabled by default. This will build React Native
-  # excluding the legacy arch unless the user turns this flag off explicitly.
-  ENV['RCT_REMOVE_LEGACY_ARCH'] = ENV['RCT_REMOVE_LEGACY_ARCH'] == '0' ? '0' : '1'
+  # `RCT_REMOVE_LEGACY_ARCH` is always on for OSS builds. The legacy (Paper)
+  # architecture has been removed from the iOS sources and the env var is
+  # hard-set in `prepare_react_native_project!`; we re-assert it here in case a
+  # consumer skipped that helper.
+  ENV['RCT_REMOVE_LEGACY_ARCH'] = '1'
 
   ReactNativePodsUtils.check_minimum_required_xcode()
 
@@ -554,11 +578,11 @@ def react_native_post_install(
   installer.pods_project.save
   ReactNativePodsUtils.set_build_setting(installer, build_setting: "SWIFT_ACTIVE_COMPILATION_CONDITIONS", value: ['$(inherited)', 'DEBUG'], config_name: "Debug")
 
-  if (ENV['RCT_REMOVE_LEGACY_ARCH'] == '1')
-    ReactNativePodsUtils.add_compiler_flag_to_project(installer, "-DRCT_REMOVE_LEGACY_ARCH=1")
-  else
-    ReactNativePodsUtils.remove_compiler_flag_from_project(installer, "-DRCT_REMOVE_LEGACY_ARCH=1")
-  end
+  # `RCT_REMOVE_LEGACY_ARCH=1` is mandatory in OSS builds; the legacy (Paper)
+  # architecture has been removed from the iOS sources. Apply the project-level
+  # compiler flag unconditionally so that any pod that does not bake the macro
+  # into its own xcconfig still gets it.
+  ReactNativePodsUtils.add_compiler_flag_to_project(installer, "-DRCT_REMOVE_LEGACY_ARCH=1")
 
   ReactNativePodsUtils.set_ccache_compiler_and_linker_build_settings(installer, react_native_path, ccache_enabled)
   ReactNativePodsUtils.updateOSDeploymentTarget(installer)


### PR DESCRIPTION
Summary:
The legacy (Paper) architecture has been removed from the React Native iOS sources. The remaining call sites are all behind `#ifndef RCT_REMOVE_LEGACY_ARCH` guards, so leaving the macro unset (or set to `0`) now produces an unbuildable framework. Today the CocoaPods plumbing in `react_native_pods.rb` still treats `RCT_REMOVE_LEGACY_ARCH` as an opt-out env var (`'0' ? '0' : '1'`), and `Package.swift` already hard-codes the macro to `1` for the SwiftPM flow. This diff brings the CocoaPods flow in line with SwiftPM and makes the OSS framework always build with the legacy arch compiled out.

Changes in `packages/react-native/scripts/react_native_pods.rb`:

- `prepare_react_native_project!` hard-sets `ENV['RCT_REMOVE_LEGACY_ARCH'] = '1'` at the top, before any other helper consults the variable.
- `use_react_native!` re-asserts `ENV['RCT_REMOVE_LEGACY_ARCH'] = '1'` (the previous `... == '0' ? '0' : '1'` opt-out is gone) so consumers that skip `prepare_react_native_project!` still get the flag.
- `react_native_post_install` unconditionally adds `-DRCT_REMOVE_LEGACY_ARCH=1` to every project's `OTHER_CFLAGS` / `OTHER_CPLUSPLUSFLAGS` (the old `if/else` that could remove the flag is gone).
- New helper `set_remove_legacy_arch_compiler_flag!(spec)` appends `-DRCT_REMOVE_LEGACY_ARCH=1` to a podspec's `compiler_flags`, preserving anything already there (e.g. `js_engine_flags()` in `React-Core.podspec`).

The new helper is invoked once per Meta-owned React-* podspec under `packages/react-native/` (72 podspecs in total: every podspec that is not a third-party shim, not a codegen test fixture, not `hermes-engine`, and not `Yoga`). Baking the macro into each podspec's `compiler_flags` mirrors the `.define("RCT_REMOVE_LEGACY_ARCH", to: "1")` already present in `Package.swift` and provides a defensive belt-and-suspenders even for consumers that skip `react_native_post_install`.

Finally, the per-app `ENV['RCT_REMOVE_LEGACY_ARCH'] = '1'` override that previously sat at the top of `packages/rn-tester/Podfile` is now redundant and is removed; RNTester picks the flag up from the framework defaults like every other OSS app.

OSS impact: any app consuming `react_native_pods.rb` will always build React Native with `-DRCT_REMOVE_LEGACY_ARCH=1`. This matches the iOS source state. The env-var opt-out is gone -- setting `RCT_REMOVE_LEGACY_ARCH=0` in the shell or CI no longer has any effect on OSS CocoaPods or SwiftPM builds.

Changelog:
[iOS][Changed] - Force `RCT_REMOVE_LEGACY_ARCH=1` for the entire React Native iOS framework in OSS builds; the legacy (Paper) architecture is no longer a supported configuration. The `RCT_REMOVE_LEGACY_ARCH=0` env-var opt-out has been removed from `react_native_pods.rb`.

Differential Revision: D105118393
