### PR TITLE
Fix Event constructor self-conflict on Hermes

### DIFF
--- a/packages/react-native/src/private/webapis/dom/events/Event.js
+++ b/packages/react-native/src/private/webapis/dom/events/Event.js
@@ -45,16 +45,6 @@ export interface EventInit {
 }
 
 export default class Event {
-  static readonly NONE: 0;
-  static readonly CAPTURING_PHASE: 1;
-  static readonly AT_TARGET: 2;
-  static readonly BUBBLING_PHASE: 3;
-
-  readonly NONE: 0;
-  readonly CAPTURING_PHASE: 1;
-  readonly AT_TARGET: 2;
-  readonly BUBBLING_PHASE: 3;
-
   _bubbles: boolean;
   _cancelable: boolean;
   _composed: boolean;


### PR DESCRIPTION
## Summary:

Removes the `readonly NONE/CAPTURING_PHASE/AT_TARGET/BUBBLING_PHASE` declarations from `Event.js`.

These declarations were intended as type-only annotations, but Babel emits them as runtime class fields, generating constructor assignments such as:

```js
this.NONE = void 0;
```

That assignment conflicts with the non-writable `Event.prototype.NONE` property defined later in the same file via `Object.defineProperty`, causing Hermes to throw:

```text
TypeError: Cannot assign to read-only property 'NONE'
```

This affected `new Event(...)` construction and broke APIs relying on Event creation, including `fetch`, XHR, and `AbortController` in RN 0.81.x / Expo SDK 54 Hermes environments.

The runtime constants themselves are already defined via `Object.defineProperty` below, so removing these declarations preserves the public API and DOM constant semantics while preventing the conflicting class field emission.

Related:

* #54732
* #55002

## Changelog:

[GENERAL] [FIXED] - Prevent Hermes crash when constructing `Event` instances caused by emitted class fields in `Event.js`

## Test Plan:

* Verified the emitted constructor no longer contains:

```js
this.NONE = void 0;
```

* Reproduced before fix in Expo SDK 54 / RN 0.81.5 Hermes app using:

```js
new Event('foo')
```

and:

```js
fetch('https://example.com')
```

Both previously threw:

```text
TypeError: Cannot assign to read-only property 'NONE'
```

* After patch:

  * `new Event('foo')` succeeds
  * `fetch(...)` succeeds
  * `Event.NONE === 0`
  * `Event.CAPTURING_PHASE === 1`
  * existing constant definitions remain unchanged
