### PR TITLE
feat: add performance budget checker

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -119,6 +119,7 @@
     "scripts/node-binary.sh",
     "scripts/packager-reporter.js",
     "scripts/packager.sh",
+    "scripts/performance",
     "scripts/react_native_pods_utils/script_phases.rb",
     "scripts/react_native_pods_utils/script_phases.sh",
     "scripts/react_native_pods.rb",

--- a/packages/react-native/scripts/performance/__tests__/performance-budget-cli-test.js
+++ b/packages/react-native/scripts/performance/__tests__/performance-budget-cli-test.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const {formatResult, parseArgs} = require('../performance-budget-cli');
+
+describe('performance-budget-cli', () => {
+  describe('parseArgs', () => {
+    it('parses budget, input, and baseline paths', () => {
+      expect(
+        parseArgs([
+          '--budget',
+          'react-native.performance.json',
+          '--input',
+          'current-a.json',
+          '--input',
+          'current-b.json',
+          '--baseline',
+          'baseline-a.json',
+        ]),
+      ).toEqual({
+        budget: 'react-native.performance.json',
+        inputs: ['current-a.json', 'current-b.json'],
+        baselines: ['baseline-a.json'],
+      });
+    });
+  });
+
+  describe('formatResult', () => {
+    it('formats passing results with warnings', () => {
+      expect(
+        formatResult({
+          ok: true,
+          failures: [],
+          warnings: [
+            {
+              flow: 'cold-start-home',
+              message:
+                'cold-start-home startupTimeMs has no reported p75 value',
+            },
+          ],
+        }),
+      ).toEqual([
+        'Performance budget passed',
+        '',
+        'Warnings:',
+        '- cold-start-home startupTimeMs has no reported p75 value',
+      ]);
+    });
+
+    it('formats failing results', () => {
+      expect(
+        formatResult({
+          ok: false,
+          failures: [
+            {
+              type: 'absolute',
+              flow: 'cold-start-home',
+              metric: 'startupTimeMs',
+              stat: 'p75',
+              actual: 2460,
+              budget: 2200,
+              message:
+                'cold-start-home startupTimeMs p75 is 2460, exceeding budget 2200',
+            },
+          ],
+          warnings: [],
+        }),
+      ).toEqual([
+        'Performance budget failed',
+        '',
+        'Failures:',
+        '- cold-start-home startupTimeMs p75 is 2460, exceeding budget 2200',
+      ]);
+    });
+  });
+});

--- a/packages/react-native/scripts/performance/__tests__/performance-budget-cli-test.js
+++ b/packages/react-native/scripts/performance/__tests__/performance-budget-cli-test.js
@@ -44,7 +44,7 @@ describe('performance-budget-cli', () => {
             {
               flow: 'cold-start-home',
               message:
-                'cold-start-home startupTimeMs has no reported p75 value',
+                'cold-start-home startupTimeMs p75 has no baseline value for regression comparison',
             },
           ],
         }),
@@ -52,7 +52,7 @@ describe('performance-budget-cli', () => {
         'Performance budget passed',
         '',
         'Warnings:',
-        '- cold-start-home startupTimeMs has no reported p75 value',
+        '- cold-start-home startupTimeMs p75 has no baseline value for regression comparison',
       ]);
     });
 

--- a/packages/react-native/scripts/performance/__tests__/performance-budget-test.js
+++ b/packages/react-native/scripts/performance/__tests__/performance-budget-test.js
@@ -175,7 +175,7 @@ describe('checkPerformanceBudget', () => {
     ]);
   });
 
