### PR TITLE
fix missing headers on image source in android

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -124,6 +124,7 @@ const EMPTY_IMAGE_SOURCE = {
   uri: undefined,
   width: undefined,
   height: undefined,
+  headers: undefined,
 };
 
 /**
@@ -215,9 +216,17 @@ let BaseImage: AbstractImageAndroid = ({
     ];
     nativeProps.source = source_;
   } else {
-    const {uri, width: sourceWidth, height: sourceHeight} = source_;
+    const {
+      uri,
+      width: sourceWidth,
+      height: sourceHeight,
+      headers: sourceHeaders,
+    } = source_;
     if (uri === '') {
       console.warn('source.uri should not be an empty string');
+    }
+    if (sourceHeaders != null) {
+      nativeProps.headers = sourceHeaders;
     }
     nativeProps.style = [
       {width: sourceWidth ?? width, height: sourceHeight ?? height},

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -352,10 +352,7 @@ describe('Image', () => {
     );
 
     const tree = instance.toJSON();
-    if (tree == null || Array.isArray(tree)) {
-      throw new Error('Expected a single rendered element');
-    }
-    expect(tree.props.headers).toEqual({Authorization: 'Bearer xyz'});
+    expect(tree?.props.headers).toEqual({Authorization: 'Bearer xyz'});
   });
 
   it('forwards source.headers as a top-level prop on Android for array sources', async () => {

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -340,4 +340,31 @@ describe('Image', () => {
       'foo-bar.jpg',
     ]);
   });
+  it('forwards source.headers as a top-level prop on Android', async () => {
+    jest.dontMock('../Image.android');
+    const ImageAndroid = require('../Image.android').default;
+
+    const instance = await render.create(
+      <ImageAndroid
+        source={{uri: 'foo-bar.jpg', headers: {Authorization: 'Bearer xyz'}}}
+      />,
+    );
+
+    const tree = instance.toJSON();
+    expect(tree.props.headers).toEqual({Authorization: 'Bearer xyz'});
+  });
+
+  it('forwards source.headers as a top-level prop on Android for array sources', async () => {
+    jest.dontMock('../Image.android');
+    const ImageAndroid = require('../Image.android').default;
+
+    const instance = await render.create(
+      <ImageAndroid
+        source={[{uri: 'foo-bar.jpg', headers: {Authorization: 'Bearer xyz'}}]}
+      />,
+    );
+
+    const tree = instance.toJSON();
+    expect(tree.props.headers).toEqual({Authorization: 'Bearer xyz'});
+  });
 });

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -370,9 +370,6 @@ describe('Image', () => {
     );
 
     const tree = instance.toJSON();
-    if (tree == null || Array.isArray(tree)) {
-      throw new Error('Expected a single rendered element');
-    }
-    expect(tree.props.headers).toEqual({Authorization: 'Bearer xyz'});
+    expect(tree?.props.headers).toEqual({Authorization: 'Bearer xyz'});
   });
 });

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -342,6 +342,7 @@ describe('Image', () => {
   });
   it('forwards source.headers as a top-level prop on Android', async () => {
     jest.dontMock('../Image.android');
+    // $FlowExpectedError[missing-platform-support] Intentionally testing the Android-specific Image component.
     const ImageAndroid = require('../Image.android').default;
 
     const instance = await render.create(
@@ -351,11 +352,15 @@ describe('Image', () => {
     );
 
     const tree = instance.toJSON();
+    if (tree == null || Array.isArray(tree)) {
+      throw new Error('Expected a single rendered element');
+    }
     expect(tree.props.headers).toEqual({Authorization: 'Bearer xyz'});
   });
 
   it('forwards source.headers as a top-level prop on Android for array sources', async () => {
     jest.dontMock('../Image.android');
+    // $FlowExpectedError[missing-platform-support] Intentionally testing the Android-specific Image component.
     const ImageAndroid = require('../Image.android').default;
 
     const instance = await render.create(
@@ -365,6 +370,9 @@ describe('Image', () => {
     );
 
     const tree = instance.toJSON();
+    if (tree == null || Array.isArray(tree)) {
+      throw new Error('Expected a single rendered element');
+    }
     expect(tree.props.headers).toEqual({Authorization: 'Bearer xyz'});
   });
 });


### PR DESCRIPTION
## Summary:

Discovered that Image headers are not passed to image component correctly for Android

## Changelog:

Added headers to case where image props have headers in sources in Android Images

Pick one each for the category and type tags:

[ANDROID] [FIXED] - Source props in image headers in Android

## Test Plan:

Added platform specific tests and validated headers were not ignored, removed them as don't want to create separate tests for this one specific case.
