### PR TITLE
Cache prebuilt iOS binaries in ~/Library/Caches/ReactNative (#56847)

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -406,17 +406,69 @@ class ReactNativeCoreUtils
     end
 
     def self.download_rncore_tarball(react_native_path, tarball_url, version, configuration, dsyms = false)
-        destination_path = configuration == nil ?
-            "#{artifacts_dir()}/reactnative-core-#{version}#{dsyms ? "-dSYM" : ""}.tar.gz" :
-            "#{artifacts_dir()}/reactnative-core-#{version}#{dsyms ? "-dSYM" : ""}-#{configuration}.tar.gz"
+        filename = configuration == nil ?
+            "reactnative-core-#{version}#{dsyms ? "-dSYM" : ""}.tar.gz" :
+            "reactnative-core-#{version}#{dsyms ? "-dSYM" : ""}-#{configuration}.tar.gz"
+        destination_path = "#{artifacts_dir()}/#{filename}"
 
-        unless File.exist?(destination_path)
-          # Download to a temporary file first so we don't cache incomplete downloads.
-          rncore_log("Downloading ReactNativeCore-prebuilt #{dsyms ? "dSYMs " : ""}#{configuration ? configuration.to_s : ""} tarball from #{tarball_url} to #{Pathname.new(destination_path).relative_path_from(Pathname.pwd).to_s}")
+        if File.exist?(destination_path)
+          rncore_log("Tarball #{filename} already exists in Pods. Skipping download.")
+          return destination_path
+        end
+
+        `mkdir -p "#{artifacts_dir()}"`
+
+        if ReactNativePodsUtils.skip_caches?
+          rncore_log("RCT_SKIP_CACHES is set. Downloading #{filename} directly (bypassing shared cache).")
           tmp_file = "#{artifacts_dir()}/reactnative-core.download"
-          `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          unless File.exist?(destination_path)
+            abort("[ReactNativeCore] Failed to download #{filename} from #{tarball_url}. Aborting.")
+          end
+          return destination_path
+        end
+
+        cached_path = File.join(ReactNativePodsUtils.shared_cache_dir(), filename)
+        if File.exist?(cached_path)
+          rncore_log("Verifying checksum for cached #{filename}...")
+          if ReactNativePodsUtils.validate_tarball(cached_path, tarball_url)
+            rncore_log("Cache hit: copying #{filename} from shared cache (#{ReactNativePodsUtils.shared_cache_dir()})")
+            FileUtils.cp(cached_path, destination_path)
+          else
+            rncore_log("Shared cache file #{filename} failed SHA verification. Re-downloading.")
+            File.delete(cached_path)
+            tmp_file = "#{artifacts_dir()}/reactnative-core.download"
+            `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+            unless File.exist?(destination_path)
+              abort("[ReactNativeCore] Failed to download #{filename} from #{tarball_url}. Aborting.")
+            end
+            rncore_log("Verifying checksum for downloaded #{filename}...")
+            if ReactNativePodsUtils.validate_tarball(destination_path, tarball_url)
+              FileUtils.cp(destination_path, cached_path)
+              rncore_log("Saved #{filename} to shared cache (#{ReactNativePodsUtils.shared_cache_dir()})")
+            else
+              File.delete(destination_path) if File.exist?(destination_path)
+              abort("[ReactNativeCore] Downloaded file #{filename} failed SHA verification. Aborting.")
+            end
+          end
         else
-          rncore_log("Using downloaded ReactNativeCore-prebuilt #{dsyms ? "dSYMs " : ""}#{configuration ? configuration.to_s : ""} tarball at #{Pathname.new(destination_path).relative_path_from(Pathname.pwd).to_s}")
+          rncore_log("Cache miss: downloading #{filename} from #{tarball_url}")
+          # Download to a temporary file first so we don't cache incomplete downloads.
+          tmp_file = "#{artifacts_dir()}/reactnative-core.download"
+          `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          unless File.exist?(destination_path)
+            abort("[ReactNativeCore] Failed to download #{filename} from #{tarball_url}. Aborting.")
+          end
+          rncore_log("Verifying checksum for downloaded #{filename}...")
+          if ReactNativePodsUtils.validate_tarball(destination_path, tarball_url)
+            # Save to shared cache for future use
+            `mkdir -p "#{ReactNativePodsUtils.shared_cache_dir()}"`
+            FileUtils.cp(destination_path, cached_path)
+            rncore_log("Saved #{filename} to shared cache (#{ReactNativePodsUtils.shared_cache_dir()})")
+          else
+            File.delete(destination_path) if File.exist?(destination_path)
+            abort("[ReactNativeCore] Downloaded file #{filename} failed SHA verification. Aborting.")
+          end
         end
 
         return destination_path

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -232,14 +232,69 @@ class ReactNativeDependenciesUtils
     end
 
     def self.download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
-        destination_path = configuration == nil ?
-            "#{artifacts_dir()}/reactnative-dependencies-#{version}.tar.gz" :
-            "#{artifacts_dir()}/reactnative-dependencies-#{version}-#{configuration}.tar.gz"
+        filename = configuration == nil ?
+            "reactnative-dependencies-#{version}.tar.gz" :
+            "reactnative-dependencies-#{version}-#{configuration}.tar.gz"
+        destination_path = "#{artifacts_dir()}/#{filename}"
 
-        unless File.exist?(destination_path)
+        if File.exist?(destination_path)
+          rndeps_log("Tarball #{filename} already exists in Pods. Skipping download.")
+          return destination_path
+        end
+
+        `mkdir -p "#{artifacts_dir()}"`
+
+        if ReactNativePodsUtils.skip_caches?
+          rndeps_log("RCT_SKIP_CACHES is set. Downloading #{filename} directly (bypassing shared cache).")
+          tmp_file = "#{artifacts_dir()}/reactnative-dependencies.download"
+          `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          unless File.exist?(destination_path)
+            abort("[ReactNativeDependencies] Failed to download #{filename} from #{tarball_url}. Aborting.")
+          end
+          return destination_path
+        end
+
+        cached_path = File.join(ReactNativePodsUtils.shared_cache_dir(), filename)
+        if File.exist?(cached_path)
+          rndeps_log("Verifying checksum for cached #{filename}...")
+          if ReactNativePodsUtils.validate_tarball(cached_path, tarball_url)
+            rndeps_log("Cache hit: copying #{filename} from shared cache (#{ReactNativePodsUtils.shared_cache_dir()})")
+            FileUtils.cp(cached_path, destination_path)
+          else
+            rndeps_log("Shared cache file #{filename} failed SHA verification. Re-downloading.")
+            File.delete(cached_path)
+            tmp_file = "#{artifacts_dir()}/reactnative-dependencies.download"
+            `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+            unless File.exist?(destination_path)
+              abort("[ReactNativeDependencies] Failed to download #{filename} from #{tarball_url}. Aborting.")
+            end
+            rndeps_log("Verifying checksum for downloaded #{filename}...")
+            if ReactNativePodsUtils.validate_tarball(destination_path, tarball_url)
+              FileUtils.cp(destination_path, cached_path)
+              rndeps_log("Saved #{filename} to shared cache (#{ReactNativePodsUtils.shared_cache_dir()})")
+            else
+              File.delete(destination_path) if File.exist?(destination_path)
+              abort("[ReactNativeDependencies] Downloaded file #{filename} failed SHA verification. Aborting.")
+            end
+          end
+        else
+          rndeps_log("Cache miss: downloading #{filename} from #{tarball_url}")
           # Download to a temporary file first so we don't cache incomplete downloads.
           tmp_file = "#{artifacts_dir()}/reactnative-dependencies.download"
-          `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+          unless File.exist?(destination_path)
+            abort("[ReactNativeDependencies] Failed to download #{filename} from #{tarball_url}. Aborting.")
+          end
+          rndeps_log("Verifying checksum for downloaded #{filename}...")
+          if ReactNativePodsUtils.validate_tarball(destination_path, tarball_url)
+            # Save to shared cache for future use
+            `mkdir -p "#{ReactNativePodsUtils.shared_cache_dir()}"`
+            FileUtils.cp(destination_path, cached_path)
+            rndeps_log("Saved #{filename} to shared cache (#{ReactNativePodsUtils.shared_cache_dir()})")
+          else
+            File.delete(destination_path) if File.exist?(destination_path)
+            abort("[ReactNativeDependencies] Downloaded file #{filename} failed SHA verification. Aborting.")
+          end
         end
 
         return destination_path

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 require 'shellwords'
+require 'digest'
 
 require_relative "./helpers.rb"
 require_relative "./jsengine.rb"
@@ -722,6 +723,51 @@ class ReactNativePodsUtils
 
         if header_mappings_dir != nil && ReactNativeCoreUtils.build_rncore_from_source()
             spec.header_mappings_dir = header_mappings_dir
+        end
+    end
+
+    # ==================== #
+    # Shared download cache #
+    # ==================== #
+
+    def self.skip_caches?
+        ENV['RCT_SKIP_CACHES'] == '1'
+    end
+
+    def self.shared_cache_dir()
+        return File.join(Dir.home, "Library", "Caches", "ReactNative")
+    end
+
+    def self.fetch_maven_sha1(tarball_url)
+        sha1 = `curl -sL "#{tarball_url}.sha1"`.strip
+        return sha1.downcase if $?.success? && sha1.match?(/\A[a-fA-F0-9]{40}\z/)
+        nil
+    end
+
+    def self.validate_tarball(path, tarball_url)
+        expected_sha1 = fetch_maven_sha1(tarball_url)
+        basename = File.basename(path)
+        if expected_sha1.nil?
+          cache_log("SHA1 not available from Maven for #{basename}. Skipping validation.")
+          return true
+        end
+        actual_sha1 = Digest::SHA1.file(path).hexdigest
+        if actual_sha1 == expected_sha1
+          cache_log("SHA1 verified for #{basename}")
+          return true
+        end
+        cache_log("SHA1 mismatch for #{basename}: expected #{expected_sha1}, got #{actual_sha1}", :error)
+        return false
+    end
+
+    def self.cache_log(message, level = :info)
+        return unless Object.const_defined?("Pod::UI")
+        prefix = '[Cache] '
+        case level
+        when :error
+            Pod::UI.puts prefix.red + message
+        else
+            Pod::UI.puts prefix.green + message
         end
     end
 end

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+require 'digest'
+
 HERMES_GITHUB_URL = "https://github.com/facebook/hermes.git"
 ENV_BUILD_FROM_SOURCE = "RCT_BUILD_HERMES_FROM_SOURCE"
 
@@ -206,16 +208,102 @@ def download_stable_hermes(react_native_path, version, configuration)
     download_hermes_tarball(react_native_path, tarball_url, version, configuration)
 end
 
-def download_hermes_tarball(react_native_path, tarball_url, version, configuration)
-    destination_path = configuration == nil ?
-        "#{artifacts_dir()}/hermes-ios-#{version}.tar.gz" :
-        "#{artifacts_dir()}/hermes-ios-#{version}-#{configuration}.tar.gz"
+def shared_cache_dir()
+    return File.join(Dir.home, "Library", "Caches", "ReactNative")
+end
 
-    unless File.exist?(destination_path)
+def fetch_maven_sha1(tarball_url)
+    sha1 = `curl -sL "#{tarball_url}.sha1"`.strip
+    return sha1.downcase if $?.success? && sha1.match?(/\A[a-fA-F0-9]{40}\z/)
+    nil
+end
+
+def skip_caches?
+    ENV['RCT_SKIP_CACHES'] == '1'
+end
+
+def validate_hermes_tarball(path, tarball_url)
+    expected_sha1 = fetch_maven_sha1(tarball_url)
+    basename = File.basename(path)
+    if expected_sha1.nil?
+      hermes_log("SHA1 not available from Maven for #{basename}. Skipping validation.", :info)
+      return true
+    end
+    actual_sha1 = Digest::SHA1.file(path).hexdigest
+    if actual_sha1 == expected_sha1
+      hermes_log("SHA1 verified for #{basename}", :info)
+      return true
+    end
+    hermes_log("SHA1 mismatch for #{basename}: expected #{expected_sha1}, got #{actual_sha1}", :error)
+    return false
+end
+
+def download_hermes_tarball(react_native_path, tarball_url, version, configuration)
+    filename = configuration == nil ?
+        "hermes-ios-#{version}.tar.gz" :
+        "hermes-ios-#{version}-#{configuration}.tar.gz"
+    destination_path = "#{artifacts_dir()}/#{filename}"
+
+    if File.exist?(destination_path)
+      hermes_log("Tarball #{filename} already exists in Pods. Skipping download.", :info)
+      return destination_path
+    end
+
+    `mkdir -p "#{artifacts_dir()}"`
+
+    if skip_caches?
+      hermes_log("RCT_SKIP_CACHES is set. Downloading #{filename} directly (bypassing shared cache).", :info)
+      tmp_file = "#{artifacts_dir()}/hermes-ios.download"
+      `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+      unless File.exist?(destination_path)
+        abort("[Hermes] Failed to download #{filename} from #{tarball_url}. Aborting.")
+      end
+      return destination_path
+    end
+
+    cached_path = File.join(shared_cache_dir(), filename)
+    if File.exist?(cached_path)
+      hermes_log("Verifying checksum for cached #{filename}...", :info)
+      if validate_hermes_tarball(cached_path, tarball_url)
+        hermes_log("Cache hit: copying #{filename} from shared cache (#{shared_cache_dir()})", :info)
+        FileUtils.cp(cached_path, destination_path)
+      else
+        hermes_log("Shared cache file #{filename} failed SHA verification. Re-downloading.", :info)
+        File.delete(cached_path)
+        tmp_file = "#{artifacts_dir()}/hermes-ios.download"
+        `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+        unless File.exist?(destination_path)
+          abort("[Hermes] Failed to download #{filename} from #{tarball_url}. Aborting.")
+        end
+        hermes_log("Verifying checksum for downloaded #{filename}...", :info)
+        if validate_hermes_tarball(destination_path, tarball_url)
+          FileUtils.cp(destination_path, cached_path)
+          hermes_log("Saved #{filename} to shared cache (#{shared_cache_dir()})", :info)
+        else
+          File.delete(destination_path) if File.exist?(destination_path)
+          abort("[Hermes] Downloaded file #{filename} failed SHA verification. Aborting.")
+        end
+      end
+    else
+      hermes_log("Cache miss: downloading #{filename} from #{tarball_url}", :info)
       # Download to a temporary file first so we don't cache incomplete downloads.
       tmp_file = "#{artifacts_dir()}/hermes-ios.download"
-      `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+      `curl -A "react-native-#{version}" "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+      unless File.exist?(destination_path)
+        abort("[Hermes] Failed to download #{filename} from #{tarball_url}. Aborting.")
+      end
+      hermes_log("Verifying checksum for downloaded #{filename}...", :info)
+      if validate_hermes_tarball(destination_path, tarball_url)
+        # Save to shared cache for future use
+        `mkdir -p "#{shared_cache_dir()}"`
+        FileUtils.cp(destination_path, cached_path)
+        hermes_log("Saved #{filename} to shared cache (#{shared_cache_dir()})", :info)
+      else
+        File.delete(destination_path) if File.exist?(destination_path)
+        abort("[Hermes] Downloaded file #{filename} failed SHA verification. Aborting.")
+      end
     end
+
     return destination_path
 end
 

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -19,6 +19,7 @@
     "clean-android": "rm -rf android/app/build",
     "prepare-ios": "node ./cli.js bootstrap ios",
     "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock RNTesterPods.xcworkspace/ ../react-native-codegen/lib/",
+    "ios:clear-prebuild-caches": "rm -rf $HOME/Library/Caches/ReactNative",
     "e2e-build-android": "../../gradlew :packages:rn-tester:android:app:installRelease -PreactNativeArchitectures=arm64-v8a",
     "e2e-build-ios": "./scripts/maestro-build-ios.sh",
     "e2e-test-android": "maestro test .maestro/ -e APP_ID=com.facebook.react.uiapp",


### PR DESCRIPTION
Summary:
Adds a shared cache layer at
  `~/Library/Caches/ReactNative/` for prebuilt iOS tarballs
   (Hermes, ReactNativeDependencies, ReactNativeCore).
  - On first download, tarballs are saved to both the local
   Pods artifacts dir **and** the shared cache.
  - On subsequent `pod install` runs, if the local Pods
  cache is empty but the shared cache has the tarball for
  that version, it is copied locally instead of
  re-downloaded from Maven.
  - Adds descriptive log messages for each scenario: local
  Pods hit, shared cache hit, and cache miss (download).

  This avoids redundant downloads when:
  - The Pods directory is deleted between installs
  - Multiple projects use the same React Native version
  - CI environments have a persistent home directory

  ## Changelog:

  [IOS] [CHANGED] - Cache prebuilt iOS binaries (Hermes,
  ReactNativeDependencies, ReactNativeCore) in
  ~/Library/Caches/ReactNative to avoid redundant downloads
   across pod installs


Test Plan:
### Cold start ==> Downloading

```
[ReactNativeDependencies] Setting up ReactNativeDependencies...
[ReactNativeDependencies] Building from source: false
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Cache miss: downloading reactnative-dependencies-0.81.6-debug.tar.gz from https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:-  0     0    0     0    0     0      0      0 --:--:-- --:- 35 18.3M   35 6580k    0     0  6386k      0  0:00:02  0:0 73 18.3M   73 13.5M    0     0  6827k      0  0:00:02  0:0100 18.3M  100 18.3M    0     0  6915k      0  0:00:02  0:00:02 --:--:-- 6914k
[ReactNativeDependencies] Saved reactnative-dependencies-0.81.6-debug.tar.gz to shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeDependencies] Cache miss: downloading reactnative-dependencies-0.81.6-release.tar.gz from https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-release.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:-  0     0    0     0    0     0      0      0 --:--:-- --:- 67  9.9M   67 6948k    0     0  6332k      0  0:00:01  0:0100  9.9M  100  9.9M    0     0  6607k      0  0:00:01  0:00:01 --:--:-- 6603k
[ReactNativeDependencies] Saved reactnative-dependencies-0.81.6-release.tar.gz to shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeDependencies] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz"}
[ReactNativeCore] Setting up ReactNativeCore...
[ReactNativeCore] Building from source: false
[ReactNativeCore] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz
[ReactNativeCore] Cache miss: downloading reactnative-core-0.81.6-debug.tar.gz from https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:-  1 78.5M    1 1557k    0     0  5035k      0  0:00:15 --:- 10 78.5M   10 8537k    0     0  6536k      0  0:00:12  0:0 19 78.5M   19 15.4M    0     0  6866k      0  0:00:11  0:0 28 78.5M   28 22.5M    0     0  6990k      0  0:00:11  0:0 37 78.5M   37 29.7M    0     0  7062k      0  0:00:11  0:0 46 78.5M   46 36.4M    0     0  7037k      0  0:00:11  0:0 55 78.5M   55 43.5M    0     0  7065k      0  0:00:11  0:0 64 78.5M   64 50.5M    0     0  7077k      0  0:00:11  0:0100 78.5M  100 78.5M    0     0  6852k      0  0:00:11  0:00:11 --:--:-- 6482k
[ReactNativeCore] Saved reactnative-core-0.81.6-debug.tar.gz to shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeCore] Cache miss: downloading reactnative-core-0.81.6-release.tar.gz from https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-release.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 26.3M  100 26.3M    0     0  5683k      0  0:00:04  0:00:04 --:--:-- 5793k
[ReactNativeCore] Saved reactnative-core-0.81.6-release.tar.gz to shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeCore] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz"}
Configuring the target with the New Architecture
[ReactNativeCore] Using React Native Core and React Native Dependencies prebuilt versions.
[Codegen] Analyzing /Users/cipolleschi/Tests/My0_81App/package.json
```

### Warn shared cache, Empty Pods dir ==> Copy

```
[ReactNativeDependencies] Setting up ReactNativeDependencies...
[ReactNativeDependencies] Building from source: false
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Cache hit: copying reactnative-dependencies-0.81.6-debug.tar.gz from shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeDependencies] Cache hit: copying reactnative-dependencies-0.81.6-release.tar.gz from shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeDependencies] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz"}
[ReactNativeCore] Setting up ReactNativeCore...
[ReactNativeCore] Building from source: false
[ReactNativeCore] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz
[ReactNativeCore] Cache hit: copying reactnative-core-0.81.6-debug.tar.gz from shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeCore] Cache hit: copying reactnative-core-0.81.6-release.tar.gz from shared cache (/Users/cipolleschi/Library/Caches/ReactNative)
[ReactNativeCore] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz"}
Configuring the target with the New Architecture
[ReactNativeCore] Using React Native Core and React Native Dependencies prebuilt versions.
[Codegen] Analyzing /Users/cipolleschi/Tests/My0_81App/package.json
...
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-debug.tar.gz already exists in Pods. Skipping download.
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-release.tar.gz already exists in Pods. Skipping download.
```

### Warm Cache, Pods folder populated ==> Nothing happens

```
[ReactNativeDependencies] Setting up ReactNativeDependencies...
[ReactNativeDependencies] Building from source: false
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-debug.tar.gz already exists in Pods. Skipping download.
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-release.tar.gz already exists in Pods. Skipping download.
[ReactNativeDependencies] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz"}
[ReactNativeCore] Setting up ReactNativeCore...
[ReactNativeCore] Building from source: false
[ReactNativeCore] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz
[ReactNativeCore] Tarball reactnative-core-0.81.6-debug.tar.gz already exists in Pods. Skipping download.
[ReactNativeCore] Tarball reactnative-core-0.81.6-release.tar.gz already exists in Pods. Skipping download.
[ReactNativeCore] Source: {http: "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-core-debug.tar.gz"}
Configuring the target with the New Architecture
[ReactNativeCore] Using React Native Core and React Native Dependencies prebuilt versions.
[Codegen] Analyzing /Users/cipolleschi/Tests/My0_81App/package.json
[Codegen] Searching for codegen-enabled libraries in the app.
[Codegen] The "codegenConfig" field is not defined in package.json. Assuming there is nothing to generate at the app level.
[Codegen] Searching for codegen-enabled libraries in react-native.config.js
[Codegen] Found react-native-safe-area-context
[Codegen] Processing safeareacontext
[Codegen] Searching for podspec in the project dependencies.
[Codegen] Supported Apple platforms: ios, macos, tvos, visionos for safeareacontext
[Codegen] Generating Native Code for safeareacontext - ios
[Codegen] Generated artifacts: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios
[Codegen] Generating RCTThirdPartyComponentsProvider.h
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTThirdPartyComponentsProvider.h
[Codegen] Generating RCTThirdPartyComponentsProvider.mm
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTThirdPartyComponentsProvider.mm
[Codegen] Generating RCTModulesProvider.h
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTModuleProviders.h
[Codegen] Generating RCTModuleProviders.mm
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTModuleProviders.mm
[Codegen] Generating RCTAppDependencyProvider
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTAppDependencyProvider.h
[Codegen] Generated artifact: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/RCTAppDependencyProvider.mm
[Codegen] Generated podspec: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/ReactAppDependencyProvider.podspec
[Codegen] Generated podspec: /Users/cipolleschi/Tests/My0_81App/ios/build/generated/ios/ReactCodegen.podspec
[Codegen] Done.
[ReactNativeDependencies] Using release tarball
[ReactNativeDependencies] Using tarball from URL: https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.6/react-native-artifacts-0.81.6-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-debug.tar.gz already exists in Pods. Skipping download.
[ReactNativeDependencies] Tarball reactnative-dependencies-0.81.6-release.tar.gz already exists in Pods. Skipping download.
Analyzing dependencies
```

Reviewed By: cortinico

Differential Revision: D105315202

Pulled By: cipolleschi


