### PR TITLE
Delete `ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture` wrapper method (#57001)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -65,8 +65,6 @@ public abstract class com/facebook/react/ReactActivity : androidx/appcompat/app/
 	public fun getReactActivityDelegate ()Lcom/facebook/react/ReactActivityDelegate;
 	public fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;
 	protected fun getReactHost ()Lcom/facebook/react/ReactHost;
-	protected final fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
-	protected final fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 	public fun invokeDefaultOnBackPressed ()V
 	protected final fun loadApp (Ljava/lang/String;)V
 	public fun onActivityResult (IILandroid/content/Intent;)V
@@ -99,8 +97,6 @@ public class com/facebook/react/ReactActivityDelegate {
 	protected fun getReactActivity ()Lcom/facebook/react/ReactActivity;
 	protected fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;
 	public fun getReactHost ()Lcom/facebook/react/ReactHost;
-	public fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
-	protected fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 	protected fun isFabricEnabled ()Z
 	protected fun isWideColorGamutEnabled ()Z
 	protected fun loadApp (Ljava/lang/String;)V
@@ -119,7 +115,6 @@ public class com/facebook/react/ReactActivityDelegate {
 	public fun onUserLeaveHint ()V
 	public fun onWindowFocusChanged (Z)V
 	public fun requestPermissions ([Ljava/lang/String;ILcom/facebook/react/modules/core/PermissionListener;)V
-	public fun setReactRootView (Lcom/facebook/react/ReactRootView;)V
 	public fun setReactSurface (Lcom/facebook/react/interfaces/fabric/ReactSurface;)V
 }
 
@@ -130,14 +125,9 @@ public abstract interface class com/facebook/react/ReactApplication {
 
 public class com/facebook/react/ReactDelegate {
 	public fun <init> (Landroid/app/Activity;Lcom/facebook/react/ReactHost;Ljava/lang/String;Landroid/os/Bundle;)V
-	public fun <init> (Landroid/app/Activity;Lcom/facebook/react/ReactNativeHost;Ljava/lang/String;Landroid/os/Bundle;)V
-	public fun <init> (Landroid/app/Activity;Lcom/facebook/react/ReactNativeHost;Ljava/lang/String;Landroid/os/Bundle;Z)V
-	protected fun createRootView ()Lcom/facebook/react/ReactRootView;
 	public final fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	public final fun getReactHost ()Lcom/facebook/react/ReactHost;
-	public final fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	public final fun getReactRootView ()Lcom/facebook/react/ReactRootView;
-	protected final fun isFabricEnabled ()Z
 	public final fun loadApp ()V
 	public final fun loadApp (Ljava/lang/String;)V
 	public final fun onActivityResult (IILandroid/content/Intent;Z)V
@@ -152,7 +142,6 @@ public class com/facebook/react/ReactDelegate {
 	public final fun onUserLeaveHint ()V
 	public final fun onWindowFocusChanged (Z)V
 	public final fun reload ()V
-	public final fun setReactRootView (Lcom/facebook/react/ReactRootView;)V
 	public final fun setReactSurface (Lcom/facebook/react/interfaces/fabric/ReactSurface;)V
 	public final fun shouldShowDevMenuOrReload (ILandroid/view/KeyEvent;)Z
 	public final fun unloadApp ()V
@@ -170,7 +159,6 @@ public class com/facebook/react/ReactFragment : androidx/fragment/app/Fragment, 
 	public fun checkSelfPermission (Ljava/lang/String;)I
 	protected final fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;
 	protected fun getReactHost ()Lcom/facebook/react/ReactHost;
-	protected fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 	public fun onActivityResult (IILandroid/content/Intent;)V
 	public fun onBackPressed ()Z
 	public fun onCreate (Landroid/os/Bundle;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
@@ -17,7 +17,6 @@ import android.os.PowerManager
 import android.os.PowerManager.WakeLock
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
 import com.facebook.react.jstasks.HeadlessJsTaskContext.Companion.getInstance
 import com.facebook.react.jstasks.HeadlessJsTaskEventListener
@@ -126,40 +125,21 @@ public abstract class HeadlessJsTaskService : Service(), HeadlessJsTaskEventList
 
   protected val reactContext: ReactContext?
     get() {
-      if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-        val reactHost =
-            checkNotNull(reactHost) { "ReactHost is not initialized in New Architecture" }
-        return reactHost.currentReactContext
-      } else {
-        val reactInstanceManager = reactNativeHost.reactInstanceManager
-        return reactInstanceManager.currentReactContext
-      }
+      val reactHost = checkNotNull(reactHost) { "ReactHost is not initialized in New Architecture" }
+      return reactHost.currentReactContext
     }
 
   private fun createReactContextAndScheduleTask(taskConfig: HeadlessJsTaskConfig) {
-    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-      val reactHost = checkNotNull(reactHost)
-      reactHost.addReactInstanceEventListener(
-          object : ReactInstanceEventListener {
-            override fun onReactContextInitialized(context: ReactContext) {
-              invokeStartTask(context, taskConfig)
-              reactHost.removeReactInstanceEventListener(this)
-            }
+    val reactHost = checkNotNull(reactHost)
+    reactHost.addReactInstanceEventListener(
+        object : ReactInstanceEventListener {
+          override fun onReactContextInitialized(context: ReactContext) {
+            invokeStartTask(context, taskConfig)
+            reactHost.removeReactInstanceEventListener(this)
           }
-      )
-      reactHost.start()
-    } else {
-      val reactInstanceManager = reactNativeHost.reactInstanceManager
-      reactInstanceManager.addReactInstanceEventListener(
-          object : ReactInstanceEventListener {
-            override fun onReactContextInitialized(context: ReactContext) {
-              invokeStartTask(context, taskConfig)
-              reactInstanceManager.removeReactInstanceEventListener(this)
-            }
-          }
-      )
-      reactInstanceManager.createReactContextInBackground()
-    }
+        }
+    )
+    reactHost.start()
   }
 
   public companion object {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -167,16 +167,8 @@ public abstract class ReactActivity extends AppCompatActivity
     mDelegate.onConfigurationChanged(newConfig);
   }
 
-  protected final ReactNativeHost getReactNativeHost() {
-    return mDelegate.getReactNativeHost();
-  }
-
   protected ReactHost getReactHost() {
     return mDelegate.getReactHost();
-  }
-
-  protected final ReactInstanceManager getReactInstanceManager() {
-    return mDelegate.getReactInstanceManager();
   }
 
   protected final void loadApp(String appKey) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -23,7 +23,6 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.interfaces.fabric.ReactSurface;
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.modules.core.PermissionListener;
 import com.facebook.react.views.view.WindowUtilKt;
 import com.facebook.systrace.Systrace;
@@ -84,21 +83,6 @@ public class ReactActivityDelegate {
   }
 
   /**
-   * Get the {@link ReactNativeHost} used by this app with Bridge enabled. By default, assumes
-   * {@link Activity#getApplication()} is an instance of {@link ReactApplication} and calls {@link
-   * ReactApplication#getReactNativeHost()}. Override this method if your application class does not
-   * implement {@code ReactApplication} or you simply have a different mechanism for storing a
-   * {@code ReactNativeHost}, e.g. as a static field somewhere.
-   *
-   * @deprecated "Do not access {@link ReactNativeHost} directly. This class is going away in the
-   *     New Architecture. You should access {@link ReactHost} instead."
-   */
-  @Deprecated
-  protected ReactNativeHost getReactNativeHost() {
-    return ((ReactApplication) getPlainActivity().getApplication()).getReactNativeHost();
-  }
-
-  /**
    * Get the {@link ReactHost} used by this app with Bridgeless enabled. By default, assumes {@link
    * Activity#getApplication()} is an instance of {@link ReactApplication} and calls {@link
    * ReactApplication#getReactHost()}. Override this method if your application class does not
@@ -111,16 +95,6 @@ public class ReactActivityDelegate {
 
   protected @Nullable ReactDelegate getReactDelegate() {
     return mReactDelegate;
-  }
-
-  /**
-   * @deprecated @deprecated "Do not access {@link ReactInstanceManager} directly. This class is
-   *     going away in the New Architecture. You should access {@link ReactHost} instead."
-   * @noinspection deprecation
-   */
-  @Deprecated
-  public ReactInstanceManager getReactInstanceManager() {
-    return Objects.requireNonNull(mReactDelegate).getReactInstanceManager();
   }
 
   @Nullable
@@ -144,29 +118,9 @@ public class ReactActivityDelegate {
               }
             }
           }
-          if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-            mReactDelegate =
-                new ReactDelegate(
-                    getPlainActivity(), getReactHost(), mainComponentName, launchOptions);
-          } else {
-            mReactDelegate =
-                new ReactDelegate(
-                    getPlainActivity(),
-                    getReactNativeHost(),
-                    mainComponentName,
-                    launchOptions,
-                    isFabricEnabled()) {
-                  @Override
-                  @Nullable
-                  protected ReactRootView createRootView() {
-                    ReactRootView rootView = ReactActivityDelegate.this.createRootView();
-                    if (rootView == null) {
-                      rootView = super.createRootView();
-                    }
-                    return rootView;
-                  }
-                };
-          }
+          mReactDelegate =
+              new ReactDelegate(
+                  getPlainActivity(), getReactHost(), mainComponentName, launchOptions);
           if (mainComponentName != null) {
             loadApp(mainComponentName);
           }
@@ -180,10 +134,6 @@ public class ReactActivityDelegate {
 
   public void setReactSurface(ReactSurface reactSurface) {
     Objects.requireNonNull(mReactDelegate).setReactSurface(reactSurface);
-  }
-
-  public void setReactRootView(ReactRootView reactRootView) {
-    Objects.requireNonNull(mReactDelegate).setReactRootView(reactRootView);
   }
 
   public void onUserLeaveHint() {
@@ -256,18 +206,9 @@ public class ReactActivityDelegate {
           }
         };
 
-    LifecycleState lifecycle;
-    if (isFabricEnabled()) {
-      ReactHost reactHost = getReactHost();
-      lifecycle = reactHost != null ? reactHost.getLifecycleState() : LifecycleState.BEFORE_CREATE;
-    } else {
-      ReactNativeHost reactNativeHost = getReactNativeHost();
-      if (!reactNativeHost.hasInstance()) {
-        lifecycle = LifecycleState.BEFORE_CREATE;
-      } else {
-        lifecycle = reactNativeHost.getReactInstanceManager().getLifecycleState();
-      }
-    }
+    ReactHost reactHost = getReactHost();
+    LifecycleState lifecycle =
+        reactHost != null ? reactHost.getLifecycleState() : LifecycleState.BEFORE_CREATE;
 
     // If the permission request didn't show a dialog to the user, we can call the callback
     // immediately.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
@@ -13,107 +13,32 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.KeyEvent
 import com.facebook.react.bridge.ReactContext
-import com.facebook.react.bridge.UiThreadUtil.runOnUiThread
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer
 import com.facebook.react.devsupport.ReleaseDevSupportManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.interfaces.fabric.ReactSurface
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 
 /**
  * A delegate for handling React Application support. This delegate is unaware whether it is used in
  * an [Activity] or a [android.app.Fragment].
  */
-@Suppress("DEPRECATION")
-public open class ReactDelegate {
-  private val activity: Activity
-  private var internalReactRootView: ReactRootView? = null
-  private val mainComponentName: String?
-  private var launchOptions: Bundle?
-  private var doubleTapReloadRecognizer: DoubleTapReloadRecognizer?
+public open class ReactDelegate
+public constructor(
+    private val activity: Activity,
+    reactHost: ReactHost?,
+    private val mainComponentName: String?,
+    private var launchOptions: Bundle?,
+) {
+  private val doubleTapReloadRecognizer: DoubleTapReloadRecognizer = DoubleTapReloadRecognizer()
 
-  @Deprecated(
-      "You should not use ReactNativeHost directly in the New Architecture. Use ReactHost instead.",
-      ReplaceWith("reactHost"),
-  )
-  private var reactNativeHost: ReactNativeHost? = null
-  public var reactHost: ReactHost? = null
+  public var reactHost: ReactHost? = reactHost
     private set
 
   private var reactSurface: ReactSurface? = null
 
-  /**
-   * Override this method if you wish to selectively toggle Fabric for a specific surface. This will
-   * also control if Concurrent Root (React 18) should be enabled or not.
-   *
-   * @return true if Fabric is enabled for this Activity, false otherwise.
-   */
-  protected val isFabricEnabled: Boolean = true
-
-  /**
-   * Do not use this constructor as it's not accounting for New Architecture at all. You should use
-   * [ReactDelegate(Activity, ReactNativeHost, String, Bundle, boolean)] as it's the constructor
-   * used for New Architecture.
-   */
-  @Deprecated(
-      "Use one of the other constructors instead to account for New Architecture. Deprecated since 0.75.0"
-  )
-  public constructor(
-      activity: Activity,
-      reactNativeHost: ReactNativeHost?,
-      appKey: String?,
-      launchOptions: Bundle?,
-  ) {
-    this.activity = activity
-    this.mainComponentName = appKey
-    this.launchOptions = launchOptions
-    this.doubleTapReloadRecognizer = DoubleTapReloadRecognizer()
-    this.reactNativeHost = reactNativeHost
-  }
-
-  public constructor(
-      activity: Activity,
-      reactHost: ReactHost?,
-      appKey: String?,
-      launchOptions: Bundle?,
-  ) {
-    this.activity = activity
-    this.mainComponentName = appKey
-    this.launchOptions = launchOptions
-    this.doubleTapReloadRecognizer = DoubleTapReloadRecognizer()
-    this.reactHost = reactHost
-  }
-
-  @Deprecated("Deprecated since 0.81.0, use one of the other constructors instead.")
-  public constructor(
-      activity: Activity,
-      reactNativeHost: ReactNativeHost?,
-      appKey: String?,
-      launchOptions: Bundle?,
-      fabricEnabled: Boolean,
-  ) {
-    this.activity = activity
-    this.mainComponentName = appKey
-    this.launchOptions = launchOptions
-    this.doubleTapReloadRecognizer = DoubleTapReloadRecognizer()
-    this.reactNativeHost = reactNativeHost
-  }
-
   private val devSupportManager: DevSupportManager?
-    get() =
-        if (
-            ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-                reactHost?.devSupportManager != null
-        ) {
-          reactHost?.devSupportManager
-        } else if (
-            reactNativeHost?.hasInstance() == true && reactNativeHost?.reactInstanceManager != null
-        ) {
-          reactNativeHost?.reactInstanceManager?.devSupportManager
-        } else {
-          null
-        }
+    get() = reactHost?.devSupportManager
 
   public fun onHostResume() {
     if (activity !is DefaultHardwareBackBtnHandler) {
@@ -121,81 +46,28 @@ public open class ReactDelegate {
           "Host Activity `${activity.javaClass.simpleName}` does not implement DefaultHardwareBackBtnHandler"
       )
     }
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-    ) {
-      reactHost?.onHostResume(activity, activity as DefaultHardwareBackBtnHandler)
-    } else {
-      if (reactNativeHost?.hasInstance() == true) {
-        reactNativeHost
-            ?.reactInstanceManager
-            ?.onHostResume(activity, activity as DefaultHardwareBackBtnHandler)
-      }
-    }
+    reactHost?.onHostResume(activity, activity as DefaultHardwareBackBtnHandler)
   }
 
   public fun onUserLeaveHint() {
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-    ) {
-      reactHost?.onHostLeaveHint(activity)
-    } else {
-      if (reactNativeHost?.hasInstance() == true) {
-        reactNativeHost?.reactInstanceManager?.onUserLeaveHint(activity)
-      }
-    }
+    reactHost?.onHostLeaveHint(activity)
   }
 
   public fun onHostPause() {
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-    ) {
-      reactHost?.onHostPause(activity)
-    } else {
-      if (reactNativeHost?.hasInstance() == true) {
-        reactNativeHost?.reactInstanceManager?.onHostPause(activity)
-      }
-    }
+    reactHost?.onHostPause(activity)
   }
 
   public fun onHostDestroy() {
     unloadApp()
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-    ) {
-      reactHost?.onHostDestroy(activity)
-    } else {
-      if (reactNativeHost?.hasInstance() == true) {
-        reactNativeHost?.reactInstanceManager?.onHostDestroy(activity)
-      }
-    }
+    reactHost?.onHostDestroy(activity)
   }
 
-  public fun onBackPressed(): Boolean {
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-    ) {
-      return reactHost?.onBackPressed() == true
-    } else if (reactNativeHost?.hasInstance() == true) {
-      reactNativeHost?.reactInstanceManager?.onBackPressed()
-      return true
-    }
-    return false
-  }
+  public fun onBackPressed(): Boolean = reactHost?.onBackPressed() == true
 
   public fun onNewIntent(intent: Intent): Boolean {
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-    ) {
-      reactHost?.onNewIntent(intent)
-      return true
-    } else {
-      if (reactNativeHost?.hasInstance() == true) {
-        reactNativeHost?.reactInstanceManager?.onNewIntent(intent)
-        return true
-      }
-    }
-    return false
+    val reactHost = reactHost ?: return false
+    reactHost.onNewIntent(intent)
+    return true
   }
 
   public fun onActivityResult(
@@ -204,53 +76,21 @@ public open class ReactDelegate {
       data: Intent?,
       shouldForwardToReactInstance: Boolean,
   ) {
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-            reactHost != null &&
-            shouldForwardToReactInstance
-    ) {
+    if (shouldForwardToReactInstance) {
       reactHost?.onActivityResult(activity, requestCode, resultCode, data)
-    } else {
-      if (reactNativeHost?.hasInstance() == true && shouldForwardToReactInstance) {
-        reactNativeHost
-            ?.reactInstanceManager
-            ?.onActivityResult(activity, requestCode, resultCode, data)
-      }
     }
   }
 
   public fun onWindowFocusChanged(hasFocus: Boolean) {
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-    ) {
-      reactHost?.onWindowFocusChange(hasFocus)
-    } else {
-      if (reactNativeHost?.hasInstance() == true) {
-        reactNativeHost?.reactInstanceManager?.onWindowFocusChange(hasFocus)
-      }
-    }
+    reactHost?.onWindowFocusChange(hasFocus)
   }
 
   public fun onConfigurationChanged(newConfig: Configuration?) {
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-    ) {
-      reactHost?.onConfigurationChanged(checkNotNull(activity))
-    } else {
-      if (reactNativeHost?.hasInstance() == true) {
-        getReactInstanceManager().onConfigurationChanged(checkNotNull(activity), newConfig)
-      }
-    }
+    reactHost?.onConfigurationChanged(checkNotNull(activity))
   }
 
   public fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-    if (
-        keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD &&
-            ((ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-                reactHost?.devSupportManager != null) ||
-                (reactNativeHost?.hasInstance() == true &&
-                    reactNativeHost?.getUseDeveloperSupport() == true))
-    ) {
+    if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD && reactHost?.devSupportManager != null) {
       event.startTracking()
       return true
     }
