### PR TITLE
Propagate `RCT_REMOVE_LEGACY_ARCH` to `SWIFT_ACTIVE_COMPILATION_CONDITIONS`

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -480,6 +480,57 @@ class ReactNativePodsUtils
         end
     end
 
+    def self.add_swift_active_compilation_condition_to_project(installer, condition)
+        projects = self.extract_projects(installer)
+
+        projects.each do |project|
+            project.build_configurations.each do |config|
+                self.add_swift_condition_in_config(config, condition)
+            end
+            project.save()
+        end
+    end
+
+    def self.remove_swift_active_compilation_condition_from_project(installer, condition)
+        projects = self.extract_projects(installer)
+
+        projects.each do |project|
+            project.build_configurations.each do |config|
+                self.remove_swift_condition_in_config(config, condition)
+            end
+            project.save()
+        end
+    end
+
+    def self.add_swift_condition_in_config(config, condition)
+        key = "SWIFT_ACTIVE_COMPILATION_CONDITIONS"
+        current = config.build_settings[key]
+
+        # Normalise to array form so we can dedupe and preserve $(inherited)
+        # alongside any pre-existing conditions (e.g. DEBUG).
+        list = case current
+               when nil    then ["$(inherited)"]
+               when Array  then current.dup
+               when String then current.split(/\s+/).reject(&:empty?)
+               end
+
+        list << "$(inherited)" unless list.include?("$(inherited)")
+        list << condition unless list.include?(condition)
+
+        config.build_settings[key] = list
+    end
+
+    def self.remove_swift_condition_in_config(config, condition)
+        key = "SWIFT_ACTIVE_COMPILATION_CONDITIONS"
+        current = config.build_settings[key]
+        return if current.nil?
+
+        list = current.kind_of?(Array) ? current.dup : current.split(/\s+/).reject(&:empty?)
+        list.delete(condition)
+
+        config.build_settings[key] = list
+    end
+
     def self.add_compiler_flag_to_pods(installer, flag, configuration: nil)
         installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
             target_installation_result.native_target.build_configurations.each do |config|

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -556,8 +556,10 @@ def react_native_post_install(
 
   if (ENV['RCT_REMOVE_LEGACY_ARCH'] == '1')
     ReactNativePodsUtils.add_compiler_flag_to_project(installer, "-DRCT_REMOVE_LEGACY_ARCH=1")
+    ReactNativePodsUtils.add_swift_active_compilation_condition_to_project(installer, "RCT_REMOVE_LEGACY_ARCH")
   else
     ReactNativePodsUtils.remove_compiler_flag_from_project(installer, "-DRCT_REMOVE_LEGACY_ARCH=1")
+    ReactNativePodsUtils.remove_swift_active_compilation_condition_from_project(installer, "RCT_REMOVE_LEGACY_ARCH")
   end
 
   ReactNativePodsUtils.set_ccache_compiler_and_linker_build_settings(installer, react_native_path, ccache_enabled)


### PR DESCRIPTION
Summary:
Mirrors the existing C/C++ `-DRCT_REMOVE_LEGACY_ARCH=1` flag into Swift's `SWIFT_ACTIVE_COMPILATION_CONDITIONS` so Swift sources (notably user `AppDelegate.swift` files derived from the community template) can branch on `#if !RCT_REMOVE_LEGACY_ARCH`.

Until now, `react_native_pods.rb` only added `-DRCT_REMOVE_LEGACY_ARCH=1` via `add_compiler_flag_to_project`, which sets `OTHER_CFLAGS` / `OTHER_CPLUSPLUSFLAGS`. Swift does not consume those; it reads `SWIFT_ACTIVE_COMPILATION_CONDITIONS`. As a result, `#if RCT_REMOVE_LEGACY_ARCH` in Swift was silently always false, and templates that need to keep `sourceURLForBridge:` for legacy-arch builds while compiling cleanly against legacy-arch-removed builds had no way to express that.

Adds two helpers in `ReactNativePodsUtils`:

- `add_swift_active_compilation_condition_to_project(installer, condition)`
- `remove_swift_active_compilation_condition_from_project(installer, condition)`

Both are additive and idempotent: they normalise the existing `SWIFT_ACTIVE_COMPILATION_CONDITIONS` value (which may be nil, a string, or an array) into an array, preserve `$(inherited)` and any pre-existing conditions such as `DEBUG`, and dedupe on insert. Repeated `pod install` runs produce stable output.

`react_native_pods.rb` now calls the add/remove helpers alongside the existing C-flag add/remove inside the `RCT_REMOVE_LEGACY_ARCH` env-var branch.

Changelog:
[iOS][Added] - Propagate `RCT_REMOVE_LEGACY_ARCH` into `SWIFT_ACTIVE_COMPILATION_CONDITIONS` so Swift code in apps and the community template can branch on `#if !RCT_REMOVE_LEGACY_ARCH`, matching the existing C/C++ `-DRCT_REMOVE_LEGACY_ARCH=1` flag.

Differential Revision: D106466169


