### PR TITLE
Add Fantom.getHostPlatform() to expose test runner host OS (#56990)

### DIFF
--- a/private/react-native-fantom/runner/entrypoint-template.js
+++ b/private/react-native-fantom/runner/entrypoint-template.js
@@ -9,11 +9,31 @@
  */
 
 import type {SnapshotConfig} from '../runtime/snapshotContext';
-import type {FantomRuntimeConstants} from '../src/Constants';
+import type {FantomRuntimeConstants, HostPlatform} from '../src/Constants';
 import type {FantomTestConfig} from './getFantomTestConfigs';
 
 import * as EnvironmentOptions from './EnvironmentOptions';
 import formatFantomConfig from './formatFantomConfig';
+
+function getHostPlatform(): HostPlatform {
+  match (process.platform) {
+    'darwin' => {
+      return 'macos';
+    }
+    'win32' => {
+      return 'windows';
+    }
+    'linux' => {
+      return 'linux';
+    }
+    'android' => {
+      return 'android';
+    }
+    _ => {
+      throw new Error(`Unsupported platform: ${process.platform}`);
+    }
+  }
+}
 
 module.exports = function entrypointTemplate({
   testPath,
@@ -42,6 +62,7 @@ module.exports = function entrypointTemplate({
     jsTraceOutputPath,
     jsHeapSnapshotOutputPathTemplate,
     jsHeapSnapshotOutputPathTemplateToken,
+    hostPlatform: getHostPlatform(),
   };
 
   return `/**

--- a/private/react-native-fantom/src/Constants.js
+++ b/private/react-native-fantom/src/Constants.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+export type HostPlatform = 'android' | 'windows' | 'macos' | 'linux';
+
 export type FantomRuntimeConstants = Readonly<{
   isOSS: boolean,
   isRunningFromCI: boolean,
@@ -16,6 +18,7 @@ export type FantomRuntimeConstants = Readonly<{
   jsHeapSnapshotOutputPathTemplate: string,
   jsHeapSnapshotOutputPathTemplateToken: string,
   jsTraceOutputPath: ?string,
+  hostPlatform: HostPlatform,
 }>;
 
 let constants: FantomRuntimeConstants = {
@@ -26,6 +29,7 @@ let constants: FantomRuntimeConstants = {
   jsHeapSnapshotOutputPathTemplate: '',
   jsHeapSnapshotOutputPathTemplateToken: '',
   jsTraceOutputPath: null,
+  hostPlatform: 'linux',
 };
 
 export function getConstants(): FantomRuntimeConstants {

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import type {HostPlatform} from './Constants';
 import type {
   FantomRenderedOutput,
   RenderOutputConfig,
@@ -45,6 +46,16 @@ export type RootConfig = {
 };
 
 export {getConstants} from './Constants';
+
+/**
+ * Returns the host OS where the Fantom test runner is running (e.g.
+ * 'linux', 'macos', 'windows'). This is different from React Native's
+ * `Platform.OS`, which always reflects the React Native target platform
+ * being tested.
+ */
+export function getHostPlatform(): HostPlatform {
+  return getConstants().hostPlatform;
+}
 
 // Defaults use iPhone 14 values (very common device).
 const DEFAULT_VIEWPORT_WIDTH = 390;


### PR DESCRIPTION
Summary:

Adds a new `Fantom.getHostPlatform()` API that returns the host
operating system where the Fantom test runner is running (e.g. 'linux',
'macos', 'windows', 'android'). This is different from React Native's
`Platform.OS`, which always reflects the React Native target platform
being tested.

The value is determined by the Node.js Jest runner (via
`process.platform`) and baked into the JS bundle through the existing
`setConstants(...)` pipeline, so no native changes are needed.

- Add `HostPlatform` type and `hostPlatform` field to
  `FantomRuntimeConstants`.
- Populate `hostPlatform` from the host platform in the entrypoint
  template (maps darwin -> macos, win32 -> windows, etc.).
- Expose `getHostPlatform()` from the public Fantom API.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D106669673