@@ -259,23 +99,11 @@ public open class ReactDelegate {
 
   public fun onKeyLongPress(keyCode: Int): Boolean {
     if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_BACK) {
-      if (
-          ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
-      ) {
-        val devSupportManager = reactHost?.devSupportManager
-        // onKeyLongPress is a Dev API and not supported in RELEASE mode.
-        if (devSupportManager != null && devSupportManager !is ReleaseDevSupportManager) {
-          devSupportManager.showDevOptionsDialog()
-          return true
-        }
-      } else {
-        if (
-            reactNativeHost?.hasInstance() == true &&
-                reactNativeHost?.getUseDeveloperSupport() == true
-        ) {
-          reactNativeHost?.reactInstanceManager?.showDevOptionsDialog()
-          return true
-        }
+      val devSupportManager = reactHost?.devSupportManager
+      // onKeyLongPress is a Dev API and not supported in RELEASE mode.
+      if (devSupportManager != null && devSupportManager !is ReleaseDevSupportManager) {
+        devSupportManager.showDevOptionsDialog()
+        return true
       }
     }
     return false
@@ -287,18 +115,7 @@ public open class ReactDelegate {
     // Reload in RELEASE mode
     if (devSupportManager is ReleaseDevSupportManager) {
       // Do not reload the bundle from JS as there is no bundler running in release mode.
-      if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-        reactHost?.reload("ReactDelegate.reload()")
-      } else {
-        runOnUiThread {
-          if (
-              reactNativeHost?.hasInstance() == true &&
-                  reactNativeHost?.reactInstanceManager != null
-          ) {
-            reactNativeHost?.reactInstanceManager?.recreateReactContextInBackground()
-          }
-        }
-      }
+      reactHost?.reload("ReactDelegate.reload()")
       return
     }
 
@@ -318,65 +135,25 @@ public open class ReactDelegate {
    * @param appKey The ID of the app to load into the surface.
    */
   public fun loadApp(appKey: String) {
-    // With Bridgeless enabled, create and start the surface
-    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-      val reactHost = reactHost
-      if (reactSurface == null && reactHost != null) {
-        reactSurface = reactHost.createSurface(activity, appKey, launchOptions)
-      }
-      reactSurface?.start()
-    } else {
-      check(internalReactRootView == null) { "Cannot loadApp while app is already running." }
-      internalReactRootView = createRootView()
-      if (reactNativeHost != null) {
-        internalReactRootView?.startReactApplication(
-            reactNativeHost?.reactInstanceManager,
-            appKey,
-            launchOptions,
-        )
-      }
+    val reactHost = reactHost
+    if (reactSurface == null && reactHost != null) {
+      reactSurface = reactHost.createSurface(activity, appKey, launchOptions)
     }
+    reactSurface?.start()
   }
 
   /** Stop the React surface started with [ReactDelegate.loadApp]. */
   public fun unloadApp() {
-    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-      reactSurface?.stop()
-      reactSurface = null
-    } else {
-      if (internalReactRootView != null) {
-        internalReactRootView?.unmountReactApplication()
-        internalReactRootView = null
-      }
-    }
+    reactSurface?.stop()
+    reactSurface = null
   }
 
   public fun setReactSurface(reactSurface: ReactSurface?) {
     this.reactSurface = reactSurface
   }
 
-  public var reactRootView: ReactRootView?
-    get() {
-      return if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-        if (reactSurface != null) {
-          reactSurface?.view as ReactRootView?
-        } else {
-          null
-        }
-      } else {
-        internalReactRootView
-      }
-    }
-    set(reactRootView) {
-      internalReactRootView = reactRootView
-    }
-
-  // Not used in bridgeless
-  protected open fun createRootView(): ReactRootView? {
-    val reactRootView = ReactRootView(activity)
-    reactRootView.setIsFabric(isFabricEnabled)
-    return reactRootView
-  }
+  public val reactRootView: ReactRootView?
+    get() = reactSurface?.view as ReactRootView?
 
   /**
    * Handles delegating the [Activity.onKeyUp] method to determine whether the application should
@@ -400,7 +177,7 @@ public open class ReactDelegate {
       devSupportManager.showDevOptionsDialog()
       return true
     }
-    val didDoubleTapR = doubleTapReloadRecognizer?.didDoubleTapR(keyCode, activity.currentFocus)
+    val didDoubleTapR = doubleTapReloadRecognizer.didDoubleTapR(keyCode, activity.currentFocus)
     if (didDoubleTapR == true) {
       devSupportManager.handleReloadJS()
       return true
@@ -408,33 +185,12 @@ public open class ReactDelegate {
     return false
   }
 
-  @Deprecated(
-      "Do not access [ReactInstanceManager] directly. This class is going away in the New Architecture. You should use [ReactHost] instead."
-  )
-  public fun getReactInstanceManager(): ReactInstanceManager {
-    val nonNullReactNativeHost =
-        checkNotNull(reactNativeHost) {
-          "Cannot get ReactInstanceManager without a ReactNativeHost."
-        }
-    return nonNullReactNativeHost.reactInstanceManager
-  }
-
   /**
-   * Get the current [ReactContext] from [ReactHost] or [ReactInstanceManager]
+   * Get the current [ReactContext] from [ReactHost].
    *
    * Do not store a reference to this, if the React instance is reloaded or destroyed, this context
    * will no longer be valid.
    */
   public val currentReactContext: ReactContext?
-    get() {
-      return if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-        if (reactHost != null) {
-          reactHost?.currentReactContext
-        } else {
-          null
-        }
-      } else {
-        getReactInstanceManager().currentReactContext
-      }
-    }
+    get() = reactHost?.currentReactContext
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.kt
@@ -15,7 +15,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 
@@ -32,53 +31,22 @@ public open class ReactFragment : Fragment(), PermissionAwareActivity {
     super.onCreate(savedInstanceState)
     var mainComponentName: String? = null
     var launchOptions: Bundle? = null
-    var fabricEnabled = false
     arguments?.let { args ->
       mainComponentName = args.getString(ARG_COMPONENT_NAME)
       launchOptions = args.getBundle(ARG_LAUNCH_OPTIONS)
-      fabricEnabled = args.getBoolean(ARG_FABRIC_ENABLED)
       @Suppress("DEPRECATION")
       disableHostLifecycleEvents = args.getBoolean(ARG_DISABLE_HOST_LIFECYCLE_EVENTS)
     }
     checkNotNull(mainComponentName) { "Cannot loadApp if component name is null" }
 
-    reactDelegate =
-        if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
-          ReactDelegate(requireActivity(), reactHost, mainComponentName, launchOptions)
-        } else {
-          @Suppress("DEPRECATION")
-          ReactDelegate(
-              requireActivity(),
-              reactNativeHost,
-              mainComponentName,
-              launchOptions,
-              fabricEnabled,
-          )
-        }
+    reactDelegate = ReactDelegate(requireActivity(), reactHost, mainComponentName, launchOptions)
   }
