### PR TITLE
remove AnimatedPropsRegistry entries on node disconnect (#56876)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -257,6 +257,13 @@ void NativeAnimatedNodesManager::disconnectAnimatedNodeFromView(
   if (node != nullptr) {
     node->disconnectFromView(viewTag);
     if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+      // Remove from AnimatedPropsRegistry to prevent unbounded memory growth
+      // on long-lived surfaces. connectedRootTag() is the surfaceId set at
+      // node creation time — no weak_ptr lock needed.
+      if (auto animationBackend = animationBackend_.lock()) {
+        animationBackend->clearRegistryForTag(
+            node->connectedRootTag(), viewTag);
+      }
       node->disconnectFromShadowNodeFamily();
     }
     {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.cpp
@@ -60,7 +60,7 @@ std::pair<
     SnapshotMap&>
 AnimatedPropsRegistry::getMap(SurfaceId surfaceId) {
   auto lock = std::lock_guard(mutex_);
-  auto& [pendingMap, map, pendingFamilies, families] =
+  auto& [pendingMap, map, pendingFamilies, families, pendingRemovals] =
       surfaceContexts_[surfaceId];
 
   for (auto& family : pendingFamilies) {
@@ -88,6 +88,11 @@ AnimatedPropsRegistry::getMap(SurfaceId surfaceId) {
   pendingMap.clear();
   pendingFamilies.clear();
 
+  for (auto& tag : pendingRemovals) {
+    map.erase(tag);
+  }
+  pendingRemovals.clear();
+
   return {families, map};
 }
 
@@ -104,6 +109,14 @@ void AnimatedPropsRegistry::clear(SurfaceId surfaceId) {
 void AnimatedPropsRegistry::clearOnSurfaceStop(SurfaceId surfaceId) {
   auto lock = std::lock_guard(mutex_);
   surfaceContexts_.erase(surfaceId);
+}
+
+void AnimatedPropsRegistry::clearRegistryForTag(SurfaceId surfaceId, Tag tag) {
+  auto lock = std::lock_guard(mutex_);
+  if (auto it = surfaceContexts_.find(surfaceId);
+      it != surfaceContexts_.end()) {
+    it->second.pendingRemovals.insert(tag);
+  }
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
@@ -25,6 +25,7 @@ struct PropsSnapshot {
 struct SurfaceContext {
   std::unordered_map<Tag, std::unique_ptr<PropsSnapshot>> pendingMap, map;
   std::unordered_set<std::shared_ptr<const ShadowNodeFamily>> pendingFamilies, families;
+  std::unordered_set<Tag> pendingRemovals;
 };
 
 struct SurfaceUpdates {
@@ -35,11 +36,24 @@ struct SurfaceUpdates {
 
 using SnapshotMap = std::unordered_map<Tag, std::unique_ptr<PropsSnapshot>>;
 
+// Threading model:
+// - UI thread writes to pending* containers (update(), clearRegistryForTag())
+// - Commit thread drains pending* into active containers in getMap(), then
+//   returns references for safe iteration by the commit hook.
+// - The mutex protects the handoff. After getMap() returns, only the commit
+//   thread reads map/families, while the UI thread only writes pending*.
 class AnimatedPropsRegistry {
  public:
+  // UI thread (animation frame). Writes to pending* containers.
   void update(const std::unordered_map<SurfaceId, SurfaceUpdates> &surfaceUpdates);
+  // UI thread (node disconnect). Writes to pendingRemovals.
+  void clearRegistryForTag(SurfaceId surfaceId, Tag tag);
+  // Commit/JS thread (flush at completeSurface and after animation end).
   void clear(SurfaceId surfaceId);
+  // JS thread (surface teardown).
   void clearOnSurfaceStop(SurfaceId surfaceId);
+  // JS thread (commit hook). Drains all pending* into active
+  // containers and returns references for iteration.
   std::pair<std::unordered_set<std::shared_ptr<const ShadowNodeFamily>> &, SnapshotMap &> getMap(SurfaceId surfaceId);
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -261,6 +261,10 @@ void AnimationBackend::clearRegistryOnSurfaceStop(SurfaceId surfaceId) {
   animatedPropsRegistry_->clearOnSurfaceStop(surfaceId);
 }
 
+void AnimationBackend::clearRegistryForTag(SurfaceId surfaceId, Tag tag) {
+  animatedPropsRegistry_->clearRegistryForTag(surfaceId, tag);
+}
+
 void AnimationBackend::registerJSInvoker(
     std::shared_ptr<CallInvoker> jsInvoker) {
   if (!jsInvoker_) {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -56,6 +56,7 @@ class AnimationBackend : public UIManagerAnimationBackend {
   void requestAsyncFlushForSurfaces(const std::set<SurfaceId> &surfaces);
   void clearRegistry(SurfaceId surfaceId) override;
   void clearRegistryOnSurfaceStop(SurfaceId surfaceId) override;
+  void clearRegistryForTag(SurfaceId surfaceId, Tag tag) override;
   void registerJSInvoker(std::shared_ptr<CallInvoker> jsInvoker) override;
 
   void onAnimationFrame(AnimationTimestamp timestamp) override;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
@@ -31,6 +31,7 @@ class UIManagerAnimationBackend {
   virtual void stop(CallbackId callbackId) = 0;
   virtual void clearRegistry(SurfaceId surfaceId) = 0;
   virtual void clearRegistryOnSurfaceStop(SurfaceId surfaceId) = 0;
+  virtual void clearRegistryForTag(SurfaceId surfaceId, Tag tag) = 0;
   virtual void trigger() = 0;
   virtual void pushAnimationMutations(const Callback &callback) = 0;
   virtual void registerJSInvoker(std::shared_ptr<CallInvoker> jsInvoker) = 0;


### PR DESCRIPTION
Summary:

## Changelog:

[Internal] [Changed] - Remove AnimatedPropsRegistry entries on node disconnect

AnimatedPropsRegistry accumulates (SurfaceId, Tag) → PropsSnapshot entries
that are never cleaned up when animated nodes are disconnected from their views.
For long-lived surfaces like Feed, this causes unbounded memory growth
proportional to the number of animated views ever created (not concurrently
active). Each leaked entry retains a PropsSnapshot (BaseViewProps +
folly::dynamic) and a shared_ptr<ShadowNodeFamily> that keeps the entire
view subtree alive.

The fix adds AnimatedPropsRegistry::remove(surfaceId, tag) and calls it
from NativeAnimatedNodesManager::disconnectAnimatedNodeFromView — the
moment we know no animation will target that view tag anymore. The family's
surfaceId is read before the weak_ptr is reset.

This addresses the remaining OOM regression in the shared animated
backend experiment.

Differential Revision: D105590609


