### PR TITLE
Remove unnecessary HERMES_V1_ENABLED=1 inside build.gradle

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -580,8 +580,6 @@ android {
             "-DCMAKE_POLICY_DEFAULT_CMP0069=NEW",
         )
 
-        arguments("-DHERMES_V1_ENABLED=1")
-
         targets(
             "reactnative",
             "jsi",


### PR DESCRIPTION
## Summary:

This is no longer necessary and just creates a warning:

```
C/C++: CMake Warning:
C/C++:   Manually-specified variables were not used by the project:
C/C++:     HERMES_V1_ENABLED
```

Let's clean this up.

## Changelog:

[INTERNAL] -

## Test Plan:

CI