### PR TITLE
Bump Kotlin API version from 1.9 to 2.0

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
@@ -64,7 +64,7 @@ kotlin { jvmToolchain(17) }
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    apiVersion.set(KotlinVersion.KOTLIN_1_9)
+    apiVersion.set(KotlinVersion.KOTLIN_2_0)
     // See comment above on JDK 11 support
     jvmTarget.set(JvmTarget.JVM_11)
     allWarningsAsErrors.set(

--- a/packages/gradle-plugin/settings-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/settings-plugin/build.gradle.kts
@@ -54,7 +54,7 @@ kotlin { jvmToolchain(17) }
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    apiVersion.set(KotlinVersion.KOTLIN_1_9)
+    apiVersion.set(KotlinVersion.KOTLIN_2_0)
     // See comment above on JDK 11 support
     jvmTarget.set(JvmTarget.JVM_11)
     allWarningsAsErrors.set(

--- a/packages/gradle-plugin/shared-testutil/build.gradle.kts
+++ b/packages/gradle-plugin/shared-testutil/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin { jvmToolchain(17) }
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    apiVersion.set(KotlinVersion.KOTLIN_1_9)
+    apiVersion.set(KotlinVersion.KOTLIN_2_0)
     // See comment above on JDK 11 support
     jvmTarget.set(JvmTarget.JVM_11)
     allWarningsAsErrors.set(

--- a/packages/gradle-plugin/shared/build.gradle.kts
+++ b/packages/gradle-plugin/shared/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin { jvmToolchain(17) }
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    apiVersion.set(KotlinVersion.KOTLIN_1_9)
+    apiVersion.set(KotlinVersion.KOTLIN_2_0)
     // See comment above on JDK 11 support
     jvmTarget.set(JvmTarget.JVM_11)
     allWarningsAsErrors.set(


### PR DESCRIPTION
## Summary:

Kotlin 2.2.0 deprecated API versions 1.8 and 1.9, which causes a build failure when combined with -Werror. Bump apiVersion to KOTLIN_2_0 in all four gradle-plugin build files.

## Changelog:

[ANDROID] [CHANGED] - Bumped min Kotlin version to 2.0+

## Test Plan:

CI