### PR TITLE
Fix deprecation warnings in NetworkEventUtilTest

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
@@ -306,6 +306,7 @@ class NetworkEventUtilTest {
   @Test
   fun testGetRequestBodyPreviewReturnsBodyForStringRequest() {
     val payload = """{"key":"value"}"""
+    @Suppress("DEPRECATION")
     val body = RequestBody.create(MediaType.parse("application/json"), payload)
 
     assertThat(NetworkEventUtil.getRequestBodyPreview(body)).isEqualTo(payload)
@@ -314,7 +315,7 @@ class NetworkEventUtilTest {
   @Test
   fun testGetRequestBodyPreviewUnwrapsProgressRequestBody() {
     val payload = "hello world"
-    val inner = RequestBody.create(MediaType.parse("text/plain"), payload)
+    @Suppress("DEPRECATION") val inner = RequestBody.create(MediaType.parse("text/plain"), payload)
     val wrapped = ProgressRequestBody(inner) { _, _, _ -> }
 
     assertThat(NetworkEventUtil.getRequestBodyPreview(wrapped)).isEqualTo(payload)


### PR DESCRIPTION
Summary:
Android builds have been failing with the following:
```
> Task :packages:react-native:ReactAndroid:compileDebugOptimizedUnitTestKotlin
e: warnings found and -Werror specified
w: file:///__w/react-native/react-native/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt:309:28 'fun create(contentType: MediaType?, content: String): RequestBody' is deprecated. Moved to extension function. Put the 'content' argument first to fix Java.
w: file:///__w/react-native/react-native/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt:317:29 'fun create(contentType: MediaType?, content: String): RequestBody' is deprecated. Moved to extension function. Put the 'content' argument first to fix Java.
```

Warnings show as errors but we're not on OkHttp 4 yet and don't have extension functions, so it's fine to suppress these for now.

Changelog: [Internal]

Differential Revision: D106200232


