### PR TITLE
Inline true in ReactDelegate.isFabricEnabled initializer (#56859)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
@@ -49,9 +49,7 @@ public open class ReactDelegate {
    *
    * @return true if Fabric is enabled for this Activity, false otherwise.
    */
-  protected var isFabricEnabled: Boolean =
-      ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()
-    private set
+  protected val isFabricEnabled: Boolean = true
 
   /**
    * Do not use this constructor as it's not accounting for New Architecture at all. You should use
@@ -95,7 +93,6 @@ public open class ReactDelegate {
       launchOptions: Bundle?,
       fabricEnabled: Boolean,
   ) {
-    this.isFabricEnabled = fabricEnabled
     this.activity = activity
     this.mainComponentName = appKey
     this.launchOptions = launchOptions


### PR DESCRIPTION
Summary:

The `ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()` flag is being deleted; it always returns true on the canary release stage. The default initializer of `ReactDelegate.isFabricEnabled` reads the flag — change it to `true` directly.

The field itself is preserved because it can be set by the deprecated `(activity, reactNativeHost, appKey, launchOptions, fabricEnabled)` constructor that lets callers override the default.

Behavior is unchanged.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D105231216


