### PR TITLE
fix(types): expose Modal native ref prop

### DIFF
--- a/packages/react-native/Libraries/Modal/Modal.d.ts
+++ b/packages/react-native/Libraries/Modal/Modal.d.ts
@@ -50,6 +50,11 @@ export interface ModalBaseProps {
    * Defaults to `white` if not provided and transparent is `false`. Ignored if `transparent` is `true`.
    */
   backdropColor?: ColorValue | undefined;
+
+  /**
+   * A ref to the native Modal component.
+   */
+  modalRef?: React.RefObject<Modal | null> | undefined;
 }
 
 export interface ModalPropsIOS {

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -46,6 +46,7 @@ import {
   FocusEvent,
   GestureResponderEvent,
   HostComponent,
+  HostInstance,
   I18nManager,
   Image,
   ImageBackground,
@@ -1540,6 +1541,10 @@ const KeyboardAvoidingViewTest = () => <KeyboardAvoidingView enabled />;
 
 const ModalTest = () => <Modal hardwareAccelerated />;
 const ModalTest2 = () => <Modal hardwareAccelerated testID="modal-test-2" />;
+const ModalRefTest = () => {
+  const modalRef = React.useRef<Modal & HostInstance>(null);
+  return <Modal modalRef={modalRef} />;
+};
 
 // $ExpectType HostComponent<{ nativeProp: string; }>
 const NativeBridgedComponent = requireNativeComponent<{nativeProp: string}>(


### PR DESCRIPTION
## Summary

- add `modalRef` to the hand-written `Modal` TypeScript declarations
- align the hand-written declaration with existing `React.RefObject` ref prop typing patterns
- add typetest coverage for passing a Modal ref through `modalRef`

This replaces #56889, which GitHub auto-closed after its pull ref got stuck on a bad force-pushed commit. The branch here contains the same scoped fix plus the review feedback from #56889.

`Modal` already accepts `modalRef` at runtime and the generated API snapshot already includes it. The hand-written declarations were the odd one out, so TypeScript users could not pass the supported ref prop without a local cast.

## Changelog:

[General] [Fixed] - Expose Modal native ref prop in TypeScript declarations

## Test Plan

- `npx prettier --check packages/react-native/Libraries/Modal/Modal.d.ts packages/react-native/types/__typetests__/index.tsx`
- `npm run test-typescript -- --pretty false`
- `npm run build-types`
- `npm run test-generated-typescript -- --pretty false`
