### PR TITLE
Remove enableFabricRenderer() overrides from downstream consumers (#56896)

### DIFF
--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
@@ -17,10 +17,6 @@ class ReactNativeFeatureFlagsOverridesOSSStable : public ReactNativeFeatureFlags
   {
     return true;
   }
-  bool enableFabricRenderer() override
-  {
-    return true;
-  }
   bool useTurboModules() override
   {
     return true;


### PR DESCRIPTION
Summary:

The `enableFabricRenderer()` virtual method is being removed from `ReactNativeFeatureFlagsDefaults`. This diff removes the now-stale `enableFabricRenderer() override` methods from downstream `ReactNativeFeatureFlagsDefaults` subclasses so they compile cleanly once the parent method is gone.

Also removes the now-unused `enableFabric` parameter from `createFBReactModuleDefaultsFeatureFlagsProvider` and its single caller.

Behavior is unchanged because every override returned `true` (the value the runtime always took at this point) and no other code path depends on the flag.

Changelog:
[Internal]

Reviewed By: christophpurrer

Differential Revision: D105347594


