### PR TITLE
Remove makeKeyWindow call in RCTLogBoxView dealloc

### DIFF
--- a/packages/react-native/React/CoreModules/RCTLogBoxView.mm
+++ b/packages/react-native/React/CoreModules/RCTLogBoxView.mm
@@ -83,9 +83,7 @@
 
 - (void)dealloc
 {
-#if !TARGET_OS_MACCATALYST // sharedApplication.delegate is not available on Mac Catalyst
-  [RCTSharedApplication().delegate.window makeKeyWindow];
-#endif
+
 }
 
 - (void)show


### PR DESCRIPTION
This pull request makes a minor cleanup to the [RCTLogBoxView.mm](vscode-file://vscode-app/c:/Users/agloryvimalabai/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file by removing code in the dealloc method that referenced the application delegate and window. This change eliminates unnecessary code, particularly for Mac Catalyst targets.

Removed the call to [RCTSharedApplication().delegate.window makeKeyWindow] in the dealloc method, cleaning up platform-specific code and improving maintainability. The conditional block (including the Mac Catalyst guard) is deleted, leaving the dealloc implementation empty and removing window manipulation at teardown.
Summary
Removes unsafe window manipulation from [RCTLogBoxView](vscode-file://vscode-app/c:/Users/agloryvimalabai/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)’s dealloc method. This prevents a crash when using SceneDelegate, as [AppDelegate.window](vscode-file://vscode-app/c:/Users/agloryvimalabai/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) may not exist in modern iOS app setups.

Changelog:
[iOS] [Fixed] - Remove unsafe window manipulation in [RCTLogBoxView](vscode-file://vscode-app/c:/Users/agloryvimalabai/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) dealloc to prevent crash with SceneDelegate

Test Plan
Verified that the app no longer crashes on teardown when using SceneDelegate.
Ran the full test suite; no regressions related to LogBox or RCTLogBoxView.
Manual test: Opened and dismissed LogBox in a SceneDelegate-based app without crash.
This pull request includes a small change to the [RCTLogBoxView.mm](vscode-file://vscode-app/c:/Users/agloryvimalabai/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file, specifically in the dealloc method. The code that previously made the main window key again on deallocation (except for Mac Catalyst) has been removed, simplifying the cleanup logic.

Updated todo list

GPT-4.1 • 0x