### PR TITLE
Promote event loop control JSI interface out of UNSTABLE (#57005)

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/hermes-interfaces.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/hermes-interfaces.h
@@ -26,7 +26,6 @@ namespace debugger {
 class Debugger;
 }
 
-#ifdef JSI_UNSTABLE
 /// IEventLoopControl is defined by the integrator to allow the Runtime to
 /// schedule some task to be run when convenient, and to keep track of "Task
 /// sources". After it is set to a Runtime, the integrator must ensure that the
@@ -79,7 +78,6 @@ struct JSI_EXPORT ISetEventLoopControl : public jsi::ICast {
  protected:
   ~ISetEventLoopControl() = default;
 };
-#endif
 
 /// Interface for Hermes-specific runtime methods.The actual implementations of
 /// the pure virtual methods are provided by Hermes API.

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -438,6 +438,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AndroidHorizontalScrollContentViewShadowNodeComponentName[];
 const char facebook::react::AndroidProgressBarComponentName[];

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -438,6 +438,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AndroidHorizontalScrollContentViewShadowNodeComponentName[];
 const char facebook::react::AndroidProgressBarComponentName[];

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -438,6 +438,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AndroidHorizontalScrollContentViewShadowNodeComponentName[];
 const char facebook::react::AndroidProgressBarComponentName[];

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -3380,6 +3380,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AppleSwitchComponentName[];
 const char facebook::react::ImageComponentName[];

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -3367,6 +3367,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AppleSwitchComponentName[];
 const char facebook::react::ImageComponentName[];

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -3380,6 +3380,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AppleSwitchComponentName[];
 const char facebook::react::ImageComponentName[];

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -136,6 +136,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AndroidProgressBarComponentName[];
 const char facebook::react::AndroidSwitchComponentName[];

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -136,6 +136,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AndroidProgressBarComponentName[];
 const char facebook::react::AndroidSwitchComponentName[];

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -136,6 +136,20 @@ class facebook::hermes::IHermesSHUnit : public facebook::jsi::ICast {
   public virtual SHUnitCreator getSHUnitCreator() const = 0;
 }
 
+struct facebook::hermes::IEventLoopControl {
+  protected ~IEventLoopControl() = default;
+  public virtual uint64_t registerTaskQueueSource() = 0;
+  public virtual void scheduleTask(const std::function<void()>& task) = 0;
+  public virtual void unregisterTaskQueueSource(uint64_t sourceId) = 0;
+}
+
+struct facebook::hermes::ISetEventLoopControl : public facebook::jsi::ICast {
+  protected ~ISetEventLoopControl() = default;
+  public static constexpr facebook::jsi::UUID uuid;
+  public virtual facebook::hermes::IEventLoopControl* getEventLoopControl() = 0;
+  public virtual void setEventLoopControl(facebook::hermes::IEventLoopControl* eventLoopControl) = 0;
+}
+
 
 const char facebook::react::AndroidProgressBarComponentName[];
 const char facebook::react::AndroidSwitchComponentName[];


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/hermes/pull/2037


Promote `IEventLoopControl` and `ISetEventLoopControl` out of `JSI_UNSTABLE` and make `HermesRuntimeImpl` always implement the setter interface. Keep unrelated unstable APIs such as serialization, tracing helpers, and Worker installation behind `JSI_UNSTABLE`.

Other hermes branches do not implement `ISetEventLoopControl`, for now.

Changelog: [Internal]

Reviewed By: tmikov

Differential Revision: D106744174


