### PR TITLE
Fix script_phases.sh error() helper: missing echo + arg truncation (fixes #56955)

### DIFF
--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -16,8 +16,13 @@ cd "$RCT_SCRIPT_RN_DIR"
 CODEGEN_CLI_PATH=""
 
 error () {
-    echo "$1"
-    "[Codegen] $1" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
+    # Print the full message (all positional args, space-separated) so multi-arg
+    # callers like find_node don't get truncated to just $1. Mirror the same
+    # message into SCRIPT_OUTPUT_FILE_0; the previous version was missing the
+    # leading `echo`, so the formatted string was instead being executed as a
+    # command and the shell error landed in the log file.
+    echo "$*"
+    echo "[Codegen] $*" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
     exit 1
 }
 


### PR DESCRIPTION
Fixes #56955.

## Bug

`packages/react-native/scripts/react_native_pods_utils/script_phases.sh` defines:

```bash
error () {
    echo "$1"
    "[Codegen] $1" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
    exit 1
}
```

This has two problems that have been present since the script was extracted from `react_native_pods.rb` in commit [1dbbeb4](https://github.com/facebook/react-native/commit/1dbbeb4462e67ffecf0a4634cf3eb039886e21a2) (`Move script_phases script out of ruby file`):

1. **Missing `echo` on the log line.** The second line does not actually write to the file — it tries to *execute* the formatted string as a command. Under `set -e` (which this script enables on line 8) this aborts with status 127 before reaching `exit 1`, and `SCRIPT_OUTPUT_FILE_0` ends up containing a shell `command not found` error instead of the intended `[Codegen] ...` log line.
2. **Args after `$1` are silently dropped.** `find_node` calls `error` with three space-and-backslash continuation strings (lines 27-29). Each is a separate positional arg. The helper only prints `$1`, so chunks 2 and 3 are lost from both the visible message and the log file.

## Repro (standalone shell, no react-native checkout needed)

```bash
bash -lc 'set -e; rm -f /tmp/rn-test.log; \
  f(){ echo "$1"; "[Codegen] $1" >> /tmp/rn-test.log 2>&1; echo after; }; \
  f hello'

# observed: prints "hello", exits 127, never prints "after"
# /tmp/rn-test.log contains: bash: [Codegen] hello: command not found
```

## Fix

Switch both lines to `$*` so all positional arguments are joined into a single space-separated message, and add the missing `echo` so the second line actually appends to the log file:

```bash
error () {
    echo "$*"
    echo "[Codegen] $*" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
    exit 1
}
```

After the fix:
- `error hello` → prints `hello`, log contains `[Codegen] hello`
- `error "[Error] line 1" "line 2" "line 3"` → prints `[Error] line 1 line 2 line 3`, log contains `[Codegen] [Error] line 1 line 2 line 3`
- `set -e` no longer aborts mid-helper; `exit 1` runs as intended

## Test plan

Single-file change in a Pods build-phase helper script. The fix preserves the original message-to-stderr behavior and adds the missing message-to-log-file behavior plus correct multi-arg handling.

Verified the broken behavior with the shell repro above against current `main` (`b32a6c9e9db`). The same repro succeeds after the fix.


## Changelog:

[iOS] [Fixed] - Fix `error()` helper in `script_phases.sh` that swallowed multi-arg messages and crashed with status 127 under `set -e` due to a missing `echo`