### PR TITLE
Support resource drawable URIs in `Image.getSize()` on Android (#56944)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
@@ -35,6 +35,7 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.modules.fresco.ReactNetworkImageRequest
 import com.facebook.react.views.image.ReactCallerContextFactory
 import com.facebook.react.views.imagehelper.ImageSource
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
 
 @ReactModule(name = NativeImageLoaderAndroidSpec.NAME)
 internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventListener {
@@ -85,6 +86,13 @@ internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventL
       return
     }
     val source = ImageSource(reactApplicationContext, uriString)
+    // Fast path: resolve resource drawables (including VectorDrawables) via the
+    // Android resource system instead of Fresco's encoded-image pipeline, which
+    // does not support res:// URIs.
+    if (source.isResource) {
+      resolveResourceSize(uriString, promise)
+      return
+    }
     val request: ImageRequest =
         ImageRequestBuilder.newBuilderWithSource(source.uri)
             .setRotationOptions(RotationOptions.disableRotation())
@@ -109,6 +117,11 @@ internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventL
       return
     }
     val source = ImageSource(reactApplicationContext, uriString)
+    // Fast path: resource drawables are resolved locally; headers are not applicable.
+    if (source.isResource) {
+      resolveResourceSize(uriString, promise)
+      return
+    }
     val imageRequestBuilder: ImageRequestBuilder =
         ImageRequestBuilder.newBuilderWithSource(source.uri)
             .setRotationOptions(RotationOptions.disableRotation())
@@ -166,6 +179,43 @@ internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventL
           promise.reject(ERROR_GET_SIZE_FAILURE, dataSource.failureCause)
         }
       }
