### PR TITLE
fix: parse Image srcSet densities consistently

### DIFF
--- a/packages/react-native/Libraries/Image/ImageSourceUtils.js
+++ b/packages/react-native/Libraries/Image/ImageSourceUtils.js
@@ -47,17 +47,20 @@ export function getImageSourcesFromImageProps(imageProps: ImageProps):
   }
   if (srcSet != null) {
     const sourceList = [];
-    const srcSetList = srcSet.split(', ');
+    const srcSetList = srcSet
+      .split(',')
+      .map(imageSrc => imageSrc.trim())
+      .filter(Boolean);
     // `src` prop should be used with default scale if `srcSet` does not have 1x scale.
     let shouldUseSrcForDefaultScale = true;
     srcSetList.forEach(imageSrc => {
-      const [uri, xScale = '1x'] = imageSrc.split(' ');
+      const [uri, xScale = '1x'] = imageSrc.split(/\s+/);
       if (!xScale.endsWith('x')) {
         console.warn(
           'The provided format for scale is not supported yet. Please use scales like 1x, 2x, etc.',
         );
       } else {
-        const scale = parseInt(xScale.split('x')[0], 10);
+        const scale = parseFloat(xScale.slice(0, -1));
         if (!isNaN(scale)) {
           // 1x scale is provided in `srcSet` prop so ignore the `src` prop if provided.
           shouldUseSrcForDefaultScale =

--- a/packages/react-native/Libraries/Image/__tests__/ImageSourceUtils-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/ImageSourceUtils-test.js
@@ -105,6 +105,67 @@ describe('ImageSourceUtils', () => {
     expect(sources[1]).toEqual(expect.objectContaining({uri: uri2, scale: 1}));
   });
 
+  it('should parse srcSet values without spaces after commas', () => {
+    const imageProps = {
+      srcSet: 'uri1 1x,uri2 2x,uri3 3x',
+    };
+    const sources = getImageSourcesFromImageProps(imageProps);
+
+    expect(sources).toBeDefined();
+    expect(sources).toHaveLength(3);
+    if (!Array.isArray(sources)) {
+      throw new Error('Expected `sources` to be an array');
+    }
+    expect(sources[0]).toEqual(
+      expect.objectContaining({uri: 'uri1', scale: 1}),
+    );
+    expect(sources[1]).toEqual(
+      expect.objectContaining({uri: 'uri2', scale: 2}),
+    );
+    expect(sources[2]).toEqual(
+      expect.objectContaining({uri: 'uri3', scale: 3}),
+    );
+  });
+
+  it('should parse fractional srcSet scales', () => {
+    const imageProps = {
+      srcSet: 'uri1 1.5x, uri2 2x',
+    };
+    const sources = getImageSourcesFromImageProps(imageProps);
+
+    expect(sources).toBeDefined();
+    expect(sources).toHaveLength(2);
+    if (!Array.isArray(sources)) {
+      throw new Error('Expected `sources` to be an array');
+    }
+    expect(sources[0]).toEqual(
+      expect.objectContaining({uri: 'uri1', scale: 1.5}),
+    );
+    expect(sources[1]).toEqual(
+      expect.objectContaining({uri: 'uri2', scale: 2}),
+    );
+  });
+
+  it('should ignore srcSet entries with a bare x descriptor', () => {
+    const imageProps = {
+      src: 'fallbackUri',
+      srcSet: 'invalid x, uri2 2x',
+    };
+    const sources = getImageSourcesFromImageProps(imageProps);
+
+    expect(sources).toBeDefined();
+    expect(sources).toHaveLength(2);
+    if (!Array.isArray(sources)) {
+      throw new Error('Expected `sources` to be an array');
+    }
+    expect(sources[0]).toEqual(
+      expect.objectContaining({uri: 'uri2', scale: 2}),
+    );
+    expect(sources[1]).toEqual(
+      expect.objectContaining({uri: 'fallbackUri', scale: 1}),
+    );
+  });
+
   it('should warn when an unsupported scale is provided in srcSet', () => {
     const mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     let uri1 = 'uri1';


### PR DESCRIPTION
## Summary

- parse Image `srcSet` entries even when there is no space after the comma
- keep fractional density descriptors like `1.5x`
- keep bare `x` descriptors out of the source list

## Changelog:

[General] [Fixed] - Parse Image srcSet density descriptors consistently

## Test Plan

- `yarn jest packages/react-native/Libraries/Image/__tests__/ImageSourceUtils-test.js --runInBand`
- `npx prettier --check packages/react-native/Libraries/Image/ImageSourceUtils.js packages/react-native/Libraries/Image/__tests__/ImageSourceUtils-test.js`
- `yarn flow-check`
