### PR TITLE
Remove unused privateConcurrentReactEnabled field

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -103,7 +103,6 @@ public object DefaultNewArchitectureEntryPoint {
     }
 
     privateTurboModulesEnabled = turboModulesEnabled
-    privateConcurrentReactEnabled = fabricEnabled
     privateBridgelessEnabled = bridgelessEnabled
 
     DefaultSoLoader.maybeLoadSoLibrary()
@@ -138,8 +137,6 @@ public object DefaultNewArchitectureEntryPoint {
   @JvmStatic
   public val turboModulesEnabled: Boolean
     get() = privateTurboModulesEnabled
-
-  private var privateConcurrentReactEnabled: Boolean = false
 
   @JvmStatic
   public val concurrentReactEnabled: Boolean


### PR DESCRIPTION
Summary:
Remove dead code that assigned to `privateConcurrentReactEnabled` since the public getter unconditionally returns `true`. This mirrors the cleanup already done for `privateFabricEnabled` in a previous diff.

Changelog: [Internal]

Differential Revision: D105812201