-
-  /**
-   * Get the [ReactNativeHost] used by this app. By default, assumes [Activity.getApplication] is an
-   * instance of [ReactApplication] and calls [ReactApplication.reactNativeHost]. Override this
-   * method if your application class does not implement `ReactApplication` or you simply have a
-   * different mechanism for storing a `ReactNativeHost`, e.g. as a static field somewhere.
-   */
-  @Suppress("DEPRECATION")
-  @Deprecated(
-      "You should not use ReactNativeHost directly in the New Architecture. Use ReactHost instead.",
-      ReplaceWith("reactHost"),
-  )
-  protected open val reactNativeHost: ReactNativeHost?
-    get() = (activity?.application as ReactApplication?)?.reactNativeHost
 
   /**
    * Get the [ReactHost] used by this app. By default, assumes [Activity.getApplication] is an
    * instance of [ReactApplication] and calls [ReactApplication.reactHost]. Override this method if
    * your application class does not implement `ReactApplication` or you simply have a different
    * mechanism for storing a `ReactHost`, e.g. as a static field somewhere.
-   *
-   * If you're using Old Architecture/Bridge Mode, this method should return null as [ReactHost] is
-   * a Bridgeless-only concept.
    */
   protected open val reactHost: ReactHost?
     get() = (activity?.application as ReactApplication?)?.reactHost

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.kt
@@ -24,8 +24,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate : TurboModuleManage
   private val moduleProviders = mutableListOf<ModuleProvider>()
   private val packageModuleInfos = mutableMapOf<ModuleProvider, Map<String, ReactModuleInfo>>()
   private val shouldEnableLegacyModuleInterop =
