### PR TITLE
Fix accessibilityLabelledBy crash on empty array (#57029)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -309,7 +309,8 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
   @ReactProp(name = ViewProps.ACCESSIBILITY_LABELLED_BY)
   public void setAccessibilityLabelledBy(@NonNull T view, @Nullable Dynamic nativeId) {
-    if (nativeId.isNull()) {
+    if (nativeId == null || nativeId.isNull()) {
+      view.setTag(R.id.labelled_by, null);
       return;
     }
     if (nativeId.getType() == ReadableType.String) {
@@ -317,7 +318,8 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     } else if (nativeId.getType() == ReadableType.Array) {
       // On Android, this takes a single View as labeledBy. If an array is specified, set the first
       // element in the tag.
-      view.setTag(R.id.labelled_by, nativeId.asArray().getString(0));
+      ReadableArray array = nativeId.asArray();
+      view.setTag(R.id.labelled_by, array.size() > 0 ? array.getString(0) : null);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
@@ -12,6 +12,8 @@ package com.facebook.react.uimanager
 import android.view.View.OnFocusChangeListener
 import com.facebook.react.R
 import com.facebook.react.bridge.BridgeReactContext
+import com.facebook.react.bridge.DynamicFromObject
+import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.views.view.ReactViewGroup
@@ -100,5 +102,32 @@ class BaseViewManagerTest {
     view.onFocusChangeListener.onFocusChange(view, true)
     verify(originalFocusListener, times(2)).onFocusChange(view, true)
     Assertions.assertThat(originalFocusListener).isEqualTo(view.onFocusChangeListener)
+  }
+
+  @Test
+  fun testAccessibilityLabelledByString() {
+    viewManager.setAccessibilityLabelledBy(view, DynamicFromObject("target_id"))
+    Assertions.assertThat(view.getTag(R.id.labelled_by)).isEqualTo("target_id")
+  }
+
+  @Test
+  fun testAccessibilityLabelledByArray() {
+    val array = JavaOnlyArray.of("first_id", "second_id")
+    viewManager.setAccessibilityLabelledBy(view, DynamicFromObject(array))
+    Assertions.assertThat(view.getTag(R.id.labelled_by)).isEqualTo("first_id")
+  }
+
+  @Test
+  fun testAccessibilityLabelledByNullClearsTag() {
+    view.setTag(R.id.labelled_by, "stale_id")
+    viewManager.setAccessibilityLabelledBy(view, DynamicFromObject(null))
+    Assertions.assertThat(view.getTag(R.id.labelled_by)).isNull()
+  }
+
+  @Test
+  fun testAccessibilityLabelledByEmptyArrayDoesNotCrash() {
+    view.setTag(R.id.labelled_by, "stale_id")
+    viewManager.setAccessibilityLabelledBy(view, DynamicFromObject(JavaOnlyArray()))
+    Assertions.assertThat(view.getTag(R.id.labelled_by)).isNull()
   }
 }


### PR DESCRIPTION
Summary:

Fixes a crash in `BaseViewManager.setAccessibilityLabelledBy` when an empty array is passed. The method now guards against accessing index 0 on empty arrays and properly clears the tag when null or empty arrays are provided, instead of leaving stale associations.

## Changelog

[Android][Fixed] - Issue when clearing accessibilityLabelledBy

Reviewed By: bvanderhoof

Differential Revision: D107127388


