### PR TITLE
fix(cocoapods): escape local file URIs for unicode paths

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -39,6 +39,53 @@ class UtilsTests < Test::Unit::TestCase
         $RN_PLATFORMS = nil
     end
 
+    # ===================== #
+    # TEST - localFileUri   #
+    # ===================== #
+
+    def test_localFileUri_whenPathContainsUnicode_returnsEscapedFileUri
+        # Arrange
+        path = "/tmp/rn-unicode/💻dev/React-Core-prebuilt.tar.gz"
+
+        # Act
+        result = ReactNativePodsUtils.local_file_uri(path)
+
+        # Assert
+        assert_equal("file:///tmp/rn-unicode/%F0%9F%92%BBdev/React-Core-prebuilt.tar.gz", result)
+    end
+
+    def test_localFileUri_whenPathContainsSpaces_returnsEscapedFileUri
+        # Arrange
+        path = "/tmp/rn space/React Core.tar.gz"
+
+        # Act
+        result = ReactNativePodsUtils.local_file_uri(path)
+
+        # Assert
+        assert_equal("file:///tmp/rn%20space/React%20Core.tar.gz", result)
+    end
+
+    def test_localFileUri_whenPathContainsOnlyAscii_returnsFileUri
+        # Arrange
+        path = "/tmp/rn-ascii/React-Core-prebuilt.tar.gz"
+
+        # Act
+        result = ReactNativePodsUtils.local_file_uri(path)
+
+        # Assert
+        assert_equal("file:///tmp/rn-ascii/React-Core-prebuilt.tar.gz", result)
+    end
+
+    def test_localFileUri_whenPathContainsUnicode_withoutEscapingUriFileBuildRaises
+        # Arrange
+        path = "/tmp/rn-unicode/💻dev/React-Core-prebuilt.tar.gz"
+
+        # Act & Assert
+        assert_raise(URI::InvalidComponentError) do
+            URI::File.build(path: path).to_s
+        end
+    end
+
     # ======================= #
     # TEST - warnIfNotOnArm64 #
     # ======================= #

--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -103,7 +103,7 @@ class ReactNativeCoreUtils
         if ENV["RCT_TESTONLY_RNCORE_TARBALL_PATH"]
             abort_if_use_local_rncore_with_no_file()
             rncore_log("Using local xcframework at #{ENV["RCT_TESTONLY_RNCORE_TARBALL_PATH"]}")
-            return {:http => "file://#{ENV["RCT_TESTONLY_RNCORE_TARBALL_PATH"]}" }
+            return {:http => ReactNativePodsUtils.local_file_uri(ENV["RCT_TESTONLY_RNCORE_TARBALL_PATH"]) }
         end
 
         if ENV["RCT_USE_PREBUILT_RNCORE"] == "1"
@@ -161,7 +161,7 @@ class ReactNativeCoreUtils
         rncore_log("  #{Pathname.new(destinationRelease).relative_path_from(Pathname.pwd).to_s}")
 
         return {:http => stable_tarball_url(@@react_native_version, :debug) } unless @@download_dsyms
-        return {:http => URI::File.build(path: destinationDebug).to_s }
+        return {:http => ReactNativePodsUtils.local_file_uri(destinationDebug) }
     end
 
     def self.podspec_source_download_prebuilt_nightly_tarball()
@@ -198,7 +198,7 @@ class ReactNativeCoreUtils
         rncore_log("  #{Pathname.new(destinationDebug).relative_path_from(Pathname.pwd).to_s}")
         rncore_log("  #{Pathname.new(destinationRelease).relative_path_from(Pathname.pwd).to_s}")
         return {:http => nightly_tarball_url(@@react_native_version, :debug) } unless @@download_dsyms
-        return {:http => URI::File.build(path: destinationDebug).to_s }
+        return {:http => ReactNativePodsUtils.local_file_uri(destinationDebug) }
     end
 
     def self.process_dsyms(frameworkTarball, dSymsTarball)

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -70,7 +70,7 @@ class ReactNativeDependenciesUtils
         if ENV["RCT_USE_LOCAL_RN_DEP"]
             abort_if_use_local_rndeps_with_no_file()
             rndeps_log("Using local xcframework at #{ENV["RCT_USE_LOCAL_RN_DEP"]}")
-            return {:http => "file://#{ENV["RCT_USE_LOCAL_RN_DEP"]}" }
+            return {:http => ReactNativePodsUtils.local_file_uri(ENV["RCT_USE_LOCAL_RN_DEP"]) }
         end
 
         if ENV["RCT_USE_RN_DEP"] && ENV["RCT_USE_RN_DEP"] == "1"

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -5,12 +5,18 @@
 
 require 'shellwords'
 require 'digest'
+require 'uri'
 
 require_relative "./helpers.rb"
 require_relative "./jsengine.rb"
 
 # Utilities class for React Native Cocoapods
 class ReactNativePodsUtils
+    # URI::File.build validates path components as ASCII, so escape the filesystem path first.
+    def self.local_file_uri(path)
+        URI::File.build(path: URI::DEFAULT_PARSER.escape(path)).to_s
+    end
+
     def self.warn_if_not_on_arm64
         if SysctlChecker.new().call_sysctl_arm64() == 1 && !Environment.new().ruby_platform().include?('arm64')
             Pod::UI.warn 'Do not use "pod install" from inside Rosetta2 (x86_64 emulation on arm64).'


### PR DESCRIPTION
## Summary:

#56878 shows that using unicode characters in paths fails with pod install. 

Expo fixed this internally here: https://github.com/expo/expo/pull/45779

Fixes #56878

## How:

Build local `file://` sources through a shared helper that percent-encodes filesystem paths before passing them to `URI::File.build`. This avoids Ruby/CocoaPods URI failures when React Native projects or local prebuilt tarballs live under paths containing Unicode characters or spaces.

Apply the helper to `RNCore` and `ReactNativeDependencies` local tarball sources, including RNCore dSYM-processed prebuilt paths, while leaving remote Maven and Sonatype URLs unchanged.

Add focused coverage for Unicode, spaces, ASCII paths, and the raw `URI::File.build` regression case.

## Changelog:

[IOS] [FIXED] - fixed escaping local file URIs for unicode paths in ruby scripts

## Test Plan:

- Test with creating a new project in a path containing a unicode character and the run pod install.