### PR TITLE
Spec-correct CSS Flexbox §4.5 auto-min-size opt-in on YGConfig (#57015)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfig.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfig.kt
@@ -19,6 +19,14 @@ public abstract class YogaConfig {
 
   public abstract fun setErrata(errata: YogaErrata)
 
+  /**
+   * Sets the errata bitmask directly from an [Int]. Use this when combining multiple [YogaErrata]
+   * values (e.g., `YogaErrata.CLASSIC.intValue() and
+   * YogaErrata.STRETCH_FLEX_BASIS.intValue().inv()`) — the [YogaErrata] enum cannot represent
+   * arbitrary bitmask combinations.
+   */
+  public abstract fun setErrata(errata: Int)
+
   public abstract fun getErrata(): YogaErrata
 
   public abstract fun setLogger(logger: YogaLogger?)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfigJNIBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfigJNIBase.kt
@@ -50,6 +50,10 @@ private constructor(@JvmField protected var nativePointer: Long) : YogaConfig() 
     YogaNative.jni_YGConfigSetErrataJNI(nativePointer, errata.intValue())
   }
 
+  public override fun setErrata(errata: Int) {
+    YogaNative.jni_YGConfigSetErrataJNI(nativePointer, errata)
+  }
+
   public override fun getErrata(): YogaErrata =
       YogaErrata.fromInt(YogaNative.jni_YGConfigGetErrataJNI(nativePointer))
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.kt
@@ -14,6 +14,7 @@ public enum class YogaErrata(public val intValue: Int) {
   STRETCH_FLEX_BASIS(1),
   ABSOLUTE_POSITION_WITHOUT_INSETS_EXCLUDES_PADDING(2),
   ABSOLUTE_PERCENT_AGAINST_INNER_SIZE(4),
+  MIN_SIZE_UNDEFINED_INSTEAD_OF_AUTO(8),
   ALL(2147483647),
   CLASSIC(2147483646);
 
@@ -27,6 +28,7 @@ public enum class YogaErrata(public val intValue: Int) {
           1 -> STRETCH_FLEX_BASIS
           2 -> ABSOLUTE_POSITION_WITHOUT_INSETS_EXCLUDES_PADDING
           4 -> ABSOLUTE_PERCENT_AGAINST_INNER_SIZE
+          8 -> MIN_SIZE_UNDEFINED_INSTEAD_OF_AUTO
           2147483647 -> ALL
           2147483646 -> CLASSIC
           else -> throw IllegalArgumentException("Unknown enum value: $value")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.kt
@@ -312,6 +312,22 @@ public object YogaNative {
   public external fun jni_YGNodeSetHasMeasureFuncJNI(nativePointer: Long, hasMeasureFunc: Boolean)
 
   @JvmStatic
+  public external fun jni_YGNodeSetHasMinContentMeasureFuncJNI(
+      nativePointer: Long,
+      hasMinContentMeasureFunc: Boolean,
+  )
+
+  @JvmStatic
+  public external fun jni_YGNodeSetMinContentWidthJNI(nativePointer: Long, minContentWidth: Float)
+
+  @JvmStatic
+  public external fun jni_YGNodeSetMinContentHeightJNI(nativePointer: Long, minContentHeight: Float)
+
+  @JvmStatic public external fun jni_YGNodeGetMinContentWidthJNI(nativePointer: Long): Float
+
+  @JvmStatic public external fun jni_YGNodeGetMinContentHeightJNI(nativePointer: Long): Float
+
+  @JvmStatic
   public external fun jni_YGNodeSetHasBaselineFuncJNI(nativePointer: Long, hasMeasureFunc: Boolean)
 
   @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNode.kt
@@ -228,6 +228,16 @@ public abstract class YogaNode : YogaProps {
 
   abstract override fun setMeasureFunction(measureFunction: YogaMeasureFunction?)
 
+  abstract override fun setMinContentMeasureFunction(measureFunction: YogaMeasureFunction?)
+
+  abstract override fun setMinContentWidth(minContentWidth: Float)
+
+  abstract override fun setMinContentHeight(minContentHeight: Float)
+
+  abstract override fun getMinContentWidth(): Float
+
+  abstract override fun getMinContentHeight(): Float
+
   abstract override fun setBaselineFunction(yogaBaselineFunction: YogaBaselineFunction?)
 
   public abstract val isMeasureDefined: Boolean

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.kt
@@ -16,6 +16,7 @@ public abstract class YogaNodeJNIBase : YogaNode, Cloneable {
   private var config: YogaConfig? = null
   private var children: MutableList<YogaNodeJNIBase>? = null
   private var measureFunction: YogaMeasureFunction? = null
+  private var minContentMeasureFunction: YogaMeasureFunction? = null
   private var baselineFunction: YogaBaselineFunction? = null
   protected var nativePointer: Long = 0
 
@@ -46,6 +47,7 @@ public abstract class YogaNodeJNIBase : YogaNode, Cloneable {
 
   override fun reset() {
     measureFunction = null
+    minContentMeasureFunction = null
     baselineFunction = null
     data = null
     arr = null
@@ -524,6 +526,25 @@ public abstract class YogaNodeJNIBase : YogaNode, Cloneable {
     YogaNative.jni_YGNodeSetHasMeasureFuncJNI(nativePointer, measureFunction != null)
   }
 
+  override fun setMinContentMeasureFunction(measureFunction: YogaMeasureFunction?) {
+    this.minContentMeasureFunction = measureFunction
+    YogaNative.jni_YGNodeSetHasMinContentMeasureFuncJNI(nativePointer, measureFunction != null)
+  }
+
+  override fun setMinContentWidth(minContentWidth: Float) {
+    YogaNative.jni_YGNodeSetMinContentWidthJNI(nativePointer, minContentWidth)
+  }
+
+  override fun setMinContentHeight(minContentHeight: Float) {
+    YogaNative.jni_YGNodeSetMinContentHeightJNI(nativePointer, minContentHeight)
+  }
+
+  override fun getMinContentWidth(): Float =
+      YogaNative.jni_YGNodeGetMinContentWidthJNI(nativePointer)
+
+  override fun getMinContentHeight(): Float =
+      YogaNative.jni_YGNodeGetMinContentHeightJNI(nativePointer)
+
   override fun setAlwaysFormsContainingBlock(alwaysFormsContainingBlock: Boolean) {
     YogaNative.jni_YGNodeSetAlwaysFormsContainingBlockJNI(
         nativePointer,
@@ -538,6 +559,27 @@ public abstract class YogaNodeJNIBase : YogaNode, Cloneable {
   @DoNotStrip
   public fun measure(width: Float, widthMode: Int, height: Float, heightMode: Int): Long {
     val mf = checkNotNull(measureFunction) { "Measure function isn't defined!" }
+    return mf.measure(
+        this,
+        width,
+        YogaMeasureMode.fromInt(widthMode),
+        height,
+        YogaMeasureMode.fromInt(heightMode),
+    )
+  }
+
+  // Native callback invoked by Yoga during the CSS Flexbox §4.5 auto-min
+  // probe when a min-content measure function is registered. Mirrors
+  // [measure]; see that method's note on non-overridability.
+  @DoNotStrip
+  public fun measureMinContent(
+      width: Float,
+      widthMode: Int,
+      height: Float,
+      heightMode: Int,
+  ): Long {
+    val mf =
+        checkNotNull(minContentMeasureFunction) { "Min-content measure function isn't defined!" }
     return mf.measure(
         this,
         width,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaProps.kt
@@ -125,6 +125,28 @@ public interface YogaProps {
 
   public fun setMeasureFunction(measureFunction: YogaMeasureFunction?)
 
+  public fun setMinContentMeasureFunction(measureFunction: YogaMeasureFunction?)
+
+  /**
+   * Sets the static min-content width used by the CSS Flexbox §4.5 automatic minimum sizing probe.
+   * Pass `YogaConstants.UNDEFINED` to clear. See `YGNodeSetMinContentWidth` in the Yoga C API for
+   * full precedence rules.
+   */
+  public fun setMinContentWidth(minContentWidth: Float)
+
+  /**
+   * Sets the static min-content height used by the CSS Flexbox §4.5 automatic minimum sizing probe.
+   * Pass `YogaConstants.UNDEFINED` to clear. See `YGNodeSetMinContentHeight` in the Yoga C API for
+   * full precedence rules.
+   */
+  public fun setMinContentHeight(minContentHeight: Float)
+
+  /** Returns the static min-content width, or `YogaConstants.UNDEFINED` if not set. */
+  public fun getMinContentWidth(): Float
+
+  /** Returns the static min-content height, or `YogaConstants.UNDEFINED` if not set. */
+  public fun getMinContentHeight(): Float
+
   public fun setBaselineFunction(yogaBaselineFunction: YogaBaselineFunction?)
 
   /* Mutable properties - getter and setter with matching types */

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -683,6 +683,83 @@ static void jni_YGNodeSetHasMeasureFuncJNI(
       static_cast<bool>(hasMeasureFunc) ? YGJNIMeasureFunc : nullptr);
 }
 
+static YGSize YGJNIMinContentMeasureFunc(
+    YGNodeConstRef node,
+    float width,
+    YGMeasureMode widthMode,
+    float height,
+    YGMeasureMode heightMode) {
+  if (auto obj = YGNodeJobject(node)) {
+    YGTransferLayoutDirection(node, obj.get());
+    JNIEnv* env = getCurrentEnv();
+    auto objectClass = facebook::yoga::vanillajni::make_local_ref(
+        env, env->GetObjectClass(obj.get()));
+    // NOLINTNEXTLINE(misc-misplaced-const)
+    static const jmethodID methodId = facebook::yoga::vanillajni::getMethodId(
+        env, objectClass.get(), "measureMinContent", "(FIFI)J");
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    const auto measureResult = facebook::yoga::vanillajni::callLongMethod(
+        env, obj.get(), methodId, width, widthMode, height, heightMode);
+
+    uint32_t wBits = 0xFFFFFFFF & (measureResult >> 32);
+    uint32_t hBits = 0xFFFFFFFF & measureResult;
+    auto measuredWidth = std::bit_cast<float>(wBits);
+    auto measuredHeight = std::bit_cast<float>(hBits);
+
+    return YGSize{measuredWidth, measuredHeight};
+  } else {
+    return YGSize{
+        widthMode == YGMeasureModeUndefined ? 0 : width,
+        heightMode == YGMeasureModeUndefined ? 0 : height,
+    };
+  }
+}
+
+static void jni_YGNodeSetHasMinContentMeasureFuncJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer,
+    jboolean hasMinContentMeasureFunc) {
+  YGNodeSetMinContentMeasureFunc(
+      _jlong2YGNodeRef(nativePointer),
+      static_cast<bool>(hasMinContentMeasureFunc) ? YGJNIMinContentMeasureFunc
+                                                  : nullptr);
+}
+
+static void jni_YGNodeSetMinContentWidthJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer,
+    jfloat minContentWidth) {
+  YGNodeSetMinContentWidth(
+      _jlong2YGNodeRef(nativePointer), static_cast<float>(minContentWidth));
+}
+
+static void jni_YGNodeSetMinContentHeightJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer,
+    jfloat minContentHeight) {
+  YGNodeSetMinContentHeight(
+      _jlong2YGNodeRef(nativePointer), static_cast<float>(minContentHeight));
+}
+
+static jfloat jni_YGNodeGetMinContentWidthJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer) {
+  return static_cast<jfloat>(
+      YGNodeGetMinContentWidth(_jlong2YGNodeRef(nativePointer)));
+}
+
+static jfloat jni_YGNodeGetMinContentHeightJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer) {
+  return static_cast<jfloat>(
+      YGNodeGetMinContentHeight(_jlong2YGNodeRef(nativePointer)));
+}
+
 static float YGJNIBaselineFunc(YGNodeConstRef node, float width, float height) {
   if (auto obj = YGNodeJobject(node)) {
     JNIEnv* env = getCurrentEnv();
@@ -1058,6 +1135,23 @@ static JNINativeMethod methods[] = {
     {"jni_YGNodeSetHasMeasureFuncJNI",
      "(JZ)V",
      (void*)jni_YGNodeSetHasMeasureFuncJNI},
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast)
+    {"jni_YGNodeSetHasMinContentMeasureFuncJNI",
+     "(JZ)V",
+     (void*)jni_YGNodeSetHasMinContentMeasureFuncJNI},
+    {"jni_YGNodeSetMinContentWidthJNI",
+     "(JF)V",
+     (void*)jni_YGNodeSetMinContentWidthJNI},
+    {"jni_YGNodeSetMinContentHeightJNI",
+     "(JF)V",
+     (void*)jni_YGNodeSetMinContentHeightJNI},
+    {"jni_YGNodeGetMinContentWidthJNI",
+     "(J)F",
+     (void*)jni_YGNodeGetMinContentWidthJNI},
+    {"jni_YGNodeGetMinContentHeightJNI",
+     "(J)F",
+     (void*)jni_YGNodeGetMinContentHeightJNI},
+    // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast)
     {"jni_YGNodeStyleGetGapJNI", "(JI)J", (void*)jni_YGNodeStyleGetGapJNI},
     {"jni_YGNodeStyleSetGapJNI", "(JIF)V", (void*)jni_YGNodeStyleSetGapJNI},
     {"jni_YGNodeStyleSetGapPercentJNI",

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -117,6 +117,8 @@ const char* YGErrataToString(const YGErrata value) {
       return "absolute-position-without-insets-excludes-padding";
     case YGErrataAbsolutePercentAgainstInnerSize:
       return "absolute-percent-against-inner-size";
+    case YGErrataMinSizeUndefinedInsteadOfAuto:
+      return "min-size-undefined-instead-of-auto";
     case YGErrataAll:
       return "all";
     case YGErrataClassic:

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -67,6 +67,7 @@ YG_ENUM_DECL(
     YGErrataStretchFlexBasis = 1,
     YGErrataAbsolutePositionWithoutInsetsExcludesPadding = 2,
     YGErrataAbsolutePercentAgainstInnerSize = 4,
+    YGErrataMinSizeUndefinedInsteadOfAuto = 8,
     YGErrataAll = 2147483647,
     YGErrataClassic = 2147483646)
 YG_DEFINE_ENUM_FLAG_OPERATORS(YGErrata)

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -309,6 +309,32 @@ bool YGNodeHasMeasureFunc(YGNodeConstRef node) {
   return resolveRef(node)->hasMeasureFunc();
 }
 
+void YGNodeSetMinContentMeasureFunc(
+    YGNodeRef node,
+    YGMinContentMeasureFunc minContentMeasureFunc) {
+  resolveRef(node)->setMinContentMeasureFunc(minContentMeasureFunc);
+}
+
+bool YGNodeHasMinContentMeasureFunc(YGNodeConstRef node) {
+  return resolveRef(node)->hasMinContentMeasureFunc();
+}
+
+void YGNodeSetMinContentWidth(YGNodeRef node, float minContentWidth) {
+  resolveRef(node)->setMinContentWidth(FloatOptional{minContentWidth});
+}
+
+void YGNodeSetMinContentHeight(YGNodeRef node, float minContentHeight) {
+  resolveRef(node)->setMinContentHeight(FloatOptional{minContentHeight});
+}
+
+float YGNodeGetMinContentWidth(YGNodeConstRef node) {
+  return resolveRef(node)->getMinContentWidth().unwrapOrDefault(YGUndefined);
+}
+
+float YGNodeGetMinContentHeight(YGNodeConstRef node) {
+  return resolveRef(node)->getMinContentHeight().unwrapOrDefault(YGUndefined);
+}
+
 void YGNodeSetBaselineFunc(YGNodeRef node, YGBaselineFunc baselineFunc) {
   resolveRef(node)->setBaselineFunc(baselineFunc);
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -221,6 +221,75 @@ YG_EXPORT void YGNodeSetMeasureFunc(YGNodeRef node, YGMeasureFunc measureFunc);
 YG_EXPORT bool YGNodeHasMeasureFunc(YGNodeConstRef node);
 
 /**
+ * Optional companion to `YGMeasureFunc` invoked by the CSS Flexbox §4.5
+ * automatic minimum sizing path when probing this node for its min-content
+ * size along the main axis.
+ *
+ * The signature mirrors `YGMeasureFunc`. The algorithm calls this with
+ * `AtMost 0` along the probed axis and `Undefined` on the other. A
+ * min-content-aware Primitive can return its true minimum (e.g., `Image`
+ * and `Collection` along the scroll axis can return 0; text returns its
+ * longest-word width; etc.) without doing a full measure pass.
+ *
+ * When unset, the algorithm falls back to the regular `YGMeasureFunc`
+ * invoked with the same `AtMost 0` constraint — preserving today's
+ * behavior. Setting this is a perf opt-in for Primitives whose min-content
+ * size is cheap to compute or differs from what the regular measure would
+ * return.
+ */
+typedef YGSize (*YGMinContentMeasureFunc)(
+    YGNodeConstRef node,
+    float width,
+    YGMeasureMode widthMode,
+    float height,
+    YGMeasureMode heightMode);
+
+/**
+ * Provides a measure function specialised for min-content probes. See
+ * `YGMinContentMeasureFunc`.
+ */
+YG_EXPORT void YGNodeSetMinContentMeasureFunc(
+    YGNodeRef node,
+    YGMinContentMeasureFunc minContentMeasureFunc);
+
+/**
+ * Whether a min-content measure function is set.
+ */
+YG_EXPORT bool YGNodeHasMinContentMeasureFunc(YGNodeConstRef node);
+
+/**
+ * Static per-axis min-content size used by the CSS Flexbox §4.5 automatic
+ * minimum sizing probe. Pass `YGUndefined` to clear.
+ *
+ * When set, the algorithm's probe short-circuits at this node along the
+ * matching axis — skipping both the regular `YGMeasureFunc` / `YGMinContent
+ * MeasureFunc` callback path AND any container recursion. The most common
+ * use is declaring "0" for axes that have no min-content contribution per
+ * spec (e.g., images on both axes; scroll containers along their scroll
+ * axis).
+ *
+ * Precedence inside the probe is:
+ *   1. Static value via `YGNodeSetMinContentWidth/Height` (this API)
+ *   2. Dynamic callback via `YGNodeSetMinContentMeasureFunc`
+ *   3. Regular `YGMeasureFunc` with `AtMost 0` (today's default)
+ *   4. Container recursion (sum on main axis, max on cross)
+ *
+ * Static is preferred for known-constant values because it skips the JNI
+ * round-trip / native callback dispatch entirely.
+ */
+YG_EXPORT void YGNodeSetMinContentWidth(YGNodeRef node, float minContentWidth);
+YG_EXPORT void YGNodeSetMinContentHeight(
+    YGNodeRef node,
+    float minContentHeight);
+
+/**
+ * Returns the static min-content size along the requested axis, or
+ * `YGUndefined` if not set.
+ */
+YG_EXPORT float YGNodeGetMinContentWidth(YGNodeConstRef node);
+YG_EXPORT float YGNodeGetMinContentHeight(YGNodeConstRef node);
+
+/**
  * @returns a defined offset to baseline (ascent).
  */
 typedef float (*YGBaselineFunc)(YGNodeConstRef node, float width, float height);

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -653,6 +653,230 @@ static float computeFlexBasisForChildren(
   return totalOuterFlexBasis;
 }
 
+// Returns the min-content size of `node` along `requestedAxis`, used by CSS
+// Flexbox §4.5 automatic minimum sizing.
+//
+// Mirrors RenderCore FlexLayout's `AlgorithmBase::computeMinContentSize` /
+// `measureMinContentMainSize` pair (see `xplat/flexlayout/flexlayout/
+// FlexboxAlgorithm.h`). Unlike FlexLayout, which crosses a JNI/bridge
+// boundary for nested flex containers via thread-local min-content markers,
+// Yoga's flex containers are native nodes — so this function recurses
+// directly into containers rather than going through a measure callback.
+//
+// Algorithm:
+//   * Leaf with measure function: invoke it with `AtMost 0` on the
+//     requested axis and `Undefined` on the other. Text measure-funcs
+//     respond with longest-word width; image/collection-like measures
+//     respond with 0 along their scroll axis.
+//   * Empty leaf: return 0.
+//   * Container: iterate in-flow children. For each, take its
+//     min-content along the container's own main axis (sum into
+//     `mainTotal`) and along its cross axis (max into `crossMax`),
+//     plus the child's margins. Add the container's own padding and
+//     border on both ends of each axis. Project onto `requestedAxis`.
+//
+// Container-level recursion does no layout writes (no positions, no
+// alignment, no flex distribution); only the descendant leaf measure
+// callbacks observe state changes (the same ones a normal layout pass
+// would invoke). Roughly equivalent to FlexLayout's dedicated
+// `computeMinContentSize` cost: one measure call per leaf + linear walk
+// per container.
+static float computeMinContentMainSize(
+    yoga::Node* const node,
+    const FlexDirection requestedAxis,
+    const Direction ownerDirection,
+    const float ownerWidth,
+    const float ownerHeight) {
+  const bool wantRow = isRow(requestedAxis);
+
+  // 1. Static value wins for any node (leaf or container). Short-circuits
+  // both the measure callback path AND any container recursion. The most
+  // common use is `YGNodeSetMinContentWidth(node, 0)` declaring no
+  // contribution per CSS-Images (Image) or CSS-Overflow (scroll
+  // containers along their scroll axis).
+  const FloatOptional staticMin =
+      wantRow ? node->getMinContentWidth() : node->getMinContentHeight();
+  if (staticMin.isDefined()) {
+    return staticMin.unwrap();
+  }
+
+  if (node->hasMeasureFunc()) {
+    // 2. Dynamic min-content callback if set (for Primitives whose
+    // min-content depends on state). Otherwise fall back to the regular
+    // measure function with `AtMost 0`, which text measurers naturally
+    // answer with longest-word width.
+    const YGSize size = node->hasMinContentMeasureFunc()
+        ? node->measureMinContent(
+              wantRow ? 0.0f : YGUndefined,
+              wantRow ? MeasureMode::AtMost : MeasureMode::Undefined,
+              wantRow ? YGUndefined : 0.0f,
+              wantRow ? MeasureMode::Undefined : MeasureMode::AtMost)
+        : node->measure(
+              wantRow ? 0.0f : YGUndefined,
+              wantRow ? MeasureMode::AtMost : MeasureMode::Undefined,
+              wantRow ? YGUndefined : 0.0f,
+              wantRow ? MeasureMode::Undefined : MeasureMode::AtMost);
+    return wantRow ? size.width : size.height;
+  }
+
+  if (node->getChildCount() == 0) {
+    return 0.0f;
+  }
+
+  const Direction direction = node->resolveDirection(ownerDirection);
+  const FlexDirection nodeMainAxis =
+      resolveDirection(node->style().flexDirection(), direction);
+  const FlexDirection nodeCrossAxis =
+      resolveCrossDirection(nodeMainAxis, direction);
+
+  float mainTotal = 0.0f;
+  float crossMax = 0.0f;
+
+  for (size_t i = 0; i < node->getChildCount(); i++) {
+    auto* const child = node->getChild(i);
+    if (child->style().display() == Display::None ||
+        child->style().positionType() == PositionType::Absolute) {
+      continue;
+    }
+
+    float childMain = computeMinContentMainSize(
+        child, nodeMainAxis, direction, ownerWidth, ownerHeight);
+    childMain += child->style().computeMarginForAxis(nodeMainAxis, ownerWidth);
+
+    float childCross = computeMinContentMainSize(
+        child, nodeCrossAxis, direction, ownerWidth, ownerHeight);
+    childCross +=
+        child->style().computeMarginForAxis(nodeCrossAxis, ownerWidth);
+
+    mainTotal += childMain;
+    crossMax = std::max(crossMax, childCross);
+  }
+
+  mainTotal += node->style().computeFlexStartPaddingAndBorder(
+                   nodeMainAxis, direction, ownerWidth) +
+      node->style().computeFlexEndPaddingAndBorder(
+          nodeMainAxis, direction, ownerWidth);
+  crossMax += node->style().computeFlexStartPaddingAndBorder(
+                  nodeCrossAxis, direction, ownerWidth) +
+      node->style().computeFlexEndPaddingAndBorder(
+          nodeCrossAxis, direction, ownerWidth);
+
+  const bool nodeMainIsRow = isRow(nodeMainAxis);
+  const float widthMin = nodeMainIsRow ? mainTotal : crossMax;
+  const float heightMin = nodeMainIsRow ? crossMax : mainTotal;
+  return wantRow ? widthMin : heightMin;
+}
+
+// Computes the CSS Flexbox §4.5 automatic minimum main-axis size for
+// `child`. Returns Undefined when no auto-min applies (feature off, explicit
+// `min-{w,h}` already set, or `display:none`); 0 when the item's own
+// `overflow != visible` (the spec's per-item escape hatch); or a concrete
+// floor otherwise.
+//
+// Floor = min(content-size, specified-size) capped by max-size, with the
+// transferred (aspect-ratio × cross-size) suggestion replacing the
+// specified-size leg when the item has an aspect ratio but no specified
+// main size. See https://www.w3.org/TR/css-flexbox-1/#min-size-auto.
+static FloatOptional computeAutoMinMainSize(
+    yoga::Node* const child,
+    const FlexDirection mainAxis,
+    const Direction direction,
+    const float ownerMainAxisSize,
+    const float ownerWidth,
+    const float ownerHeight) {
+  if (child->hasErrata(Errata::MinSizeUndefinedInsteadOfAuto)) {
+    return FloatOptional{};
+  }
+  if (child->style().display() == Display::None) {
+    return FloatOptional{};
+  }
+  // Explicit `min-{w,h}` (including `0`) wins over auto. This is the
+  // CSS-spec opt-out (§4.5).
+  if (child->style().minDimension(dimension(mainAxis)).isDefined()) {
+    return FloatOptional{};
+  }
+  // Per CSS §4.5: a flex item whose own `overflow` is not `visible` gets
+  // auto-min = 0 (let scroll/clip handle overflow rather than enforce a
+  // content-based minimum).
+  if (child->style().overflow() != Overflow::Visible) {
+    return FloatOptional{0.0f};
+  }
+
+  const Dimension mainDim = dimension(mainAxis);
+  const Dimension crossDim =
+      isRow(mainAxis) ? Dimension::Height : Dimension::Width;
+  const bool isMainAxisRow = isRow(mainAxis);
+
+  // Specified size suggestion: the resolved main-axis style dimension.
+  const FloatOptional specifiedMain = child->getResolvedDimension(
+      direction, mainDim, ownerMainAxisSize, ownerWidth);
+
+  // Transferred size suggestion: cross × aspect-ratio, if both are definite.
+  FloatOptional transferredMain;
+  const FloatOptional aspectRatio = child->style().aspectRatio();
+  if (aspectRatio.isDefined()) {
+    const float crossOwner = isMainAxisRow ? ownerHeight : ownerWidth;
+    const FloatOptional crossResolved = child->getResolvedDimension(
+        direction, crossDim, crossOwner, ownerWidth);
+    if (crossResolved.isDefined()) {
+      const float ratio = aspectRatio.unwrap();
+      const float crossValue = crossResolved.unwrap();
+      transferredMain = FloatOptional{
+          isMainAxisRow ? crossValue * ratio : crossValue / ratio};
+    }
+  }
+
+  // Content size suggestion: probe via min-content recursion.
+  const FloatOptional contentMain = FloatOptional{computeMinContentMainSize(
+      child, mainAxis, direction, ownerWidth, ownerHeight)};
+
+  // Combine per §4.5: floor = min(content, specified) when specified is
+  // definite; otherwise floor = min(content, transferred) when transferred
+  // applies (item has aspect-ratio + definite cross + no specified main);
+  // else floor = content.
+  FloatOptional floor = contentMain;
+  if (specifiedMain.isDefined()) {
+    if (floor.isUndefined() || specifiedMain < floor) {
+      floor = specifiedMain;
+    }
+  } else if (transferredMain.isDefined()) {
+    if (floor.isUndefined() || transferredMain < floor) {
+      floor = transferredMain;
+    }
+  }
+
+  // §4.5: cap by the max main size.
+  const FloatOptional maxMain = child->style().resolvedMaxDimension(
+      direction, mainDim, ownerMainAxisSize, ownerWidth);
+  if (maxMain.isDefined() && floor > maxMain) {
+    floor = maxMain;
+  }
+
+  if (floor.isUndefined() || floor.unwrap() < 0.0f) {
+    floor = FloatOptional{0.0f};
+  }
+  return floor;
+}
+
+// boundAxis with an additional lower bound from `child`'s cached
+// `computedAutoMinMainSize`, applied on the main axis only. Used inside
+// the flex-shrink distribution to honor CSS §4.5 auto-min while preserving
+// the existing min/max/padding-and-border clamping.
+static float boundAxisWithAutoMin(
+    const yoga::Node* const child,
+    const FlexDirection axis,
+    const Direction direction,
+    const float value,
+    const float axisSize,
+    const float widthSize) {
+  float bounded = boundAxis(child, axis, direction, value, axisSize, widthSize);
+  const FloatOptional autoMin = child->getLayout().computedAutoMinMainSize;
+  if (autoMin.isDefined() && bounded < autoMin.unwrap()) {
+    bounded = autoMin.unwrap();
+  }
+  return bounded;
+}
+
 // It distributes the free space to the flexible items and ensures that the size
 // of the flex items abide the min and max constraints. At the end of this
 // function the child nodes would have proper size. Prior using this function
@@ -711,7 +935,7 @@ static float distributeFreeSpaceSecondPass(
                   flexShrinkScaledFactor;
         }
 
-        updatedMainSize = boundAxis(
+        updatedMainSize = boundAxisWithAutoMin(
             currentLineChild,
             mainAxis,
             direction,
@@ -726,7 +950,7 @@ static float distributeFreeSpaceSecondPass(
 
       // Is this child able to grow?
       if (!std::isnan(flexGrowFactor) && flexGrowFactor != 0) {
-        updatedMainSize = boundAxis(
+        updatedMainSize = boundAxisWithAutoMin(
             currentLineChild,
             mainAxis,
             direction,
@@ -891,7 +1115,7 @@ static void distributeFreeSpaceFirstPass(
             flexLine.layout.remainingFreeSpace /
                 flexLine.layout.totalFlexShrinkScaledFactors *
                 flexShrinkScaledFactor;
-        boundMainSize = boundAxis(
+        boundMainSize = boundAxisWithAutoMin(
             currentLineChild,
             mainAxis,
             direction,
@@ -984,6 +1208,29 @@ static void resolveFlexibleLength(
     const uint32_t depth,
     const uint32_t generationCount) {
   const float originalFreeSpace = flexLine.layout.remainingFreeSpace;
+
+  // CSS Flexbox §4.5: compute each item's automatic minimum main-axis size
+  // up front so the bounding helpers below can floor shrunk values.
+  // computeAutoMinMainSize returns Undefined when the feature is off or an
+  // explicit `min-{w,h}` already pins the floor, in which case the cached
+  // value is also Undefined and `boundAxisWithAutoMin` reduces to `boundAxis`.
+  if (!node->hasErrata(Errata::MinSizeUndefinedInsteadOfAuto)) {
+    for (auto currentLineChild : flexLine.itemsInFlow) {
+      currentLineChild->getLayout().computedAutoMinMainSize =
+          computeAutoMinMainSize(
+              currentLineChild,
+              mainAxis,
+              direction,
+              mainAxisOwnerSize,
+              availableInnerWidth,
+              availableInnerHeight);
+    }
+  } else {
+    for (auto currentLineChild : flexLine.itemsInFlow) {
+      currentLineChild->getLayout().computedAutoMinMainSize = FloatOptional{};
+    }
+  }
+
   // First pass: detect the flex items whose min/max constraints trigger
   distributeFreeSpaceFirstPass(
       flexLine,

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
@@ -76,7 +76,7 @@ class YG_EXPORT Config : public ::YGConfig {
 
   uint32_t version_ = 0;
   ExperimentalFeatureSet experimentalFeatures_{};
-  Errata errata_ = Errata::None;
+  Errata errata_ = Errata::MinSizeUndefinedInsteadOfAuto;
   float pointScaleFactor_ = 1.0f;
   void* context_ = nullptr;
 };

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
@@ -20,6 +20,7 @@ enum class Errata : uint32_t {
   StretchFlexBasis = YGErrataStretchFlexBasis,
   AbsolutePositionWithoutInsetsExcludesPadding = YGErrataAbsolutePositionWithoutInsetsExcludesPadding,
   AbsolutePercentAgainstInnerSize = YGErrataAbsolutePercentAgainstInnerSize,
+  MinSizeUndefinedInsteadOfAuto = YGErrataMinSizeUndefinedInsteadOfAuto,
   All = YGErrataAll,
   Classic = YGErrataClassic,
 };

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
@@ -27,6 +27,14 @@ struct LayoutResults {
   uint32_t computedFlexBasisGeneration = 0;
   FloatOptional computedFlexBasis = {};
 
+  // Per-flex-item floor along the main axis derived from CSS Flexbox §4.5
+  // automatic minimum sizing. Set by `resolveFlexibleLength` when the parent's
+  // config does NOT carry the `MinSizeUndefinedInsteadOfAuto` errata and the
+  // item has no explicit main-axis `min-{width,height}`. Read by the
+  // shrink/bound machinery to keep items at least this large. `Undefined`
+  // means "no auto-min applies."
+  FloatOptional computedAutoMinMainSize = {};
+
   // Instead of recomputing the entire layout every single time, we cache some
   // information to break early when nothing changed
   uint32_t generationCount = 0;

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -36,6 +36,9 @@ Node::Node(Node&& node) noexcept
       nodeType_(node.nodeType_),
       context_(node.context_),
       measureFunc_(node.measureFunc_),
+      minContentMeasureFunc_(node.minContentMeasureFunc_),
+      minContentWidth_(node.minContentWidth_),
+      minContentHeight_(node.minContentHeight_),
       baselineFunc_(node.baselineFunc_),
       dirtiedFunc_(node.dirtiedFunc_),
       style_(std::move(node.style_)),
@@ -72,6 +75,35 @@ YGSize Node::measure(
         size.width,
         size.height);
     return {
+        .width = maxOrDefined(0.0f, size.width),
+        .height = maxOrDefined(0.0f, size.height)};
+  }
+
+  return size;
+}
+
+YGSize Node::measureMinContent(
+    float availableWidth,
+    MeasureMode widthMode,
+    float availableHeight,
+    MeasureMode heightMode) {
+  auto size = minContentMeasureFunc_(
+      this,
+      availableWidth,
+      unscopedEnum(widthMode),
+      availableHeight,
+      unscopedEnum(heightMode));
+
+  if (yoga::isUndefined(size.height) || size.height < 0 ||
+      yoga::isUndefined(size.width) || size.width < 0) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    yoga::log(
+        this,
+        LogLevel::Warn,
+        "Min-content measure function returned an invalid dimension to Yoga: [width=%f, height=%f]",
+        size.width,
+        size.height);
+    size = {
         .width = maxOrDefined(0.0f, size.width),
         .height = maxOrDefined(0.0f, size.height)};
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -73,6 +73,24 @@ class YG_EXPORT Node : public ::YGNode {
       float availableHeight,
       MeasureMode heightMode);
 
+  bool hasMinContentMeasureFunc() const noexcept {
+    return minContentMeasureFunc_ != nullptr;
+  }
+
+  YGSize measureMinContent(
+      float availableWidth,
+      MeasureMode widthMode,
+      float availableHeight,
+      MeasureMode heightMode);
+
+  FloatOptional getMinContentWidth() const noexcept {
+    return minContentWidth_;
+  }
+
+  FloatOptional getMinContentHeight() const noexcept {
+    return minContentHeight_;
+  }
+
   bool hasBaselineFunc() const noexcept {
     return baselineFunc_ != nullptr;
   }
@@ -220,6 +238,18 @@ class YG_EXPORT Node : public ::YGNode {
 
   void setMeasureFunc(YGMeasureFunc measureFunc);
 
+  void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc) {
+    minContentMeasureFunc_ = minContentMeasureFunc;
+  }
+
+  void setMinContentWidth(FloatOptional minContentWidth) noexcept {
+    minContentWidth_ = minContentWidth;
+  }
+
+  void setMinContentHeight(FloatOptional minContentHeight) noexcept {
+    minContentHeight_ = minContentHeight;
+  }
+
   void setBaselineFunc(YGBaselineFunc baseLineFunc) {
     baselineFunc_ = baseLineFunc;
   }
@@ -315,6 +345,9 @@ class YG_EXPORT Node : public ::YGNode {
   NodeType nodeType_ : bitCount<NodeType>() = NodeType::Default;
   void* context_ = nullptr;
   YGMeasureFunc measureFunc_ = nullptr;
+  YGMinContentMeasureFunc minContentMeasureFunc_ = nullptr;
+  FloatOptional minContentWidth_{};
+  FloatOptional minContentHeight_{};
   YGBaselineFunc baselineFunc_ = nullptr;
   YGDirtiedFunc dirtiedFunc_ = nullptr;
   Style style_;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -12960,6 +12960,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -12967,6 +12968,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -12977,6 +12979,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -13030,6 +13034,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -13279,6 +13286,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -13538,6 +13546,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -12598,6 +12598,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -12605,6 +12606,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -12615,6 +12617,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -12668,6 +12672,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -12917,6 +12924,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -13176,6 +13184,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -12813,6 +12813,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -12820,6 +12821,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -12830,6 +12832,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -12883,6 +12887,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -13132,6 +13139,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -13391,6 +13399,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -15176,6 +15176,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -15183,6 +15184,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -15193,6 +15195,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -15246,6 +15250,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -15495,6 +15502,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -15754,6 +15762,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -14497,6 +14497,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -14504,6 +14505,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -14514,6 +14516,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -14567,6 +14571,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -14816,6 +14823,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -15075,6 +15083,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -15039,6 +15039,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -15046,6 +15047,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -15056,6 +15058,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -15109,6 +15113,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -15358,6 +15365,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -15617,6 +15625,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -9925,6 +9925,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -9932,6 +9933,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -9942,6 +9944,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -9995,6 +9999,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -10244,6 +10251,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -10503,6 +10511,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -9765,6 +9765,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -9772,6 +9773,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -9782,6 +9784,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -9835,6 +9839,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -10084,6 +10091,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -10343,6 +10351,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -9916,6 +9916,7 @@ class facebook::yoga::Node : public YGNode {
   public Node(facebook::yoga::Node&& node) noexcept;
   public YGDirtiedFunc getDirtiedFunc() const;
   public YGSize measure(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
+  public YGSize measureMinContent(float availableWidth, facebook::yoga::MeasureMode widthMode, float availableHeight, facebook::yoga::MeasureMode heightMode);
   public bool alwaysFormsContainingBlock() const;
   public bool getHasNewLayout() const;
   public bool hasBaselineFunc() const noexcept;
@@ -9923,6 +9924,7 @@ class facebook::yoga::Node : public YGNode {
   public bool hasDefiniteLength(facebook::yoga::Dimension dimension, float ownerSize);
   public bool hasErrata(facebook::yoga::Errata errata) const;
   public bool hasMeasureFunc() const noexcept;
+  public bool hasMinContentMeasureFunc() const noexcept;
   public bool isDirty() const;
   public bool isLayoutDimensionDefined(facebook::yoga::FlexDirection axis);
   public bool isNodeFlexible();
@@ -9933,6 +9935,8 @@ class facebook::yoga::Node : public YGNode {
   public const facebook::yoga::Style& style() const;
   public const std::vector<facebook::yoga::Node*>& getChildren() const;
   public facebook::yoga::Direction resolveDirection(facebook::yoga::Direction ownerDirection);
+  public facebook::yoga::FloatOptional getMinContentHeight() const noexcept;
+  public facebook::yoga::FloatOptional getMinContentWidth() const noexcept;
   public facebook::yoga::FloatOptional getResolvedDimension(facebook::yoga::Direction direction, facebook::yoga::Dimension dimension, float referenceLength, float ownerWidth) const;
   public facebook::yoga::FloatOptional resolveFlexBasis(facebook::yoga::Direction direction, facebook::yoga::FlexDirection flexDirection, float referenceLength, float ownerWidth) const;
   public facebook::yoga::LayoutResults& getLayout();
@@ -9986,6 +9990,9 @@ class facebook::yoga::Node : public YGNode {
   public void setLayoutPosition(float position, facebook::yoga::PhysicalEdge edge);
   public void setLineIndex(size_t lineIndex);
   public void setMeasureFunc(YGMeasureFunc measureFunc);
+  public void setMinContentHeight(facebook::yoga::FloatOptional minContentHeight) noexcept;
+  public void setMinContentMeasureFunc(YGMinContentMeasureFunc minContentMeasureFunc);
+  public void setMinContentWidth(facebook::yoga::FloatOptional minContentWidth) noexcept;
   public void setNodeType(facebook::yoga::NodeType nodeType);
   public void setOwner(facebook::yoga::Node* owner);
   public void setPosition(facebook::yoga::Direction direction, float ownerWidth, float ownerHeight);
@@ -10235,6 +10242,7 @@ enum facebook::yoga::Errata : uint32_t {
   AbsolutePositionWithoutInsetsExcludesPadding,
   All,
   Classic,
+  MinSizeUndefinedInsteadOfAuto,
   None,
   StretchFlexBasis,
 }
@@ -10494,6 +10502,7 @@ struct facebook::yoga::LayoutResults {
   public facebook::yoga::CachedMeasurement cachedLayout;
   public facebook::yoga::Direction direction() const;
   public facebook::yoga::Direction lastOwnerDirection;
+  public facebook::yoga::FloatOptional computedAutoMinMainSize;
   public facebook::yoga::FloatOptional computedFlexBasis;
   public float border(facebook::yoga::PhysicalEdge physicalEdge) const;
   public float dimension(facebook::yoga::Dimension axis) const;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1966


Implements CSS Flexbox §4.5 automatic minimum sizing in Yoga. When opted in on a `YGConfig`, every flex item whose main-axis `min-{width,height}` is undefined receives a content-derived floor — `min(min-content, specified-size, max-size)` plus any aspect-ratio-transferred lower bound — so it cannot shrink below the size CSS browsers would honor.

How to opt in: clear the new `YGErrataMinSizeUndefinedInsteadOfAuto` errata bit on the config. Default configs carry the bit (preserves today's behaviour); existing trees see no change. The bit is added to `YGErrataClassic` so consumers using that constant continue to get the same default.

Three ways for a node to declare its min-content size along an axis, in this precedence order:

1. **Static per-axis value** via `YGNodeSetMinContentWidth/Height(node, value)`. Pass `YGUndefined` to clear. When set, the §4.5 probe short-circuits at this node — skipping both the dynamic callback and any container recursion. Use for known constants (e.g., images returning 0 per CSS-Images; scroll containers returning 0 on their scroll axis).

2. **Dynamic callback** via `YGNodeSetMinContentMeasureFunc(node, fn)`. Mirrors `YGMeasureFunc`'s shape. The algorithm invokes it for measure-func leaves when no static value is set.

3. **Default fallback**: the existing `YGMeasureFunc` invoked with `AtMost 0`, which text measurers naturally answer with their longest-word width.

For container nodes without a static value, the algorithm walks children directly — sum on the container's own main axis, max on the cross axis — mirroring RenderCore FlexLayout's `computeMinContentSize`. This replaces the previous `calculateLayoutInternal(performLayout=false)` re-entry and skips cross-axis sizing, padding/border resolution, alignment, and baseline machinery that the probe doesn't need.

Per-item opt-outs follow the CSS spec: explicit `min-{width,height}` (including 0), `display: none`, and `overflow != visible`.

Cost when off (default): a single errata-bit check per flex line plus one `FloatOptional` short-circuit per `boundAxisWithAutoMin` call. Sub-microsecond.

Cost when on: one min-content probe per opted-in flex item per layout pass. Static values short-circuit in ~30 ns; measure-func leaves cost one extra `measure()` call; container subtrees do one recursive sum/max walk over in-flow descendants.

Reference: https://www.w3.org/TR/css-flexbox-1/#min-size-auto. Modeled after `xplat/flexlayout/`'s `MinSizeUndefinedInsteadOfAuto` errata path.

Changelog:
[General][Added] - Add CSS Flexbox §4.5 automatic minimum sizing. Opt in by clearing the new `YGErrataMinSizeUndefinedInsteadOfAuto` errata bit on `YGConfig`. Adds `YGNodeSetMinContentWidth/Height` for static contributions and `YGMinContentMeasureFunc` for dynamic ones.'

GH pull request
https://github.com/facebook/react-native/pull/57015
https://github.com/facebook/yoga/pull/1966

Reviewed By: fbcbl

Differential Revision: D105720159


