### PR TITLE
fix: avoid bare DebuggerInternal access

### DIFF
--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -384,12 +384,7 @@ class MessageQueue {
   // The parameter DebuggerInternal.shouldPauseOnThrow is used to check before catching all exceptions and
   // can be configured by the VM or any Inspector
   __shouldPauseOnThrow(): boolean {
-    return (
-      // $FlowFixMe[cannot-resolve-name]
-      typeof DebuggerInternal !== 'undefined' &&
-      // $FlowFixMe[cannot-resolve-name]
-      DebuggerInternal.shouldPauseOnThrow === true
-    );
+    return global.DebuggerInternal?.shouldPauseOnThrow === true;
   }
 
   __callReactNativeMicrotasks() {

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
@@ -42,6 +42,7 @@ const assertQueue = (
 describe('MessageQueue', () => {
   beforeEach(() => {
     jest.resetModules();
+    delete global.DebuggerInternal;
     MessageQueue = require('../MessageQueue').default;
     MessageQueueTestModule = require('../__mocks__/MessageQueueTestModule');
     queue = new MessageQueue();
@@ -161,6 +162,18 @@ describe('MessageQueue', () => {
     queue.registerLazyCallableModule(name, factory);
     queue.callFunctionReturnFlushedQueue(name, 'dummy', []);
     expect(queue.__shouldPauseOnThrow).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not pause on throw when DebuggerInternal is unavailable', () => {
+    expect(queue.__shouldPauseOnThrow()).toBe(false);
+  });
+
+  it('should pause on throw when DebuggerInternal enables it', () => {
+    global.DebuggerInternal = {
+      shouldPauseOnThrow: true,
+    };
+
+    expect(queue.__shouldPauseOnThrow()).toBe(true);
   });
 
   it('should check if the global error handler is overridden by the DebuggerInternal object', () => {


### PR DESCRIPTION
## Summary

Fixes one of the release bundle warnings from #45636 by reading `DebuggerInternal` through `global` instead of referencing the bare global binding. This keeps the same pause-on-throw behavior while avoiding Hermes warning about an undeclared `DebuggerInternal` variable in release bundles.

Changelog: [General][Fixed] - Avoid bare DebuggerInternal access in MessageQueue

## Test Plan

Using Node 22.22.0 because current main requires Node >=20.19.4 or >=22.13.0.

- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn jest packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js --runInBand`
- `yarn prettier --check packages/react-native/Libraries/BatchedBridge/MessageQueue.js packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js`
- `yarn eslint packages/react-native/Libraries/BatchedBridge/MessageQueue.js packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js`
- `yarn flow focus-check packages/react-native/Libraries/BatchedBridge/MessageQueue.js packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js`
- `yarn flow check --lazy --timeout 90`

Note: `yarn flow check --lazy --max-warnings 0 --timeout 90` was also tried, but it fails on existing unrelated libdef unused-suppression warnings in `packages/react-native/flow/prettier.js.flow` and `packages/react-native/flow/streams.js.flow`.

