### PR TITLE
Delete enableFabricRenderer() from ReactNativeNewArchitectureFeatureFlags (#56860)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
@@ -49,9 +49,7 @@ public open class ReactDelegate {
    *
    * @return true if Fabric is enabled for this Activity, false otherwise.
    */
-  protected var isFabricEnabled: Boolean =
-      ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()
-    private set
+  protected val isFabricEnabled: Boolean = true
 
   /**
    * Do not use this constructor as it's not accounting for New Architecture at all. You should use
@@ -95,7 +93,6 @@ public open class ReactDelegate {
       launchOptions: Bundle?,
       fabricEnabled: Boolean,
   ) {
-    this.isFabricEnabled = fabricEnabled
     this.activity = activity
     this.mainComponentName = appKey
     this.launchOptions = launchOptions

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
@@ -36,18 +36,6 @@ public object ReactNativeNewArchitectureFeatureFlags {
   }
 
   @JvmStatic
-  public fun enableFabricRenderer(): Boolean {
-    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
-      Assertions.assertCondition(
-          ReactNativeFeatureFlags.enableFabricRenderer(),
-          "ReactNativeFeatureFlags.enableFabricRenderer() should be set to TRUE when Strict Mode is enabled",
-      )
-      return true
-    }
-    return ReactNativeFeatureFlags.enableFabricRenderer()
-  }
-
-  @JvmStatic
   public fun useFabricInterop(): Boolean {
     if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       Assertions.assertCondition(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
@@ -25,8 +25,6 @@ public open class ReactNativeNewArchitectureFeatureFlagsDefaults() :
 
   override fun enableBridgelessArchitecture(): Boolean = true
 
-  override fun enableFabricRenderer(): Boolean = true
-
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
 
   override fun useTurboModuleInterop(): Boolean = true


### PR DESCRIPTION
Summary:

The `enableFabricRenderer()` flag is being removed entirely; it was always set to true in the canary release stage. All callers of `ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()` were inlined in earlier diffs.

This diff:
- Removes the wrapper method `ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()`.
- Removes the `override fun enableFabricRenderer(): Boolean = true` from `ReactNativeNewArchitectureFeatureFlagsDefaults`.

Both classes are non-`generated`, so they are edited directly. The next diff will remove the underlying `ReactNativeFeatureFlags.enableFabricRenderer()` API by regenerating the codegen output.

Behavior is unchanged.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D105231777


