### PR TITLE
Skip initial yogaLayoutableChildren_ build when fragment.children is set (#57020)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -113,22 +113,15 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
               .yogaNode_) == YGNodeIsDirty(&yogaNode_) &&
       "Yoga node must inherit dirty flag.");
 #endif
-  if (!getTraits().check(ShadowNodeTraits::Trait::LeafYogaNode)) {
-    if (!fragment.children) {
-      // Children unchanged - copy the filtered list directly from the source
-      // node, avoiding expensive dynamic_pointer_cast on every child.
-      yogaLayoutableChildren_ =
-          static_cast<const YogaLayoutableShadowNode&>(sourceShadowNode)
-              .yogaLayoutableChildren_;
-    } else {
-      for (auto& child : getChildren()) {
-        if (auto layoutableChild =
-                std::dynamic_pointer_cast<const YogaLayoutableShadowNode>(
-                    child)) {
-          yogaLayoutableChildren_.push_back(std::move(layoutableChild));
-        }
-      }
-    }
+  if (!getTraits().check(ShadowNodeTraits::Trait::LeafYogaNode) &&
+      !fragment.children) {
+    // Children unchanged: copy the filtered list directly from the source,
+    // skipping per-child dynamic_pointer_cast. When fragment.children is set,
+    // updateYogaChildren() below rebuilds the vector from the new children
+    // list — populating it here would be immediately discarded.
+    yogaLayoutableChildren_ =
+        static_cast<const YogaLayoutableShadowNode&>(sourceShadowNode)
+            .yogaLayoutableChildren_;
   }
 
   YGConfigConstRef previousConfig =

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -114,11 +114,19 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
       "Yoga node must inherit dirty flag.");
 #endif
   if (!getTraits().check(ShadowNodeTraits::Trait::LeafYogaNode)) {
-    for (auto& child : getChildren()) {
-      if (auto layoutableChild =
-              std::dynamic_pointer_cast<const YogaLayoutableShadowNode>(
-                  child)) {
-        yogaLayoutableChildren_.push_back(std::move(layoutableChild));
+    if (!fragment.children) {
+      // Children unchanged - copy the filtered list directly from the source
+      // node, avoiding expensive dynamic_pointer_cast on every child.
+      yogaLayoutableChildren_ =
+          static_cast<const YogaLayoutableShadowNode&>(sourceShadowNode)
+              .yogaLayoutableChildren_;
+    } else {
+      for (auto& child : getChildren()) {
+        if (auto layoutableChild =
+                std::dynamic_pointer_cast<const YogaLayoutableShadowNode>(
+                    child)) {
+          yogaLayoutableChildren_.push_back(std::move(layoutableChild));
+        }
       }
     }
   }
@@ -349,6 +357,7 @@ void YogaLayoutableShadowNode::updateYogaChildren() {
 
   yogaNode_.setChildren({});
   yogaLayoutableChildren_.clear();
+  yogaLayoutableChildren_.reserve(getChildren().size());
 
   for (size_t i = 0; i < getChildren().size(); i++) {
     if (auto yogaLayoutableChild =


### PR DESCRIPTION
Summary:

On the `fragment.children` path, the clone constructor used to
iterate every child with `dynamic_pointer_cast` only to have
`updateYogaChildren()` clear and rebuild the same vector a few
lines later. Drop the initial loop — `updateYogaChildren()` is the
single source of truth on this path.

`updateYogaChildrenOwnersIfNeeded()` runs in between but iterates
`yogaNode_.getChildren()` (inherited from the source's Yoga node
copy) rather than `yogaLayoutableChildren_`, so leaving the vector
empty here is safe.

Changelog:
[Internal]

Reviewed By: lenaic, christophpurrer

Differential Revision: D107076026


