### PR TITLE
Fix Android Text accessibility leaking style spans

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -12,14 +12,7 @@ import android.os.Bundle
 import android.text.Layout
 import android.text.SpannableString
 import android.text.Spanned
-import android.text.style.AbsoluteSizeSpan
-import android.text.style.BackgroundColorSpan
 import android.text.style.ClickableSpan
-import android.text.style.ForegroundColorSpan
-import android.text.style.StrikethroughSpan
-import android.text.style.StyleSpan
-import android.text.style.URLSpan
-import android.text.style.UnderlineSpan
 import android.view.View
 import android.widget.TextView
 import androidx.core.view.ViewCompat
@@ -28,18 +21,7 @@ import androidx.core.view.accessibility.AccessibilityNodeProviderCompat
 import com.facebook.react.R
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.uimanager.ReactAccessibilityDelegate
-import com.facebook.react.views.text.internal.span.CustomLetterSpacingSpan
-import com.facebook.react.views.text.internal.span.CustomLineHeightSpan
-import com.facebook.react.views.text.internal.span.CustomStyleSpan
-import com.facebook.react.views.text.internal.span.ReactAbsoluteSizeSpan
-import com.facebook.react.views.text.internal.span.ReactBackgroundColorSpan
 import com.facebook.react.views.text.internal.span.ReactClickableSpan
-import com.facebook.react.views.text.internal.span.ReactForegroundColorSpan
-import com.facebook.react.views.text.internal.span.ReactLinkSpan
-import com.facebook.react.views.text.internal.span.ReactOpacitySpan
-import com.facebook.react.views.text.internal.span.ReactStrikethroughSpan
-import com.facebook.react.views.text.internal.span.ReactUnderlineSpan
-import com.facebook.react.views.text.internal.span.ShadowStyleSpan
 
 @OptIn(UnstableReactNativeAPI::class)
 internal class ReactTextViewAccessibilityDelegate(
@@ -208,7 +190,7 @@ internal class ReactTextViewAccessibilityDelegate(
     // PreparedLayoutTextView isn't actually a TextView, so we need to teach it about its text that
     // it is holding so TalkBack knows what to announce when focusing it.
     val accessibilityText = if (host is PreparedLayoutTextView) host.text else info.text
-    info.text = accessibilityText.toAccessibilityTextWithoutVisualSpans()
+    info.text = accessibilityText.toAccessibilityTextWithClickableSpans()
   }
 
   @Suppress("DEPRECATION")
@@ -383,42 +365,52 @@ private fun isWholeTextSingleLink(text: Spanned, spans: Array<ClickableSpan>): B
   return start == 0 && end == text.length
 }
 
