### PR TITLE
Avoid expensive exception throw in SynchronousMountItem for stopped surfaces

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.kt
@@ -265,7 +265,7 @@ internal class MountingManager(
       return
     }
 
-    getSurfaceManagerForViewEnforced(reactTag).storeSynchronousMountPropsOverride(reactTag, props)
+    getSurfaceManagerForView(reactTag)?.storeSynchronousMountPropsOverride(reactTag, props)
   }
 
   @UiThread
@@ -275,7 +275,7 @@ internal class MountingManager(
       return
     }
 
-    getSurfaceManagerForViewEnforced(reactTag).updatePropsSynchronously(reactTag, props)
+    getSurfaceManagerForView(reactTag)?.updatePropsSynchronously(reactTag, props)
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/SynchronousMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/SynchronousMountItem.kt
@@ -20,12 +20,10 @@ internal class SynchronousMountItem(private val reactTag: Int, private val props
       mountingManager.storeSynchronousMountPropsOverride(reactTag, props)
       mountingManager.updatePropsSynchronously(reactTag, props)
     } catch (ex: Exception) {
-      // TODO T42943890: Fix animations in Fabric and remove this try/catch?
-      // There might always be race conditions between surface teardown and
-      // animations/other operations, so it may not be feasible to remove this.
-      // Practically 100% of reported errors from this point are because the
-      // surface has stopped by this point, but the MountItem was queued before
-      // the surface was stopped. It's likely not feasible to prevent all such races.
+      // The surface-stopped race condition (which was the primary source of exceptions here)
+      // is now handled by null-safe lookups in MountingManager. This catch remains as a
+      // safety net for other potential failures (e.g., view manager bugs, state
+      // inconsistencies during prop updates).
     }
   }
 


### PR DESCRIPTION
Summary:
When a `SynchronousMountItem` is dispatched for a reactTag whose surface has already been torn down, the `RetryableMountingLayerException ` is thrown in `storeSynchronousMountPropsOverride` and `updatePropsSynchronously`. The exception was immediately caught in the `SynchronousMountItem.execute`, making it a costly no-op. For each throw the stack trace is captured while holding the ART mutator lock in shared mode. On devices with high thread counts and deep Choreographer call stacks, this contributes to ANR during `doFrame`.

This diff switches `storeSynchronousMountPropsOverride` and `updatePropsSynchronously` to use the nullable `getSurfaceManagerForView` variant, which returns null and silently no-ops when the surface is missing — the same end behavior as before, without the exception overhead.

Changelog:
[Internal]

Differential Revision: D106094737


