### PR TITLE
Remove enableFabricRenderer() call from DefaultNewArchitectureEntryPoint (#56854)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -114,9 +114,7 @@ public object DefaultNewArchitectureEntryPoint {
   internal fun loadWithFeatureFlags(featureFlags: ReactNativeFeatureFlagsProvider) {
     ReactNativeFeatureFlags.override(featureFlags)
 
-    privateFabricEnabled = featureFlags.enableFabricRenderer()
     privateTurboModulesEnabled = featureFlags.useTurboModules()
-    privateConcurrentReactEnabled = featureFlags.enableFabricRenderer()
     privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
 
     val (isValid, errorMessage) =
@@ -136,7 +134,7 @@ public object DefaultNewArchitectureEntryPoint {
 
   @JvmStatic
   public val fabricEnabled: Boolean
-    get() = privateFabricEnabled
+    get() = true
 
   private var privateTurboModulesEnabled: Boolean = false
 
@@ -148,7 +146,7 @@ public object DefaultNewArchitectureEntryPoint {
 
   @JvmStatic
   public val concurrentReactEnabled: Boolean
-    get() = privateConcurrentReactEnabled
+    get() = true
 
   private var privateBridgelessEnabled: Boolean = false
 


### PR DESCRIPTION
Summary:

The `enableFabricRenderer()` flag is being deleted; it always returns true on the canary release stage. In `loadWithFeatureFlags`, replace both `featureFlags.enableFabricRenderer()` reads with the literal `true` for `privateFabricEnabled` and `privateConcurrentReactEnabled`.

Behavior is unchanged.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D105229919