-      ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-          ReactNativeNewArchitectureFeatureFlags.useTurboModuleInterop()
+      ReactNativeNewArchitectureFeatureFlags.useTurboModuleInterop()
 
   protected constructor(
       reactApplicationContext: ReactApplicationContext,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -113,7 +113,7 @@ public object DefaultNewArchitectureEntryPoint {
     ReactNativeFeatureFlags.override(featureFlags)
 
     privateTurboModulesEnabled = true
-    privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
+    privateBridgelessEnabled = true
 
     val (isValid, errorMessage) =
         isConfigurationValid(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -71,7 +71,6 @@ import com.facebook.react.devsupport.interfaces.StackFrame
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorDevHelper
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorOverlayManager
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.RequestHandler
@@ -243,8 +242,7 @@ public abstract class DevSupportManagerBase(
           )
     }
     if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-            ReactNativeFeatureFlags.perfMonitorV2Enabled() &&
+        ReactNativeFeatureFlags.perfMonitorV2Enabled() &&
             reactInstanceDevHelper is PerfMonitorDevHelper
     ) {
       perfMonitorOverlayManager =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
@@ -24,18 +24,6 @@ import com.facebook.react.common.build.ReactBuildConfig
 public object ReactNativeNewArchitectureFeatureFlags {
 
   @JvmStatic
-  public fun enableBridgelessArchitecture(): Boolean {
-    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
-      Assertions.assertCondition(
-          ReactNativeFeatureFlags.enableBridgelessArchitecture(),
-          "ReactNativeFeatureFlags.enableBridgelessArchitecture() should be set to TRUE when Strict Mode is enabled",
-      )
-      return true
-    }
-    return ReactNativeFeatureFlags.enableBridgelessArchitecture()
-  }
-
-  @JvmStatic
   public fun useFabricInterop(): Boolean {
     if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       Assertions.assertCondition(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -851,12 +851,6 @@ public class ReactHostImpl(
     }
 
     stateTracker.enterState("getOrCreateStartTask()", "Schedule")
-    if (ReactBuildConfig.DEBUG) {
-      Assertions.assertCondition(
-          ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture(),
-          "enableBridgelessArchitecture FeatureFlag must be set to start ReactNative.",
-      )
-    }
     if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       Assertions.assertCondition(
           !ReactNativeNewArchitectureFeatureFlags.useFabricInterop(),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -23,7 +23,6 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.uimanager.annotations.ReactProp;
@@ -406,8 +405,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * Map contains the names (key) and types (value) of the ViewManager's props.
    */
   public Map<String, String> getNativeProps() {
-    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
-        && ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       // TODO: review if we need to check fabricInterop here
       return ViewManagerPropertyUpdater.getNativeProps(getClass(), null);
     } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -49,8 +49,6 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.annotations.VisibleForTesting
-import com.facebook.react.common.build.ReactBuildConfig
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.modules.fresco.ImageCacheControl
 import com.facebook.react.modules.fresco.ReactNetworkImageRequest
 import com.facebook.react.uimanager.BackgroundStyleApplicator
@@ -61,7 +59,6 @@ import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.uimanager.style.LogicalEdge
-import com.facebook.react.util.RNLog
 import com.facebook.react.views.image.ImageLoadEvent.Companion.createErrorEvent
 import com.facebook.react.views.image.ImageLoadEvent.Companion.createLoadEndEvent
 import com.facebook.react.views.image.ImageLoadEvent.Companion.createLoadEvent
@@ -282,7 +279,6 @@ public class ReactImageView(
       val cacheControl = computeCacheControl(source.getString("cache"))
       var imageSource = ImageSource(context, source.getString("uri"), cacheControl = cacheControl)
       if (Uri.EMPTY == imageSource.uri) {
-        warnImageSource(source.getString("uri"))
         imageSource = getTransparentBitmapImageSource(context)
       }
       tmpSources.add(imageSource)
@@ -299,7 +295,6 @@ public class ReactImageView(
                 cacheControl,
             )
         if (Uri.EMPTY == imageSource.uri) {
-          warnImageSource(source.getString("uri"))
           imageSource = getTransparentBitmapImageSource(context)
         }
         tmpSources.add(imageSource)
@@ -588,23 +583,6 @@ public class ReactImageView(
       }
       return ResizeOptions(width, height)
     }
-
-  private fun warnImageSource(uri: String?) {
-    // TODO(T189014077): This code-path produces an infinite loop of js calls with logbox.
-    // This is an issue with Fabric view preallocation, react, and LogBox. Fix.
-    // The bug:
-    // 1. An app renders an <Image/>
-    // 2. Fabric preallocates <Image/>; sets a null src to ReactImageView (potential problem?).
-    // 3. ReactImageView detects the null src; displays a warning in LogBox (via this code).
-    // 3. LogBox renders an <Image/>, which fabric preallocates.
-    // 4. Rinse and repeat.
-    if (
-        ReactBuildConfig.DEBUG &&
-            !ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()
-    ) {
-      RNLog.w(context as ReactContext, "ReactImageView: Image source \"$uri\" doesn't exist")
-    }
-  }
 
   private inner class TilePostprocessor : BasePostprocessor() {
     override fun process(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -48,7 +48,6 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger.logSoftException
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.uimanager.BackgroundStyleApplicator.clipToPaddingBox
 import com.facebook.react.uimanager.BackgroundStyleApplicator.getBackgroundColor
 import com.facebook.react.uimanager.BackgroundStyleApplicator.getBorderColor
@@ -916,10 +915,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
   public override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
 
-    if (
-        ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
-            ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()
-    ) {
+    if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
       applyTextAttributes()
     }
   }


### PR DESCRIPTION
Summary:

Final cleanup in the stack. All Android call sites of the wrapper have moved to the bridgeless-only path in the earlier diffs of this stack, so the wrapper method is unused and can be deleted. The surrounding `ReactNativeNewArchitectureFeatureFlags` object stays — `useFabricInterop()` and `useTurboModuleInterop()` still live there.

Also:
- Drop the `"enableBridgelessArchitecture"` entry from `UseReactNativeNewArchitectureFeatureFlagDetector` — the wrapper for that flag no longer exists, so the lint rule is moot for it.
- Update the detector's tests to exercise `useFabricInterop` (still tracked by the detector) instead of `enableBridgelessArchitecture`.

The underlying generated `ReactNativeFeatureFlags.enableBridgelessArchitecture()` is untouched. `ReactAndroid.api` is unchanged because the wrapper lives in an `internal` package which is excluded from public API tracking.

Changelog: [Internal]

Differential Revision: D106719841


