### PR TITLE
Remove legacy WebSocket-based React DevTools connection

### DIFF
--- a/packages/react-native/Libraries/Core/setUpReactDevTools.js
+++ b/packages/react-native/Libraries/Core/setUpReactDevTools.js
@@ -34,7 +34,6 @@ if (__DEV__) {
   require('../../src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher');
   const {
     initialize,
-    connectToDevTools,
     connectWithCustomMessagingProtocol,
   } = require('react-devtools-core');
 
@@ -117,94 +116,6 @@ if (__DEV__) {
     });
   }
 
-  let isWebSocketOpen = false;
-  let ws = null;
-  function connectToWSBasedReactDevToolsFrontend() {
-    if (ws !== null && isWebSocketOpen) {
-      // If the DevTools backend is already connected, don't recreate the WebSocket.
-      // This would break the connection.
-      // If there isn't an active connection, a backend may be waiting to connect,
-      // in which case it's okay to make a new one.
-      return;
-    }
-
-    // not when debugging in chrome
-    // TODO(t12832058) This check is broken
-    if (!window.document) {
-      const AppState = require('../AppState/AppState').default;
-      const getDevServer = require('./Devtools/getDevServer').default;
-
-      // Don't steal the DevTools from currently active app.
-      // Note: if you add any AppState subscriptions to this file,
-      // you will also need to guard against `AppState.isAvailable`,
-      // or the code will throw for bundles that don't have it.
-      const isAppActive = () => AppState.currentState !== 'background';
-
-      // Get hostname from development server (packager)
-      const devServer = getDevServer();
-      const host = devServer.bundleLoadedFromServer
-        ? guessHostFromDevServerUrl(devServer.url)
-        : 'localhost';
-
-      // Derive scheme and port from the dev server URL when possible,
-      // falling back to ws://host:8097 for local development.
-      let wsScheme = 'ws';
-      let port = 8097;
-
-      if (
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        window.__REACT_DEVTOOLS_PORT__ != null
-      ) {
-        // $FlowFixMe[prop-missing]
-        port = window.__REACT_DEVTOOLS_PORT__;
-      } else if (devServer.bundleLoadedFromServer) {
-        try {
-          const devUrl = new URL(devServer.url);
-          if (devUrl.protocol === 'https:') {
-            wsScheme = 'wss';
-          }
-          if (devUrl.port) {
-            port = parseInt(devUrl.port, 10);
-          } else if (devUrl.protocol === 'https:') {
-            port = 443;
-          }
-        } catch (e) {}
-      }
-
-      const WebSocket = require('../WebSocket/WebSocket').default;
-      ws = new WebSocket(wsScheme + '://' + host + ':' + port);
-      ws.addEventListener('close', event => {
-        isWebSocketOpen = false;
-      });
-      ws.addEventListener('open', event => {
-        isWebSocketOpen = true;
-      });
-
-      const {
-        isReloadAndProfileSupported,
-        isProfiling,
-        onReloadAndProfile,
-        onReloadAndProfileFlagsReset,
-      } = readReloadAndProfileConfig(
-        maybeReactDevToolsRuntimeSettingsModuleModule,
-      );
-      connectToDevTools({
-        isAppActive,
-        resolveRNStyle,
-        nativeStyleEditorValidAttributes: Object.keys(
-          ReactNativeStyleAttributes,
-        ),
-        websocket: ws,
-        onSettingsUpdated: handleReactDevToolsSettingsUpdate,
-        isReloadAndProfileSupported,
-        isProfiling,
-        onReloadAndProfile,
-        onReloadAndProfileFlagsReset,
-      });
-    }
-  }
-
   // 1. If React DevTools has already been opened and initialized in Fusebox, bindings survive reloads
   if (global[reactDevToolsFuseboxGlobalBindingName] != null) {
     disconnectBackendFromReactDevToolsInFuseboxIfNeeded();
@@ -223,15 +134,6 @@ if (__DEV__) {
       }
     },
   );
-
-  // 3. Fallback to attempting to connect WS-based RDT frontend
-  const RCTNativeAppEventEmitter =
-    require('../EventEmitter/RCTNativeAppEventEmitter').default;
-  RCTNativeAppEventEmitter.addListener(
-    'RCTDevMenuShown',
-    connectToWSBasedReactDevToolsFrontend,
-  );
-  connectToWSBasedReactDevToolsFrontend(); // Try connecting once on load
 }
 
 function readReloadAndProfileConfig(
@@ -272,24 +174,4 @@ function readReloadAndProfileConfig(
     onReloadAndProfile,
     onReloadAndProfileFlagsReset,
   };
-}
-
-/**
- * This is a bad, no good, broken hack to get the host from a dev server URL for the purposes
- * of connecting to the legacy React DevTools socket (for the standalone react-devtools package).
- * It has too many bugs to list. Please don't use it in new code.
- *
- * The correct implementation would just be `return new URL(url).host`, but React Native does not
- * ship with a spec-compliant `URL` class yet. Alternatively, this can be deleted when we delete
- * `connectToWSBasedReactDevToolsFrontend`.
- */
-function guessHostFromDevServerUrl(url: string): string {
-  const hopefullyHostAndPort = url
-    .replace(/https?:\/\//, '')
-    .replace(/\/$/, '');
-  // IPv6 addresses contain colons, so the split(':') below will return garbage.
-  if (hopefullyHostAndPort.includes(']')) {
-    return hopefullyHostAndPort.split(']')[0] + ']';
-  }
-  return hopefullyHostAndPort.split(':')[0];
 }


### PR DESCRIPTION
Summary:
Remove `connectToWSBasedReactDevToolsFrontend` and the `guessHostFromDevServerUrl` helper function. This was the legacy fallback path that connected to the standalone `react-devtools` package via a raw WebSocket on port 8097.

React DevTools now connects exclusively through Fusebox (React Native DevTools), which uses the CDP-based `connectWithCustomMessagingProtocol` API. The `connectToDevTools` API from `react-devtools-core` and the `RCTDevMenuShown` event listener are no longer used.

Changelog:
[General][Breaking] - Remove support for connecting to the standalone `react-devtools` package via WebSocket. Use React Native DevTools instead.

Differential Revision: D105711439


