### PR TITLE
Remove legacy NativeMethods types

### DIFF
--- a/packages/eslint-plugin-react-native/utils.js
+++ b/packages/eslint-plugin-react-native/utils.js
@@ -505,8 +505,6 @@ const publicAPIMapping = {
     default: null,
     types: [
       'HostInstance',
-      'NativeMethods',
-      'NativeMethodsMixin',
       'MeasureInWindowOnSuccessCallback',
       'MeasureLayoutOnSuccessCallback',
       'MeasureOnSuccessCallback',

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -41,7 +41,6 @@ import typeof Platform from '../Utilities/Platform';
 export type {
   HostInstance as PublicInstance,
   // These types are only necessary for Paper
-  NativeMethods as LegacyPublicInstance,
   MeasureOnSuccessCallback,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js.flow
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js.flow
@@ -14,7 +14,6 @@ export type {
   HostInstance as PublicInstance,
 
   // These types are only necessary for Paper
-  NativeMethods as LegacyPublicInstance,
   MeasureOnSuccessCallback,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -455,8 +455,6 @@ export type * from './Libraries/Types/CodegenTypesNamespace';
 
 export type {
   HostInstance,
-  NativeMethods,
-  NativeMethodsMixin,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,

--- a/packages/react-native/src/private/types/HostInstance.js
+++ b/packages/react-native/src/private/types/HostInstance.js
@@ -109,11 +109,3 @@ export interface LegacyHostInstanceMethods {
 }
 
 export type HostInstance = ReactNativeElement;
-
-/** @deprecated Use HostInstance instead */
-export type NativeMethods = LegacyHostInstanceMethods;
-
-/**
- * @deprecated Use HostInstance instead.
- */
-export type NativeMethodsMixin = LegacyHostInstanceMethods;

--- a/packages/react-native/types/public/ReactNativeTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTypes.d.ts
@@ -112,15 +112,6 @@ export interface NativeMethods {
 }
 
 /**
- * @deprecated Use NativeMethods instead.
- */
-export type NativeMethodsMixin = NativeMethods;
-/**
- * @deprecated Use NativeMethods instead.
- */
-export type NativeMethodsMixinType = NativeMethods;
-
-/**
  * Represents a native component, such as those returned from `requireNativeComponent`.
  *
  * @see https://github.com/facebook/react-native/blob/v0.62.0-rc.5/Libraries/Renderer/shims/ReactNativeTypes.js


### PR DESCRIPTION
Summary:
Long deprecated, drop from our public API.

Relates to https://github.com/react-native-community/discussions-and-proposals/pull/1003.

Changelog:
[General][Breaking] - Remove `NativeMethods` and `NativeMethodsMixin` types. Use `ReactNativeElement` instead.

Differential Revision: D107108484


