### PR TITLE
Remove enableFabricRenderer() call from InteropModuleRegistry

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
@@ -10,7 +10,6 @@ package com.facebook.react.bridge.interop
 import com.facebook.react.bridge.JavaScriptModule
 import com.facebook.react.common.annotations.internal.InteropLegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer
 import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags.useFabricInterop
 
 /**
@@ -44,8 +43,7 @@ internal class InteropModuleRegistry {
     }
   }
 
-  private fun checkReactFeatureFlagsConditions(): Boolean =
-      enableFabricRenderer() && useFabricInterop()
+  private fun checkReactFeatureFlagsConditions(): Boolean = useFabricInterop()
 
   private companion object {
     init {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager
 import androidx.annotation.VisibleForTesting
 import com.facebook.common.logging.FLog
 import com.facebook.react.common.build.ReactBuildConfig
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer
 import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags.useFabricInterop
 import java.util.Locale
 
@@ -144,7 +143,7 @@ internal object UIManagerModuleConstantsHelper {
     var viewManagerBubblingEvents: MutableMap<String, Any>? =
         viewManager.exportedCustomBubblingEventTypeConstants
     if (viewManagerBubblingEvents != null) {
-      if (enableFabricRenderer() && useFabricInterop()) {
+      if (useFabricInterop()) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.
@@ -161,7 +160,7 @@ internal object UIManagerModuleConstantsHelper {
         viewManager.exportedCustomDirectEventTypeConstants
     validateDirectEventNames(viewManager.getName(), viewManagerDirectEvents)
     if (viewManagerDirectEvents != null) {
-      if (enableFabricRenderer() && useFabricInterop()) {
+      if (useFabricInterop()) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
@@ -48,7 +48,7 @@ class InteropModuleRegistryTest {
 
   @Test
   fun getInteropModule_withRegisteredClassAndInvalidFlags_returnsNull() {
-    overrideFeatureFlags(false, false)
+    overrideFeatureFlags(false)
     underTest.registerInteropModule(RCTEventEmitter::class.java, FakeRCTEventEmitter())
 
     val interopModule = underTest.getInteropModule(RCTEventEmitter::class.java)
@@ -58,7 +58,7 @@ class InteropModuleRegistryTest {
 
   @Test
   fun getInteropModule_withRegisteredClassAndValidFlags_returnsInteropModule() {
-    overrideFeatureFlags(true, true)
+    overrideFeatureFlags(true)
     underTest.registerInteropModule(RCTEventEmitter::class.java, FakeRCTEventEmitter())
 
     val interopModule = underTest.getInteropModule(RCTEventEmitter::class.java)
@@ -68,18 +68,16 @@ class InteropModuleRegistryTest {
 
   @Test
   fun getInteropModule_withUnregisteredClass_returnsNull() {
-    overrideFeatureFlags(true, true)
+    overrideFeatureFlags(true)
     val missingModule = underTest.getInteropModule(FakeJavaScriptModule::class.java)
 
     assertThat(missingModule).isNull()
   }
 
-  private fun overrideFeatureFlags(useFabricInterop: Boolean, enableFabricRenderer: Boolean) {
+  private fun overrideFeatureFlags(useFabricInterop: Boolean) {
     ReactNativeFeatureFlags.override(
         object : ReactNativeFeatureFlagsDefaults() {
           override fun useFabricInterop(): Boolean = useFabricInterop
-
-          override fun enableFabricRenderer(): Boolean = enableFabricRenderer
         }
     )
   }


### PR DESCRIPTION
Summary:
The `ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()` flag is being deleted; it always returns true on the canary release stage.

Production:
- `checkReactFeatureFlagsConditions` now returns `useFabricInterop()` only.
- Remove the now-unused `enableFabricRenderer` import.

Test:
- `overrideFeatureFlags` test helper drops the `enableFabricRenderer` parameter.
- Existing test cases continue to exercise both true/false branches of `useFabricInterop`.

Behavior is unchanged.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D105229610


