### PR TITLE
Inline true in ReactActivityDelegate.isFabricEnabled() (#56857)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -309,7 +309,7 @@ public class ReactActivityDelegate {
    * @return true if Fabric is enabled for this Activity, false otherwise.
    */
   protected boolean isFabricEnabled() {
-    return ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer();
+    return true;
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -75,7 +75,6 @@ import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.interfaces.TaskInterface;
 import com.facebook.react.internal.AndroidChoreographerProvider;
 import com.facebook.react.internal.ChoreographerProvider;
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -320,8 +319,6 @@ public class ReactInstanceManager {
         Activity currentActivity = getCurrentActivity();
         if (currentActivity != null) {
           ReactRootView rootView = new ReactRootView(currentActivity);
-          boolean isFabric = ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer();
-          rootView.setIsFabric(isFabric);
           rootView.startReactApplication(ReactInstanceManager.this, appKey, new Bundle());
           return rootView;
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -114,9 +114,7 @@ public object DefaultNewArchitectureEntryPoint {
   internal fun loadWithFeatureFlags(featureFlags: ReactNativeFeatureFlagsProvider) {
     ReactNativeFeatureFlags.override(featureFlags)
 
-    privateFabricEnabled = featureFlags.enableFabricRenderer()
     privateTurboModulesEnabled = featureFlags.useTurboModules()
-    privateConcurrentReactEnabled = featureFlags.enableFabricRenderer()
     privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
 
     val (isValid, errorMessage) =
@@ -136,7 +134,7 @@ public object DefaultNewArchitectureEntryPoint {
 
   @JvmStatic
   public val fabricEnabled: Boolean
-    get() = privateFabricEnabled
+    get() = true
 
   private var privateTurboModulesEnabled: Boolean = false
 
@@ -148,7 +146,7 @@ public object DefaultNewArchitectureEntryPoint {
 
   @JvmStatic
   public val concurrentReactEnabled: Boolean
-    get() = privateConcurrentReactEnabled
+    get() = true
 
   private var privateBridgelessEnabled: Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -858,11 +858,6 @@ public class ReactHostImpl(
       )
 
       Assertions.assertCondition(
-          ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer(),
-          "enableFabricRenderer FeatureFlag must be set to start ReactNative.",
-      )
-
-      Assertions.assertCondition(
           ReactNativeNewArchitectureFeatureFlags.useTurboModules(),
           "useTurboModules FeatureFlag must be set to start ReactNative.",
       )


### PR DESCRIPTION
Summary:

The `ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()` flag is being deleted; it always returns true on the canary release stage. The default body of `ReactActivityDelegate.isFabricEnabled()` reads the flag — change it to `return true` directly.

The method itself is preserved because it is a polymorphic `protected` hook that subclasses (e.g., `DefaultReactActivityDelegate`) override to provide per-activity behavior.

Behavior is unchanged.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D105230961