-  it('warns when budgeted data is missing from reports', () => {
+  it('fails when budgeted data is missing from reports', () => {
     const result = checkPerformanceBudget(
       {
         flows: {
@@ -202,20 +202,170 @@ describe('checkPerformanceBudget', () => {
     );
 
     expect(result).toEqual({
-      ok: true,
-      failures: [],
-      warnings: [
+      ok: false,
+      failures: [
         {
+          type: 'missing',
           flow: 'cold-start-home',
           metric: 'startupTimeMs',
           stat: 'p75',
           message: 'cold-start-home startupTimeMs has no reported p75 value',
         },
         {
+          type: 'missing',
           flow: 'open-search-screen',
           message: 'open-search-screen has no performance report',
         },
       ],
+      warnings: [],
+    });
+  });
+
+  it('fails when duplicate flow reports would make input ambiguous', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 2460,
+            },
+          },
+        },
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 2100,
+            },
+          },
+        },
+      ],
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toEqual([
+      {
+        type: 'duplicate_report',
+        flow: 'cold-start-home',
+        reportKind: 'current',
+        firstReportIndex: 0,
+        duplicateReportIndex: 1,
+        message:
+          'current performance reports contain duplicate flow cold-start-home at indexes 0 and 1',
+      },
+      {
+        type: 'absolute',
+        flow: 'cold-start-home',
+        metric: 'startupTimeMs',
+        stat: 'p75',
+        actual: 2460,
+        budget: 2200,
+        message:
+          'cold-start-home startupTimeMs p75 is 2460, exceeding budget 2200',
+      },
+    ]);
+  });
+
+  it('fails when duplicate baseline reports would make regression comparison ambiguous', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+              maxRegressionPct: 10,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 1080,
+            },
+          },
+        },
+      ],
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 1000,
+            },
+          },
+        },
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 500,
+            },
+          },
+        },
+      ],
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toEqual([
+      {
+        type: 'duplicate_report',
+        flow: 'cold-start-home',
+        reportKind: 'baseline',
+        firstReportIndex: 0,
+        duplicateReportIndex: 1,
+        message:
+          'baseline performance reports contain duplicate flow cold-start-home at indexes 0 and 1',
+      },
+    ]);
+  });
+
+  it('fails with structured output for invalid report shapes', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+        },
+      ],
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      failures: [
+        {
+          type: 'invalid_report',
+          reportKind: 'current',
+          reportIndex: 0,
+          message: 'current performance report at index 0 must include metrics',
+        },
+        {
+          type: 'missing',
+          flow: 'cold-start-home',
+          message: 'cold-start-home has no performance report',
+        },
+      ],
+      warnings: [],
     });
   });
 

--- a/packages/react-native/scripts/performance/__tests__/performance-budget-test.js
+++ b/packages/react-native/scripts/performance/__tests__/performance-budget-test.js
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const {checkPerformanceBudget} = require('../performance-budget');
+
+describe('checkPerformanceBudget', () => {
+  it('passes when report metrics are within absolute budgets', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+              p95: 2600,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 2100,
+              p95: 2500,
+            },
+          },
+        },
+      ],
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      failures: [],
+      warnings: [],
+    });
+  });
+
+  it('fails when report metrics exceed absolute budgets', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 2460,
+            },
+          },
+        },
+      ],
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toEqual([
+      {
+        type: 'absolute',
+        flow: 'cold-start-home',
+        metric: 'startupTimeMs',
+        stat: 'p75',
+        actual: 2460,
+        budget: 2200,
+        message:
+          'cold-start-home startupTimeMs p75 is 2460, exceeding budget 2200',
+      },
+    ]);
+  });
+
+  it('passes when report metrics stay within the allowed baseline regression', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+              maxRegressionPct: 10,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 1080,
+            },
+          },
+        },
+      ],
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 1000,
+            },
+          },
+        },
+      ],
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      failures: [],
+      warnings: [],
+    });
+  });
+
+  it('fails when report metrics exceed the allowed baseline regression', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+              maxRegressionPct: 10,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 1120,
+            },
+          },
+        },
+      ],
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 1000,
+            },
+          },
+        },
+      ],
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toEqual([
+      {
+        type: 'regression',
+        flow: 'cold-start-home',
+        metric: 'startupTimeMs',
+        stat: 'p75',
+        actual: 1120,
+        baseline: 1000,
+        regressionPct: 12,
+        maxRegressionPct: 10,
+        message:
+          'cold-start-home startupTimeMs p75 regressed by 12.00%, exceeding allowed regression 10%',
+      },
+    ]);
+  });
+
+  it('warns when budgeted data is missing from reports', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+            },
+          },
+          'open-search-screen': {
+            transitionCompleteMs: {
+              p75: 500,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {},
+          },
+        },
+      ],
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      failures: [],
+      warnings: [
+        {
+          flow: 'cold-start-home',
+          metric: 'startupTimeMs',
+          stat: 'p75',
+          message: 'cold-start-home startupTimeMs has no reported p75 value',
+        },
+        {
+          flow: 'open-search-screen',
+          message: 'open-search-screen has no performance report',
+        },
+      ],
+    });
+  });
+
+  it('warns when a regression budget has no matching baseline data', () => {
+    const result = checkPerformanceBudget(
+      {
+        flows: {
+          'cold-start-home': {
+            startupTimeMs: {
+              p75: 2200,
+              maxRegressionPct: 10,
+            },
+          },
+        },
+      },
+      [
+        {
+          flow: 'cold-start-home',
+          metrics: {
+            startupTimeMs: {
+              p75: 1080,
+            },
+          },
+        },
+      ],
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      failures: [],
+      warnings: [
+        {
+          flow: 'cold-start-home',
+          metric: 'startupTimeMs',
+          stat: 'p75',
+          message:
+            'cold-start-home startupTimeMs p75 has no baseline value for regression comparison',
+        },
+      ],
+    });
+  });
+});

