### PR TITLE
fix: align AccessibilityRole TypeScript definitions

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.d.ts
@@ -188,6 +188,7 @@ export interface AccessibilityValue {
 export type AccessibilityRole =
   | 'none'
   | 'button'
+  | 'dropdownlist'
   | 'togglebutton'
   | 'link'
   | 'search'
@@ -215,7 +216,16 @@ export type AccessibilityRole =
   | 'tablist'
   | 'timer'
   | 'list'
-  | 'toolbar';
+  | 'toolbar'
+  | 'grid'
+  | 'pager'
+  | 'scrollview'
+  | 'horizontalscrollview'
+  | 'viewgroup'
+  | 'webview'
+  | 'drawerlayout'
+  | 'slidingdrawer'
+  | 'iconmenu';
 
 export interface AccessibilityPropsAndroid {
   /**

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -543,6 +543,8 @@ export class TouchableOpacityTest extends React.Component {
           accessibilityLabelledBy="my-label-text"
           aria-labelledby="my-label-text"
         />
+        <TouchableOpacity accessibilityRole="grid" />
+        <TouchableOpacity accessibilityRole="pager" />
         <TouchableOpacity
           // @ts-expect-error - expected boolean value
           focusable={1}


### PR DESCRIPTION
## Summary

- Align `ViewAccessibility.d.ts`'s `AccessibilityRole` union with the roles already supported by the Flow type and generated API snapshot.
- Add TypeScript type coverage for `grid` and `pager`, which are among the roles missing from this declaration.

## Changelog:

[General] [Fixed] - Align TypeScript accessibility role definitions with supported React Native accessibility roles

## Test plan

- `npx prettier --check packages/react-native/Libraries/Components/View/ViewAccessibility.d.ts packages/react-native/types/__typetests__/index.tsx`
- `npm run test-typescript -- --pretty false`
- `npm run test-generated-typescript -- --pretty false`
