### PR TITLE
codemod `in/out` (#56930)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -45,6 +45,7 @@ packages/react-native/flow/
 [options]
 enums=true
 experimental.pattern_matching=true
+experimental.allow_variance_keywords=true
 casting_syntax=both
 component_syntax=true
 

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -72,14 +72,14 @@ export type ArrayBufferTypeAnnotation = Readonly<{
   type: 'ArrayBufferTypeAnnotation',
 }>;
 
-export type ObjectTypeAnnotation<+T> = Readonly<{
+export type ObjectTypeAnnotation<out T> = Readonly<{
   type: 'ObjectTypeAnnotation',
   properties: ReadonlyArray<NamedShape<T>>,
   // metadata for objects that generated from interfaces
   baseTypes?: ReadonlyArray<string>,
 }>;
 
-export type UnionTypeAnnotation<+T> = Readonly<{
+export type UnionTypeAnnotation<out T> = Readonly<{
   type: 'UnionTypeAnnotation',
   types: ReadonlyArray<T>,
 }>;
@@ -93,13 +93,13 @@ export type EventEmitterTypeAnnotation = Readonly<{
   typeAnnotation: NativeModuleEventEmitterTypeAnnotation | $FlowFixMe,
 }>;
 
-type FunctionTypeAnnotation<+P, +R> = Readonly<{
+type FunctionTypeAnnotation<out P, out R> = Readonly<{
   type: 'FunctionTypeAnnotation',
   params: ReadonlyArray<NamedShape<P>>,
   returnTypeAnnotation: R,
 }>;
 
-export type NamedShape<+T> = Readonly<{
+export type NamedShape<out T> = Readonly<{
   name: string,
   optional: boolean,
   typeAnnotation: T,
@@ -195,7 +195,7 @@ export type ComponentCommandArrayTypeAnnotation = ArrayTypeAnnotation<
   | MixedTypeAnnotation,
 >;
 
-export type ArrayTypeAnnotation<+T> = Readonly<{
+export type ArrayTypeAnnotation<out T> = Readonly<{
   type: 'ArrayTypeAnnotation',
   elementType: T,
 }>;
@@ -269,11 +269,11 @@ export type ReservedTypeAnnotation = Readonly<{
 /**
  * NativeModule Types
  */
-export type Nullable<+T extends NativeModuleTypeAnnotation> =
+export type Nullable<out T extends NativeModuleTypeAnnotation> =
   | NullableTypeAnnotation<T>
   | T;
 
-export type NullableTypeAnnotation<+T extends NativeModuleTypeAnnotation> =
+export type NullableTypeAnnotation<out T extends NativeModuleTypeAnnotation> =
   Readonly<{
     type: 'NullableTypeAnnotation',
     typeAnnotation: T,
@@ -321,7 +321,7 @@ export type NativeModuleObjectTypeAnnotation = ObjectTypeAnnotation<
 >;
 
 export type NativeModuleArrayTypeAnnotation<
-  +T extends Nullable<NativeModuleBaseTypeAnnotation>,
+  out T extends Nullable<NativeModuleBaseTypeAnnotation>,
 > = ArrayTypeAnnotation<
   | T
   /**

--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -17,7 +17,7 @@ const {verifyPropNotAlreadyDefined} = require('../../parsers-commons');
 const {getValueFromTypes} = require('../utils.js');
 
 // $FlowFixMe[unsupported-variance-annotation]
-function getTypeAnnotationForArray<+T>(
+function getTypeAnnotationForArray<out T>(
   name: string,
   typeAnnotation: $FlowFixMe,
   defaultValue: $FlowFixMe | null,
@@ -219,7 +219,7 @@ function flattenProperties(
 }
 
 // $FlowFixMe[unsupported-variance-annotation]
-function getTypeAnnotation<+T>(
+function getTypeAnnotation<out T>(
   name: string,
   annotation: $FlowFixMe | ASTNode,
   defaultValue: $FlowFixMe | null,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -107,7 +107,7 @@ function wrapModuleSchema(
 }
 
 // $FlowFixMe[unsupported-variance-annotation]
-function unwrapNullable<+T extends NativeModuleTypeAnnotation>(
+function unwrapNullable<out T extends NativeModuleTypeAnnotation>(
   x: Nullable<T>,
 ): [T, boolean] {
   if (x.type === 'NullableTypeAnnotation') {
@@ -118,7 +118,7 @@ function unwrapNullable<+T extends NativeModuleTypeAnnotation>(
 }
 
 // $FlowFixMe[unsupported-variance-annotation]
-function wrapNullable<+T extends NativeModuleTypeAnnotation>(
+function wrapNullable<out T extends NativeModuleTypeAnnotation>(
   nullable: boolean,
   typeAnnotation: T,
 ): Nullable<T> {

--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -31,7 +31,7 @@ type Nullable = void | null;
 type Primitive = string | number | boolean | symbol | void;
 type Builtin = (...ReadonlyArray<empty>) => unknown | Date | Error | RegExp;
 
-export type WithAnimatedValue<+T> = T extends Builtin | Nullable
+export type WithAnimatedValue<out T> = T extends Builtin | Nullable
   ? T
   : T extends Primitive
     ?
@@ -91,7 +91,7 @@ export type AnimatedBaseProps<Props extends {...}> = LooseOmit<
 
 export type AnimatedComponentType<
   Props extends {...},
-  +Instance = unknown,
+  out Instance = unknown,
 > = component(ref?: React.RefSetter<Instance>, ...AnimatedProps<Props>);
 
 export default function createAnimatedComponent<

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -118,7 +118,7 @@ export type DangerouslyImpreciseStyleProp =
  * This will correctly give you the type 'absolute' | 'relative'
  */
 export type TypeForStyleKey<
-  +key extends keyof ____DangerouslyImpreciseStyle_Internal,
+  out key extends keyof ____DangerouslyImpreciseStyle_Internal,
 > = ____DangerouslyImpreciseStyle_Internal[key];
 
 /**

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js.flow
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js.flow
@@ -119,7 +119,7 @@ export type DangerouslyImpreciseStyleProp =
  * This will correctly give you the type 'absolute' | 'relative'
  */
 export type TypeForStyleKey<
-  +key extends keyof ____DangerouslyImpreciseStyle_Internal,
+  out key extends keyof ____DangerouslyImpreciseStyle_Internal,
 > = ____DangerouslyImpreciseStyle_Internal[key];
 
 /**

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js
@@ -179,7 +179,7 @@ export default {
    * An identity function for creating style sheets.
    */
   // $FlowFixMe[unsupported-variance-annotation]
-  create<+S extends ____Styles_Internal>(obj: S): Readonly<S> {
+  create<out S extends ____Styles_Internal>(obj: S): Readonly<S> {
     // TODO: This should return S as the return type. But first,
     // we need to codemod all the callsites that are typing this
     // return value as a number (even though it was opaque).

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js.flow
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js.flow
@@ -95,6 +95,6 @@ declare export const setStyleAttributePreprocessor: (
  * An identity function for creating style sheets.
  */
 // $FlowFixMe[unsupported-variance-annotation]
-declare export const create: <+S extends ____Styles_Internal>(
+declare export const create: <out S extends ____Styles_Internal>(
   obj: S & ____Styles_Internal,
 ) => Readonly<S>;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -1064,7 +1064,7 @@ export type ____DangerouslyImpreciseStyle_Internal = Readonly<{
   ...
 }>;
 
-export type StyleProp<+T> =
+export type StyleProp<out T> =
   | null
   | void
   | T
@@ -1100,7 +1100,7 @@ export type ____Styles_Internal = {
 // ____FlattenStyleProp_Helper should be considered internal.
 type FlattenDepthLimiter = [void, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 type ____FlattenStyleProp_Helper<
-  +TStyleProp extends StyleProp<unknown>,
+  out TStyleProp extends StyleProp<unknown>,
   Depth extends Values<FlattenDepthLimiter> = 9,
 > = Depth extends 0
   ? empty
@@ -1114,7 +1114,7 @@ type ____FlattenStyleProp_Helper<
       : TStyleProp;
 
 export type ____FlattenStyleProp_Internal<
-  +TStyleProp extends StyleProp<unknown>,
+  out TStyleProp extends StyleProp<unknown>,
 > =
   ____FlattenStyleProp_Helper<TStyleProp> extends empty // $FlowFixMe[unclear-type]
     ? any

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -10,7 +10,7 @@
 
 import type {HostInstance} from '../../src/private/types/HostInstance';
 
-export type NativeSyntheticEvent<+T> = Readonly<{
+export type NativeSyntheticEvent<out T> = Readonly<{
   bubbles: ?boolean,
   cancelable: ?boolean,
   currentTarget: number | HostInstance,

--- a/packages/react-native/flow/dom.js.flow
+++ b/packages/react-native/flow/dom.js.flow
@@ -1379,7 +1379,7 @@ declare class Attr extends Node {
   localName: string;
 }
 
-declare class HTMLCollection<+Elem extends HTMLElement> {
+declare class HTMLCollection<out Elem extends HTMLElement> {
   @@iterator(): Iterator<Elem>;
   length: number;
   item(nameOrIndex?: any, optionalIndex?: any): Elem | null;

--- a/packages/react-native/src/private/components/virtualcollection/Virtual.js
+++ b/packages/react-native/src/private/components/virtualcollection/Virtual.js
@@ -19,7 +19,7 @@ export interface Item {}
  * An interface for a collection of items, without requiring that each item be
  * eagerly (or lazily) allocated.
  */
-export interface VirtualCollection<+T extends Item> {
+export interface VirtualCollection<out T extends Item> {
   /**
    * The number of items in the collection. This can either be a numeric scalar
    * or a getter function that is computed on access. However, it should remain
@@ -40,7 +40,7 @@ export interface VirtualCollection<+T extends Item> {
  * use, this is not recommended for larger arrays because each element of an
  * array is eagerly allocated.
  */
-export class VirtualArray<+T extends Item> implements VirtualCollection<T> {
+export class VirtualArray<out T extends Item> implements VirtualCollection<T> {
   +size: number;
   +at: (index: number) => T;
 

--- a/packages/react-native/src/private/components/virtualcollection/VirtualCollectionView.js
+++ b/packages/react-native/src/private/components/virtualcollection/VirtualCollectionView.js
@@ -40,7 +40,7 @@ export type VirtualCollectionGenerator = Readonly<{
 }>;
 
 export type VirtualCollectionViewComponent<TLayoutProps extends {...}> =
-  component<+TItem extends Item>(
+  component<out TItem extends Item>(
     children: (item: TItem, key: string) => React.Node,
     items: VirtualCollection<TItem>,
     itemToKey?: (TItem) => string,
@@ -87,7 +87,7 @@ export function createVirtualCollectionView<TLayoutProps extends {...}>(
   VirtualLayout: VirtualCollectionLayoutComponent<TLayoutProps>,
   {initial, next}: VirtualCollectionGenerator,
 ): VirtualCollectionViewComponent<TLayoutProps> {
-  component VirtualCollectionView<+TItem extends Item>(
+  component VirtualCollectionView<out TItem extends Item>(
     children: (item: TItem, key: string) => React.Node,
     items: VirtualCollection<TItem>,
     itemToKey: TItem => string = defaultItemToKey,

--- a/packages/react-native/src/private/components/virtualcollection/column/VirtualColumn.js
+++ b/packages/react-native/src/private/components/virtualcollection/column/VirtualColumn.js
@@ -34,7 +34,7 @@ const VirtualColumn = createVirtualCollectionView(
 // TODO: Figure out component generic resolution.
 // @see https://fb.workplace.com/groups/flow/posts/29355518614070041
 // export default VirtualColumn as VirtualCollectionViewComponent<VirtualColumnLayoutProps>;
-export default VirtualColumn as component<+TItem extends Item>(
+export default VirtualColumn as component<out TItem extends Item>(
   children: (item: TItem, key: string) => React.Node,
   items: VirtualCollection<TItem>,
   itemToKey?: (TItem) => string,

--- a/packages/react-native/src/private/components/virtualcollection/row/VirtualRow.js
+++ b/packages/react-native/src/private/components/virtualcollection/row/VirtualRow.js
@@ -34,7 +34,7 @@ const VirtualRow = createVirtualCollectionView(
 // TODO: Figure out component generic resolution.
 // @see https://fb.workplace.com/groups/flow/posts/29355518614070041
 // export default VirtualRow as VirtualCollectionViewComponent<VirtualRowLayoutProps>;
-export default VirtualRow as component<+TItem extends Item>(
+export default VirtualRow as component<out TItem extends Item>(
   children: (item: TItem, key: string) => React.Node,
   items: VirtualCollection<TItem>,
   itemToKey?: (TItem) => string,

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection.js.flow
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection.js.flow
@@ -10,7 +10,7 @@
 
 import type {ArrayLike} from '../../utils/ArrayLikeUtils';
 
-declare export default class HTMLCollection<+T>
+declare export default class HTMLCollection<out T>
   // $FlowFixMe[incompatible-variance]
   implements Iterable<T>, ArrayLike<T>
 {

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js.flow
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js.flow
@@ -10,8 +10,10 @@
 
 import type {ArrayLike} from '../../utils/ArrayLikeUtils';
 
-// $FlowFixMe[incompatible-variance]
-declare export default class NodeList<+T> implements Iterable<T>, ArrayLike<T> {
+declare export default class NodeList<out T>
+  // $FlowFixMe[incompatible-variance]
+  implements Iterable<T>, ArrayLike<T>
+{
   // This property should've been read-only as well, but Flow doesn't handle
   // read-only indexers correctly (thinks reads are writes and fails).
   // $FlowFixMe[incompatible-variance]


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebook/relay/pull/5290

```
pastry P2346790458 | sed 's|^|xplat/js/|' | js1 flow-runner codemod flow/transformAllVariance --variance in,out --format-files=false @
```

Reviewed By: SamChou19815

Differential Revision: D106021144


