### PR TITLE
Mark JSPointerDispatcher and JSTouchDispatcher as open (#57022)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3319,14 +3319,14 @@ public class com/facebook/react/uimanager/IllegalViewOperationException : com/fa
 	public final fun getView ()Landroid/view/View;
 }
 
-public final class com/facebook/react/uimanager/JSPointerDispatcher {
+public class com/facebook/react/uimanager/JSPointerDispatcher {
 	public fun <init> (Landroid/view/ViewGroup;)V
 	public final fun handleMotionEvent (Landroid/view/MotionEvent;Lcom/facebook/react/uimanager/events/EventDispatcher;Z)V
 	public final fun onChildEndedNativeGesture ()V
 	public final fun onChildStartedNativeGesture (Landroid/view/View;Landroid/view/MotionEvent;Lcom/facebook/react/uimanager/events/EventDispatcher;)V
 }
 
-public final class com/facebook/react/uimanager/JSTouchDispatcher {
+public class com/facebook/react/uimanager/JSTouchDispatcher {
 	public fun <init> (Landroid/view/ViewGroup;)V
 	public final fun handleTouchEvent (Landroid/view/MotionEvent;Lcom/facebook/react/uimanager/events/EventDispatcher;)V
 	public final fun handleTouchEvent (Landroid/view/MotionEvent;Lcom/facebook/react/uimanager/events/EventDispatcher;Lcom/facebook/react/bridge/ReactContext;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.kt
@@ -28,7 +28,7 @@ import com.facebook.react.uimanager.events.PointerEventHelper.EVENT
  * onHoverEvent, onInterceptHoverEvent. It will correctly find the right view to handle the touch
  * and also dispatch the appropriate event to JS
  */
-public class JSPointerDispatcher(private val rootViewGroup: ViewGroup) {
+public open class JSPointerDispatcher(private val rootViewGroup: ViewGroup) {
 
   private var lastHitPathByPointerId: MutableMap<Int, List<ViewTarget>>? = null
   private var lastEventCoordinatesByPointerId: MutableMap<Int, FloatArray>? = null

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.kt
@@ -25,7 +25,7 @@ import com.facebook.react.uimanager.events.TouchEventType
  * need to call handleTouchEvent from onTouchEvent and onInterceptTouchEvent. It will correctly find
  * the right view to handle the touch and also dispatch the appropriate event to JS
  */
-public class JSTouchDispatcher(private val viewGroup: ViewGroup) {
+public open class JSTouchDispatcher(private val viewGroup: ViewGroup) {
   private var targetTag = -1
   private val targetCoordinates = FloatArray(2)
   private var childIsHandlingNativeGesture = false


### PR DESCRIPTION
Summary:
The Java-to-Kotlin migration of these classes made them implicitly final (Kotlin default), breaking downstream libraries that subclass them (e.g. react-native-keyboard-controller's JSPointerDispatcherCompat).

Adding `open` restores the pre-migration extensibility.

## Changelog:

[ANDROID] [CHANGED] - Mark JSPointerDispatcher and JSTouchDispatcher as open


Test Plan: CI

Reviewed By: javache

Differential Revision: D107089429

Pulled By: cortinico


