### PR TITLE
fix(codegen): log error message instead of executing it in script_phases.sh

### DIFF
--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -16,8 +16,9 @@ cd "$RCT_SCRIPT_RN_DIR"
 CODEGEN_CLI_PATH=""
 
 error () {
-    echo "$1"
-    "[Codegen] $1" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
+    message="$*"
+    echo "$message"
+    echo "[Codegen] $message" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
     exit 1
 }
 


### PR DESCRIPTION
## Summary:

`packages/react-native/scripts/react_native_pods_utils/script_phases.sh` defines its error helper as:

```bash
error () {
    echo "$1"
    "[Codegen] $1" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
    exit 1
}
```

The second line does not log the message; it tries to **execute** a command whose name is the formatted string `[Codegen] <message>`. The script runs with `set -e` and `set -o pipefail`, so the resulting `command not found` aborts with status `127` before the intended `exit 1`, and `SCRIPT_OUTPUT_FILE_0` ends up holding the shell error instead of the diagnostic.

It also only references `$1`, so the multi-part message passed by `find_node` ("[Error] Could not find node..." continued across three arguments) is silently truncated to its first line.

This regressed when the logic moved out of `scripts/react_native_pods.rb` into this shell script in 1dbbeb4462e67ffecf0a4634cf3eb039886e21a2; the earlier inline implementation wrote the message directly rather than executing it.

The fix joins the arguments with `$*` and echoes the message, restoring full multi-part logging and a clean `exit 1`.

## Changelog:

[IOS] [FIXED] - Codegen build script now logs error messages instead of trying to execute them

## Test Plan:

The behavior is reproducible standalone with the same construct the script uses.

Before (current `main`):

```console
$ bash -c 'set -e; set -o pipefail; rm -f /tmp/log; error(){ echo "$1"; "[Codegen] $1" >> /tmp/log 2>&1; exit 1; }; error "[Error] part one " "part two " "part three"; echo after'
[Error] part one
$ echo $?
127
$ cat /tmp/log
bash: [Codegen] [Error] part one : command not found
```

`echo after` never runs, the exit code is `127` rather than `1`, parts two and three are dropped, and the log captures a shell error.

After (this change):

```console
$ bash -c 'set -e; set -o pipefail; rm -f /tmp/log; error(){ message="$*"; echo "$message"; echo "[Codegen] $message" >> /tmp/log 2>&1; exit 1; }; error "[Error] part one " "part two " "part three"; echo after'
[Error] part one  part two  part three
$ echo $?
1
$ cat /tmp/log
[Codegen] [Error] part one  part two  part three
```

Exit code is `1`, all three message parts are preserved, and the log holds the intended diagnostic. `bash -n` on the full script passes.

Fixes #56955