### PR TITLE
Fix codegen script phase error logging

### DIFF
--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -16,8 +16,9 @@ cd "$RCT_SCRIPT_RN_DIR"
 CODEGEN_CLI_PATH=""
 
 error () {
-    echo "$1"
-    "[Codegen] $1" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
+    message="$*"
+    echo "$message"
+    echo "[Codegen] $message" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
     exit 1
 }
 


### PR DESCRIPTION
## Summary:

This fixes the `error()` helper in `packages/react-native/scripts/react_native_pods_utils/script_phases.sh` so it logs messages instead of attempting to execute them as shell commands.

The current implementation does:

```bash
"[Codegen] $1" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
```

That causes the error path to fail with `command not found` under `set -e`, writes the shell error to `SCRIPT_OUTPUT_FILE_0` instead of the intended `[Codegen] ...` line, and truncates multi-part messages to `$1`.

This change captures the full message with `$*`, prints it to stdout, and appends the formatted `[Codegen] ...` line to `SCRIPT_OUTPUT_FILE_0`.

Fixes #56955.

## Changelog:

[IOS] [FIXED] - Fix codegen script phase error logging in `script_phases.sh`

## Test Plan:

```bash
bash -n packages/react-native/scripts/react_native_pods_utils/script_phases.sh
```

```bash
bash -lc 'set +e; bash -lc '\''set -e; rm -f /tmp/rn-codegen-test.log; f(){ message="$*"; echo "$message"; echo "[Codegen] $message" >> /tmp/rn-codegen-test.log 2>&1; exit 1; }; f hello world'\''; status=$?; echo STATUS=$status; echo LOG_CONTENT_START; cat /tmp/rn-codegen-test.log 2>/dev/null; echo LOG_CONTENT_END'
```

Observed output:

```text
hello world
STATUS=1
LOG_CONTENT_START
[Codegen] hello world
LOG_CONTENT_END
```
