### PR TITLE
Add Maestro test for `Image.getSize` with local drawable resources (#56945)

### DIFF
--- a/packages/rn-tester/.maestro/image-getsize-local-drawables.yml
+++ b/packages/rn-tester/.maestro/image-getsize-local-drawables.yml
@@ -1,0 +1,57 @@
+appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
+tags:
+  - android-only
+---
+# This flow exercises Android-only behavior (Image.getSize on local drawable
+# resources). The RNTester E2E job runs the entire .maestro/ folder on iOS as
+# well, so guard the whole flow with a platform condition: on iOS the wrapped
+# runFlow is skipped, leaving an empty (passing) flow; on Android it runs in full.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      # Navigate to Image examples
+      - runFlow: ./helpers/launch-app-and-search.yml
+      - inputText:
+          text: "Image"
+      - assertVisible:
+          id: "Image"
+      - tapOn:
+          id: "Image"
+
+      # Search for the local drawables example
+      - assertVisible:
+          id: "example_search"
+      - tapOn:
+          id: "example_search"
+      - inputText:
+          text: "local drawables"
+      - hideKeyboard
+
+      # Navigate to the example
+      # RNTester appends " (android only)" to platform-scoped example titles, so
+      # match with an inline regex rather than the bare title.
+      - scrollUntilVisible:
+          element: "Image.getSize with local drawables.*"
+          direction: DOWN
+          speed: 40
+          timeout: 10000
+      - tapOn: "Image.getSize with local drawables.*"
+
+      # Tap the run button
+      - tapOn: "Run Image.getSize on local drawable resources"
+
+      # Assert success results contain dp dimensions
+      - extendedWaitUntil:
+          visible: "24x24 dp"
+          timeout: 10000
+      - assertVisible: "108x108 dp"
+
+      # Assert error case shows error message. The six getSize results render
+      # asynchronously in callback-completion order, so the non-existent resource
+      # row may land below the fold; scroll until the error text is visible.
+      - scrollUntilVisible:
+          element: "error:.*"
+          direction: DOWN
+          speed: 40
+          timeout: 10000

--- a/packages/rn-tester/scripts/maestro-test-ios.sh
+++ b/packages/rn-tester/scripts/maestro-test-ios.sh
@@ -5,4 +5,4 @@
 # LICENSE file in the root directory of this source tree.
 
 UDID=$(xcrun simctl list devices booted -j | jq -r '[.devices[]] | add | first | .udid')
-maestro --udid="$UDID" test .maestro/ -e APP_ID=com.meta.RNTester.localDevelopment
+maestro --udid="$UDID" test --exclude-tags android-only .maestro/ -e APP_ID=com.meta.RNTester.localDevelopment


### PR DESCRIPTION
Summary:

Adds a Maestro E2E test that exercises the new RNTester example for `Image.getSize()` with Android drawable resources. The test navigates to the Image examples, opens the "Image.getSize with local drawables" example, taps the run button, and verifies that VectorDrawable and PNG drawable dimensions are returned correctly in dp, and that the error case for a nonexistent drawable shows an error message.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D106089813


