### PR TITLE
Expose RuntimeExecutor on ReactContext (#56987)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -967,6 +967,7 @@ public abstract class com/facebook/react/bridge/ReactContext : android/content/C
 	public abstract fun getNativeModule (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeModule;
 	public abstract fun getNativeModules ()Ljava/util/Collection;
 	public fun getNativeModulesMessageQueueThread ()Lcom/facebook/react/bridge/queue/MessageQueueThread;
+	public abstract fun getRuntimeExecutor ()Lcom/facebook/react/bridge/RuntimeExecutor;
 	public fun getScrollEndedListeners ()Lcom/facebook/react/bridge/ScrollEndedListeners;
 	public abstract fun getSourceURL ()Ljava/lang/String;
 	public fun getSystemService (Ljava/lang/String;)Ljava/lang/Object;
@@ -4162,6 +4163,7 @@ public final class com/facebook/react/uimanager/ThemedReactContext : com/faceboo
 	public fun getNativeModule (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeModule;
 	public fun getNativeModules ()Ljava/util/Collection;
 	public final fun getReactApplicationContext ()Lcom/facebook/react/bridge/ReactApplicationContext;
+	public fun getRuntimeExecutor ()Lcom/facebook/react/bridge/RuntimeExecutor;
 	public fun getScrollEndedListeners ()Lcom/facebook/react/bridge/ScrollEndedListeners;
 	public fun getSourceURL ()Ljava/lang/String;
 	public final fun getSurfaceID ()Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
@@ -282,4 +282,6 @@ public open class BridgeReactContext(context: Context) : ReactApplicationContext
     private const val LATE_NATIVE_MODULE_EXCEPTION_MESSAGE: String =
         "Trying to call native module after CatalystInstance has been destroyed!"
   }
+
+  override fun getRuntimeExecutor(): RuntimeExecutor? = mCatalystInstance?.runtimeExecutor
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -201,6 +201,12 @@ public abstract class ReactContext extends ContextWrapper {
   }
 
   /**
+   * Returns the {@link RuntimeExecutor} for the underlying JavaScript runtime, or {@code null} if
+   * the runtime has not been initialized. Works in both bridged and bridgeless modes.
+   */
+  public abstract @Nullable RuntimeExecutor getRuntimeExecutor();
+
+  /**
    * This allows scroll views to notify NativeAnimatedModule when user-driven scrolling ends.
    *
    * @return The ScrollEndedListeners instance

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
@@ -20,6 +20,7 @@ import com.facebook.react.bridge.JavaScriptModuleRegistry
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactSoftExceptionLogger.logSoftException
+import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
@@ -180,4 +181,6 @@ internal class BridgelessReactContext(context: Context, private val reactHost: R
   }
 
   override fun getJSCallInvokerHolder(): CallInvokerHolder? = reactHost.jsCallInvokerHolder
+
+  override fun getRuntimeExecutor(): RuntimeExecutor? = reactHost.runtimeExecutor
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.kt
@@ -20,6 +20,7 @@ import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.react.bridge.ScrollEndedListeners
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
@@ -161,6 +162,8 @@ public class ThemedReactContext(
 
   override fun getJSCallInvokerHolder(): CallInvokerHolder? =
       reactApplicationContext.getJSCallInvokerHolder()
+
+  override fun getRuntimeExecutor(): RuntimeExecutor? = reactApplicationContext.runtimeExecutor
 
   @Deprecated(
       "This method is deprecated, please use UIManagerHelper.getUIManager() instead.",


### PR DESCRIPTION
Summary:

Add `ReactContext.getRuntimeExecutor()` so callers can obtain the `RuntimeExecutor` without reaching into `CatalystInstance`. The bridge subclass forwards to `CatalystInstance.getRuntimeExecutor()`; the bridgeless subclass forwards to `ReactHost.runtimeExecutor`; `ThemedReactContext` proxies to its wrapped `ReactApplicationContext`. Previously, callers that needed the runtime executor had to reach through `catalystInstance.getRuntimeExecutor()`, which is bridge-only and required a `NoGetCatalystInstance` lint suppression. The new accessor works uniformly in both bridged and bridgeless modes.

Changelog:
[Android][Added] - Add `ReactContext.getRuntimeExecutor()`

Reviewed By: mdvacca

Differential Revision: D106647233


