### PR TITLE
test: add KeyboardAvoidingView multiline repro

### DIFF
--- a/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
+++ b/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
@@ -20,6 +20,7 @@ import {
   KeyboardAvoidingView,
   Modal,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -199,6 +200,34 @@ const KeyboardAvoidingContentContainerStyle = () => {
   );
 };
 
+const KeyboardAvoidingMultilineTextInput = () => {
+  const [message, setMessage] = useState('');
+
+  return (
+    <KeyboardAvoidingView
+      behavior="padding"
+      keyboardVerticalOffset={64}
+      style={styles.multilineContainer}>
+      <ScrollView
+        contentContainerStyle={styles.multilineContent}
+        keyboardShouldPersistTaps="handled">
+        {Array.from({length: 10}, (_, index) => (
+          <Text key={index} style={styles.messageText}>
+            Message {index + 1}
+          </Text>
+        ))}
+        <TextInput
+          multiline
+          onChangeText={setMessage}
+          placeholder="Type something here..."
+          style={styles.multilineTextInput}
+          value={message}
+        />
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+};
+
 const styles = StyleSheet.create({
   outerContainer: {
     flex: 1,
@@ -243,6 +272,22 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: 'blue',
   },
+  multilineContainer: {
+    flex: 1,
+  },
+  multilineContent: {
+    padding: 12,
+  },
+  messageText: {
+    fontSize: 20,
+    padding: 40,
+  },
+  multilineTextInput: {
+    borderRadius: 5,
+    borderWidth: 1,
+    minHeight: 96,
+    padding: 8,
+  },
 });
 
 exports.title = 'KeyboardAvoidingView';
@@ -277,6 +322,14 @@ exports.examples = [
     title: 'Keyboard Avoiding View with contentContainerStyle',
     render(): React.Node {
       return <KeyboardAvoidingContentContainerStyle />;
+    },
+  },
+  {
+    title: 'Keyboard Avoiding View with multiline TextInput in ScrollView',
+    description:
+      'Reproduces the nested ScrollView and multiline TextInput layout from issue #16826.',
+    render(): React.Node {
+      return <KeyboardAvoidingMultilineTextInput />;
     },
   },
 ] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
+++ b/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
@@ -326,8 +326,9 @@ exports.examples = [
   },
   {
     title: 'Keyboard Avoiding View with multiline TextInput in ScrollView',
+    // Regression coverage for https://github.com/facebook/react-native/issues/16826.
     description:
-      'Reproduces the nested ScrollView and multiline TextInput layout from issue #16826.',
+      'Keeps a multiline TextInput visible when it grows inside a nested ScrollView.',
     render(): React.Node {
       return <KeyboardAvoidingMultilineTextInput />;
     },


### PR DESCRIPTION
## Summary

Adds an RNTester example that reproduces the layout from #16826: a `KeyboardAvoidingView` wrapping a `ScrollView` with a multiline `TextInput` at the bottom. This does not claim to fix the underlying iOS keyboard avoidance behavior; it gives maintainers and contributors a concrete in-tree case to validate the issue and future fixes.

Changelog: [INTERNAL] - Add KeyboardAvoidingView multiline TextInput repro to RNTester

## Test Plan

Using Node 22.22.0 because current main requires Node >=20.19.4 or >=22.13.0.

- `yarn prettier --check packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js`
- `yarn eslint packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js`
- `yarn flow focus-check packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js`
