### PR TITLE
Remove __DEV__ stubs for previously-removed legacy modules

### DIFF
--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -27,7 +27,6 @@
 import typeof * as ReactNativePublicAPI from './index.js.flow';
 
 const warnOnce = require('./Libraries/Utilities/warnOnce').default;
-const invariant = require('invariant');
 
 module.exports = {
   // #region Components
@@ -395,82 +394,3 @@ module.exports = {
   },
   // #endregion
 } as ReactNativePublicAPI;
-
-if (__DEV__) {
-  /* $FlowFixMe[prop-missing] This is intentional: Flow will error when
-   * attempting to access AsyncStorage. */
-  /* $FlowFixMe[invalid-export] This is intentional: Flow will error when
-   * attempting to access AsyncStorage. */
-  Object.defineProperty(module.exports, 'AsyncStorage', {
-    configurable: true,
-    get() {
-      invariant(
-        false,
-        'AsyncStorage has been removed from react-native core. ' +
-          "It can now be installed and imported from '@react-native-async-storage/async-storage' instead of 'react-native'. " +
-          'See https://github.com/react-native-async-storage/async-storage',
-      );
-    },
-  });
-  /* $FlowFixMe[prop-missing] This is intentional: Flow will error when
-   * attempting to access ImagePickerIOS. */
-  /* $FlowFixMe[invalid-export] This is intentional: Flow will error when
-   * attempting to access ImagePickerIOS. */
-  Object.defineProperty(module.exports, 'ImagePickerIOS', {
-    configurable: true,
-    get() {
-      invariant(
-        false,
-        'ImagePickerIOS has been removed from React Native. ' +
-          "Please upgrade to use either 'react-native-image-picker' or 'expo-image-picker'. " +
-          "If you cannot upgrade to a different library, please install the deprecated '@react-native-community/image-picker-ios' package. " +
-          'See https://github.com/rnc-archive/react-native-image-picker-ios',
-      );
-    },
-  });
-  /* $FlowFixMe[prop-missing] This is intentional: Flow will error when
-   * attempting to access ProgressViewIOS. */
-  /* $FlowFixMe[invalid-export] This is intentional: Flow will error when
-   * attempting to access ProgressViewIOS. */
-  Object.defineProperty(module.exports, 'ProgressViewIOS', {
-    configurable: true,
-    get() {
-      invariant(
-        false,
-        'ProgressViewIOS has been removed from react-native core. ' +
-          "It can now be installed and imported from '@react-native-community/progress-view' instead of 'react-native'. " +
-          'See https://github.com/react-native-progress-view/progress-view',
-      );
-    },
-  });
-  /* $FlowFixMe[prop-missing] This is intentional: Flow will error when
-   * attempting to access DatePickerIOS. */
-  /* $FlowFixMe[invalid-export] This is intentional: Flow will error when
-   * attempting to access DatePickerIOS. */
-  Object.defineProperty(module.exports, 'DatePickerIOS', {
-    configurable: true,
-    get() {
-      invariant(
-        false,
-        'DatePickerIOS has been removed from react-native core. ' +
-          "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
-          'See https://github.com/react-native-datetimepicker/datetimepicker',
-      );
-    },
-  });
-  /* $FlowFixMe[prop-missing] This is intentional: Flow will error when
-   * attempting to access Slider. */
-  /* $FlowFixMe[invalid-export] This is intentional: Flow will error when
-   * attempting to access Slider. */
-  Object.defineProperty(module.exports, 'Slider', {
-    configurable: true,
-    get() {
-      invariant(
-        false,
-        'Slider has been removed from react-native core. ' +
-          "It can now be installed and imported from '@react-native-community/slider' instead of 'react-native'. " +
-          'See https://github.com/callstack/react-native-slider',
-      );
-    },
-  });
-}


### PR DESCRIPTION
Summary:
The following modules were removed from `react-native` core years ago: `AsyncStorage`, `ImagePickerIOS`, `ProgressViewIOS`, `DatePickerIOS`, and `Slider`. Until now, accessing them from `react-native` triggered a `__DEV__`-only invariant that threw a helpful error directing users to the community package replacement.

Enough release cycles have passed that the friendly invariant is no longer needed. This commit removes the five `Object.defineProperty(module.exports, …)` blocks from `index.js`, along with the wrapping `if (__DEV__) { … }` shell and the now-unused `invariant` import.

After this change, accessing one of these names from `react-native` returns `undefined` (matching the behavior of any other non-exported name).

Replacement packages, for reference:
- `AsyncStorage` → `react-native-async-storage/async-storage`
- `ImagePickerIOS` → `react-native-image-picker` or `expo-image-picker`
- `ProgressViewIOS` → `react-native-community/progress-view`
- `DatePickerIOS` → `react-native-community/datetimepicker`
- `Slider` → `react-native-community/slider`

Changelog: [Internal]

Differential Revision: D106640956


