### PR TITLE
Turn on `allow_variance_keywords` for xplat/js/react-native-github/.github.flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -45,6 +45,7 @@ packages/react-native/flow/
 [options]
 enums=true
 experimental.pattern_matching=true
+experimental.allow_variance_keywords=true
 casting_syntax=both
 component_syntax=true
 


### PR DESCRIPTION
Summary: default to true version is not released yet. turning it on

Reviewed By: gkz

Differential Revision: D106027737


