### PR TITLE
Fix Kotlin parameter name mismatches with supertypes (#56840)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
@@ -154,8 +154,8 @@ public class WebSocketModule(context: ReactApplicationContext) :
             sendEvent("websocketOpen", params)
           }
 
-          override fun onClosing(websocket: WebSocket, code: Int, reason: String) {
-            websocket.close(code, reason)
+          override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+            webSocket.close(code, reason)
           }
 
           override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
@@ -34,10 +34,14 @@ class MultipartStreamReaderTest {
 
     val callback: CallCountTrackingChunkCallback =
         object : CallCountTrackingChunkCallback() {
-          override fun onChunkComplete(headers: Map<String, String>, body: Buffer, done: Boolean) {
-            super.onChunkComplete(headers, body, done)
+          override fun onChunkComplete(
+              headers: Map<String, String>,
+              body: Buffer,
+              isLastChunk: Boolean,
+          ) {
+            super.onChunkComplete(headers, body, isLastChunk)
 
-            assertThat(done).isTrue
+            assertThat(isLastChunk).isTrue
             assertThat(headers["Content-Type"]).isEqualTo("application/json; charset=utf-8")
             assertThat(body.readUtf8()).isEqualTo("{}")
           }
@@ -70,10 +74,14 @@ class MultipartStreamReaderTest {
 
     val callback: CallCountTrackingChunkCallback =
         object : CallCountTrackingChunkCallback() {
-          override fun onChunkComplete(headers: Map<String, String>, body: Buffer, done: Boolean) {
-            super.onChunkComplete(headers, body, done)
+          override fun onChunkComplete(
+              headers: Map<String, String>,
+              body: Buffer,
+              isLastChunk: Boolean,
+          ) {
+            super.onChunkComplete(headers, body, isLastChunk)
 
-            assertThat(done).isEqualTo(callCount == 3)
+            assertThat(isLastChunk).isEqualTo(callCount == 3)
             assertThat(body.readUtf8()).isEqualTo("$callCount")
           }
         }


### PR DESCRIPTION
Summary:

Fix Kotlin compiler warnings about overridden method parameter names not matching their supertypes. Rename `websocket` to `webSocket` in `WebSocketModule.onClosing` to match `WebSocketListener`, and rename `done` to `isLastChunk` in `MultipartStreamReaderTest` callbacks to match `CallCountTrackingChunkCallback`.

Changelog: [Internal]

Differential Revision: D105299024


