### PR TITLE
Fix duplicated words in source comments

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
@@ -39,7 +39,7 @@ export type CdpMessageToTarget = Readonly<{
 }>;
 
 /**
- * Send a CDP message from from the target with the given pageId to the debugger.
+ * Send a CDP message from the target with the given pageId to the debugger.
  * Returns the message as received by the debugger.
  */
 export async function sendFromTargetToDebugger<

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
 internal object JdkConfiguratorUtils {
   /**
-   * Function that takes care of configuring the JDK toolchain for all the projects projects. As we
+   * Function that takes care of configuring the JDK toolchain for all the projects. As we
    * do decide the JDK version based on the AGP version that RNGP brings over, here we can safely
    * configure the toolchain to 17.
    */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewRenderState.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewRenderState.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.views.virtual
 
 /**
- * Represents the the render state of children in the most recent commit.
+ * Represents the render state of children in the most recent commit.
  *
  * This enables `ReactVirtualView` to know whether a previously emitted `VirtualViewModeChangeEvent`
  * has been committed, in order to only emit subsequent events that would change it.

--- a/scripts/releases/upload-release-assets-for-dotslash.js
+++ b/scripts/releases/upload-release-assets-for-dotslash.js
@@ -180,7 +180,7 @@ async function uploadReleaseAssetsForDotSlashFile(
  * Given a description of a DotSlash artifact for a particular platform,
  * infers the upstream URL ( = where the binary is currently available) and
  * release asset URL ( = where the binary will be hosted after the release),
- * then downloads the asset from the the upstream URL and uploads it to GitHub
+ * then downloads the asset from the upstream URL and uploads it to GitHub
  * at the desired URL.
  */
 async function fetchUpstreamAssetAndUploadToRelease(


### PR DESCRIPTION
## Summary:
Remove duplicated words from comments in a release script, a dev middleware test helper, the Gradle plugin JDK utility, and the virtual view render state.

## Changelog:
[INTERNAL] [FIXED] - Fix duplicated words in source comments.

## Test Plan:
- `git diff --check`
- `rg -n "projects projects|the the upstream URL|from from the target|the the render state" scripts/releases/upload-release-assets-for-dotslash.js packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewRenderState.kt` returns no matches
- `prettier --check scripts/releases/upload-release-assets-for-dotslash.js packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js` with Prettier 3.6.2 and prettier-plugin-hermes-parser 0.36.0