### PR TITLE
Inline true for fabricEnabled in DefaultNewArchitectureEntryPoint

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -102,7 +102,6 @@ public object DefaultNewArchitectureEntryPoint {
       }
     }
 
-    privateFabricEnabled = fabricEnabled
     privateTurboModulesEnabled = turboModulesEnabled
     privateConcurrentReactEnabled = fabricEnabled
     privateBridgelessEnabled = bridgelessEnabled
@@ -120,7 +119,7 @@ public object DefaultNewArchitectureEntryPoint {
     val (isValid, errorMessage) =
         isConfigurationValid(
             privateTurboModulesEnabled,
-            privateFabricEnabled,
+            true,
             privateBridgelessEnabled,
         )
     if (!isValid) {
@@ -129,8 +128,6 @@ public object DefaultNewArchitectureEntryPoint {
 
     DefaultSoLoader.maybeLoadSoLibrary()
   }
-
-  private var privateFabricEnabled: Boolean = false
 
   @JvmStatic
   public val fabricEnabled: Boolean


### PR DESCRIPTION
Summary:
Now that `fabricEnabled` always returns `true`, delete the `privateFabricEnabled` backing field. Remove the redundant assignment in `load()` and inline `true` at its remaining usage in `isConfigurationValid` from `loadWithFeatureFlags`.

Behavior is unchanged.

Changelog:
[Internal]

Differential Revision: D105639307


