### PR TITLE
Fix Android FlatList accessibility collection positions

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -177,6 +177,78 @@ function isArrayLike(data: unknown): boolean {
   return typeof Object(data).length === 'number';
 }
 
+function getItemCountForAccessibility<ItemT>(
+  data: ?Readonly<$ArrayLike<ItemT>>,
+): number {
+  return data != null && isArrayLike(data) ? data.length : 0;
+}
+
+function createAccessibilityCollection<ItemT>(
+  data: ?Readonly<$ArrayLike<ItemT>>,
+  numColumns: number,
+): {
+  itemCount: number,
+  rowCount: number,
+  columnCount: number,
+  hierarchical: boolean,
+} {
+  const itemCount = getItemCountForAccessibility(data);
+  return {
+    itemCount,
+    rowCount: numColumns > 1 ? Math.ceil(itemCount / numColumns) : itemCount,
+    columnCount: numColumns,
+    hierarchical: false,
+  };
+}
+
+type AccessibilityCollectionItem = Readonly<{
+  itemIndex: number,
+  rowIndex: number,
+  rowSpan: number,
+  columnIndex: number,
+  columnSpan: number,
+  heading: boolean,
+  ...
+}>;
+
+function createAccessibilityCollectionItem(
+  itemIndex: number,
+  rowIndex: number,
+  columnIndex: number,
+  horizontal: boolean,
+): AccessibilityCollectionItem {
+  return {
+    itemIndex,
+    rowIndex: horizontal ? 0 : rowIndex,
+    rowSpan: 1,
+    columnIndex: horizontal ? itemIndex : columnIndex,
+    columnSpan: 1,
+    heading: false,
+  };
+}
+
+function addAccessibilityCollectionItem(
+  element: React.Node,
+  accessibilityCollectionItem: ?AccessibilityCollectionItem,
+): React.Node {
+  if (
+    accessibilityCollectionItem == null ||
+    !React.isValidElement(element) ||
+    element.type === React.Fragment
+  ) {
+    return element;
+  }
+
+  // $FlowFixMe[prop-missing] React.Element internal inspection.
+  if (element.props.accessibilityCollectionItem !== undefined) {
+    return element;
+  }
+
+  return React.cloneElement(element, {
+    accessibilityCollectionItem,
+  });
+}
+
 type FlatListBaseProps<ItemT> = {
   ...RequiredFlatListProps<ItemT>,
   ...OptionalFlatListProps<ItemT>,
@@ -634,6 +706,8 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
     };
 
     const renderProp = (info: ListRenderItemInfo<ItemT>) => {
+      const isAndroid = Platform.OS === 'android';
+      const isHorizontal = this.props.horizontal === true;
       if (cols > 1) {
         const {item, index} = info;
         invariant(
@@ -641,22 +715,49 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
           'Expected array of items with numColumns > 1',
         );
         return (
-          <View style={StyleSheet.compose(styles.row, columnWrapperStyle)}>
+          <View
+            accessibilityCollectionItem={isAndroid ? null : undefined}
+            style={StyleSheet.compose(styles.row, columnWrapperStyle)}>
             {item.map((it, kk) => {
+              const itemIndex = index * cols + kk;
+              const itemAccessibilityCollectionItem = isAndroid
+                ? createAccessibilityCollectionItem(
+                    itemIndex,
+                    index,
+                    kk,
+                    isHorizontal,
+                  )
+                : undefined;
               const element = render({
                 // $FlowFixMe[incompatible-type]
                 item: it,
-                index: index * cols + kk,
+                index: itemIndex,
                 separators: info.separators,
               });
               return element != null ? (
-                <React.Fragment key={kk}>{element}</React.Fragment>
+                <React.Fragment key={kk}>
+                  {addAccessibilityCollectionItem(
+                    element,
+                    itemAccessibilityCollectionItem,
+                  )}
+                </React.Fragment>
               ) : null;
             })}
           </View>
         );
       } else {
-        return render(info);
+        const itemAccessibilityCollectionItem = isAndroid
+          ? createAccessibilityCollectionItem(
+              info.index,
+              info.index,
+              0,
+              isHorizontal,
+            )
+          : undefined;
+        return addAccessibilityCollectionItem(
+          render(info),
+          itemAccessibilityCollectionItem,
+        );
       }
     };
 
