### PR TITLE
Gate legacy TurboModule interop behind `RCT_REMOVE_LEGACY_MODULE_INTEROP` (#56984)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -152,7 +152,9 @@
                         devMenuConfiguration:(RCTDevMenuConfiguration *)devMenuConfiguration
 {
   // Enable TurboModule interop by default in Bridgeless mode
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
   RCTEnableTurboModuleInterop(YES);
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
   [self createReactHostIfNeeded:launchOptions
             bundleConfiguration:bundleConfiguration

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -50,9 +50,11 @@ NSMutableArray<NSString *> *getModulesLoadedWithOldArch(void);
 BOOL RCTTurboModuleEnabled(void);
 void RCTEnableTurboModule(BOOL enabled);
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
 // Turn on TurboModule interop
 BOOL RCTTurboModuleInteropEnabled(void);
 void RCTEnableTurboModuleInterop(BOOL enabled);
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
 // Turn on the fabric interop layer
 BOOL RCTFabricInteropLayerEnabled(void);

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -199,6 +199,7 @@ void RCTEnableTurboModule(BOOL enabled)
   // The new Architecture is enabled by default and we are ignoring changes to the TurboModule system.
 }
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
 static BOOL turboModuleInteropEnabled = NO;
 BOOL RCTTurboModuleInteropEnabled(void)
 {
@@ -208,6 +209,7 @@ void RCTEnableTurboModuleInterop(BOOL enabled)
 {
   turboModuleInteropEnabled = enabled;
 }
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
 static BOOL fabricInteropLayerEnabled = YES;
 BOOL RCTFabricInteropLayerEnabled()

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -24,6 +24,7 @@
 
 namespace facebook::react {
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
 namespace {
 
 class JMethodDescriptor : public jni::JavaClass<JMethodDescriptor> {
@@ -93,6 +94,7 @@ class JMethodDescriptor : public jni::JavaClass<JMethodDescriptor> {
   }
 };
 } // namespace
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
 TurboModuleManager::TurboModuleManager(
     std::shared_ptr<CallInvoker> jsCallInvoker,
@@ -222,6 +224,7 @@ std::shared_ptr<TurboModule> TurboModuleManager::getTurboModule(
   return nullptr;
 }
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
 TurboModuleProviderFunctionTypeWithRuntime
 TurboModuleManager::createLegacyModuleProvider(
     jni::alias_ref<jhybridobject> javaPart) {
@@ -318,14 +321,19 @@ std::shared_ptr<TurboModule> TurboModuleManager::getLegacyModule(
 
   return nullptr;
 }
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
 void TurboModuleManager::installJSBindings(
     jsi::Runtime& runtime,
     jni::alias_ref<jhybridobject> javaPart) {
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
   TurboModuleBinding::install(
       runtime,
       createTurboModuleProvider(javaPart),
       createLegacyModuleProvider(javaPart));
+#else
+  TurboModuleBinding::install(runtime, createTurboModuleProvider(javaPart));
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 }
 
 void TurboModuleManager::dispatchJSBindingInstall(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -48,7 +48,9 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
    * they want to be long-lived or short-lived.
    */
   ModuleCache turboModuleCache_;
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
   ModuleCache legacyModuleCache_;
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
   explicit TurboModuleManager(
       std::shared_ptr<CallInvoker> jsCallInvoker,
@@ -64,8 +66,10 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
   std::shared_ptr<TurboModule>
   getTurboModule(jni::alias_ref<jhybridobject> javaPart, const std::string &name, jsi::Runtime &runtime);
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
   static TurboModuleProviderFunctionTypeWithRuntime createLegacyModuleProvider(jni::alias_ref<jhybridobject> javaPart);
   std::shared_ptr<TurboModule> getLegacyModule(jni::alias_ref<jhybridobject> javaPart, const std::string &name);
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.cpp
@@ -7,6 +7,8 @@
 
 #include "JavaInteropTurboModule.h"
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
+
 namespace facebook::react {
 
 namespace {
@@ -189,3 +191,5 @@ std::vector<facebook::jsi::PropNameID> JavaInteropTurboModule::getPropertyNames(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
+
 #include <string>
 #include <vector>
 
@@ -46,3 +48,5 @@ class JSI_EXPORT JavaInteropTurboModule : public JavaTurboModule {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
+
 #import <string>
 #import <vector>
 
@@ -88,3 +90,5 @@ class JSI_EXPORT ObjCInteropTurboModule : public ObjCTurboModule {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
@@ -7,6 +7,8 @@
 
 #include "RCTInteropTurboModule.h"
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
+
 #import <objc/message.h>
 #import <objc/runtime.h>
 
@@ -694,3 +696,5 @@ std::vector<facebook::jsi::PropNameID> ObjCInteropTurboModule::getPropertyNames(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -161,10 +161,12 @@ bool isTurboModuleClass(Class cls)
   return [cls conformsToProtocol:@protocol(RCTTurboModule)];
 }
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
 bool isTurboModuleInstance(id module)
 {
   return isTurboModuleClass([module class]);
 }
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
 struct ModuleQueuePair {
   id<RCTBridgeModule> module;
@@ -236,6 +238,7 @@ Class getFallbackClassFromName(const char *name)
     _sharedModuleQueue = dispatch_queue_create("com.meta.react.turbomodulemanager.queue", DISPATCH_QUEUE_SERIAL);
     _devMenuConfigurationDecorator = devMenuConfigurationDecorator;
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
     if (RCTTurboModuleInteropEnabled()) {
       // TODO(T174674274): Implement lazy loading of legacy modules in the new architecture.
       NSMutableDictionary<NSString *, id<RCTBridgeModule>> *legacyInitializedModules = [NSMutableDictionary new];
@@ -257,6 +260,7 @@ Class getFallbackClassFromName(const char *name)
       }
       _legacyEagerlyRegisteredModuleClasses = legacyEagerlyRegisteredModuleClasses;
     }
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(bridgeWillInvalidateModules:)
@@ -418,6 +422,7 @@ Class getFallbackClassFromName(const char *name)
   return nullptr;
 }
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
 - (std::shared_ptr<TurboModule>)provideLegacyModule:(const char *)moduleName
 {
   auto legacyModuleLookup = _legacyModuleCache.find(moduleName);
@@ -465,6 +470,7 @@ Class getFallbackClassFromName(const char *name)
   _legacyModuleCache.insert({moduleName, turboModule});
   return turboModule;
 }
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
 #pragma mark - Private Methods
 
@@ -492,9 +498,11 @@ Class getFallbackClassFromName(const char *name)
     moduleProvider = [_delegate getModuleProvider:moduleName];
   }
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
   if (RCTTurboModuleInteropEnabled() && ![self _isTurboModule:moduleName] && !moduleProvider) {
     return nil;
   }
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
   if (moduleProvider) {
     if ([moduleProvider conformsToProtocol:@protocol(RCTTurboModule)]) {
@@ -631,9 +639,11 @@ Class getFallbackClassFromName(const char *name)
 
 - (BOOL)_shouldCreateObjCModule:(Class)moduleClass
 {
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
   if (RCTTurboModuleInteropEnabled()) {
     return [moduleClass conformsToProtocol:@protocol(RCTBridgeModule)];
   }
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
   return [moduleClass conformsToProtocol:@protocol(RCTTurboModule)];
 }
@@ -946,6 +956,7 @@ Class getFallbackClassFromName(const char *name)
     return turboModule;
   };
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
   if (RCTTurboModuleInteropEnabled()) {
     auto legacyModuleProvider =
         [self](jsi::Runtime & /*runtime*/, const std::string &name) -> std::shared_ptr<react::TurboModule> {
@@ -972,6 +983,9 @@ Class getFallbackClassFromName(const char *name)
   } else {
     TurboModuleBinding::install(runtime, std::move(turboModuleProvider));
   }
+#else
+  TurboModuleBinding::install(runtime, std::move(turboModuleProvider));
+#endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 }
 
 #pragma mark RCTTurboModuleRegistry


### PR DESCRIPTION
Summary:

Wraps all legacy TurboModule interop code paths in `#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP` so that apps which opt into the `react-remove-legacy-module-interop` buck constraint (added in the parent diff D106830763) compile them out entirely. This enables dead-code elimination of the legacy `RCTBridgeModule` interop surface in both iOS and Android, leaving only the pure TurboModule path.

Changes:

iOS (Objective-C / C++):
- `Libraries/AppDelegate/RCTRootViewFactory.mm`: Skip `RCTEnableTurboModuleInterop(YES)` when the flag is defined and always call `RCTEnableTurboModuleInteropBridgeProxy(YES)`.
- `React/Base/RCTBridge.{h,mm}`: Hide `RCTTurboModuleInteropEnabled` / `RCTEnableTurboModuleInterop` API and the backing `turboModuleInteropEnabled` static when the flag is defined.
- `ReactCommon/.../ios/ReactCommon/RCTInteropTurboModule.{h,mm}`: Compile the entire RCTInteropTurboModule translation unit only when the flag is undefined.
- `ReactCommon/.../ios/ReactCommon/RCTTurboModuleManager.mm`: Gate `isTurboModuleInstance`, legacy module eager registration, `provideLegacyModule:`, legacy short-circuit in `_provideObjCModule:` / `_shouldCreateObjCModule:`, and the legacy branch of `installJSBindings` so that `TurboModuleBinding::install` is called with only the turbo module provider when the flag is defined.

Android (C++/JNI):
- `ReactAndroid/.../TurboModuleManager.{h,cpp}`: Gate `JMethodDescriptor`/`JavaTurboModule` helpers, `legacyModuleCache_`, `createLegacyModuleProvider`, and `getLegacyModule`. `installJSBindings` falls back to the two-argument `TurboModuleBinding::install` when the flag is defined.
- `ReactCommon/.../android/ReactCommon/JavaInteropTurboModule.{h,cpp}`: Compile the entire JavaInteropTurboModule translation unit only when the flag is undefined.

Default behavior is unchanged because `RCT_REMOVE_LEGACY_MODULE_INTEROP` is not defined unless the new constraint is selected.

## Changelog: [GENERAL][ADDED] Gate legacy TurboModule interop behind `RCT_REMOVE_LEGACY_MODULE_INTEROP`

Reviewed By: zeyap

Differential Revision: D106109160


