### PR TITLE
Remove enableFabricRenderer() call from ReactInstanceManager (#56855)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -75,7 +75,6 @@ import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.interfaces.TaskInterface;
 import com.facebook.react.internal.AndroidChoreographerProvider;
 import com.facebook.react.internal.ChoreographerProvider;
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -320,8 +319,6 @@ public class ReactInstanceManager {
         Activity currentActivity = getCurrentActivity();
         if (currentActivity != null) {
           ReactRootView rootView = new ReactRootView(currentActivity);
-          boolean isFabric = ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer();
-          rootView.setIsFabric(isFabric);
           rootView.startReactApplication(ReactInstanceManager.this, appKey, new Bundle());
           return rootView;
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -114,9 +114,7 @@ public object DefaultNewArchitectureEntryPoint {
   internal fun loadWithFeatureFlags(featureFlags: ReactNativeFeatureFlagsProvider) {
     ReactNativeFeatureFlags.override(featureFlags)
 
-    privateFabricEnabled = featureFlags.enableFabricRenderer()
     privateTurboModulesEnabled = featureFlags.useTurboModules()
-    privateConcurrentReactEnabled = featureFlags.enableFabricRenderer()
     privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
 
     val (isValid, errorMessage) =
@@ -136,7 +134,7 @@ public object DefaultNewArchitectureEntryPoint {
 
   @JvmStatic
   public val fabricEnabled: Boolean
-    get() = privateFabricEnabled
+    get() = true
 
   private var privateTurboModulesEnabled: Boolean = false
 
@@ -148,7 +146,7 @@ public object DefaultNewArchitectureEntryPoint {
 
   @JvmStatic
   public val concurrentReactEnabled: Boolean
-    get() = privateConcurrentReactEnabled
+    get() = true
 
   private var privateBridgelessEnabled: Boolean = false
 


### PR DESCRIPTION
Summary:

The `ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()` flag is being deleted; it always returns true on the canary release stage. In `createRootView`, inline `setIsFabric(true)` and remove the now-unused import.

Behavior is unchanged.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D105230246