@@ -677,11 +778,28 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
     } = this.props;
 
     const renderer = strictMode ? this._memoizedRenderer : this._renderer;
+    const numColumnsValue = numColumnsOrDefault(numColumns);
+    const androidAccessibilityProps =
+      Platform.OS === 'android'
+        ? {
+            accessibilityCollection:
+              // $FlowFixMe[prop-missing] Internal native prop.
+              this.props.accessibilityCollection ??
+              createAccessibilityCollection(this.props.data, numColumnsValue),
+            accessibilityRole:
+              this.props.role == null && this.props.accessibilityRole == null
+                ? numColumnsValue > 1
+                  ? 'grid'
+                  : 'list'
+                : this.props.accessibilityRole,
+          }
+        : {};
 
     return (
       // $FlowFixMe[incompatible-exact] - `restProps` (`Props`) is inexact.
       <VirtualizedList
         {...restProps}
+        {...androidAccessibilityProps}
         getItem={this._getItem}
         getItemCount={this._getItemCount}
         keyExtractor={this._keyExtractor}

--- a/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
+++ b/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const FlatList = require('../FlatList').default;
+const Platform = require('../../Utilities/Platform').default;
 const {create} = require('@react-native/jest-preset/jest/renderer');
 const React = require('react');
 const {createRef} = require('react');
@@ -34,6 +35,141 @@ describe('FlatList', () => {
       />,
     );
     expect(component).toMatchSnapshot();
+  });
+  it('adds Android accessibility collection metadata to list items', async () => {
+    const originalOS = Platform.OS;
+    // $FlowFixMe[incompatible-type] Platform.OS is read-only in production.
+    Platform.OS = 'android';
+
+    try {
+      const component = await create(
+        <FlatList
+          data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+          renderItem={({item}) => <item value={item.key} />}
+        />,
+      );
+
+      const root = component.toJSON();
+      expect(root?.props.accessibilityRole).toBe('list');
+      expect(root?.props.accessibilityCollection).toEqual({
+        itemCount: 3,
+        rowCount: 3,
+        columnCount: 1,
+        hierarchical: false,
+      });
+      expect(
+        component.root
+          .findAllByType('item')
+          .map(item => item.props.accessibilityCollectionItem),
+      ).toEqual([
+        {
+          itemIndex: 0,
+          rowIndex: 0,
+          rowSpan: 1,
+          columnIndex: 0,
+          columnSpan: 1,
+          heading: false,
+        },
+        {
+          itemIndex: 1,
+          rowIndex: 1,
+          rowSpan: 1,
+          columnIndex: 0,
+          columnSpan: 1,
+          heading: false,
+        },
+        {
+          itemIndex: 2,
+          rowIndex: 2,
+          rowSpan: 1,
+          columnIndex: 0,
+          columnSpan: 1,
+          heading: false,
+        },
+      ]);
+    } finally {
+      // $FlowFixMe[incompatible-type] Platform.OS is read-only in production.
+      Platform.OS = originalOS;
+    }
+  });
+  it('adds Android accessibility collection metadata to multi-column list items', async () => {
+    const originalOS = Platform.OS;
+    // $FlowFixMe[incompatible-type] Platform.OS is read-only in production.
+    Platform.OS = 'android';
+
+    try {
+      const component = await create(
+        <FlatList
+          data={[
+            {key: 'i1'},
+            {key: 'i2'},
+            {key: 'i3'},
+            {key: 'i4'},
+            {key: 'i5'},
+          ]}
+          renderItem={({item}) => <item value={item.key} />}
+          numColumns={2}
+        />,
+      );
+
+      const root = component.toJSON();
+      expect(root?.props.accessibilityRole).toBe('grid');
+      expect(root?.props.accessibilityCollection).toEqual({
+        itemCount: 5,
+        rowCount: 3,
+        columnCount: 2,
+        hierarchical: false,
+      });
+      expect(
+        component.root
+          .findAllByType('item')
+          .map(item => item.props.accessibilityCollectionItem),
+      ).toEqual([
+        {
+          itemIndex: 0,
+          rowIndex: 0,
+          rowSpan: 1,
+          columnIndex: 0,
+          columnSpan: 1,
+          heading: false,
+        },
+        {
+          itemIndex: 1,
+          rowIndex: 0,
+          rowSpan: 1,
+          columnIndex: 1,
+          columnSpan: 1,
+          heading: false,
+        },
+        {
+          itemIndex: 2,
+          rowIndex: 1,
+          rowSpan: 1,
+          columnIndex: 0,
+          columnSpan: 1,
+          heading: false,
+        },
+        {
+          itemIndex: 3,
+          rowIndex: 1,
+          rowSpan: 1,
+          columnIndex: 1,
+          columnSpan: 1,
+          heading: false,
+        },
+        {
+          itemIndex: 4,
+          rowIndex: 2,
+          rowSpan: 1,
+          columnIndex: 0,
+          columnSpan: 1,
+          heading: false,
+        },
+      ]);
+    } finally {
+      // $FlowFixMe[incompatible-type] Platform.OS is read-only in production.
+      Platform.OS = originalOS;
+    }
   });
   it('renders simple list using ListItemComponent', async () => {
     function ListItemComponent({item}: Readonly<{item: {key: string}}>) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegate.kt
@@ -70,39 +70,49 @@ internal class ReactScrollViewAccessibilityDelegate : AccessibilityDelegateCompa
           } else {
             return
           }
-      var accessibilityCollectionItem: ReadableMap? =
-          nextChild.getTag(R.id.accessibility_collection_item) as ReadableMap
+      val accessibilityCollectionItemRange = findAccessibilityCollectionItemRange(nextChild)
 
-      if (nextChild !is ViewGroup) {
-        return
-      }
-
-      // If this child's accessibilityCollectionItem is null, we'll check one more
-      // nested child.
-      // Happens when getItemLayout is not passed in FlatList which adds an additional
-      // View in the hierarchy.
-      if (nextChild.childCount > 0 && accessibilityCollectionItem == null) {
-        val nestedNextChild = nextChild.getChildAt(0)
-        if (nestedNextChild != null) {
-          val nestedChildAccessibility =
-              nestedNextChild.getTag(R.id.accessibility_collection_item) as? ReadableMap
-          if (nestedChildAccessibility != null) {
-            accessibilityCollectionItem = nestedChildAccessibility
-          }
-        }
-      }
-
-      if (isVisible && accessibilityCollectionItem != null) {
+      if (isVisible && accessibilityCollectionItemRange != null) {
         if (firstVisibleIndex == null) {
-          firstVisibleIndex = accessibilityCollectionItem.getInt("itemIndex")
+          firstVisibleIndex = accessibilityCollectionItemRange.first
         }
-        lastVisibleIndex = accessibilityCollectionItem.getInt("itemIndex")
+        lastVisibleIndex = accessibilityCollectionItemRange.second
       }
 
       if (firstVisibleIndex != null && lastVisibleIndex != null) {
         event.fromIndex = firstVisibleIndex
         event.toIndex = lastVisibleIndex
       }
+    }
+  }
+
+  private fun findAccessibilityCollectionItemRange(view: View): Pair<Int, Int>? {
+    val accessibilityCollectionItem =
+        view.getTag(R.id.accessibility_collection_item) as? ReadableMap
+    if (accessibilityCollectionItem != null) {
+      val itemIndex = accessibilityCollectionItem.getInt("itemIndex")
+      return Pair(itemIndex, itemIndex)
+    }
+
+    if (view !is ViewGroup) {
+      return null
+    }
+
+    var firstItemIndex: Int? = null
+    var lastItemIndex: Int? = null
+    for (index in 0..<view.childCount) {
+      val childItemRange =
+          findAccessibilityCollectionItemRange(view.getChildAt(index)) ?: continue
+      if (firstItemIndex == null) {
+        firstItemIndex = childItemRange.first
+      }
+      lastItemIndex = childItemRange.second
+    }
+
+    return if (firstItemIndex != null && lastItemIndex != null) {
+      Pair(firstItemIndex, lastItemIndex)
+    } else {
+      null
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegateTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@file:Suppress("DEPRECATION")
+
+package com.facebook.react.views.scroll
+
+import android.content.Context
+import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.widget.FrameLayout
+import com.facebook.react.R
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ReactScrollViewAccessibilityDelegateTest {
+
+  private lateinit var context: Context
+  private lateinit var accessibilityDelegate: ReactScrollViewAccessibilityDelegate
+
+  @Before
+  fun setUp() {
+    ReactNativeFeatureFlagsForTests.setUp()
+    context = RuntimeEnvironment.getApplication()
+    accessibilityDelegate = ReactScrollViewAccessibilityDelegate()
+  }
+
+  @Test
+  fun onInitializeAccessibilityEvent_readsNestedCollectionItems() {
+    val scrollView = TestAccessibleScrollView(context)
+    val contentView = FrameLayout(context)
+    val spacer = View(context)
+    val row = FrameLayout(context)
+    val firstItem = View(context)
+    val secondItem = View(context)
+    val event = AccessibilityEvent.obtain()
+
+    scrollView.setTag(R.id.accessibility_collection, collection(itemCount = 3))
+    firstItem.setTag(
+        R.id.accessibility_collection_item,
+        collectionItem(itemIndex = 0, rowIndex = 0, columnIndex = 0),
+    )
+    secondItem.setTag(
+        R.id.accessibility_collection_item,
+        collectionItem(itemIndex = 1, rowIndex = 0, columnIndex = 1),
+    )
+
+    row.addView(firstItem)
+    row.addView(secondItem)
+    contentView.addView(spacer)
+    contentView.addView(row)
+    scrollView.addView(contentView)
+
+    accessibilityDelegate.onInitializeAccessibilityEvent(scrollView, event)
+
+    assertThat(event.itemCount).isEqualTo(3)
+    assertThat(event.fromIndex).isEqualTo(0)
+    assertThat(event.toIndex).isEqualTo(1)
+  }
+
+  private fun collection(itemCount: Int): JavaOnlyMap =
+      JavaOnlyMap().apply {
+        putInt("itemCount", itemCount)
+        putInt("rowCount", itemCount)
+        putInt("columnCount", 1)
+        putBoolean("hierarchical", false)
+      }
+
+  private fun collectionItem(
+      itemIndex: Int,
+      rowIndex: Int,
+      columnIndex: Int,
+  ): JavaOnlyMap =
+      JavaOnlyMap().apply {
+        putInt("itemIndex", itemIndex)
+        putInt("rowIndex", rowIndex)
+        putInt("rowSpan", 1)
+        putInt("columnIndex", columnIndex)
+        putInt("columnSpan", 1)
+        putBoolean("heading", false)
+      }
+
+  private class TestAccessibleScrollView(context: Context) :
+      FrameLayout(context), ReactAccessibleScrollView {
+
+    override val scrollEnabled: Boolean = true
+
+    override fun isPartiallyScrolledInView(view: View): Boolean = true
+  }
+}

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -92,8 +92,49 @@ type State = {
   pendingScrollUpdateCount: number,
 };
 
+type AccessibilityCollectionItem = Readonly<{
+  itemIndex: number,
+  rowIndex: number,
+  rowSpan: number,
+  columnIndex: number,
+  columnSpan: number,
+  heading: boolean,
+  ...
+}>;
+
 function getScrollingThreshold(threshold: number, visibleLength: number) {
   return (threshold * visibleLength) / 2;
+}
+
+function createAccessibilityCollection(
+  itemCount: number,
+  horizontal: boolean,
+): {
+  itemCount: number,
+  rowCount: number,
+  columnCount: number,
+  hierarchical: boolean,
+} {
+  return {
+    itemCount,
+    rowCount: horizontal ? (itemCount > 0 ? 1 : 0) : itemCount,
+    columnCount: horizontal ? itemCount : 1,
+    hierarchical: false,
+  };
+}
+
+function createAccessibilityCollectionItem(
+  index: number,
+  horizontal: ?boolean,
+): AccessibilityCollectionItem {
+  return {
+    itemIndex: index,
+    rowIndex: horizontal === true ? 0 : index,
+    rowSpan: 1,
+    columnIndex: horizontal === true ? index : 0,
+    columnSpan: 1,
+    heading: false,
+  };
 }
 
 /**
@@ -811,6 +852,11 @@ class VirtualizedList extends StateSafePureComponent<
           CellRendererComponent={CellRendererComponent}
           ItemSeparatorComponent={ii < end ? ItemSeparatorComponent : undefined}
           ListItemComponent={ListItemComponent}
+          accessibilityCollectionItem={
+            Platform.OS === 'android'
+              ? createAccessibilityCollectionItem(ii, horizontal)
+              : undefined
+          }
           cellKey={key}
           horizontal={horizontal}
           index={ii}
@@ -1120,6 +1166,23 @@ class VirtualizedList extends StateSafePureComponent<
             }
           : undefined,
     };
+
+    if (Platform.OS === 'android' && !this._isNestedWithSameOrientation()) {
+      const scrollPropsForAndroid: any = scrollProps;
+      if (scrollPropsForAndroid.accessibilityCollection == null) {
+        scrollPropsForAndroid.accessibilityCollection =
+          createAccessibilityCollection(
+            itemCount,
+            horizontalOrDefault(this.props.horizontal),
+          );
+      }
+      if (
+        scrollPropsForAndroid.role == null &&
+        scrollPropsForAndroid.accessibilityRole == null
+      ) {
+        scrollPropsForAndroid.accessibilityRole = 'list';
+      }
+    }
 
     this._hasMore = this.state.cellsAroundViewport.last < itemCount - 1;
 

--- a/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
@@ -22,6 +22,16 @@ import * as React from 'react';
 import {isValidElement} from 'react';
 import {StyleSheet, View} from 'react-native';
 
+type AccessibilityCollectionItem = Readonly<{
+  itemIndex: number,
+  rowIndex: number,
+  rowSpan: number,
+  columnIndex: number,
+  columnSpan: number,
+  heading: boolean,
+  ...
+}>;
+
 export type Props<ItemT> = {
   CellRendererComponent?: ?React.ComponentType<CellRendererProps<ItemT>>,
   ItemSeparatorComponent?: ?(
@@ -29,6 +39,7 @@ export type Props<ItemT> = {
     | React.MixedElement
   ),
   ListItemComponent?: ?(React.ComponentType<any> | React.MixedElement),
+  accessibilityCollectionItem?: ?AccessibilityCollectionItem,
   cellKey: string,
   horizontal: ?boolean,
   index: number,
@@ -49,6 +60,28 @@ export type Props<ItemT> = {
   renderItem?: ?ListRenderItem<ItemT>,
   ...
 };
+
+function addAccessibilityCollectionItem(
+  element: React.Node,
+  accessibilityCollectionItem: ?AccessibilityCollectionItem,
+): React.Node {
+  if (
+    accessibilityCollectionItem == null ||
+    !React.isValidElement(element) ||
+    element.type === React.Fragment
+  ) {
+    return element;
+  }
+
+  // $FlowFixMe[prop-missing] React.Element internal inspection.
+  if (element.props.accessibilityCollectionItem !== undefined) {
+    return element;
+  }
+
+  return React.cloneElement(element, {
+    accessibilityCollectionItem,
+  });
+}
 
 type SeparatorProps<ItemT> = Readonly<{
   highlighted: boolean,
@@ -178,6 +211,7 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
       CellRendererComponent,
       ItemSeparatorComponent,
       ListItemComponent,
+      accessibilityCollectionItem,
       cellKey,
       horizontal,
       item,
@@ -186,11 +220,9 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
       onCellLayout,
       renderItem,
     } = this.props;
-    const element = this._renderElement(
-      renderItem,
-      ListItemComponent,
-      item,
-      index,
+    const element = addAccessibilityCollectionItem(
+      this._renderElement(renderItem, ListItemComponent, item, index),
+      accessibilityCollectionItem,
     );
 
     // NOTE: that when this is a sticky header, `onLayout` will get automatically extracted and


### PR DESCRIPTION
## Summary:

Fixes #30973. Related to #30975 and #30977.

On Android, FlatList and VirtualizedList now provide accessibility collection metadata so TalkBack can report collection positions for rendered items. FlatList sets list/grid collection info, attaches collection item data to rendered item roots, and the Android scroll delegate resolves visible item ranges from nested tagged descendants.

### Relation to previous attempts

This area has prior history in #33180 and the currently open #56692.

- #33180 landed in 2022 and was later reverted because of Meta internal land-safety issues. The current codebase already retains the native Android plumbing for `accessibilityCollection` and `accessibilityCollectionItem`, so this PR focuses on wiring list metadata through FlatList/VirtualizedList instead of re-adding the broader native View API surface.
- Compared with #56692, this PR keeps the change narrower and includes the fields expected by the current Android scroll accessibility delegate (`itemCount`, `rowCount`, `columnCount`, and `hierarchical`).
- The FlatList path attaches `accessibilityCollectionItem` to the rendered item root when possible, while preserving an explicit `accessibilityCollectionItem` supplied by user code. For multi-column FlatList rows, each rendered item gets its own item/column index.
- The scroll delegate now recursively scans visible descendants for collection item tags. This avoids assuming that the first direct child is the accessible item, which matters for spacers, wrappers, and multi-column rows.
- The PR preserves explicit user-provided `role`, `accessibilityRole`, and `accessibilityCollection` props.
- This is implemented without changing the public JS API snapshot; `accessibilityCollectionItem` stays an internal native prop wiring detail for these list components.

## Changelog:

[ANDROID] [FIXED] - Fix FlatList accessibility collection position announcements.

## Test Plan:

- `PATH=/Users/liumin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/jest packages/react-native/Libraries/Lists/__tests__/FlatList-test.js --runInBand`
- `PATH=/Users/liumin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/jest packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js --runInBand`
- `PATH=/Users/liumin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH yarn build-types --validate`
- `PATH=/Users/liumin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH YARN_BINARY=/Users/liumin/.cache/node/corepack/v1/yarn/1.22.22/bin/yarn ./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests com.facebook.react.views.scroll.ReactScrollViewAccessibilityDelegateTest -Preact.internal.useHermesStable=true`
- `PATH=/Users/liumin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH YARN_BINARY=/Users/liumin/.cache/node/corepack/v1/yarn/1.22.22/bin/yarn ./gradlew :packages:react-native:ReactAndroid:ktfmtCheck -Preact.internal.useHermesStable=true`
- `PATH=/Users/liumin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/prettier --check packages/react-native/Libraries/Lists/FlatList.js packages/react-native/Libraries/Lists/__tests__/FlatList-test.js packages/virtualized-lists/Lists/VirtualizedList.js packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js packages/virtualized-lists/Lists/VirtualizedListProps.js`
- `git diff --check`
