### PR TITLE
Deprecate legacy DefaultReactActivityDelegate constructors (#56906)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1750,10 +1750,9 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 }
 
 public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/facebook/react/ReactActivityDelegate {
+	public fun <init> (Lcom/facebook/react/ReactActivity;Ljava/lang/String;)V
 	public fun <init> (Lcom/facebook/react/ReactActivity;Ljava/lang/String;Z)V
-	public synthetic fun <init> (Lcom/facebook/react/ReactActivity;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/facebook/react/ReactActivity;Ljava/lang/String;ZZ)V
-	protected fun isFabricEnabled ()Z
 }
 
 public final class com/facebook/react/defaults/DefaultReactHost {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
@@ -22,24 +22,28 @@ import com.facebook.react.ReactActivityDelegate
 public open class DefaultReactActivityDelegate(
     activity: ReactActivity,
     mainComponentName: String,
-    private val fabricEnabled: Boolean = false,
 ) : ReactActivityDelegate(activity, mainComponentName) {
 
   @Deprecated(
-      message =
-          "Creating DefaultReactActivityDelegate with both fabricEnabled and " +
-              "concurrentReactEnabled is deprecated. Please pass only one boolean value that will" +
-              " be used for both flags",
+      message = "Creating DefaultReactActivityDelegate with flags is deprecated.",
       level = DeprecationLevel.WARNING,
-      replaceWith =
-          ReplaceWith("DefaultReactActivityDelegate(activity, mainComponentName, fabricEnabled)"),
+      replaceWith = ReplaceWith("DefaultReactActivityDelegate(activity, mainComponentName)"),
   )
   public constructor(
       activity: ReactActivity,
       mainComponentName: String,
-      fabricEnabled: Boolean,
+      @Suppress("UNUSED_PARAMETER") fabricEnabled: Boolean,
       @Suppress("UNUSED_PARAMETER") concurrentReactEnabled: Boolean,
-  ) : this(activity, mainComponentName, fabricEnabled)
+  ) : this(activity, mainComponentName)
 
-  override fun isFabricEnabled(): Boolean = fabricEnabled
+  @Deprecated(
+      message = "Creating DefaultReactActivityDelegate with flags is deprecated.",
+      level = DeprecationLevel.WARNING,
+      replaceWith = ReplaceWith("DefaultReactActivityDelegate(activity, mainComponentName)"),
+  )
+  public constructor(
+      activity: ReactActivity,
+      mainComponentName: String,
+      @Suppress("UNUSED_PARAMETER") fabricEnabled: Boolean,
+  ) : this(activity, mainComponentName)
 }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -17,7 +17,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.FBRNTesterEndToEndHelper
 import com.facebook.react.ReactActivity
-import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 import com.facebook.react.devsupport.DevMenuConfiguration
 import java.io.FileDescriptor
@@ -25,7 +24,7 @@ import java.io.PrintWriter
 
 internal class RNTesterActivity : ReactActivity() {
   class RNTesterActivityDelegate(val activity: ReactActivity, mainComponentName: String) :
-      DefaultReactActivityDelegate(activity, mainComponentName, fabricEnabled) {
+      DefaultReactActivityDelegate(activity, mainComponentName) {
     private val PARAM_ROUTE = "route"
     private lateinit var initialProps: Bundle
 


### PR DESCRIPTION
Summary:

These flags were already ignored.

Changelog: [Android][Deprecated] DefaultReactActivityDelegate's constructor taking new arch flags are deprecated

Reviewed By: cortinico

Differential Revision: D105816717


