### PR TITLE
feat: adopt AGP v9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,6 @@ org.gradle.caching=true
 
 android.useAndroidX=true
 
-# Those 2 properties are needed to make our project compatible with
-# AGP 9.0.0 for the time being. Ideally we should not opt-out of
-# builtInKotlin and newDsl once AGP 9.0.0 hits stable.
-# More on this: https://developer.android.com/build/releases/agp-preview#android-gradle-plugin-built-in-kotlin
-android.builtInKotlin=false
-android.newDsl=false
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using

--- a/packages/gradle-plugin/gradle/libs.versions.toml
+++ b/packages/gradle-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.0"
+agp = "9.2.1"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -116,9 +116,9 @@ class ReactPlugin : Plugin<Project> {
     }
 
     // Library Only Configuration
-    // configureBuildConfigFieldsForLibraries(project)
-    // configureNamespaceForLibraries(project)
     project.pluginManager.withPlugin("com.android.library") {
+      configureBuildConfigFieldsForLibraries(project)
+      configureNamespaceForLibraries(project)
       configureCodegen(project, extension, rootExtension, isLibrary = true)
     }
   }
@@ -222,12 +222,12 @@ class ReactPlugin : Plugin<Project> {
     if (isLibrary) {
       project.extensions.getByType(LibraryAndroidComponentsExtension::class.java).finalizeDsl { ext
         ->
-        ext.sourceSets.getByName("main").java.srcDir(generatedSrcDir.get().dir("java").asFile)
+        ext.sourceSets.getByName("main").java.directories.add(generatedSrcDir.get().dir("java").asFile.path)
       }
     } else {
       project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java).finalizeDsl {
           ext ->
-        ext.sourceSets.getByName("main").java.srcDir(generatedSrcDir.get().dir("java").asFile)
+        ext.sourceSets.getByName("main").java.directories.add(generatedSrcDir.get().dir("java").asFile.path)
       }
     }
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -116,8 +116,8 @@ class ReactPlugin : Plugin<Project> {
     }
 
     // Library Only Configuration
-    configureBuildConfigFieldsForLibraries(project)
-    configureNamespaceForLibraries(project)
+    // configureBuildConfigFieldsForLibraries(project)
+    // configureNamespaceForLibraries(project)
     project.pluginManager.withPlugin("com.android.library") {
       configureCodegen(project, extension, rootExtension, isLibrary = true)
     }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -9,7 +9,6 @@ package com.facebook.react.utils
 
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
-import com.android.build.gradle.LibraryExtension
 import com.facebook.react.ReactExtension
 import com.facebook.react.utils.ProjectUtils.isEdgeToEdgeEnabled
 import com.facebook.react.utils.ProjectUtils.isHermesEnabled
@@ -18,7 +17,6 @@ import java.net.Inet4Address
 import java.net.NetworkInterface
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
-import kotlin.plus
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.AppliedPlugin
@@ -77,14 +75,12 @@ internal object AgpConfiguratorUtils {
     project.pluginManager.withPlugin("com.android.library", action)
   }
 
