### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "15 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   set_release_type:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-cxx-api-snapshots.yml
+++ b/.github/workflows/validate-cxx-api-snapshots.yml
@@ -25,6 +25,9 @@ on:
 env:
   DOXYGEN_VERSION: "1.16.1"
 
+permissions:
+  contents: read
+
 jobs:
   validate_cxx_api_snapshots:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `cache-reaper.yml`, `check-for-reproducer.yml`, `retry-workflow.yml`, `validate-dotslash-artifacts.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.

## Changelog

[Internal] [Changed] -