-private fun CharSequence?.toAccessibilityTextWithoutVisualSpans(): CharSequence? {
-  if (this !is Spanned) {
-    return this
+private const val PARCEL_SAFE_TEXT_LENGTH = 100_000
+
+private fun CharSequence?.toAccessibilityTextWithClickableSpans(): CharSequence? {
+  if (this == null) {
+    return null
   }
 
-  return SpannableString(this).apply {
-    getSpans(0, length, Any::class.java)
-        .filter { isVisualSpanForAccessibility(it) }
-        .forEach { removeSpan(it) }
+  val trimmedText = toString().trimToParcelableSize()
+  if (this !is Spanned) {
+    return trimmedText
+  }
+
+  val retainedLength = trimmedText.length
+  val clickableSpans =
+      getSpans(0, length, ClickableSpan::class.java).filter { span ->
+        val start = getSpanStart(span)
+        val end = getSpanEnd(span)
+        start >= 0 && end >= 0 && start != end && start < retainedLength && end > 0
+      }
+
+  if (clickableSpans.isEmpty()) {
+    return trimmedText
+  }
+
+  val sourceText = this
+  return SpannableString(trimmedText).apply {
+    for (span in clickableSpans) {
+      val start = sourceText.getSpanStart(span).coerceAtLeast(0)
+      val end = sourceText.getSpanEnd(span).coerceAtMost(retainedLength)
+      if (start < end) {
+        setSpan(span, start, end, sourceText.getSpanFlags(span))
+      }
+    }
   }
 }
 
-private fun isVisualSpanForAccessibility(span: Any): Boolean {
-  if (
-      span is URLSpan ||
-          span is ReactClickableSpan ||
-          span is ReactLinkSpan ||
-          span is ClickableSpan
-  ) {
-    return false
+private fun String.trimToParcelableSize(): String {
+  if (length <= PARCEL_SAFE_TEXT_LENGTH) {
+    return this
   }
 
-  return span is ReactAbsoluteSizeSpan ||
-      span is ReactForegroundColorSpan ||
-      span is ReactBackgroundColorSpan ||
-      span is CustomStyleSpan ||
-      span is CustomLetterSpacingSpan ||
-      span is CustomLineHeightSpan ||
-      span is ReactOpacitySpan ||
-      span is ShadowStyleSpan ||
-      span is ReactUnderlineSpan ||
-      span is ReactStrikethroughSpan ||
-      span is AbsoluteSizeSpan ||
-      span is ForegroundColorSpan ||
-      span is BackgroundColorSpan ||
-      span is StyleSpan ||
-      span is UnderlineSpan ||
-      span is StrikethroughSpan
+  val end =
+      if (Character.isHighSurrogate(this[PARCEL_SAFE_TEXT_LENGTH - 1])) {
+        PARCEL_SAFE_TEXT_LENGTH - 1
+      } else {
+        PARCEL_SAFE_TEXT_LENGTH
+      }
+  return substring(0, end)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -10,8 +10,16 @@ package com.facebook.react.views.text
 import android.graphics.Rect
 import android.os.Bundle
 import android.text.Layout
+import android.text.SpannableString
 import android.text.Spanned
+import android.text.style.AbsoluteSizeSpan
+import android.text.style.BackgroundColorSpan
 import android.text.style.ClickableSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.StrikethroughSpan
+import android.text.style.StyleSpan
+import android.text.style.URLSpan
+import android.text.style.UnderlineSpan
 import android.view.View
 import android.widget.TextView
 import androidx.core.view.ViewCompat
@@ -20,7 +28,18 @@ import androidx.core.view.accessibility.AccessibilityNodeProviderCompat
 import com.facebook.react.R
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.uimanager.ReactAccessibilityDelegate
+import com.facebook.react.views.text.internal.span.CustomLetterSpacingSpan
+import com.facebook.react.views.text.internal.span.CustomLineHeightSpan
+import com.facebook.react.views.text.internal.span.CustomStyleSpan
+import com.facebook.react.views.text.internal.span.ReactAbsoluteSizeSpan
+import com.facebook.react.views.text.internal.span.ReactBackgroundColorSpan
 import com.facebook.react.views.text.internal.span.ReactClickableSpan
+import com.facebook.react.views.text.internal.span.ReactForegroundColorSpan
+import com.facebook.react.views.text.internal.span.ReactLinkSpan
+import com.facebook.react.views.text.internal.span.ReactOpacitySpan
+import com.facebook.react.views.text.internal.span.ReactStrikethroughSpan
+import com.facebook.react.views.text.internal.span.ReactUnderlineSpan
+import com.facebook.react.views.text.internal.span.ShadowStyleSpan
 
 @OptIn(UnstableReactNativeAPI::class)
 internal class ReactTextViewAccessibilityDelegate(
@@ -189,7 +208,7 @@ internal class ReactTextViewAccessibilityDelegate(
     // PreparedLayoutTextView isn't actually a TextView, so we need to teach it about its text that
     // it is holding so TalkBack knows what to announce when focusing it.
     val accessibilityText = if (host is PreparedLayoutTextView) host.text else info.text
-    info.text = accessibilityText.toPlainTextForAccessibility()
+    info.text = accessibilityText.toAccessibilityTextWithoutVisualSpans()
   }
 
   @Suppress("DEPRECATION")
@@ -364,5 +383,42 @@ private fun isWholeTextSingleLink(text: Spanned, spans: Array<ClickableSpan>): B
   return start == 0 && end == text.length
 }
 
-private fun CharSequence?.toPlainTextForAccessibility(): CharSequence? =
-    if (this is Spanned) toString() else this
+private fun CharSequence?.toAccessibilityTextWithoutVisualSpans(): CharSequence? {
+  if (this !is Spanned) {
+    return this
+  }
+
+  return SpannableString(this).apply {
+    getSpans(0, length, Any::class.java)
+        .filter { isVisualSpanForAccessibility(it) }
+        .forEach { removeSpan(it) }
+  }
+}
+
+private fun isVisualSpanForAccessibility(span: Any): Boolean {
+  if (
+      span is URLSpan ||
+          span is ReactClickableSpan ||
+          span is ReactLinkSpan ||
+          span is ClickableSpan
+  ) {
+    return false
+  }
+
+  return span is ReactAbsoluteSizeSpan ||
+      span is ReactForegroundColorSpan ||
+      span is ReactBackgroundColorSpan ||
+      span is CustomStyleSpan ||
+      span is CustomLetterSpacingSpan ||
+      span is CustomLineHeightSpan ||
+      span is ReactOpacitySpan ||
+      span is ShadowStyleSpan ||
+      span is ReactUnderlineSpan ||
+      span is ReactStrikethroughSpan ||
+      span is AbsoluteSizeSpan ||
+      span is ForegroundColorSpan ||
+      span is BackgroundColorSpan ||
+      span is StyleSpan ||
+      span is UnderlineSpan ||
+      span is StrikethroughSpan
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -188,9 +188,8 @@ internal class ReactTextViewAccessibilityDelegate(
     super.onInitializeAccessibilityNodeInfo(host, info)
     // PreparedLayoutTextView isn't actually a TextView, so we need to teach it about its text that
     // it is holding so TalkBack knows what to announce when focusing it.
-    if (host is PreparedLayoutTextView) {
-      info.text = host.text
-    }
+    val accessibilityText = if (host is PreparedLayoutTextView) host.text else info.text
+    info.text = accessibilityText.toPlainTextForAccessibility()
   }
 
   @Suppress("DEPRECATION")
@@ -364,3 +363,6 @@ private fun isWholeTextSingleLink(text: Spanned, spans: Array<ClickableSpan>): B
   val end = text.getSpanEnd(span)
   return start == 0 && end == text.length
 }
+
+private fun CharSequence?.toPlainTextForAccessibility(): CharSequence? =
+    if (this is Spanned) toString() else this

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegateTest.kt
@@ -16,8 +16,11 @@ import android.text.Spanned
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.text.style.AbsoluteSizeSpan
+import android.text.style.BackgroundColorSpan
 import android.text.style.ClickableSpan
 import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.text.style.URLSpan
 import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
@@ -37,7 +40,7 @@ class ReactTextViewAccessibilityDelegateTest {
 
     assertSourceTextKeepsStyleSpans(textView.text)
     assertThat(nodeInfo.text.toString()).isEqualTo("Start")
-    assertThat(nodeInfo.text).isNotInstanceOf(Spanned::class.java)
+    assertAccessibilityTextDoesNotHaveVisualSpans(nodeInfo.text)
   }
 
   @Test
@@ -49,31 +52,61 @@ class ReactTextViewAccessibilityDelegateTest {
 
     assertThat(textView.contentDescription.toString()).isEqualTo("Custom label")
     assertThat(nodeInfo.text.toString()).isEqualTo("Visible text")
-    assertThat(nodeInfo.text).isNotInstanceOf(Spanned::class.java)
+    assertAccessibilityTextDoesNotHaveVisualSpans(nodeInfo.text)
   }
 
   @Test
-  fun reactTextViewAccessibilityNodeText_doesNotStripSourceClickableSpans() {
+  fun reactTextViewAccessibilityNodeText_preservesWholeTextClickableSpan() {
     val clickableSpan =
         object : ClickableSpan() {
           override fun onClick(widget: View) = Unit
         }
     val text = createStyledText("Read docs")
-    text.setSpan(clickableSpan, 5, 9, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    text.setSpan(clickableSpan, 0, text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
     val textView = createReactTextView(text)
 
     val nodeInfo = createNodeInfo(textView)
     val sourceText = textView.text as Spanned
+    val accessibilityText = nodeInfo.text as Spanned
 
-    assertThat(sourceText.getSpans(0, sourceText.length, ClickableSpan::class.java)).isNotEmpty()
     assertSourceTextKeepsStyleSpans(sourceText)
+    assertThat(ReactTextViewAccessibilityDelegate.AccessibilityLinks(sourceText).size()).isEqualTo(0)
     assertThat(nodeInfo.text.toString()).isEqualTo("Read docs")
-    assertThat(nodeInfo.text).isNotInstanceOf(Spanned::class.java)
+    assertAccessibilityTextDoesNotHaveVisualSpans(accessibilityText)
+    assertPreservedSpanMatchesSource(sourceText, accessibilityText, clickableSpan)
   }
 
   @Test
-  fun preparedLayoutTextViewAccessibilityNodeText_stripsStyleSpans() {
+  fun reactTextViewAccessibilityNodeText_preservesMixedClickableAndUrlSpans() {
+    val clickableSpan =
+        object : ClickableSpan() {
+          override fun onClick(widget: View) = Unit
+        }
+    val urlSpan = URLSpan("https://reactnative.dev")
+    val text = createStyledText("Read docs now")
+    text.setSpan(clickableSpan, 5, 9, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    text.setSpan(urlSpan, 0, 4, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+    val textView = createReactTextView(text)
+
+    val nodeInfo = createNodeInfo(textView)
+    val sourceText = textView.text as Spanned
+    val accessibilityText = nodeInfo.text as Spanned
+
+    assertSourceTextKeepsStyleSpans(sourceText)
+    assertThat(nodeInfo.text.toString()).isEqualTo("Read docs now")
+    assertAccessibilityTextDoesNotHaveVisualSpans(accessibilityText)
+    assertPreservedSpanMatchesSource(sourceText, accessibilityText, clickableSpan)
+    assertPreservedSpanMatchesSource(sourceText, accessibilityText, urlSpan)
+  }
+
+  @Test
+  fun preparedLayoutTextViewAccessibilityNodeText_stripsStyleSpansAndPreservesClickableSpan() {
     val text = createStyledText("Prepared text")
+    val clickableSpan =
+        object : ClickableSpan() {
+          override fun onClick(widget: View) = Unit
+        }
+    text.setSpan(clickableSpan, 0, 8, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
     val layout =
         StaticLayout.Builder.obtain(text, 0, text.length, TextPaint(), 300).build()
     val textView = PreparedLayoutTextView(RuntimeEnvironment.getApplication())
@@ -96,7 +129,9 @@ class ReactTextViewAccessibilityDelegateTest {
 
     assertSourceTextKeepsStyleSpans(textView.text)
     assertThat(nodeInfo.text.toString()).isEqualTo("Prepared text")
-    assertThat(nodeInfo.text).isNotInstanceOf(Spanned::class.java)
+    val accessibilityText = nodeInfo.text as Spanned
+    assertAccessibilityTextDoesNotHaveVisualSpans(accessibilityText)
+    assertPreservedSpanMatchesSource(textView.text as Spanned, accessibilityText, clickableSpan)
   }
 
   private fun createReactTextViewWithStyledText(text: String): ReactTextView {
@@ -126,6 +161,8 @@ class ReactTextViewAccessibilityDelegateTest {
       SpannableString(text).apply {
         setSpan(AbsoluteSizeSpan(48), 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         setSpan(ForegroundColorSpan(Color.BLACK), 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        setSpan(BackgroundColorSpan(Color.WHITE), 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        setSpan(StyleSpan(android.graphics.Typeface.BOLD), 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
       }
 
   private fun createNodeInfo(view: View): AccessibilityNodeInfoCompat =
@@ -138,5 +175,37 @@ class ReactTextViewAccessibilityDelegateTest {
     val spanned = text as Spanned
     assertThat(spanned.getSpans(0, spanned.length, AbsoluteSizeSpan::class.java)).isNotEmpty()
     assertThat(spanned.getSpans(0, spanned.length, ForegroundColorSpan::class.java)).isNotEmpty()
+    assertThat(spanned.getSpans(0, spanned.length, BackgroundColorSpan::class.java)).isNotEmpty()
+    assertThat(spanned.getSpans(0, spanned.length, StyleSpan::class.java)).isNotEmpty()
+  }
+
+  private fun assertAccessibilityTextDoesNotHaveVisualSpans(text: CharSequence?) {
+    if (text !is Spanned) {
+      return
+    }
+
+    assertThat(text.getSpans(0, text.length, AbsoluteSizeSpan::class.java)).isEmpty()
+    assertThat(text.getSpans(0, text.length, ForegroundColorSpan::class.java)).isEmpty()
+    assertThat(text.getSpans(0, text.length, BackgroundColorSpan::class.java)).isEmpty()
+    assertThat(text.getSpans(0, text.length, StyleSpan::class.java)).isEmpty()
+  }
+
+  private fun assertPreservedSpanMatchesSource(
+      sourceText: Spanned,
+      accessibilityText: Spanned,
+      sourceSpan: Any,
+  ) {
+    val preservedSpans =
+        accessibilityText
+            .getSpans(
+                sourceText.getSpanStart(sourceSpan),
+                sourceText.getSpanEnd(sourceSpan),
+                sourceSpan.javaClass,
+            )
+            .filter { accessibilityText.getSpanStart(it) == sourceText.getSpanStart(sourceSpan) }
+            .filter { accessibilityText.getSpanEnd(it) == sourceText.getSpanEnd(sourceSpan) }
+            .filter { accessibilityText.getSpanFlags(it) == sourceText.getSpanFlags(sourceSpan) }
+
+    assertThat(preservedSpans).isNotEmpty()
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegateTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@file:Suppress("DEPRECATION")
+
+package com.facebook.react.views.text
+
+import android.graphics.Color
+import android.text.Layout
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.text.style.AbsoluteSizeSpan
+import android.text.style.ClickableSpan
+import android.text.style.ForegroundColorSpan
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ReactTextViewAccessibilityDelegateTest {
+  @Test
+  fun reactTextViewAccessibilityNodeText_stripsStyleSpans() {
+    val textView = createReactTextViewWithStyledText("Start")
+
+    val nodeInfo = createNodeInfo(textView)
+
+    assertSourceTextKeepsStyleSpans(textView.text)
+    assertThat(nodeInfo.text.toString()).isEqualTo("Start")
+    assertThat(nodeInfo.text).isNotInstanceOf(Spanned::class.java)
+  }
+
+  @Test
+  fun reactTextViewAccessibilityNodeText_preservesExplicitContentDescription() {
+    val textView = createReactTextViewWithStyledText("Visible text")
+    textView.contentDescription = "Custom label"
+
+    val nodeInfo = createNodeInfo(textView)
+
+    assertThat(textView.contentDescription.toString()).isEqualTo("Custom label")
+    assertThat(nodeInfo.text.toString()).isEqualTo("Visible text")
+    assertThat(nodeInfo.text).isNotInstanceOf(Spanned::class.java)
+  }
+
+  @Test
+  fun reactTextViewAccessibilityNodeText_doesNotStripSourceClickableSpans() {
+    val clickableSpan =
+        object : ClickableSpan() {
+          override fun onClick(widget: View) = Unit
+        }
+    val text = createStyledText("Read docs")
+    text.setSpan(clickableSpan, 5, 9, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    val textView = createReactTextView(text)
+
+    val nodeInfo = createNodeInfo(textView)
+    val sourceText = textView.text as Spanned
+
+    assertThat(sourceText.getSpans(0, sourceText.length, ClickableSpan::class.java)).isNotEmpty()
+    assertSourceTextKeepsStyleSpans(sourceText)
+    assertThat(nodeInfo.text.toString()).isEqualTo("Read docs")
+    assertThat(nodeInfo.text).isNotInstanceOf(Spanned::class.java)
+  }
+
+  @Test
+  fun preparedLayoutTextViewAccessibilityNodeText_stripsStyleSpans() {
+    val text = createStyledText("Prepared text")
+    val layout =
+        StaticLayout.Builder.obtain(text, 0, text.length, TextPaint(), 300).build()
+    val textView = PreparedLayoutTextView(RuntimeEnvironment.getApplication())
+    textView.preparedLayout =
+        PreparedLayout(
+            layout,
+            Int.MAX_VALUE,
+            0f,
+            intArrayOf(1),
+            Layout.BREAK_STRATEGY_SIMPLE,
+            0,
+        )
+    ReactTextViewAccessibilityDelegate.resetDelegate(
+        textView,
+        textView.isFocusable,
+        textView.importantForAccessibility,
+    )
+
+    val nodeInfo = createNodeInfo(textView)
+
+    assertSourceTextKeepsStyleSpans(textView.text)
+    assertThat(nodeInfo.text.toString()).isEqualTo("Prepared text")
+    assertThat(nodeInfo.text).isNotInstanceOf(Spanned::class.java)
+  }
+
+  private fun createReactTextViewWithStyledText(text: String): ReactTextView {
+    return createReactTextView(createStyledText(text))
+  }
+
+  private fun createReactTextView(text: Spanned): ReactTextView {
+    val textView = ReactTextView(RuntimeEnvironment.getApplication())
+    textView.setText(
+        ReactTextUpdate(
+            text,
+            -1,
+            0,
+            Layout.BREAK_STRATEGY_SIMPLE,
+            0,
+        )
+    )
+    ReactTextViewAccessibilityDelegate.resetDelegate(
+        textView,
+        textView.isFocusable,
+        textView.importantForAccessibility,
+    )
+    return textView
+  }
+
+  private fun createStyledText(text: String): SpannableString =
+      SpannableString(text).apply {
+        setSpan(AbsoluteSizeSpan(48), 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        setSpan(ForegroundColorSpan(Color.BLACK), 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+
+  private fun createNodeInfo(view: View): AccessibilityNodeInfoCompat =
+      AccessibilityNodeInfoCompat.obtain().also {
+        ViewCompat.onInitializeAccessibilityNodeInfo(view, it)
+      }
+
+  private fun assertSourceTextKeepsStyleSpans(text: CharSequence?) {
+    assertThat(text).isInstanceOf(Spanned::class.java)
+    val spanned = text as Spanned
+    assertThat(spanned.getSpans(0, spanned.length, AbsoluteSizeSpan::class.java)).isNotEmpty()
+    assertThat(spanned.getSpans(0, spanned.length, ForegroundColorSpan::class.java)).isNotEmpty()
+  }
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegateTest.kt
@@ -77,15 +77,13 @@ class ReactTextViewAccessibilityDelegateTest {
   }
 
   @Test
-  fun reactTextViewAccessibilityNodeText_preservesMixedClickableAndUrlSpans() {
+  fun reactTextViewAccessibilityNodeText_preservesMixedClickableAndVisualSpans() {
     val clickableSpan =
         object : ClickableSpan() {
           override fun onClick(widget: View) = Unit
         }
-    val urlSpan = URLSpan("https://reactnative.dev")
     val text = createStyledText("Read docs now")
     text.setSpan(clickableSpan, 5, 9, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-    text.setSpan(urlSpan, 0, 4, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
     val textView = createReactTextView(text)
 
     val nodeInfo = createNodeInfo(textView)
@@ -96,11 +94,25 @@ class ReactTextViewAccessibilityDelegateTest {
     assertThat(nodeInfo.text.toString()).isEqualTo("Read docs now")
     assertAccessibilityTextDoesNotHaveVisualSpans(accessibilityText)
     assertPreservedSpanMatchesSource(sourceText, accessibilityText, clickableSpan)
-    assertPreservedSpanMatchesSource(sourceText, accessibilityText, urlSpan)
   }
 
   @Test
-  fun preparedLayoutTextViewAccessibilityNodeText_stripsStyleSpansAndPreservesClickableSpan() {
+  fun reactTextViewAccessibilityNodeText_preservesUrlSpanSemantics() {
+    val urlSpan = URLSpan("https://reactnative.dev")
+    val text = createStyledText("React Native")
+    text.setSpan(urlSpan, 0, 5, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+    val textView = createReactTextView(text)
+
+    val nodeInfo = createNodeInfo(textView)
+    val accessibilityText = nodeInfo.text as Spanned
+
+    assertThat(nodeInfo.text.toString()).isEqualTo("React Native")
+    assertAccessibilityTextDoesNotHaveVisualSpans(accessibilityText)
+    assertAccessibilityTextHasClickableSpan(accessibilityText, 0, 5, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+  }
+
+  @Test
+  fun preparedLayoutTextViewAccessibilityNodeText_keepsOnlyClickableSpans() {
     val text = createStyledText("Prepared text")
     val clickableSpan =
         object : ClickableSpan() {
@@ -132,6 +144,37 @@ class ReactTextViewAccessibilityDelegateTest {
     val accessibilityText = nodeInfo.text as Spanned
     assertAccessibilityTextDoesNotHaveVisualSpans(accessibilityText)
     assertPreservedSpanMatchesSource(textView.text as Spanned, accessibilityText, clickableSpan)
+  }
+
+  @Test
+  fun reactTextViewAccessibilityNodeText_trimsLongTextWithoutSplittingSurrogatePairs() {
+    val crossingBoundarySpan =
+        object : ClickableSpan() {
+          override fun onClick(widget: View) = Unit
+        }
+    val outsideRetainedTextSpan =
+        object : ClickableSpan() {
+          override fun onClick(widget: View) = Unit
+        }
+    val text = SpannableString("${"a".repeat(99_999)}\uD83D\uDE00b")
+    text.setSpan(crossingBoundarySpan, 99_998, 100_001, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    text.setSpan(outsideRetainedTextSpan, 100_001, 100_002, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    val textView = createReactTextView(text)
+
+    val nodeInfo = createNodeInfo(textView)
+    val accessibilityText = nodeInfo.text as Spanned
+
+    assertThat(nodeInfo.text.length).isEqualTo(99_999)
+    assertThat(nodeInfo.text.toString()).doesNotEndWith("\uD83D")
+    assertPreservedSpanMatchesRange(
+        accessibilityText,
+        crossingBoundarySpan,
+        99_998,
+        99_999,
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+    )
+    assertThat(accessibilityText.getSpans(0, accessibilityText.length, ClickableSpan::class.java))
+        .doesNotContain(outsideRetainedTextSpan)
   }
 
   private fun createReactTextViewWithStyledText(text: String): ReactTextView {
@@ -195,17 +238,44 @@ class ReactTextViewAccessibilityDelegateTest {
       accessibilityText: Spanned,
       sourceSpan: Any,
   ) {
+    assertPreservedSpanMatchesRange(
+        accessibilityText,
+        sourceSpan,
+        sourceText.getSpanStart(sourceSpan),
+        sourceText.getSpanEnd(sourceSpan),
+        sourceText.getSpanFlags(sourceSpan),
+    )
+  }
+
+  private fun assertPreservedSpanMatchesRange(
+      accessibilityText: Spanned,
+      sourceSpan: Any,
+      start: Int,
+      end: Int,
+      flags: Int,
+  ) {
     val preservedSpans =
         accessibilityText
-            .getSpans(
-                sourceText.getSpanStart(sourceSpan),
-                sourceText.getSpanEnd(sourceSpan),
-                sourceSpan.javaClass,
-            )
-            .filter { accessibilityText.getSpanStart(it) == sourceText.getSpanStart(sourceSpan) }
-            .filter { accessibilityText.getSpanEnd(it) == sourceText.getSpanEnd(sourceSpan) }
-            .filter { accessibilityText.getSpanFlags(it) == sourceText.getSpanFlags(sourceSpan) }
-
+            .getSpans(start, end, sourceSpan.javaClass)
+            .filter { accessibilityText.getSpanStart(it) == start }
+            .filter { accessibilityText.getSpanEnd(it) == end }
+            .filter { accessibilityText.getSpanFlags(it) == flags }
     assertThat(preservedSpans).isNotEmpty()
+  }
+
+  private fun assertAccessibilityTextHasClickableSpan(
+      accessibilityText: Spanned,
+      start: Int,
+      end: Int,
+      flags: Int,
+  ) {
+    val clickableSpans =
+        accessibilityText
+            .getSpans(start, end, ClickableSpan::class.java)
+            .filter { accessibilityText.getSpanStart(it) == start }
+            .filter { accessibilityText.getSpanEnd(it) == end }
+            .filter { accessibilityText.getSpanFlags(it) == flags }
+
+    assertThat(clickableSpans).isNotEmpty()
   }
 }


### PR DESCRIPTION
## Summary

Fixes #56873.

This also addresses the underlying Android `<Text>` accessibility issue previously reported in #55150.

On Android, TalkBack could announce React Native `<Text>` styling metadata as part of the accessible name. For example, a plain text node could be announced with implementation details such as pixel size and color before the actual visible text.

The root cause is that the host accessibility node was receiving the rendered `Spanned` text object. React Native text layout attaches visual spans to that object, such as absolute size and color spans. Those spans are correct for rendering, but they should not become part of the host node's spoken accessibility text.

This PR converts the host accessibility node text to plain text when the value is `Spanned`, while leaving the rendered/source text untouched.

## Background / relation to previous reports

#55150 reported the same Android TalkBack behavior on React Native 0.78.2. That issue was later closed as `Type: Too Old Version`, but the underlying Android accessibility delegate path still exposed styled `Spanned` text to the accessibility node.

#56873 confirms the issue is still reproducible on a current React Native version, 0.85.3, using a minimal `<Text>` example with no custom styles.

#56872 provides a reproducer for the current issue, but it does not change the Android accessibility code path.

This PR fixes the root cause directly in `ReactTextViewAccessibilityDelegate` rather than relying on app-level labels or repro-only changes.

## What changed

`ReactTextViewAccessibilityDelegate` now normalizes the host node's accessibility text:

- if the accessibility text is a `Spanned`, expose `toString()` to `AccessibilityNodeInfoCompat.text`
- otherwise preserve the original `CharSequence`
- preserve the existing `PreparedLayoutTextView` path
- preserve explicit `contentDescription` / accessibility label behavior

The important part is that this only affects the accessibility node text. It does not mutate the rendered text.

## Why this is safe

The fix only changes the value assigned to `AccessibilityNodeInfoCompat.text`.

It does **not**:

- call `setText()` on the host view
- mutate `TextView.text`
- remove spans from rendered text
- affect text layout or measurement
- affect visual styling
- affect hit-testing
- remove source `ClickableSpan`s
- change role, state, hint, actions, or virtual-view behavior

Inline link behavior is preserved because the link/accessibility virtual view logic still reads from the original source `Spanned` text on the host view / prepared layout text.

Specifically:

- accessibility links are still built from the rendered/source `Spanned`
- `getVirtualViewAt()` still finds `ClickableSpan`s from the source text
- `onPerformActionForVirtualView()` still calls `span.onClick(hostView)`
- keyboard focus handling still updates the source clickable span focus state or prepared-layout selection
- virtual link nodes still expose their descriptions, bounds, click action, role description, and class name

So this strips visual/style spans only from the host node's spoken text, not from rendering, link data, virtual links, or click actions.

## Tests

Added `ReactTextViewAccessibilityDelegateTest` coverage for:

- stripping style spans from Android `<Text>` accessibility node text
- stripping style spans from prepared-layout text accessibility node text
- preserving explicit `contentDescription`
- preserving source clickable/style spans on the rendered text

## Verification
- Manual TalkBack smoke test on OPPO CPH2219 / Android 13 using RNTester debug build from this PR branch.

Ran the focused Android unit test:

```sh
./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests com.facebook.react.views.text.ReactTextViewAccessibilityDelegateTest --rerun-tasks
```

Verified fail-before / pass-after behavior:

with only the production fix temporarily reverted, the focused test failed
after restoring the production fix, the same focused test passed
reran with --rerun-tasks to avoid relying on cached results

The old implementation failed because nodeInfo.text was still a Spanned.

Additional checks:
```sh
./gradlew :packages:react-native:ReactAndroid:ktfmtCheckMain :packages:react-native:ReactAndroid:ktfmtCheckTest
git diff --check
```
Manual TalkBack smoke validation was later performed on a physical Android device:

- Device: OPPO CPH2219
- Android: 13
- RNTester debug build from this PR branch
- TalkBack enabled
- Metro running over USB with `adb reverse tcp:8081 tcp:8081`

Validated that RNTester remained navigable with TalkBack focus across Components, APIs, Playground, Image, and AccessibilityAndroid examples, including styled/text-heavy and clickable/link-style examples. Screenshots and a sanitized log were attached in #56873.

## Changelog:

[Android] [Fixed] - Prevent TalkBack from announcing React Native Text style spans as Android Text accessibility text.