### PR TITLE
Remove unreferenced ViewNativeComponentType

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -42,5 +42,3 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
 // Additional note: Our long term plan is to reduce the overhead of the <Text>
 // and <View> wrappers so that we no longer have any reason to export these APIs.
 export default ViewNativeComponent;
-
-export type ViewNativeComponentType = HostComponent<Props>;


### PR DESCRIPTION
Summary:
Discovered while I try to understand the best shape for ref types.

We have no other 1P component usage pattern for `React.ElementRef<ViewNativeComponentType>`, except for two now-removed fbsource instances, replaced with `React.ElementRef<typeof View>`.

Changelog: [Internal]

Differential Revision: D106093290


