### PR TITLE
Fix recycled ScrollView inheriting stale contentInset on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
@@ -102,6 +102,20 @@
       RCTSanitizeNaNValue(contentOffset.y, @"scrollView.contentOffset.y"));
 }
 
+- (void)setCenterContent:(BOOL)centerContent
+{
+  if (_centerContent != centerContent) {
+    _centerContent = centerContent;
+    [self centerContentIfNeeded];
+  }
+}
+
+- (void)setContentSize:(CGSize)contentSize
+{
+  [super setContentSize:contentSize];
+  [self centerContentIfNeeded];
+}
+
 - (void)setFrame:(CGRect)frame
 {
   [super setFrame:frame];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -396,11 +396,19 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
   MAP_SCROLL_VIEW_PROP(zoomScale);
 
-  if (oldScrollViewProps.contentInset != newScrollViewProps.contentInset) {
-    _scrollView.contentInset = RCTUIEdgeInsetsFromEdgeInsets(newScrollViewProps.contentInset);
+  RCTEnhancedScrollView *scrollView = (RCTEnhancedScrollView *)_scrollView;
+
+  // When disabling centerContent, reset inset to prop value
+  // (enabling is handled automatically by the setCenterContent: setter)
+  if (oldScrollViewProps.centerContent && !newScrollViewProps.centerContent) {
+    scrollView.contentInset = RCTUIEdgeInsetsFromEdgeInsets(newScrollViewProps.contentInset);
   }
 
-  RCTEnhancedScrollView *scrollView = (RCTEnhancedScrollView *)_scrollView;
+  // Only apply contentInset from props if centerContent is disabled
+  // When centerContent is enabled, the inset is calculated by centerContentIfNeeded
+  if (oldScrollViewProps.contentInset != newScrollViewProps.contentInset && !newScrollViewProps.centerContent) {
+    _scrollView.contentInset = RCTUIEdgeInsetsFromEdgeInsets(newScrollViewProps.contentInset);
+  }
   if (oldScrollViewProps.contentOffset != newScrollViewProps.contentOffset) {
     _scrollView.contentOffset = RCTCGPointFromPoint(newScrollViewProps.contentOffset);
   }


### PR DESCRIPTION
## Summary:

Fixes #55090

In Fabric, `prepareForRecycle` resets contentInset to zero when a `ScrollView` is recycled. But the subsequent frame reset dance (required for `contentInsetAdjustmentBehavior` see 27fe6f10796) triggers `centerContentIfNeeded` with the previous component's stale content size, silently overwriting the reset. 

As a result, a `ScrollView` with `centerContent={true}` that is unmounted and replaced by another `ScrollView` leaves behind a stale contentInset that the new component inherits causing displaced content if the new `ScrollView` does not have `centerContent={true}`.

Two fixes:

1. `RCTScrollViewComponentView`
    In updateProps, when `centerContent` transitions from true to false, explicitly reset `contentInset` to the prop value. `centerContentIfNeeded` will not self-correct once `centerContent` is disabled on the new component, so the reset must be forced. The existing `contentInset` prop check is also guarded with !centerContent to prevent it from overriding the inset calculated by centerContentIfNeeded when centering is active.
2. `RCTEnhancedScrollView`
    Override `setCenterContent:` and `setContentSize:` to trigger `centerContentIfNeeded`. This ensures centering is re-applied with the correct new content size when the new component's content arrives via `updateState:`, and that toggling `centerContent` takes effect immediately.

## Changelog:

[IOS] [FIXED] - Fix recycled ScrollView inheriting stale contentInset from centerContent on Fabric

## Test Plan:

Using the RNTester-app, replace `CenterContentList` with the following inside `ScrollViewExample.js`:

<details><summary>CenterContentList reproducer</summary>
Doing two different ScrollViews to force an unmount of the one with centerContent so the other inherits its insets

```jsx
function CenterContentList(): React.Node {
  const [centerContent, setCenterContent] = useState(true);
  if (centerContent) {
    return (
      <ScrollView
        nestedScrollEnabled
        style={styles.scrollView}
        centerContent={true}>
        <Text>This should be in center.</Text>
        <Button
          label="Toggle centerContent"
          onPress={() => setCenterContent(!centerContent)}
        />
      </ScrollView>
    );
  } else {
    return (
      <ScrollView
        nestedScrollEnabled
        style={styles.scrollView}
        centerContent={false}>
        <Text>This should not be in center.</Text>
        <Button
          label="Toggle centerContent"
          onPress={() => setCenterContent(!centerContent)}
        />
      </ScrollView>
    );
  }
}
```

</details> 

### Before the fix

Note that for both `ScrollView`s the content is centered, even though one has `centerContent={false}`.

https://github.com/user-attachments/assets/7d5916a2-dbe3-4955-ad7b-1e6596d90104

### After the fix

One is properly centered, while the other has its content at the top.

https://github.com/user-attachments/assets/ae8a41eb-0084-40e7-98fd-88433956ea40

