### PR TITLE
Guard cxxreact MethodCall tests under legacy-arch macro

### DIFF
--- a/packages/react-native/React/Tests/Text/RCTTextAttributesTest.mm
+++ b/packages/react-native/React/Tests/Text/RCTTextAttributesTest.mm
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_REMOVE_LEGACY_ARCH
+
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
@@ -47,3 +49,5 @@
 }
 
 @end
+
+#endif // RCT_REMOVE_LEGACY_ARCH

--- a/packages/react-native/ReactCommon/cxxreact/tests/methodcall.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/tests/methodcall.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_REMOVE_LEGACY_ARCH
+
 #include <cxxreact/MethodCall.h>
 
 #include <folly/json.h>
@@ -152,3 +154,5 @@ TEST(parseMethodCalls, ParseTwoCalls) {
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
   EXPECT_EQ(2, returnedCalls.size());
 }
+
+#endif // RCT_REMOVE_LEGACY_ARCH


### PR DESCRIPTION
Summary:
`parseMethodCalls` (used by `packages/react-native/ReactCommon/cxxreact/tests/methodcall.cpp`) is only declared in `<cxxreact/MethodCall.h>` when legacy architecture support is compiled in. Wrap the test body in `#ifndef RCT_REMOVE_LEGACY_ARCH` so the translation unit compiles to a no-op when legacy arch is removed, instead of failing with `use of undeclared identifier 'parseMethodCalls'`.

Also configure the `tests` target so its Apple builds run under a target platform that carries the `react-fit-enabled` constraint. A new per-package `apple_target_platforms()` declares `tests-apple-platform`, and the `rn_xplat_cxx_test` rule wires it in via `fbobjc_ios_config_backed_target_platform` / `fbobjc_macosx_config_backed_target_platform`. Under that configuration `RCT_REMOVE_LEGACY_ARCH` is defined and the guarded test body is elided, matching the behavior of the rest of the post-legacy-arch test suite.

Changelog: [Internal]

Differential Revision: D105737807


