### PR TITLE
Suppress DEPRECATION warning in NetworkEventUtilTest

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+@file:Suppress("DEPRECATION", "DEPRECATION_ERROR") // Conflicting okhttp versions
 
 package com.facebook.react.modules.network
 


### PR DESCRIPTION
Summary:
The OSS build runs Kotlin with `-Werror`, and the test calls the now-deprecated overload `RequestBody.create(MediaType?, String)`. The file already suppresses `DEPRECATION_ERROR` for the same OkHttp-version skew; extend the existing `Silvochka:Suppress` to also cover the warning-level `DEPRECATION` so the build stops failing.

## Changelog:

[Internal]

Differential Revision: D106364355


