### PR TITLE
fix: lazily evaluate Platform in Settings to resolve circular dependency startup crash (#56967)

### DIFF
--- a/packages/react-native/Libraries/Settings/Settings.js
+++ b/packages/react-native/Libraries/Settings/Settings.js
@@ -4,13 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
-import Platform from '../Utilities/Platform';
-
-let Settings: {
+type SettingsStatic = {
   get(key: string): any,
   set(settings: Object): void,
   watchKeys(keys: string | Array<string>, callback: () => void): number,
@@ -18,10 +16,37 @@ let Settings: {
   ...
 };
 
-if (Platform.OS === 'ios') {
-  Settings = require('./Settings').default;
-} else {
-  Settings = require('./SettingsFallback').default;
+let SettingsImpl: ?SettingsStatic = null;
+
+function getSettings(): SettingsStatic {
+  if (SettingsImpl != null) {
+    return SettingsImpl;
+  }
+  const Platform = require('../Utilities/Platform').default;
+  if (Platform.OS === 'ios') {
+    SettingsImpl = require('./Settings').default;
+  } else {
+    SettingsImpl = require('./SettingsFallback').default;
+  }
+  return (SettingsImpl: SettingsStatic);
 }
+
+const Settings: SettingsStatic = {
+  get(key: string): any {
+    return getSettings().get(key);
+  },
+
+  set(settings: Object): void {
+    getSettings().set(settings);
+  },
+
+  watchKeys(keys: string | Array<string>, callback: () => void): number {
+    return getSettings().watchKeys(keys, callback);
+  },
+
+  clearWatch(watchId: number): void {
+    getSettings().clearWatch(watchId);
+  },
+};
 
 export default Settings;

--- a/packages/react-native/Libraries/Settings/__tests__/Settings-test.js
+++ b/packages/react-native/Libraries/Settings/__tests__/Settings-test.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+describe('Settings', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  describe('lazy Platform initialization', () => {
+    it('does not access Platform when the module is first loaded', () => {
+      let platformAccessCount = 0;
+      jest.doMock('../../Utilities/Platform', () => ({
+        __esModule: true,
+        get default() {
+          platformAccessCount++;
+          return {OS: 'android'};
+        },
+      }));
+
+      require('../Settings.js');
+
+      expect(platformAccessCount).toBe(0);
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const Settings = require('../Settings.js').default;
+      Settings.get('any');
+      expect(platformAccessCount).toBeGreaterThan(0);
+      warnSpy.mockRestore();
+    });
+
+    it('can be required when Platform is undefined during module load', () => {
+      jest.doMock('../../Utilities/Platform', () => ({
+        __esModule: true,
+        default: undefined,
+      }));
+
+      expect(() => {
+        require('../Settings.js');
+      }).not.toThrow();
+    });
+  });
+
+  describe('platform-specific implementation', () => {
+    it('uses fallback implementation on Android', () => {
+      jest.doMock('../../Utilities/Platform', () => ({
+        __esModule: true,
+        default: {OS: 'android'},
+      }));
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const Settings = require('../Settings.js').default;
+
+      expect(Settings.get('foo')).toBeNull();
+      expect(Settings.watchKeys('foo', () => {})).toBe(-1);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('delegates get and set to the iOS implementation', () => {
+      const setValues = jest.fn();
+      jest.doMock('../../Utilities/Platform', () => ({
+        __esModule: true,
+        default: {OS: 'ios'},
+      }));
+      jest.doMock('../NativeSettingsManager', () => ({
+        __esModule: true,
+        default: {
+          getConstants: () => ({settings: {myKey: 'initial'}}),
+          setValues,
+        },
+      }));
+
+      const Settings = require('../Settings.js').default;
+
+      expect(Settings.get('myKey')).toBe('initial');
+      Settings.set({myKey: 'updated'});
+      expect(Settings.get('myKey')).toBe('updated');
+      expect(setValues).toHaveBeenCalledWith({myKey: 'updated'});
+    });
+
+    it('caches the platform implementation across calls', () => {
+      let platformAccessCount = 0;
+      jest.doMock('../../Utilities/Platform', () => ({
+        __esModule: true,
+        get default() {
+          platformAccessCount++;
+          return {OS: 'android'};
+        },
+      }));
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const Settings = require('../Settings.js').default;
+
+      Settings.get('a');
+      Settings.get('b');
+      expect(platformAccessCount).toBe(1);
+      warnSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
Closes #56967

## Summary:
This PR resolves a fatal `TypeError: Cannot read property 'OS' of undefined` startup crash occurring due to a circular dependency loop between `Settings.js` and `Platform.js`. 

Previously, `Settings.js` evaluated `Platform.OS` immediately at module load-time. If another module required `Settings` before `Platform` finished initializing its export graph, `Platform` resolved to `undefined` and crashed the environment. 

This change replaces top-level platform execution with a lazy proxy initializer (`getSettings()`). `Platform.OS` and the underlying platform implementation are now only required and resolved at runtime when a consumer invokes a method for the first time, safely eliminating the race condition.

## Changelog:
[GENERAL] [FIXED] - Lazily evaluate Platform in Settings to prevent circular dependency startup crashes

## Test Plan:
I added a dedicated test suite to `Settings-test.js` verifying that `Settings` can be successfully imported even if `Platform` is undefined during initial module load execution.

Ran the local Jest tests for the module, and all checks pass successfully:
```bash
yarn jest packages/react-native/Libraries/Settings/__tests__/Settings-test.js