### PR TITLE
Stop syncing Modal system bars from Activity on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -14,7 +14,6 @@ import android.app.Activity
 import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
-import android.os.Build
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
@@ -27,8 +26,6 @@ import android.widget.FrameLayout
 import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.UiThread
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.common.logging.FLog
 import com.facebook.react.R
 import com.facebook.react.bridge.GuardedRunnable
@@ -342,7 +339,6 @@ public class ReactModalHostView(context: ThemedReactContext) :
     }
     if (currentActivity?.isFinishing == false) {
       newDialog.show()
-      updateSystemAppearance()
       window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
       (context as ThemedReactContext).onExtraWindowCreate(window)
     }
@@ -412,62 +408,6 @@ public class ReactModalHostView(context: ThemedReactContext) :
       // java.lang.IllegalArgumentException: View=DecorView@c94931b[XxxActivity] not attached to
       // window manager
       FLog.e(TAG, "ReactModalHostView: error while setting window flags: ", e.message)
-    }
-  }
-
-  /**
-   * Updates the system appearance of the dialog to match the activity that it is being displayed
-   * on.
-   */
-  private fun updateSystemAppearance() {
-    val currentActivity = getCurrentActivity() ?: return
-    val dialog = checkNotNull(dialog) { "dialog must exist when we call updateProperties" }
-    val dialogWindow =
-        checkNotNull(dialog.window) { "dialog must have window when we call updateProperties" }
-    val activityWindow = currentActivity.window
-    // Modeled after the version check in StatusBarModule.setStyle
-    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
-      val activityWindowInsetsController =
-          WindowInsetsControllerCompat(activityWindow, activityWindow.decorView)
-      val dialogWindowInsetsController =
-          WindowInsetsControllerCompat(dialogWindow, dialogWindow.decorView)
-
-      if (isEdgeToEdgeFeatureFlagOn) {
-        activityWindowInsetsController.systemBarsBehavior =
-            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        dialogWindowInsetsController.systemBarsBehavior =
-            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-      }
-
-      dialogWindowInsetsController.isAppearanceLightStatusBars =
-          activityWindowInsetsController.isAppearanceLightStatusBars
-
-      activityWindow.decorView.rootWindowInsets?.let { insets ->
-        val activityRootWindowInsets = WindowInsetsCompat.toWindowInsetsCompat(insets)
-        syncSystemBarsVisibility(activityRootWindowInsets, dialogWindowInsetsController)
-      }
-    } else {
-      dialogWindow.decorView.systemUiVisibility = activityWindow.decorView.systemUiVisibility
-    }
-  }
-
-  /**
-   * Syncs the visibility of the system bars based on their visibility in the root window insets.
-   * This ensures consistency between the system bars visibility in the activity and the dialog.
-   */
-  private fun syncSystemBarsVisibility(
-      activityRootWindowInsets: WindowInsetsCompat,
-      dialogWindowInsetsController: WindowInsetsControllerCompat?,
-      types: List<Int> =
-          listOf(WindowInsetsCompat.Type.statusBars(), WindowInsetsCompat.Type.navigationBars()),
-  ) {
-    types.forEach { type ->
-      val isVisible = activityRootWindowInsets.isVisible(type)
-      if (isVisible) {
-        dialogWindowInsetsController?.show(type)
-      } else {
-        dialogWindowInsetsController?.hide(type)
-      }
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR removes `updateSystemAppearance()` and `syncSystemBarsVisibility()` along with their now-unused imports.

On Android, every time a `<Modal>` is shown, `ReactModalHostView.updateSystemAppearance()` reaches into the host activity's `WindowInsetsController` and copies its status bar / navigation bar style and visibility onto the dialog window. This was the only way to keep modal windows visually consistent with the activity, since native modules like `StatusBarModule` only operated on the activity window.

This is now obsolete:

- #55721 added the `ExtraWindowEventListener` interface, letting native modules be notified when extra `Window`s (e.g. modal dialogs) are created and destroyed.
- #56059 made `StatusBarModule` implement that interface, so status bar style and visibility now sync to modal windows directly from the module that owns them.

The navigation bar half of `updateSystemAppearance()` is owned by third-party libraries (`expo-navigation-bar`, `@zoontek/react-native-navigation-bar`). Their next releases will implement `ExtraWindowEventListener` the same way `StatusBarModule` does, syncing nav bar style and visibility to modal windows from the module that owns them.

At that point `updateSystemAppearance()` is fully redundant: every concern it covered is handled by the module responsible for that configuration.

## Changelog:

[ANDROID] [REMOVED] - Remove manual system bar sync from `ReactModalHostView`; modal windows are now configured by modules implementing `ExtraWindowEventListener` (e.g. `StatusBarModule`).

## Test Plan:

- Open a `<Modal>` on Android and confirm the status bar style matches the host activity (light / dark content), now driven by `StatusBarModule`'s `ExtraWindowEventListener`.
- Change `<StatusBar barStyle="light-content" />` / `"dark-content"` while a modal is open and confirm the change applies to the dialog window.
- Toggle `<StatusBar hidden />` before and during a modal presentation and confirm the dialog stays in sync with the activity.