--- a/packages/react-native/scripts/performance/performance-budget-cli.js
+++ b/packages/react-native/scripts/performance/performance-budget-cli.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+/*::
+import type {Stats} from 'fs';
+*/
+
+const {checkPerformanceBudget} = require('./performance-budget');
+const fs = require('fs');
+
+/*::
+type ParsedArgs = $ReadOnly<{
+  +budget: string,
+  +inputs: $ReadOnlyArray<string>,
+  +baselines: $ReadOnlyArray<string>,
+}>;
+
+type Message = $ReadOnly<{
+  +message: string,
+  ...,
+}>;
+
+type FormattableResult = $ReadOnly<{
+  +ok: boolean,
+  +failures: $ReadOnlyArray<Message>,
+  +warnings: $ReadOnlyArray<Message>,
+}>;
+*/
+
+function readJsonFile(path /*: string */) /*: mixed */ {
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+function expandReportInput(path /*: string */) /*: $ReadOnlyArray<mixed> */ {
+  const stat /*: Stats */ = fs.statSync(path);
+  if (stat.isDirectory()) {
+    return fs
+      .readdirSync(path)
+      .filter(file => file.endsWith('.json'))
+      .sort()
+      .map(file => readJsonFile(`${path}/${file}`));
+  }
+  return [readJsonFile(path)];
+}
+
+function readReports(
+  paths /*: $ReadOnlyArray<string> */,
+) /*: $ReadOnlyArray<mixed> */ {
+  return paths.flatMap(path => expandReportInput(path));
+}
+
+function parseArgs(argv /*: $ReadOnlyArray<string> */) /*: ParsedArgs */ {
+  let budget = '';
+  const inputs = [];
+  const baselines = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const value = argv[i + 1];
+    if (arg === '--budget') {
+      budget = value;
+      i += 1;
+    } else if (arg === '--input') {
+      inputs.push(value);
+      i += 1;
+    } else if (arg === '--baseline') {
+      baselines.push(value);
+      i += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (budget === '') {
+    throw new Error('Missing required --budget path');
+  }
+  if (inputs.length === 0) {
+    throw new Error('Missing required --input path');
+  }
+
+  return {budget, inputs, baselines};
+}
+
+function formatResult(result /*: FormattableResult */) /*: Array<string> */ {
+  const lines = [
+    result.ok ? 'Performance budget passed' : 'Performance budget failed',
+  ];
+
+  if (result.failures.length > 0) {
+    lines.push('', 'Failures:');
+    for (const failure of result.failures) {
+      lines.push(`- ${failure.message}`);
+    }
+  }
+
+  if (result.warnings.length > 0) {
+    lines.push('', 'Warnings:');
+    for (const warning of result.warnings) {
+      lines.push(`- ${warning.message}`);
+    }
+  }
+
+  return lines;
+}
+
+function main(argv /*: $ReadOnlyArray<string> */ = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const budget = readJsonFile(args.budget);
+  const reports = readReports(args.inputs);
+  const baselineReports = readReports(args.baselines);
+  // $FlowFixMe[incompatible-type] JSON is validated structurally by the checker.
+  const result = checkPerformanceBudget(budget, reports, baselineReports);
+
+  for (const line of formatResult(result)) {
+    console.log(line);
+  }
+
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  formatResult,
+  main,
+  parseArgs,
+  readReports,
+};

--- a/packages/react-native/scripts/performance/performance-budget.js
+++ b/packages/react-native/scripts/performance/performance-budget.js
@@ -61,7 +61,38 @@ type RegressionFailure = $ReadOnly<{
   +message: string,
 }>;
 
-type Failure = AbsoluteFailure | RegressionFailure;
+type MissingFailure = $ReadOnly<{
+  +type: 'missing',
+  +flow: string,
+  +metric?: string,
+  +stat?: string,
+  +message: string,
+}>;
+
+type ReportKind = 'current' | 'baseline';
+
+type InvalidReportFailure = $ReadOnly<{
+  +type: 'invalid_report',
+  +reportKind: ReportKind,
+  +reportIndex: number,
+  +message: string,
+}>;
+
+type DuplicateReportFailure = $ReadOnly<{
+  +type: 'duplicate_report',
+  +reportKind: ReportKind,
+  +flow: string,
+  +firstReportIndex: number,
+  +duplicateReportIndex: number,
+  +message: string,
+}>;
+
+type Failure =
+  | AbsoluteFailure
+  | RegressionFailure
+  | MissingFailure
+  | InvalidReportFailure
+  | DuplicateReportFailure;
 
 type Warning = $ReadOnly<{
   +flow: string,
@@ -77,30 +108,90 @@ type BudgetResult = $ReadOnly<{
 }>;
 */
 
+function isObject(value /*: mixed */) /*: boolean */ {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}
+
 function reportByFlow(
-  reports /*: $ReadOnlyArray<PerformanceReport> */,
+  reports /*: $ReadOnlyArray<mixed> */,
+  reportKind /*: ReportKind */,
+  failures /*: Array<Failure> */,
 ) /*: Map<string, PerformanceReport> */ {
   const byFlow = new Map /*:: <string, PerformanceReport> */();
-  for (const report of reports) {
-    byFlow.set(report.flow, report);
-  }
+  const reportIndexes = new Map /*:: <string, number> */();
+
+  reports.forEach((reportValue, reportIndex) => {
+    if (!isObject(reportValue)) {
+      failures.push({
+        type: 'invalid_report',
+        reportKind,
+        reportIndex,
+        message: `${reportKind} performance report at index ${reportIndex} must be an object`,
+      });
+      return;
+    }
+
+    // $FlowFixMe[incompatible-type] Runtime validation above confirms this is an object.
+    const report /*: {[string]: mixed} */ = reportValue;
+    const flow = report.flow;
+    if (typeof flow !== 'string' || flow === '') {
+      failures.push({
+        type: 'invalid_report',
+        reportKind,
+        reportIndex,
+        message: `${reportKind} performance report at index ${reportIndex} must include flow`,
+      });
+      return;
+    }
+
+    const metrics = report.metrics;
+    if (!isObject(metrics)) {
+      failures.push({
+        type: 'invalid_report',
+        reportKind,
+        reportIndex,
+        message: `${reportKind} performance report at index ${reportIndex} must include metrics`,
+      });
+      return;
+    }
+
+    const firstReportIndex = reportIndexes.get(flow);
+    if (firstReportIndex != null) {
+      failures.push({
+        type: 'duplicate_report',
+        reportKind,
+        flow,
+        firstReportIndex,
+        duplicateReportIndex: reportIndex,
+        message: `${reportKind} performance reports contain duplicate flow ${flow} at indexes ${firstReportIndex} and ${reportIndex}`,
+      });
+      return;
+    }
+
+    // $FlowFixMe[incompatible-type] Runtime validation confirms the report contract used below.
+    const validatedReport /*: PerformanceReport */ = {flow, metrics};
+    reportIndexes.set(flow, reportIndex);
+    byFlow.set(flow, validatedReport);
+  });
+
   return byFlow;
 }
 
 function checkPerformanceBudget(
   budget /*: PerformanceBudget */,
-  reports /*: $ReadOnlyArray<PerformanceReport> */,
-  baselineReports /*: $ReadOnlyArray<PerformanceReport> */ = [],
+  reports /*: $ReadOnlyArray<mixed> */,
+  baselineReports /*: $ReadOnlyArray<mixed> */ = [],
 ) /*: BudgetResult */ {
   const failures /*: Array<Failure> */ = [];
   const warnings /*: Array<Warning> */ = [];
-  const reportsByFlow = reportByFlow(reports);
-  const baselinesByFlow = reportByFlow(baselineReports);
+  const reportsByFlow = reportByFlow(reports, 'current', failures);
+  const baselinesByFlow = reportByFlow(baselineReports, 'baseline', failures);
 
   for (const flow of Object.keys(budget.flows)) {
     const report = reportsByFlow.get(flow);
     if (report == null) {
-      warnings.push({
+      failures.push({
+        type: 'missing',
         flow,
         message: `${flow} has no performance report`,
       });
@@ -111,7 +202,8 @@ function checkPerformanceBudget(
     for (const metric of Object.keys(budgetedMetrics)) {
       const metricStats = report.metrics[metric];
       if (metricStats == null) {
-        warnings.push({
+        failures.push({
+          type: 'missing',
           flow,
           metric,
           message: `${flow} ${metric} has no reported metrics`,
@@ -128,7 +220,8 @@ function checkPerformanceBudget(
         const budgetValue = budgetedStats[stat];
         const actual = metricStats[stat];
         if (actual == null) {
-          warnings.push({
+          failures.push({
+            type: 'missing',
             flow,
             metric,
             stat,

--- a/packages/react-native/scripts/performance/performance-budget.js
+++ b/packages/react-native/scripts/performance/performance-budget.js
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+/*::
+type MetricStats = $ReadOnly<{
+  +[stat: string]: number,
+}>;
+
+type FlowMetrics = $ReadOnly<{
+  +[metric: string]: MetricStats,
+}>;
+
+type BudgetMetric = $ReadOnly<{
+  +[stat: string]: number,
+  +maxRegressionPct?: number,
+}>;
+
+type BudgetFlow = $ReadOnly<{
+  +[metric: string]: BudgetMetric,
+}>;
+
+type PerformanceBudget = $ReadOnly<{
+  +flows: $ReadOnly<{
+    +[flow: string]: BudgetFlow,
+  }>,
+}>;
+
+type PerformanceReport = $ReadOnly<{
+  +flow: string,
+  +metrics: FlowMetrics,
+}>;
+
+type AbsoluteFailure = $ReadOnly<{
+  +type: 'absolute',
+  +flow: string,
+  +metric: string,
+  +stat: string,
+  +actual: number,
+  +budget: number,
+  +message: string,
+}>;
+
+type RegressionFailure = $ReadOnly<{
+  +type: 'regression',
+  +flow: string,
+  +metric: string,
+  +stat: string,
+  +actual: number,
+  +baseline: number,
+  +regressionPct: number,
+  +maxRegressionPct: number,
+  +message: string,
+}>;
+
+type Failure = AbsoluteFailure | RegressionFailure;
+
+type Warning = $ReadOnly<{
+  +flow: string,
+  +metric?: string,
+  +stat?: string,
+  +message: string,
+}>;
+
+type BudgetResult = $ReadOnly<{
+  +ok: boolean,
+  +failures: $ReadOnlyArray<Failure>,
+  +warnings: $ReadOnlyArray<Warning>,
+}>;
+*/
+
+function reportByFlow(
+  reports /*: $ReadOnlyArray<PerformanceReport> */,
+) /*: Map<string, PerformanceReport> */ {
+  const byFlow = new Map /*:: <string, PerformanceReport> */();
+  for (const report of reports) {
+    byFlow.set(report.flow, report);
+  }
+  return byFlow;
+}
+
+function checkPerformanceBudget(
+  budget /*: PerformanceBudget */,
+  reports /*: $ReadOnlyArray<PerformanceReport> */,
+  baselineReports /*: $ReadOnlyArray<PerformanceReport> */ = [],
+) /*: BudgetResult */ {
+  const failures /*: Array<Failure> */ = [];
+  const warnings /*: Array<Warning> */ = [];
+  const reportsByFlow = reportByFlow(reports);
+  const baselinesByFlow = reportByFlow(baselineReports);
+
+  for (const flow of Object.keys(budget.flows)) {
+    const report = reportsByFlow.get(flow);
+    if (report == null) {
+      warnings.push({
+        flow,
+        message: `${flow} has no performance report`,
+      });
+      continue;
+    }
+
+    const budgetedMetrics = budget.flows[flow];
+    for (const metric of Object.keys(budgetedMetrics)) {
+      const metricStats = report.metrics[metric];
+      if (metricStats == null) {
+        warnings.push({
+          flow,
+          metric,
+          message: `${flow} ${metric} has no reported metrics`,
+        });
+        continue;
+      }
+
+      const budgetedStats = budgetedMetrics[metric];
+      for (const stat of Object.keys(budgetedStats)) {
+        if (stat === 'maxRegressionPct') {
+          continue;
+        }
+
+        const budgetValue = budgetedStats[stat];
+        const actual = metricStats[stat];
+        if (actual == null) {
+          warnings.push({
+            flow,
+            metric,
+            stat,
+            message: `${flow} ${metric} has no reported ${stat} value`,
+          });
+          continue;
+        }
+
+        if (actual > budgetValue) {
+          failures.push({
+            type: 'absolute',
+            flow,
+            metric,
+            stat,
+            actual,
+            budget: budgetValue,
+            message: `${flow} ${metric} ${stat} is ${actual}, exceeding budget ${budgetValue}`,
+          });
+        }
+
+        const maxRegressionPct = budgetedStats.maxRegressionPct;
+        if (maxRegressionPct != null) {
+          const baseline = baselinesByFlow.get(flow)?.metrics[metric]?.[stat];
+          if (baseline == null || baseline <= 0) {
+            warnings.push({
+              flow,
+              metric,
+              stat,
+              message: `${flow} ${metric} ${stat} has no baseline value for regression comparison`,
+            });
+            continue;
+          }
+
+          const regressionPct = ((actual - baseline) / baseline) * 100;
+          if (regressionPct > maxRegressionPct) {
+            failures.push({
+              type: 'regression',
+              flow,
+              metric,
+              stat,
+              actual,
+              baseline,
+              regressionPct,
+              maxRegressionPct,
+              message: `${flow} ${metric} ${stat} regressed by ${regressionPct.toFixed(
+                2,
+              )}%, exceeding allowed regression ${maxRegressionPct}%`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    warnings,
+  };
+}
+
+module.exports = {
+  checkPerformanceBudget,
+};


### PR DESCRIPTION
## Summary

This is an initial implementation slice for the performance budget/reporting proposal in react-native-community/discussions-and-proposals#1004.

It adds a small, reusable performance budget checker under `packages/react-native/scripts/performance/` that can:

- compare React Native performance report JSON against absolute metric budgets
- compare current reports against baseline reports using `maxRegressionPct`
- return structured failures and warnings for missing flows, metrics, stats, or baseline data
- run from a thin Node CLI for local/CI use before full device recording support exists

The goal is to make the report/budget contract reviewable first. Follow-up work can add official report recording, platform adapters, RNTester flows, and richer schema validation.

## Test plan

- `node packages/react-native/scripts/performance/performance-budget-cli.js --budget "$TMP/budget.json" --input "$TMP/current.json" --baseline "$TMP/baseline.json"`
- `yarn jest packages/react-native/scripts/performance/__tests__/performance-budget-test.js packages/react-native/scripts/performance/__tests__/performance-budget-cli-test.js --runInBand`
- `npx prettier --check packages/react-native/scripts/performance/performance-budget.js packages/react-native/scripts/performance/performance-budget-cli.js packages/react-native/scripts/performance/__tests__/performance-budget-test.js packages/react-native/scripts/performance/__tests__/performance-budget-cli-test.js packages/react-native/package.json`
- `yarn flow check`

## Changelog:

[General] [Added] - Add a performance budget checker for React Native performance reports
