### PR TITLE
Add 'es2022.error' to TypeScript lib options

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -18,7 +18,8 @@
         "es2021.weakref",
         "es2022.array",
         "es2022.object",
-        "es2022.string"
+        "es2022.string",
+        "es2022.error"
       ],
       "allowJs": true,
       "jsx": "react-native",


### PR DESCRIPTION
## Summary:

This adds support for the `cause` parameter, which Hermes supports since 2021. The motivation is to be able to use `cause` on errors without getting TypeScript errors.

## Changelog:

```text
[GENERAL] [ADDED] - Add TypeScript support for Error `cause` property
```

## Test Plan:

I've tested this by adding `es2022.error` to my local TypeScript lib options, and that makes the type checking work 🎉 



