### PR TITLE
[RN][0.86] Cache prebuilt iOS binaries in ~/Library/Caches/ReactNative

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -403,18 +403,36 @@ class ReactNativeCoreUtils
         download_rncore_tarball(react_native_path, tarball_url, version, configuration, dsyms)
     end
 
-    def self.download_rncore_tarball(react_native_path, tarball_url, version, configuration, dsyms = false)
-        destination_path = configuration == nil ?
-            "#{artifacts_dir()}/reactnative-core-#{version}#{dsyms ? "-dSYM" : ""}.tar.gz" :
-            "#{artifacts_dir()}/reactnative-core-#{version}#{dsyms ? "-dSYM" : ""}-#{configuration}.tar.gz"
+    def self.shared_cache_dir()
+        return File.join(Dir.home, "Library", "Caches", "ReactNative")
+    end
 
-        unless File.exist?(destination_path)
-          # Download to a temporary file first so we don't cache incomplete downloads.
-          rncore_log("Downloading ReactNativeCore-prebuilt #{dsyms ? "dSYMs " : ""}#{configuration ? configuration.to_s : ""} tarball from #{tarball_url} to #{Pathname.new(destination_path).relative_path_from(Pathname.pwd).to_s}")
-          tmp_file = "#{artifacts_dir()}/reactnative-core.download"
-          `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+    def self.download_rncore_tarball(react_native_path, tarball_url, version, configuration, dsyms = false)
+        filename = configuration == nil ?
+            "reactnative-core-#{version}#{dsyms ? "-dSYM" : ""}.tar.gz" :
+            "reactnative-core-#{version}#{dsyms ? "-dSYM" : ""}-#{configuration}.tar.gz"
+        destination_path = "#{artifacts_dir()}/#{filename}"
+
+        if File.exist?(destination_path)
+          rncore_log("Tarball #{filename} already exists in Pods. Skipping download.")
+          return destination_path
+        end
+
+        `mkdir -p "#{artifacts_dir()}"`
+
+        cached_path = File.join(shared_cache_dir(), filename)
+        if File.exist?(cached_path)
+          rncore_log("Cache hit: copying #{filename} from shared cache (#{shared_cache_dir()})")
+          FileUtils.cp(cached_path, destination_path)
         else
-          rncore_log("Using downloaded ReactNativeCore-prebuilt #{dsyms ? "dSYMs " : ""}#{configuration ? configuration.to_s : ""} tarball at #{Pathname.new(destination_path).relative_path_from(Pathname.pwd).to_s}")
+          rncore_log("Cache miss: downloading #{filename} from #{tarball_url}")
+          # Download to a temporary file first so we don't cache incomplete downloads.
+          tmp_file = "#{artifacts_dir()}/reactnative-core.download"
+          `curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          # Save to shared cache for future use
+          `mkdir -p "#{shared_cache_dir()}"`
+          FileUtils.cp(destination_path, cached_path)
+          rncore_log("Saved #{filename} to shared cache (#{shared_cache_dir()})")
         end
 
         return destination_path

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -232,15 +232,36 @@ class ReactNativeDependenciesUtils
         return {:http => url}
     end
 
-    def self.download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
-        destination_path = configuration == nil ?
-            "#{artifacts_dir()}/reactnative-dependencies-#{version}.tar.gz" :
-            "#{artifacts_dir()}/reactnative-dependencies-#{version}-#{configuration}.tar.gz"
+    def self.shared_cache_dir()
+        return File.join(Dir.home, "Library", "Caches", "ReactNative")
+    end
 
-        unless File.exist?(destination_path)
+    def self.download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+        filename = configuration == nil ?
+            "reactnative-dependencies-#{version}.tar.gz" :
+            "reactnative-dependencies-#{version}-#{configuration}.tar.gz"
+        destination_path = "#{artifacts_dir()}/#{filename}"
+
+        if File.exist?(destination_path)
+          rndeps_log("Tarball #{filename} already exists in Pods. Skipping download.")
+          return destination_path
+        end
+
+        `mkdir -p "#{artifacts_dir()}"`
+
+        cached_path = File.join(shared_cache_dir(), filename)
+        if File.exist?(cached_path)
+          rndeps_log("Cache hit: copying #{filename} from shared cache (#{shared_cache_dir()})")
+          FileUtils.cp(cached_path, destination_path)
+        else
+          rndeps_log("Cache miss: downloading #{filename} from #{tarball_url}")
           # Download to a temporary file first so we don't cache incomplete downloads.
           tmp_file = "#{artifacts_dir()}/reactnative-dependencies.download"