+
+  /**
+   * Resolve the intrinsic size of a drawable resource by name. Works for all drawable types
+   * including VectorDrawable, which cannot be decoded by Fresco's encoded-image pipeline.
+   *
+   * Drawables without intrinsic dimensions (e.g. ColorDrawable) will cause the promise to be
+   * rejected since there is no meaningful size to return.
+   */
+  private fun resolveResourceSize(name: String, promise: Promise) {
+    val context = reactApplicationContext
+    val drawable =
+        try {
+          ResourceDrawableIdHelper.getResourceDrawable(context, name)
+        } catch (e: Exception) {
+          promise.reject(ERROR_GET_SIZE_FAILURE, e)
+          return
+        }
+    if (drawable == null) {
+      promise.reject(ERROR_GET_SIZE_FAILURE, "Could not resolve drawable resource: $name")
+      return
+    }
+    val width = drawable.intrinsicWidth
+    val height = drawable.intrinsicHeight
+    if (width < 0 || height < 0) {
+      promise.reject(
+          ERROR_GET_SIZE_FAILURE,
+          "Drawable resource has no intrinsic size: $name",
+      )
+      return
+    }
+    promise.resolve(
+        buildReadableMap {
+          put("width", width)
+          put("height", height)
+        }
+    )
+  }
 
   /**
    * Prefetches the given image to the Fresco image disk cache.

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/image/ImageLoaderModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/image/ImageLoaderModuleTest.kt
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.image
+
+import android.content.res.Resources
+import android.graphics.drawable.Drawable
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactTestHelper
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
+import com.facebook.testutils.shadows.ShadowArguments
+import com.facebook.testutils.shadows.ShadowSoLoader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(shadows = [ShadowArguments::class, ShadowSoLoader::class])
+@RunWith(RobolectricTestRunner::class)
+class ImageLoaderModuleTest {
+
+  private lateinit var imageLoaderModule: ImageLoaderModule
+  private lateinit var mockedHelper: MockedStatic<ResourceDrawableIdHelper>
+
+  @Before
+  fun setUp() {
+    val reactContext = ReactTestHelper.createCatalystContextForTest()
+    imageLoaderModule = ImageLoaderModule(reactContext)
+
+    mockedHelper = mockStatic(ResourceDrawableIdHelper::class.java)
+    // By default, getResourceDrawableUri returns a res:// URI so ImageSource.isResource is true
+    // when the source string has no scheme. We need getResourceDrawableId to return a valid ID
+    // for the source to be treated as a resource.
+    mockedHelper
+        .`when`<Int> { ResourceDrawableIdHelper.getResourceDrawableId(any(), any()) }
+        .thenReturn(0)
+  }
+
+  @After
+  fun tearDown() {
+    mockedHelper.close()
+  }
+
+  @Test
+  fun testGetSizeWithVectorDrawableResource() {
+    val drawableName = "res_ic_home_filled_20"
+    val expectedWidth = 20
+    val expectedHeight = 20
+
+    val mockDrawable = mock<Drawable>()
+    whenever(mockDrawable.intrinsicWidth).thenReturn(expectedWidth)
+    whenever(mockDrawable.intrinsicHeight).thenReturn(expectedHeight)
+
+    mockedHelper
+        .`when`<Int> { ResourceDrawableIdHelper.getResourceDrawableId(any(), eq(drawableName)) }
+        .thenReturn(12345)
+    mockedHelper
+        .`when`<Drawable?> { ResourceDrawableIdHelper.getResourceDrawable(any(), eq(drawableName)) }
+        .thenReturn(mockDrawable)
+
+    val promise = SimplePromise()
+    imageLoaderModule.getSize(drawableName, promise)
+
+    assertThat(promise.resolved).isEqualTo(1)
+    assertThat(promise.rejected).isEqualTo(0)
+
+    val result = promise.value as ReadableMap
+    assertThat(result.getInt("width")).isEqualTo(expectedWidth)
+    assertThat(result.getInt("height")).isEqualTo(expectedHeight)
+  }
+
+  @Test
+  fun testGetSizeWithHeadersWithVectorDrawableResource() {
+    val drawableName = "res_ic_home_filled_20"
+    val expectedWidth = 48
+    val expectedHeight = 48
+
+    val mockDrawable = mock<Drawable>()
+    whenever(mockDrawable.intrinsicWidth).thenReturn(expectedWidth)
+    whenever(mockDrawable.intrinsicHeight).thenReturn(expectedHeight)
+
+    mockedHelper
+        .`when`<Int> { ResourceDrawableIdHelper.getResourceDrawableId(any(), eq(drawableName)) }
+        .thenReturn(12345)
+    mockedHelper
+        .`when`<Drawable?> { ResourceDrawableIdHelper.getResourceDrawable(any(), eq(drawableName)) }
+        .thenReturn(mockDrawable)
+
+    val promise = SimplePromise()
+    imageLoaderModule.getSizeWithHeaders(drawableName, null, promise)
+
+    assertThat(promise.resolved).isEqualTo(1)
+    assertThat(promise.rejected).isEqualTo(0)
+
+    val result = promise.value as ReadableMap
+    assertThat(result.getInt("width")).isEqualTo(expectedWidth)
+    assertThat(result.getInt("height")).isEqualTo(expectedHeight)
+  }
+
+  @Test
+  fun testGetSizeWithNonExistentResource() {
+    val drawableName = "res_nonexistent_icon"
+
+    // getResourceDrawableId returns 0 for unknown resources; getResourceDrawable returns null
+    mockedHelper
+        .`when`<Int> { ResourceDrawableIdHelper.getResourceDrawableId(any(), eq(drawableName)) }
+        .thenReturn(0)
+    mockedHelper
+        .`when`<Drawable?> { ResourceDrawableIdHelper.getResourceDrawable(any(), eq(drawableName)) }
+        .thenReturn(null)
+
+    val promise = SimplePromise()
+    imageLoaderModule.getSize(drawableName, promise)
+
+    assertThat(promise.rejected).isEqualTo(1)
+    assertThat(promise.resolved).isEqualTo(0)
+    assertThat(promise.errorCode).isEqualTo("E_GET_SIZE_FAILURE")
+  }
+
+  @Test
+  fun testGetSizeRejectsWhenResourceDrawableThrows() {
+    val drawableName = "res_invalid_vector"
+
+    mockedHelper
+        .`when`<Int> { ResourceDrawableIdHelper.getResourceDrawableId(any(), eq(drawableName)) }
+        .thenReturn(12345)
+    mockedHelper
+        .`when`<Drawable?> { ResourceDrawableIdHelper.getResourceDrawable(any(), eq(drawableName)) }
+        .thenThrow(Resources.NotFoundException("invalid drawable XML"))
+
+    val promise = SimplePromise()
+    imageLoaderModule.getSize(drawableName, promise)
+
+    assertThat(promise.rejected).isEqualTo(1)
+    assertThat(promise.resolved).isEqualTo(0)
+    assertThat(promise.errorCode).isEqualTo("E_GET_SIZE_FAILURE")
+    assertThat(promise.errorMessage).contains("invalid drawable XML")
+  }
+
+  @Test
+  fun testGetSizeWithDrawableWithNoIntrinsicSize() {
+    val drawableName = "res_color_drawable"
+
+    val mockDrawable = mock<Drawable>()
+    // ColorDrawable and similar return -1 for intrinsic dimensions
+    whenever(mockDrawable.intrinsicWidth).thenReturn(-1)
+    whenever(mockDrawable.intrinsicHeight).thenReturn(-1)
+
+    mockedHelper
+        .`when`<Int> { ResourceDrawableIdHelper.getResourceDrawableId(any(), eq(drawableName)) }
+        .thenReturn(12345)
+    mockedHelper
+        .`when`<Drawable?> { ResourceDrawableIdHelper.getResourceDrawable(any(), eq(drawableName)) }
+        .thenReturn(mockDrawable)
+
+    val promise = SimplePromise()
+    imageLoaderModule.getSize(drawableName, promise)
+
+    assertThat(promise.rejected).isEqualTo(1)
+    assertThat(promise.resolved).isEqualTo(0)
+    assertThat(promise.errorCode).isEqualTo("E_GET_SIZE_FAILURE")
+    assertThat(promise.errorMessage).contains("no intrinsic size")
+  }
+
+  @Test
+  fun testGetSizeWithEmptyUri() {
+    val promise = SimplePromise()
+    imageLoaderModule.getSize("", promise)
+
+    assertThat(promise.rejected).isEqualTo(1)
+    assertThat(promise.resolved).isEqualTo(0)
+    assertThat(promise.errorCode).isEqualTo("E_INVALID_URI")
+  }
+
+  @Test
+  fun testGetSizeWithNullUri() {
+    val promise = SimplePromise()
+    imageLoaderModule.getSize(null, promise)
+
+    assertThat(promise.rejected).isEqualTo(1)
+    assertThat(promise.resolved).isEqualTo(0)
+    assertThat(promise.errorCode).isEqualTo("E_INVALID_URI")
+  }
+
+  internal class SimplePromise : Promise {
+    companion object {
+      private const val ERROR_DEFAULT_CODE = "EUNSPECIFIED"
+      private const val ERROR_DEFAULT_MESSAGE = "Error not specified."
+    }
+
+    var resolved = 0
+      private set
+
+    var rejected = 0
+      private set
+
+    var value: Any? = null
+      private set
+
+    var errorCode: String? = null
+      private set
+
+    var errorMessage: String? = null
+      private set
+
+    override fun resolve(value: Any?) {
+      resolved++
+      this.value = value
+    }
+
+    override fun reject(code: String?, message: String?) {
+      reject(code, message, null, null)
+    }
+
+    override fun reject(code: String?, throwable: Throwable?) {
+      reject(code, null, throwable, null)
+    }
+
+    override fun reject(code: String?, message: String?, throwable: Throwable?) {
+      reject(code, message, throwable, null)
+    }
+
+    override fun reject(throwable: Throwable) {
+      reject(null, null, throwable, null)
+    }
+
+    override fun reject(throwable: Throwable, userInfo: WritableMap) {
+      reject(null, null, throwable, userInfo)
+    }
+
+    override fun reject(code: String?, userInfo: WritableMap) {
+      reject(code, null, null, userInfo)
+    }
+
+    override fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap) {
+      reject(code, null, throwable, userInfo)
+    }
+
+    override fun reject(code: String?, message: String?, userInfo: WritableMap) {
+      reject(code, message, null, userInfo)
+    }
+
+    override fun reject(
+        code: String?,
+        message: String?,
+        throwable: Throwable?,
+        userInfo: WritableMap?,
+    ) {
+      rejected++
+      errorCode = code ?: ERROR_DEFAULT_CODE
+      errorMessage = message ?: throwable?.message ?: ERROR_DEFAULT_MESSAGE
+    }
+
+    @Deprecated("Method deprecated", ReplaceWith("reject(code, message)"))
+    override fun reject(message: String) {
+      reject(null, message, null, null)
+    }
+  }
+}

--- a/packages/rn-tester/android/app/src/main/res/drawable/ic_vector_test_24.xml
+++ b/packages/rn-tester/android/app/src/main/res/drawable/ic_vector_test_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#4CAF50"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z"/>
+</vector>

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -20,7 +20,14 @@ import RNTesterPlatformTest from '../Experimental/PlatformTest/RNTesterPlatformT
 import ImageCapInsetsExample from './ImageCapInsetsExample';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
-import {Image, ImageBackground, StyleSheet, Text, View} from 'react-native';
+import {
+  Image,
+  ImageBackground,
+  PixelRatio,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 
 const IMAGE1 =
   'https://www.facebook.com/assets/fb_lite_messaging/E2EE-settings@3x.png';
@@ -597,6 +604,76 @@ const VectorDrawableExample = () => {
   );
 };
 
+const VectorDrawableGetSizeExample = () => {
+  const [results, setResults] = useState<
+    Array<{name: string, status: string, width?: number, height?: number}>,
+  >([]);
+
+  const testResources = [
+    {name: 'ic_vector_test_24', label: 'VectorDrawable (24dp circle)'},
+    {
+      name: 'ic_launcher_foreground',
+      label: 'VectorDrawable (108dp React logo)',
+    },
+    {name: 'ic_launcher_background', label: 'VectorDrawable (108dp grid)'},
+    {name: 'ic_menu_black_24dp', label: 'PNG drawable (24dp menu icon)'},
+    {
+      name: 'ic_settings_black_48dp',
+      label: 'PNG drawable (48dp settings icon)',
+    },
+    {name: 'nonexistent_drawable', label: 'Non-existent resource'},
+  ];
+
+  const runTest = () => {
+    setResults([]);
+    const scale = PixelRatio.get();
+    testResources.forEach(({name, label}) => {
+      Image.getSize(
+        name,
+        (width, height) => {
+          setResults(prev => [
+            ...prev,
+            {
+              name: label,
+              status: 'success',
+              width: Math.round(width / scale),
+              height: Math.round(height / scale),
+            },
+          ]);
+        },
+        (error: unknown) => {
+          setResults(prev => [
+            ...prev,
+            {name: label, status: `error: ${String(error)}`},
+          ]);
+        },
+      );
+    });
+  };
+
+  return (
+    <View testID="vector-drawable-getsize-example">
+      <RNTesterButton onPress={runTest}>
+        Run Image.getSize on local drawable resources
+      </RNTesterButton>
+      {results.map((result, index) => (
+        <View key={index} style={styles.getSizeRow}>
+          <RNTesterText style={styles.getSizeLabel}>{result.name}</RNTesterText>
+          {result.status === 'success' ? (
+            <RNTesterText style={styles.getSizeSuccess}>
+              {result.width}x{result.height} dp
+            </RNTesterText>
+          ) : (
+            <RNTesterText style={styles.getSizeError}>
+              {result.status}
+            </RNTesterText>
+          )}
+        </View>
+      ))}
+    </View>
+  );
+};
+
 function CacheControlExample(): React.Node {
   const [reload, setReload] = useState(0);
 
@@ -992,6 +1069,22 @@ const styles = StyleSheet.create({
   vectorDrawable: {
     height: 64,
     width: 64,
+  },
+  getSizeRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  getSizeLabel: {
+    flex: 1,
+  },
+  getSizeSuccess: {
+    color: 'green',
+    fontWeight: 'bold',
+  },
+  getSizeError: {
+    color: 'red',
   },
   resizedImage: {
     height: 100,
@@ -1811,6 +1904,16 @@ exports.examples = [
       'Demonstrating an example of loading a vector drawable asset by name',
     render: function (): React.Node {
       return <VectorDrawableExample />;
+    },
+    platform: 'android',
+  },
+  {
+    title: 'Image.getSize with local drawables',
+    name: 'vector-drawable-getsize',
+    description:
+      'Calls Image.getSize() on Android drawable resource names (both VectorDrawable and raster PNG) and displays dimensions in density-independent pixels (dp).',
+    render: function (): React.Node {
+      return <VectorDrawableGetSizeExample />;
     },
     platform: 'android',
   },


### PR DESCRIPTION
Summary:

`Image.getSize()` and `Image.getSizeWithHeaders()` always failed for Android drawable resource URIs (e.g. `"res_ic_home_filled_20"`) because Fresco's `fetchEncodedImage` pipeline does not handle `res://` URIs — it throws `IllegalArgumentException("Unsupported uri scheme for encoded image fetch!")`.

This adds a fast path in `ImageLoaderModule` that detects resource URIs via `ImageSource.isResource` and resolves their intrinsic dimensions through Android's `Drawable` API (`ResourceDrawableIdHelper.getResourceDrawable()` -> `Drawable.getIntrinsicWidth/Height()`). This works for all drawable types including VectorDrawables, which are compiled XML and cannot be decoded by Fresco's raster-oriented pipeline.

For non-resource URIs (network, file, content), the existing Fresco `fetchEncodedImage` path is unchanged.

Changelog:
[Android][Fixed] - Fix `Image.getSize()` failing for local drawable resource URIs including VectorDrawables

Differential Revision: D106045223


