### PR TITLE
Fix HermesSamplingProfiler JNI 'disable' method mapping

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/HermesSamplingProfiler.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/HermesSamplingProfiler.cpp
@@ -34,7 +34,7 @@ void HermesSamplingProfiler::dumpSampledTraceToFile(
 void HermesSamplingProfiler::registerNatives() {
   javaClassLocal()->registerNatives({
       makeNativeMethod("enable", HermesSamplingProfiler::enable),
-      makeNativeMethod("disable", HermesSamplingProfiler::enable),
+      makeNativeMethod("disable", HermesSamplingProfiler::disable),
       makeNativeMethod(
           "dumpSampledTraceToFile",
           HermesSamplingProfiler::dumpSampledTraceToFile),


### PR DESCRIPTION
## Summary
- Fix a bug where the JNI `disable` method was incorrectly mapped to `::enable` instead of `::disable`

## Test plan
- [ ] Verify the fix compiles correctly
- [ ] Confirm `HermesSamplingProfiler.disable()` now correctly calls `disable` instead of `enable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)