### PR TITLE
Fix text layout cache key for maxFontSizeMultiplier

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -119,6 +119,7 @@ inline bool areTextAttributesEquivalentLayoutWise(const TextAttributes &lhs, con
              lhs.fontStyle,
              lhs.fontVariant,
              lhs.allowFontScaling,
+             lhs.maxFontSizeMultiplier,
              lhs.dynamicTypeRamp,
              lhs.alignment) ==
       std::tie(
@@ -127,6 +128,7 @@ inline bool areTextAttributesEquivalentLayoutWise(const TextAttributes &lhs, con
              rhs.fontStyle,
              rhs.fontVariant,
              rhs.allowFontScaling,
+             rhs.maxFontSizeMultiplier,
              rhs.dynamicTypeRamp,
              rhs.alignment) &&
       floatEquality(lhs.fontSize, rhs.fontSize) && floatEquality(lhs.fontSizeMultiplier, rhs.fontSizeMultiplier) &&
@@ -145,6 +147,7 @@ inline size_t textAttributesHashLayoutWise(const TextAttributes &textAttributes)
       textAttributes.fontStyle,
       textAttributes.fontVariant,
       textAttributes.allowFontScaling,
+      textAttributes.maxFontSizeMultiplier,
       textAttributes.dynamicTypeRamp,
       textAttributes.letterSpacing,
       textAttributes.lineHeight,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/tests/TextLayoutManagerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/tests/TextLayoutManagerTest.cpp
@@ -5,14 +5,33 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <memory>
-
 #include <gtest/gtest.h>
 
-#include <react/renderer/textlayoutmanager/TextLayoutManager.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 
 using namespace facebook::react;
 
-TEST(TextLayoutManagerTest, testSomething) {
-  // TODO:
+TEST(TextLayoutManagerTest, maxFontSizeMultiplierAffectsLayoutCacheEquality) {
+  TextAttributes lhs;
+  TextAttributes rhs;
+
+  lhs.fontSize = rhs.fontSize = 16;
+  lhs.fontSizeMultiplier = rhs.fontSizeMultiplier = 2;
+  lhs.maxFontSizeMultiplier = 1;
+  rhs.maxFontSizeMultiplier = 2;
+
+  EXPECT_FALSE(areTextAttributesEquivalentLayoutWise(lhs, rhs));
+}
+
+TEST(TextLayoutManagerTest, maxFontSizeMultiplierAffectsLayoutCacheHash) {
+  TextAttributes lhs;
+  TextAttributes rhs;
+
+  lhs.fontSize = rhs.fontSize = 16;
+  lhs.fontSizeMultiplier = rhs.fontSizeMultiplier = 2;
+  lhs.maxFontSizeMultiplier = 1;
+  rhs.maxFontSizeMultiplier = 2;
+
+  EXPECT_NE(
+      textAttributesHashLayoutWise(lhs), textAttributesHashLayoutWise(rhs));
 }


### PR DESCRIPTION
## Summary:

Text layout measurement cache keys currently consider `fontSizeMultiplier` and `allowFontScaling`, but omit `maxFontSizeMultiplier`. When that cap changes, Fabric can reuse a stale measurement even though the effective scaled font size may change.

This adds `maxFontSizeMultiplier` to the layout-wise text attribute equality and hash helpers, and covers the cache-key behavior with focused C++ tests.

Fixes #56921.

## Changelog:

[GENERAL] [FIXED] - Include `maxFontSizeMultiplier` in Fabric text layout cache keys.

## Test Plan:

- `npx --yes clang-format --dry-run --Werror packages/react-native/ReactCommon/react/renderer/textlayoutmanager/tests/TextLayoutManagerTest.cpp`
- `git diff --check`

I could not run the native gtest target locally from this sparse checkout; the patch adds focused coverage in the existing `TextLayoutManagerTest.cpp` file.