### PR TITLE
Fix React Native multiline TextInput container overflow

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -281,6 +281,11 @@ static UIColor *defaultPlaceholderColor(void)
   [super layoutSubviews];
 
   CGRect textFrame = UIEdgeInsetsInsetRect(self.bounds, self.textContainerInset);
+
+  // Sync NSTextContainer.size with the current container bounds to prevent
+  // _UITextLayoutFragmentView from retaining a stale width after frame changes.
+  self.textContainer.size = CGSizeMake(textFrame.size.width, CGFLOAT_MAX);
+
   CGFloat placeholderHeight = [_placeholderView sizeThatFits:textFrame.size].height;
   textFrame.size.height = MIN(placeholderHeight, textFrame.size.height);
   _placeholderView.frame = textFrame;


### PR DESCRIPTION
Summary:
The text input field in the Marketplace Review Response Composer (and all React Native multiline TextInput instances) incorrectly expands beyond its container bounds. The _UITextLayoutFragmentView has a width that exceeds the RCTTextInputComponentView container width by 47 points.

Root cause: RCTUITextView.layoutSubviews does not update self.textContainer.size when parent view bounds change. When RCTTextInputComponentView.updateLayoutMetrics sets a new frame and textContainerInset, the NSTextContainer.size inside the UITextView retains its old (wider) value.

Fix: Add self.textContainer.size = CGSizeMake(textFrame.size.width, CGFLOAT_MAX) in layoutSubviews after computing textFrame, so the text container width stays in sync with container bounds.

## Changelog
[iOS][Fixed] - Update text view bounding to avoid overflowing

Differential Revision: D104896433


