### PR TITLE
Transform readonly in xplatjs

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
@@ -84,7 +84,7 @@ export class DebuggerAgent {
 
 export class DebuggerMock extends DebuggerAgent {
   // Empty handlers
-  +handle: JestMockFn<[message: JSONSerializable], void> = jest.fn();
+  readonly handle: JestMockFn<[message: JSONSerializable], void> = jest.fn();
 
   __handle(message: JSONSerializable): void {
     this.handle(message);

--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -98,16 +98,18 @@ export class DeviceAgent {
 
 export class DeviceMock extends DeviceAgent {
   // Empty handlers
-  +connect: JestMockFn<[message: ConnectRequest], void> = jest.fn();
-  +disconnect: JestMockFn<[message: DisconnectRequest], void> = jest.fn();
-  +getPages: JestMockFn<
+  readonly connect: JestMockFn<[message: ConnectRequest], void> = jest.fn();
+  readonly disconnect: JestMockFn<[message: DisconnectRequest], void> =
+    jest.fn();
+  readonly getPages: JestMockFn<
     [message: GetPagesRequest],
     | GetPagesResponse['payload']
     | Promise<GetPagesResponse['payload'] | void>
     | void,
   > = jest.fn();
-  +wrappedEvent: JestMockFn<[message: WrappedEventToDevice], void> = jest.fn();
-  +wrappedEventParsed: JestMockFn<
+  readonly wrappedEvent: JestMockFn<[message: WrappedEventToDevice], void> =
+    jest.fn();
+  readonly wrappedEventParsed: JestMockFn<
     [
       payload: {
         ...WrappedEventToDevice['payload'],

--- a/packages/dev-middleware/src/__tests__/StandaloneFuseboxShell-test.js
+++ b/packages/dev-middleware/src/__tests__/StandaloneFuseboxShell-test.js
@@ -25,7 +25,7 @@ const PAGES_POLLING_DELAY = 2100;
 jest.useFakeTimers();
 
 async function setupDevice(
-  serverRef: {+serverBaseWsUrl: string, ...},
+  serverRef: {readonly serverBaseWsUrl: string, ...},
   signal: AbortSignal,
 ) {
   const device = await createDeviceMock(

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -138,7 +138,7 @@ export default class Device {
   // Logging reporting batches of cdp messages
   #cdpDebugLogging: CdpDebugLogging;
 
-  +#experiments: Experiments;
+  readonly #experiments: Experiments;
 
   constructor(deviceOptions: DeviceOptions) {
     this.#experiments = deviceOptions.experiments;

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -93,7 +93,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
 
   #eventReporter: ?EventReporter;
 
-  +#experiments: Experiments;
+  readonly #experiments: Experiments;
 
   // custom message handler factory allowing implementers to handle unsupported CDP messages.
   #customMessageHandler: ?CreateCustomMessageHandlerFn;

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -156,7 +156,7 @@ export type JSONSerializable =
   | string
   | null
   | ReadonlyArray<JSONSerializable>
-  | {+[string]: JSONSerializable};
+  | {readonly [string]: JSONSerializable};
 
 export type DeepReadOnly<T> =
   T extends ReadonlyArray<infer V>

--- a/packages/dev-middleware/src/types/DevToolLauncher.js
+++ b/packages/dev-middleware/src/types/DevToolLauncher.js
@@ -27,7 +27,7 @@ export interface DevToolLauncher {
    * the host of dev-middleware. Implementations are responsible for rewriting
    * this as necessary where the server is remote.
    */
-  +launchDebuggerAppWindow: (url: string) => Promise<void>;
+  readonly launchDebuggerAppWindow: (url: string) => Promise<void>;
 
   /**
    * Attempt to open a debugger frontend URL in a standalone shell window
@@ -47,7 +47,10 @@ export interface DevToolLauncher {
    * the host of dev-middleware. Implementations are responsible for rewriting
    * this as necessary where the server is remote.
    */
-  +launchDebuggerShell?: (url: string, windowKey: string) => Promise<void>;
+  readonly launchDebuggerShell?: (
+    url: string,
+    windowKey: string,
+  ) => Promise<void>;
 
   /**
    * Attempt to prepare the debugger shell for use and returns a coded result
@@ -60,5 +63,5 @@ export interface DevToolLauncher {
    * SHOULD NOT return a rejecting promise in any case, and instead SHOULD report
    * errors via the returned result object.
    */
-  +prepareDebuggerShell?: () => Promise<DebuggerShellPreparationResult>;
+  readonly prepareDebuggerShell?: () => Promise<DebuggerShellPreparationResult>;
 }

--- a/packages/dev-middleware/src/types/ReadonlyURL.js
+++ b/packages/dev-middleware/src/types/ReadonlyURL.js
@@ -15,7 +15,7 @@ export interface ReadonlyURLSearchParams {
   get(name: string): string | null;
   getAll(name: string): Array<string>;
   has(name: string, value?: string): boolean;
-  +size: number;
+  readonly size: number;
   entries(): Iterator<[string, string]>;
   keys(): Iterator<string>;
   values(): Iterator<string>;
@@ -37,18 +37,18 @@ export interface ReadonlyURLSearchParams {
  * Used for URLs passed between module boundaries.
  */
 export interface ReadonlyURL {
-  +hash: string;
-  +host: string;
-  +hostname: string;
-  +href: string;
-  +origin: string;
-  +password: string;
-  +pathname: string;
-  +port: string;
-  +protocol: string;
-  +search: string;
-  +searchParams: ReadonlyURLSearchParams;
-  +username: string;
+  readonly hash: string;
+  readonly host: string;
+  readonly hostname: string;
+  readonly href: string;
+  readonly origin: string;
+  readonly password: string;
+  readonly pathname: string;
+  readonly port: string;
+  readonly protocol: string;
+  readonly search: string;
+  readonly searchParams: ReadonlyURLSearchParams;
+  readonly username: string;
   toString(): string;
   toJSON(): string;
 }


### PR DESCRIPTION
Summary:
```
js1 flow-runner codemod flow/transformAllVariance --variance readonly --format-files=false @
```

Reviewed By: SamChou19815

Differential Revision: D106410842


