### PR TITLE
Remove `enableBridgelessArchitecture` branches from ReactAndroid simple call sites (#56999)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
@@ -17,7 +17,6 @@ import android.os.PowerManager
 import android.os.PowerManager.WakeLock
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
 import com.facebook.react.jstasks.HeadlessJsTaskContext.Companion.getInstance
 import com.facebook.react.jstasks.HeadlessJsTaskEventListener
@@ -126,40 +125,21 @@ public abstract class HeadlessJsTaskService : Service(), HeadlessJsTaskEventList
 
   protected val reactContext: ReactContext?
     get() {
-      if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-        val reactHost =
-            checkNotNull(reactHost) { "ReactHost is not initialized in New Architecture" }
-        return reactHost.currentReactContext
-      } else {
-        val reactInstanceManager = reactNativeHost.reactInstanceManager
-        return reactInstanceManager.currentReactContext
-      }
+      val reactHost = checkNotNull(reactHost) { "ReactHost is not initialized in New Architecture" }
+      return reactHost.currentReactContext
     }
 
   private fun createReactContextAndScheduleTask(taskConfig: HeadlessJsTaskConfig) {
-    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-      val reactHost = checkNotNull(reactHost)
-      reactHost.addReactInstanceEventListener(
-          object : ReactInstanceEventListener {
-            override fun onReactContextInitialized(context: ReactContext) {
-              invokeStartTask(context, taskConfig)
-              reactHost.removeReactInstanceEventListener(this)
-            }
+    val reactHost = checkNotNull(reactHost)
+    reactHost.addReactInstanceEventListener(
+        object : ReactInstanceEventListener {
+          override fun onReactContextInitialized(context: ReactContext) {
+            invokeStartTask(context, taskConfig)
+            reactHost.removeReactInstanceEventListener(this)
           }
-      )
-      reactHost.start()
-    } else {
-      val reactInstanceManager = reactNativeHost.reactInstanceManager
-      reactInstanceManager.addReactInstanceEventListener(
-          object : ReactInstanceEventListener {
-            override fun onReactContextInitialized(context: ReactContext) {
-              invokeStartTask(context, taskConfig)
-              reactInstanceManager.removeReactInstanceEventListener(this)
-            }
-          }
-      )
-      reactInstanceManager.createReactContextInBackground()
-    }
+        }
+    )
+    reactHost.start()
   }
 
   public companion object {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.kt
@@ -24,8 +24,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate : TurboModuleManage
   private val moduleProviders = mutableListOf<ModuleProvider>()
   private val packageModuleInfos = mutableMapOf<ModuleProvider, Map<String, ReactModuleInfo>>()
   private val shouldEnableLegacyModuleInterop =
-      ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-          ReactNativeNewArchitectureFeatureFlags.useTurboModuleInterop()
+      ReactNativeNewArchitectureFeatureFlags.useTurboModuleInterop()
 
   protected constructor(
       reactApplicationContext: ReactApplicationContext,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -113,7 +113,7 @@ public object DefaultNewArchitectureEntryPoint {
     ReactNativeFeatureFlags.override(featureFlags)
 
     privateTurboModulesEnabled = true
-    privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
+    privateBridgelessEnabled = true
 
     val (isValid, errorMessage) =
         isConfigurationValid(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -71,7 +71,6 @@ import com.facebook.react.devsupport.interfaces.StackFrame
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorDevHelper
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorOverlayManager
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.RequestHandler
@@ -243,8 +242,7 @@ public abstract class DevSupportManagerBase(
           )
     }
     if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-            ReactNativeFeatureFlags.perfMonitorV2Enabled() &&
+        ReactNativeFeatureFlags.perfMonitorV2Enabled() &&
             reactInstanceDevHelper is PerfMonitorDevHelper
     ) {
       perfMonitorOverlayManager =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -851,12 +851,6 @@ public class ReactHostImpl(
     }
 
     stateTracker.enterState("getOrCreateStartTask()", "Schedule")
-    if (ReactBuildConfig.DEBUG) {
-      Assertions.assertCondition(
-          ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture(),
-          "enableBridgelessArchitecture FeatureFlag must be set to start ReactNative.",
-      )
-    }
     if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       Assertions.assertCondition(
           !ReactNativeNewArchitectureFeatureFlags.useFabricInterop(),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -23,7 +23,6 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.uimanager.annotations.ReactProp;
@@ -406,8 +405,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * Map contains the names (key) and types (value) of the ViewManager's props.
    */
   public Map<String, String> getNativeProps() {
-    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
-        && ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       // TODO: review if we need to check fabricInterop here
       return ViewManagerPropertyUpdater.getNativeProps(getClass(), null);
     } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -49,8 +49,6 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.annotations.VisibleForTesting
-import com.facebook.react.common.build.ReactBuildConfig
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.modules.fresco.ImageCacheControl
 import com.facebook.react.modules.fresco.ReactNetworkImageRequest
 import com.facebook.react.uimanager.BackgroundStyleApplicator
@@ -61,7 +59,6 @@ import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.uimanager.style.LogicalEdge
-import com.facebook.react.util.RNLog
 import com.facebook.react.views.image.ImageLoadEvent.Companion.createErrorEvent
 import com.facebook.react.views.image.ImageLoadEvent.Companion.createLoadEndEvent
 import com.facebook.react.views.image.ImageLoadEvent.Companion.createLoadEvent
@@ -282,7 +279,6 @@ public class ReactImageView(
       val cacheControl = computeCacheControl(source.getString("cache"))
       var imageSource = ImageSource(context, source.getString("uri"), cacheControl = cacheControl)
       if (Uri.EMPTY == imageSource.uri) {
-        warnImageSource(source.getString("uri"))
         imageSource = getTransparentBitmapImageSource(context)
       }
       tmpSources.add(imageSource)
@@ -299,7 +295,6 @@ public class ReactImageView(
                 cacheControl,
             )
         if (Uri.EMPTY == imageSource.uri) {
-          warnImageSource(source.getString("uri"))
           imageSource = getTransparentBitmapImageSource(context)
         }
         tmpSources.add(imageSource)
@@ -588,23 +583,6 @@ public class ReactImageView(
       }
       return ResizeOptions(width, height)
     }
-
-  private fun warnImageSource(uri: String?) {
-    // TODO(T189014077): This code-path produces an infinite loop of js calls with logbox.
-    // This is an issue with Fabric view preallocation, react, and LogBox. Fix.
-    // The bug:
-    // 1. An app renders an <Image/>
-    // 2. Fabric preallocates <Image/>; sets a null src to ReactImageView (potential problem?).
-    // 3. ReactImageView detects the null src; displays a warning in LogBox (via this code).
-    // 3. LogBox renders an <Image/>, which fabric preallocates.
-    // 4. Rinse and repeat.
-    if (
-        ReactBuildConfig.DEBUG &&
-            !ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()
-    ) {
-      RNLog.w(context as ReactContext, "ReactImageView: Image source \"$uri\" doesn't exist")
-    }
-  }
 
   private inner class TilePostprocessor : BasePostprocessor() {
     override fun process(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -48,7 +48,6 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger.logSoftException
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.uimanager.BackgroundStyleApplicator.clipToPaddingBox
 import com.facebook.react.uimanager.BackgroundStyleApplicator.getBackgroundColor
 import com.facebook.react.uimanager.BackgroundStyleApplicator.getBorderColor
@@ -916,10 +915,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
   public override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
 
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-            ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()
-    ) {
+    if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
       applyTextAttributes()
     }
   }


### PR DESCRIPTION
Summary:

Second in a stack that collapses Android-side branches on `ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()` under the standing assumption that on Android the flag is always `true`. The underlying generated `ReactNativeFeatureFlags.enableBridgelessArchitecture()` is untouched.

Scope of this commit — ReactAndroid simple call sites:

- `DevSupportManagerBase` — drop the flag from the AND chain that gates `PerfMonitorOverlayManager` creation.
- `HeadlessJsTaskService.reactContext` getter and `createReactContextAndScheduleTask` — keep the `reactHost` branches; drop the `reactInstanceManager` fallbacks.
- `ViewManager.getNativeProps` — drop the flag from the AND with `UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE`.
- `ReactImageView` — delete the `warnImageSource` helper and its two call sites. The helper existed only to emit a debug warning that was already gated off in bridgeless mode.
- `ReactEditText.onConfigurationChanged` — drop the flag from the AND with `enableFontScaleChangesUpdatingLayout`.
- `ReactHostImpl.getOrCreateStartTask` — drop the always-true debug assertion.
- `DefaultNewArchitectureEntryPoint.loadWithFeatureFlags` — set `privateBridgelessEnabled = true` directly (was reading from the provider).
- `ReactPackageTurboModuleManagerDelegate.shouldEnableLegacyModuleInterop` — drop the flag from the AND with `useTurboModuleInterop`.

No public API surfaces change. `arc f` auto-removed the now-unused `ReactNativeNewArchitectureFeatureFlags` imports in the affected files.

Subsequent diffs in the stack will handle: `ReactDelegate` + deprecated constructors + `reactNativeHost` field; wrapper method + lint detector.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D106719839


