### PR TITLE
Remove enableFabricRenderer() call from UIManagerModuleConstantsHelper

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager
 import androidx.annotation.VisibleForTesting
 import com.facebook.common.logging.FLog
 import com.facebook.react.common.build.ReactBuildConfig
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer
 import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags.useFabricInterop
 import java.util.Locale
 
@@ -144,7 +143,7 @@ internal object UIManagerModuleConstantsHelper {
     var viewManagerBubblingEvents: MutableMap<String, Any>? =
         viewManager.exportedCustomBubblingEventTypeConstants
     if (viewManagerBubblingEvents != null) {
-      if (enableFabricRenderer() && useFabricInterop()) {
+      if (useFabricInterop()) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.
@@ -161,7 +160,7 @@ internal object UIManagerModuleConstantsHelper {
         viewManager.exportedCustomDirectEventTypeConstants
     validateDirectEventNames(viewManager.getName(), viewManagerDirectEvents)
     if (viewManagerDirectEvents != null) {
-      if (enableFabricRenderer() && useFabricInterop()) {
+      if (useFabricInterop()) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.


### PR DESCRIPTION
Summary:
The `ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()` flag is being deleted; it always returns true on the canary release stage. Inline `true` and simplify the surrounding `&&` expressions:

- Two `if (enableFabricRenderer() && useFabricInterop())` checks become `if (useFabricInterop())`.
- Remove the now-unused import.

Behavior is unchanged.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D105229106