-          `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          `curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          # Save to shared cache for future use
+          `mkdir -p "#{shared_cache_dir()}"`
+          FileUtils.cp(destination_path, cached_path)
+          rndeps_log("Saved #{filename} to shared cache (#{shared_cache_dir()})")
         end
 
         return destination_path

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -236,16 +236,38 @@ def download_stable_hermes(react_native_path, version, configuration)
     download_hermes_tarball(react_native_path, tarball_url, version, configuration)
 end
 
-def download_hermes_tarball(react_native_path, tarball_url, version, configuration)
-    destination_path = configuration == nil ?
-        "#{artifacts_dir()}/hermes-ios-#{version}.tar.gz" :
-        "#{artifacts_dir()}/hermes-ios-#{version}-#{configuration}.tar.gz"
+def shared_cache_dir()
+    return File.join(Dir.home, "Library", "Caches", "ReactNative")
+end
 
-    unless File.exist?(destination_path)
+def download_hermes_tarball(react_native_path, tarball_url, version, configuration)
+    filename = configuration == nil ?
+        "hermes-ios-#{version}.tar.gz" :
+        "hermes-ios-#{version}-#{configuration}.tar.gz"
+    destination_path = "#{artifacts_dir()}/#{filename}"
+
+    if File.exist?(destination_path)
+      hermes_log("Tarball #{filename} already exists in Pods. Skipping download.", :info)
+      return destination_path
+    end
+
+    `mkdir -p "#{artifacts_dir()}"`
+
+    cached_path = File.join(shared_cache_dir(), filename)
+    if File.exist?(cached_path)
+      hermes_log("Cache hit: copying #{filename} from shared cache (#{shared_cache_dir()})", :info)
+      FileUtils.cp(cached_path, destination_path)
+    else
+      hermes_log("Cache miss: downloading #{filename} from #{tarball_url}", :info)
       # Download to a temporary file first so we don't cache incomplete downloads.
       tmp_file = "#{artifacts_dir()}/hermes-ios.download"
-      `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+      `curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+      # Save to shared cache for future use
+      `mkdir -p "#{shared_cache_dir()}"`
+      FileUtils.cp(destination_path, cached_path)
+      hermes_log("Saved #{filename} to shared cache (#{shared_cache_dir()})", :info)
     end
+
     return destination_path
 end
 


### PR DESCRIPTION
## Summary:
 Adds a shared cache layer at
  `~/Library/Caches/ReactNative/` for prebuilt iOS tarballs
   (Hermes, ReactNativeDependencies, ReactNativeCore).
  - On first download, tarballs are saved to both the local
   Pods artifacts dir **and** the shared cache.
  - On subsequent `pod install` runs, if the local Pods
  cache is empty but the shared cache has the tarball for
  that version, it is copied locally instead of
  re-downloaded from Maven.
  - Adds descriptive log messages for each scenario: local
  Pods hit, shared cache hit, and cache miss (download).

  This avoids redundant downloads when:
  - The Pods directory is deleted between installs
  - Multiple projects use the same React Native version
  - CI environments have a persistent home directory

  ## Changelog:

  [IOS] [CHANGED] - Cache prebuilt iOS binaries (Hermes,
  ReactNativeDependencies, ReactNativeCore) in
  ~/Library/Caches/ReactNative to avoid redundant downloads
   across pod installs

## Test Plan:

### Cold start ==> Downloading

```
[ReactNativeDependencies] Setting up ReactNativeDependencies...
[ReactNativeDependencies] Building from source: false
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Cache miss: downloading reactnative-dependencies-0.81.6-debug.tar.gz from https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:-  0     0    0     0    0     0      0      0 --:--:-- --:- 35 18.3M   35 6580k    0     0  6386k      0  0:00:02  0:0 73 18.3M   73 13.5M    0     0  6827k      0  0:00:02  0:0100 18.3M  100 18.3M    0     0  6915k      0  0:00:02  0:00:02 --:--:-- 6914k
[ReactNativeDependencies] Saved reactnative-dependencies-0.81.6-debug.tar.gz to shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeDependencies] Cache miss: downloading reactnative-dependencies-0.81.6-release.tar.gz from https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-release.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:-  0     0    0     0    0     0      0      0 --:--:-- --:- 67  9.9M   67 6948k    0     0  6332k      0  0:00:01  0:0100  9.9M  100  9.9M    0     0  6607k      0  0:00:01  0:00:01 --:--:-- 6603k
[ReactNativeDependencies] Saved reactnative-dependencies-0.81.6-release.tar.gz to shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeDependencies] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz"}
[ReactNativeCore] Setting up ReactNativeCore...
[ReactNativeCore] Building from source: false
[ReactNativeCore] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz
[ReactNativeCore] Cache miss: downloading reactnative-core-0.81.6-debug.tar.gz from https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:-  1 78.5M    1 1557k    0     0  5035k      0  0:00:15 --:- 10 78.5M   10 8537k    0     0  6536k      0  0:00:12  0:0 19 78.5M   19 15.4M    0     0  6866k      0  0:00:11  0:0 28 78.5M   28 22.5M    0     0  6990k      0  0:00:11  0:0 37 78.5M   37 29.7M    0     0  7062k      0  0:00:11  0:0 46 78.5M   46 36.4M    0     0  7037k      0  0:00:11  0:0 55 78.5M   55 43.5M    0     0  7065k      0  0:00:11  0:0 64 78.5M   64 50.5M    0     0  7077k      0  0:00:11  0:0100 78.5M  100 78.5M    0     0  6852k      0  0:00:11  0:00:11 --:--:-- 6482k
[ReactNativeCore] Saved reactnative-core-0.81.6-debug.tar.gz to shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeCore] Cache miss: downloading reactnative-core-0.81.6-release.tar.gz from https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-release.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 26.3M  100 26.3M    0     0  5683k      0  0:00:04  0:00:04 --:--:-- 5793k
[ReactNativeCore] Saved reactnative-core-0.81.6-release.tar.gz to shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeCore] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz"}
Configuring the target with the New Architecture
[ReactNativeCore] Using React Native Core and React Native Dependencies prebuilt versions.
[Codegen] Analyzing /Users/cipolleschi/Tests/My0_81App/package.json
```