-  fun configureBuildConfigFieldsForLibraries(appProject: Project) {
-    appProject.rootProject.allprojects { subproject ->
-      subproject.pluginManager.withPlugin("com.android.library") {
-        subproject.extensions
-            .getByType(LibraryAndroidComponentsExtension::class.java)
-            .finalizeDsl { ext -> ext.buildFeatures.buildConfig = true }
+  fun configureBuildConfigFieldsForLibraries(project: Project) {
+    project.extensions
+      .getByType(LibraryAndroidComponentsExtension::class.java)
+      .finalizeDsl { ext ->
+        ext.buildFeatures.buildConfig = true
       }
-    }
   }
 
   fun configureDevServerLocation(project: Project) {
@@ -111,27 +107,22 @@ internal object AgpConfiguratorUtils {
     project.pluginManager.withPlugin("com.android.library", action)
   }
 
-  fun configureNamespaceForLibraries(appProject: Project) {
-    appProject.rootProject.allprojects { subproject ->
-      subproject.pluginManager.withPlugin("com.android.library") {
-        subproject.extensions
-            .getByType(LibraryAndroidComponentsExtension::class.java)
-            .finalizeDsl { ext ->
-              if (ext.namespace == null) {
-                val android = subproject.extensions.getByType(LibraryExtension::class.java)
-                val manifestFile = android.sourceSets.getByName("main").manifest.srcFile
-
-                manifestFile
-                    .takeIf { it.exists() }
-                    ?.let { file ->
-                      getPackageNameFromManifest(file)?.let { packageName ->
-                        ext.namespace = packageName
-                      }
-                    }
+  fun configureNamespaceForLibraries(project: Project) {
+    project.extensions
+      .getByType(LibraryAndroidComponentsExtension::class.java)
+      .finalizeDsl { ext ->
+        if (ext.namespace == null) {
+          val manifestFile =
+            project.layout.projectDirectory.file("src/main/AndroidManifest.xml").asFile
+          manifestFile
+            .takeIf { it.exists() }
+            ?.let { file ->
+              getPackageNameFromManifest(file)?.let { packageName ->
+                ext.namespace = packageName
               }
             }
+        }
       }
-    }
   }
 }
 

--- a/packages/react-native-popup-menu-android/android/build.gradle.kts
+++ b/packages/react-native-popup-menu-android/android/build.gradle.kts
@@ -8,7 +8,6 @@
 plugins {
   id("com.facebook.react")
   id("com.android.library")
-  id("org.jetbrains.kotlin.android")
 }
 
 android {

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -612,13 +612,15 @@ android {
 
   sourceSets {
     named("main") {
-      res.srcDirs(
-          "src/main/res/devsupport",
-          "src/main/res/shell",
-          "src/main/res/views/alert",
-          "src/main/res/views/modal",
-          "src/main/res/views/uimanager",
-          "src/main/res/views/view",
+      res.directories.addAll(
+          listOf(
+              "src/main/res/devsupport",
+              "src/main/res/shell",
+              "src/main/res/views/alert",
+              "src/main/res/views/modal",
+              "src/main/res/views/uimanager",
+              "src/main/res/views/view",
+          )
       )
     }
   }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -675,11 +675,6 @@ android {
   }
 }
 
-tasks.withType<JavaCompile>().configureEach {
-  exclude("com/facebook/react/processing/**")
-  exclude("com/facebook/react/module/processing/**")
-}
-
 tasks.withType<KotlinCompile>().configureEach {
   exclude("com/facebook/annotationprocessors/**")
   exclude("com/facebook/react/processing/**")

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -694,7 +694,6 @@ dependencies {
   api(libs.androidx.appcompat)
   api(libs.androidx.appcompat.resources)
   api(libs.androidx.autofill)
-  api(libs.androidx.collection)
   api(libs.androidx.swiperefreshlayout)
   api(libs.androidx.tracing)
   api(libs.androidx.window)
@@ -718,6 +717,8 @@ dependencies {
   // It's up to the consumer to decide if hermes or other engines should be included or not.
   // Therefore hermes-engine is a compileOnly dependencies.
   compileOnly(project(":packages:react-native:ReactAndroid:hermes-engine"))
+
+  implementation(libs.androidx.collection)
 
   testImplementation(libs.junit)
   testImplementation(libs.assertj)

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
   id("com.facebook.react")
   alias(libs.plugins.android.library)
   alias(libs.plugins.download)
-  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.ktfmt)
 }
 
@@ -611,19 +610,17 @@ android {
       ":packages:react-native:ReactAndroid:hermes-engine:preBuild"
   )
 
-  sourceSets.getByName("main") {
-    res.setSrcDirs(
-        listOf(
-            "src/main/res/devsupport",
-            "src/main/res/shell",
-            "src/main/res/views/alert",
-            "src/main/res/views/modal",
-            "src/main/res/views/uimanager",
-            "src/main/res/views/view",
-        )
-    )
-    java.exclude("com/facebook/react/processing")
-    java.exclude("com/facebook/react/module/processing")
+  sourceSets {
+    named("main") {
+      res.srcDirs(
+          "src/main/res/devsupport",
+          "src/main/res/shell",
+          "src/main/res/views/alert",
+          "src/main/res/views/modal",
+          "src/main/res/views/uimanager",
+          "src/main/res/views/view",
+      )
+    }
   }
 
   lint {
@@ -676,6 +673,11 @@ android {
   }
 }
 
+tasks.withType<JavaCompile>().configureEach {
+  exclude("com/facebook/react/processing/**")
+  exclude("com/facebook/react/module/processing/**")
+}
+
 tasks.withType<KotlinCompile>().configureEach {
   exclude("com/facebook/annotationprocessors/**")
   exclude("com/facebook/react/processing/**")
@@ -690,6 +692,7 @@ dependencies {
   api(libs.androidx.appcompat)
   api(libs.androidx.appcompat.resources)
   api(libs.androidx.autofill)
+  api(libs.androidx.collection)
   api(libs.androidx.swiperefreshlayout)
   api(libs.androidx.tracing)
   api(libs.androidx.window)

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -411,7 +411,12 @@ android {
   sourceSets {
     named("main") {
       manifest.srcFile("$hermesDir/android/hermes/src/main/AndroidManifest.xml")
-      java.srcDirs("$hermesDir/lib/Platform/Intl/java", "$hermesDir/lib/Platform/Unicode/java")
+      java.directories.addAll(
+          listOf(
+              "$hermesDir/lib/Platform/Intl/java",
+              "$hermesDir/lib/Platform/Unicode/java",
+          )
+      )
     }
   }
 

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -408,9 +408,11 @@ android {
     }
   }
 
-  sourceSets.getByName("main") {
-    manifest.srcFile("$hermesDir/android/hermes/src/main/AndroidManifest.xml")
-    java.srcDirs("$hermesDir/lib/Platform/Intl/java", "$hermesDir/lib/Platform/Unicode/java")
+  sourceSets {
+    named("main") {
+      manifest.srcFile("$hermesDir/android/hermes/src/main/AndroidManifest.xml")
+      java.srcDirs("$hermesDir/lib/Platform/Intl/java", "$hermesDir/lib/Platform/Unicode/java")
+    }
   }
 
   buildFeatures {

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -6,10 +6,11 @@ compileSdk = "36"
 buildTools = "36.0.0"
 ndkVersion = "27.1.12297006"
 # Dependencies versions
-agp = "8.12.0"
+agp = "9.2.1"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.7.0"
 androidx-autofill = "1.3.0"
+androidx-collection = "1.4.0"
 androidx-benchmark-macro-junit4 = "1.3.3"
 androidx-profileinstaller = "1.4.1"
 androidx-swiperefreshlayout = "1.1.0"
@@ -56,6 +57,7 @@ androidx-annotation = { module = "androidx.annotation:annotation", version.ref =
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-appcompat-resources = { module = "androidx.appcompat:appcompat-resources", version.ref = "androidx-appcompat" }
 androidx-autofill = { module = "androidx.autofill:autofill", version.ref = "androidx-autofill" }
+androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidx-benchmark-macro-junit4" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }

--- a/packages/rn-tester/android/app/benchmark/build.gradle.kts
+++ b/packages/rn-tester/android/app/benchmark/build.gradle.kts
@@ -7,7 +7,6 @@
 
 plugins {
   alias(libs.plugins.android.test)
-  alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -134,15 +134,18 @@ android {
   }
   sourceSets.named("main") {
     // SampleTurboModule.
-    kotlin.srcDirs(
-        "$reactNativeDirPath/ReactCommon/react/nativemodule/samples/platform/android",
+    kotlin.directories.add(
+        "$reactNativeDirPath/ReactCommon/react/nativemodule/samples/platform/android"
     )
-    res.setSrcDirs(
-        listOf(
-            "src/main/res",
-            "src/main/public_res",
-        )
-    )
+    res.directories.apply {
+      clear() // Mimics setSrcDirs by wiping out the defaults
+      addAll(
+          listOf(
+              "src/main/res",
+              "src/main/public_res"
+          )
+      )
+    }
   }
 }
 

--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   id("com.facebook.react")
   alias(libs.plugins.android.application)
-  alias(libs.plugins.kotlin.android)
 }
 
 val reactNativeDirPath = "$rootDir/packages/react-native"
@@ -135,7 +134,7 @@ android {
   }
   sourceSets.named("main") {
     // SampleTurboModule.
-    java.srcDirs(
+    kotlin.srcDirs(
         "$reactNativeDirPath/ReactCommon/react/nativemodule/samples/platform/android",
     )
     res.setSrcDirs(

--- a/private/helloworld/android/gradle.properties
+++ b/private/helloworld/android/gradle.properties
@@ -11,3 +11,8 @@ reactNativeArchitectures=arm64-v8a
 newArchEnabled=true
 hermesEnabled=true
 edgeToEdgeEnabled=false
+
+# Opt out of built-in kotlin and new DSL behavior that ships with AGP 9.
+# Starting from AGP 10.x these opt outs will be removed.
+android.builtInKotlin=false
+android.newDsl=false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is part of Android Gradle Plugin v9 adoption. With this PR, we adopt the AGP9 repository wide and address the deprecated APIs with the newer ones.

This is in combination with https://github.com/facebook/react-native/pull/57038

<details>
<summary>
<b>Changes to `configureBuildConfigFieldsForLibraries` and `configureNamespaceForLibraries`</b>
</summary>

<br/>
These helpers are called from `ReactPlugin.apply`, but they currently iterate over `rootProject.allprojects`. Since `com.facebook.react` is applied by multiple Android library projects, each application of the plugin repeats the same traversal and attempts to register `finalizeDsl` callbacks for every Android library project.

The first traversal can register the callbacks successfully. However, a later traversal can reach a project whose Android DSL finalization phase has already completed. Starting with AGP 9, AGP explicitly errors when `finalizeDsl` is called after that phase has passed, which causes the build failure. [see](https://issuetracker.google.com/issues/436595826)

To understand this, consider following modules:

```
:react-native-safe-area-context
:react-native-mmkv
:react-native-skia
```

The current code on main, would result in executing the following block 3 times:

```kt
  fun configureBuildConfigFieldsForLibraries(appProject: Project) {
    appProject.rootProject.allprojects { subproject ->
      println("=== subproject ${subproject.name}")
      subproject.pluginManager.withPlugin("com.android.library") {
        subproject.extensions
            .getByType(LibraryAndroidComponentsExtension::class.java)
            .finalizeDsl { ext -> ext.buildFeatures.buildConfig = true }
      }
   }
}
```

The output would be:

```
> Configure project: react-native-safe-area-context
=== subproject RNProject
=== subproject app
=== subproject react-native-safe-area-context
=== subproject react-native-mmkv
=== subproject react-native-skia

> Configure project: react-native-mmkv
=== subproject RNProject
=== subproject app
=== subproject react-native-safe-area-context
=== subproject react-native-mmkv
=== subproject react-native-skia

> Configure project: react-native-skia
=== subproject RNProject
=== subproject app
=== subproject react-native-safe-area-context
=== subproject react-native-mmkv
=== subproject react-native-skia
```


Now with AGP9, the same code will throw this error:

```
> Configure project: react-native-safe-area-context
=== subproject RNProject
=== subproject app
=== subproject react-native-safe-area-context
=== subproject react-native-mmkv
=== subproject react-native-skia

> Configure project: react-native-mmkv
=== subproject RNProject
=== subproject app
=== subproject react-native-safe-area-context
=== subproject react-native-mmkv

* What went wrong:
A problem occurred evaluating project': react-native-mmkv'.
> Failed to apply plugin
'com. facebook. react'
> It is too late to call
finalizeDst
as the DSL finalization
blocks have already been executed. \n
In particular, you cannot call 'finalizeDsl' within the "beforeVariants' or "onVariants' blocks.
Instead, you must call finalizeDsl' directly within the
"androidComponents' block
```

**Solution:**

Since these helpers are only intended to configure Android library projects that apply the React plugin, we can configure the current project inside `pluginManager.withPlugin("com.android.library")` instead of repeatedly configuring all projects from every plugin application.

```kt
 fun configureBuildConfigFieldsForLibraries(project: Project) {
    project.extensions
      .getByType(LibraryAndroidComponentsExtension::class.java)
      .finalizeDsl { ext ->
        ext.buildFeatures.buildConfig = true
      }
    }
```

```kt
  fun configureNamespaceForLibraries(project: Project) {
    project.extensions
      .getByType(LibraryAndroidComponentsExtension::class.java)
      .finalizeDsl { ext ->
        if (ext.namespace == null) {
          val manifestFile =
            project.layout.projectDirectory.file("src/main/AndroidManifest.xml").asFile
          manifestFile
            .takeIf { it.exists() }
            ?.let { file ->
              getPackageNameFromManifest(file)?.let { packageName ->
                ext.namespace = packageName
              }
            }
        }
      }
    }
```

One important note for `configureNamespaceForLibraries` is that the old `com.android.build.gradle.LibraryExtension` is deprecated in favor of `com.android.build.api.dsl.LibraryExtension` - which does not expose `manifestFile` from the `sourceSets`. So we have to define a path for it. For most libraries, this should be OK but for the ones which define custom path, this will fail.

Hence, I believe, if it's important to have this fallback, we take this tradeoff. Otherwise, since there has been 2 years passed for AGP8 adoption and the time when this fallback was added, we may safely remove this function as almost all libraries now define a `namespace` in `android { }` DSL.

With the above in place, we make one final change and that is to move these two functions inside the `withPlugin("com.android.library")` as these are only intended for libraries and that way, we also ensure that these will only be applied once the `com.android.library` plugin has been applied.

```kt
    project.pluginManager.withPlugin("com.android.library") {
      configureBuildConfigFieldsForLibraries(project)
      configureNamespaceForLibraries(project)
      configureCodegen(project, extension, rootExtension, isLibrary = true)
    }
```

</details>

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [BREAKING] - Adopt AGP v9

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- CI passes
- Verified on RN Tester
- Verified on Local RN App


https://github.com/user-attachments/assets/b424c211-6876-42b0-a5d1-f9ecade39a3a


