### PR TITLE
Fix secure Android TextInput same-text updates

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -22,6 +22,7 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.TextPaint
+import android.text.TextUtils
 import android.text.TextWatcher
 import android.text.method.KeyListener
 import android.text.method.QwertyKeyListener
@@ -648,7 +649,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
   public fun canUpdateWithEventCount(eventCounter: Int): Boolean = eventCounter >= nativeEventCount
 
   private fun maybeSetText(reactTextUpdate: ReactTextUpdate) {
-    if (isSecureText && (text == reactTextUpdate.text)) {
+    if (isSecureText && TextUtils.equals(text, reactTextUpdate.text)) {
       return
     }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
@@ -17,6 +17,8 @@ import android.text.InputFilter
 import android.text.InputFilter.AllCaps
 import android.text.InputType
 import android.text.Layout
+import android.text.SpannableString
+import android.text.Spanned
 import android.util.DisplayMetrics
 import android.view.Gravity
 import android.view.View
@@ -32,6 +34,7 @@ import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.text.DefaultStyleValuesUtil.getDefaultTextColorHint
+import com.facebook.react.views.text.ReactTextUpdate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -481,7 +484,34 @@ class ReactTextInputPropertyTest {
     assertThat(view.filters).isEqualTo(filters)
   }
 
+  @Test
+  fun testSecureTextDoesNotReplaceSameTextFromJS() {
+    val markerSpan = MarkerSpan()
+    val textUpdate =
+        SpannableString("secret").apply {
+          setSpan(markerSpan, 0, length, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
+        }
+
+    manager.updateProperties(view, buildStyles("secureTextEntry", true))
+    view.setText("secret")
+
+    view.maybeSetTextFromJS(
+        ReactTextUpdate(
+            textUpdate,
+            0,
+            view.gravity and Gravity.HORIZONTAL_GRAVITY_MASK,
+            Layout.BREAK_STRATEGY_HIGH_QUALITY,
+            0,
+        )
+    )
+
+    assertThat(checkNotNull(view.text).getSpans(0, view.length(), MarkerSpan::class.java))
+        .isEmpty()
+  }
+
   private fun buildStyles(vararg keysAndValues: Any?): ReactStylesDiffMap {
     return ReactStylesDiffMap(JavaOnlyMap.of(*keysAndValues))
   }
+
+  private class MarkerSpan
 }


### PR DESCRIPTION
## Summary:

Fixes #53696.

Android secure `TextInput` has a guard that skips replacing text when JS echoes the same content, preserving Android's transient password reveal timer. During the Kotlin conversion, this guard changed from `TextUtils.equals(...)` to equality between the current `Editable` and incoming `Spanned` text. Those can contain the same characters without comparing equal, so state updates re-apply the text immediately and hide the latest revealed password character.

This restores content-based equality for secure text updates and adds a regression test that same-text secure updates do not replace the existing `Editable`.

## Changelog:

[ANDROID] [FIXED] - Preserve secure TextInput password character reveal timing when JS state echoes the same text.

## Test Plan:

- `./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests com.facebook.react.views.textinput.ReactTextInputPropertyTest -Preact.internal.useHermesStable=true`
- `./gradlew :packages:react-native:ReactAndroid:ktfmtCheck -Preact.internal.useHermesStable=true`