### Warn shared cache, Empty Pods dir ==> Copy

```
[ReactNativeDependencies] Setting up ReactNativeDependencies...
[ReactNativeDependencies] Building from source: false
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Cache hit: copying reactnative-dependencies-0.81.6-debug.tar.gz from shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeDependencies] Cache hit: copying reactnative-dependencies-0.81.6-release.tar.gz from shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeDependencies] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz"}
[ReactNativeCore] Setting up ReactNativeCore...
[ReactNativeCore] Building from source: false
[ReactNativeCore] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz
[ReactNativeCore] Cache hit: copying reactnative-core-0.81.6-debug.tar.gz from shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeCore] Cache hit: copying reactnative-core-0.81.6-release.tar.gz from shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeCore] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz"}
Configuring the target with the New Architecture
[ReactNativeCore] Using React Native Core and React Native Dependencies prebuilt versions.
[Codegen] Analyzing /Users/cipolleschi/Tests/My0_81App/package.json
...
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-debug.tar.gz already exists in Pods. Skipping download.
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-release.tar.gz already exists in Pods. Skipping download.
```

### Warm Cache, Pods folder populated ==> Nothing happens

```
[ReactNativeDependencies] Setting up ReactNativeDependencies...
[ReactNativeDependencies] Building from source: false
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-debug.tar.gz already exists in Pods. Skipping download.
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-release.tar.gz already exists in Pods. Skipping download.
[ReactNativeDependencies] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz"}
[ReactNativeCore] Setting up ReactNativeCore...
[ReactNativeCore] Building from source: false
[ReactNativeCore] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz
[ReactNativeCore] Tarball reactnative-core-0.81.6-debug.tar.gz already exists in Pods. Skipping download.
[ReactNativeCore] Tarball reactnative-core-0.81.6-release.tar.gz already exists in Pods. Skipping download.
[ReactNativeCore] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz"}
Configuring the target with the New Architecture
[ReactNativeCore] Using React Native Core and React Native Dependencies prebuilt versions.
[Codegen] Analyzing /Users/cipolleschi/Tests/My0_81App/package.json
[Codegen] Searching for codegen-enabled libraries in the app.
[Codegen] The "codegenConfig" field is not defined in package.json. Assuming there is nothing to generate at the app level.
[Codegen] Searching for codegen-enabled libraries in react-native.config.js
[Codegen] Found react-native-safe-area-context
[Codegen] Processing safeareacontext
[Codegen] Searching for podspec in the project dependencies.
[Codegen] Supported Apple platforms: ios, macos, tvos, visionos for safeareacontext
[Codegen] Generating Native Code for safeareacontext - ios
[Codegen] Generated artifacts: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios
[Codegen] Generating RCTThirdPartyComponentsProvider.h
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTThirdPartyComponentsProvider.h
[Codegen] Generating RCTThirdPartyComponentsProvider.mm
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTThirdPartyComponentsProvider.mm
[Codegen] Generating RCTModulesProvider.h
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTModuleProviders.h
[Codegen] Generating RCTModuleProviders.mm
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTModuleProviders.mm
[Codegen] Generating RCTAppDependencyProvider
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTAppDependencyProvider.h
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTAppDependencyProvider.mm
[Codegen] Generated podspec: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/ReactAppDependencyProvider.podspec
[Codegen] Generated podspec: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/ReactCodegen.podspec
[Codegen] Done.
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-debug.tar.gz already exists in Pods. Skipping download.
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-release.tar.gz already exists in Pods. Skipping download.
Analyzing dependencies
```