### PR TITLE
Add @Nullable annotations to ViewManager.measure() parameters (#57039)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -442,9 +442,9 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    */
   public long measure(
       Context context,
-      ReadableMap localData,
-      ReadableMap props,
-      ReadableMap state,
+      @Nullable ReadableMap localData,
+      @Nullable ReadableMap props,
+      @Nullable ReadableMap state,
       float width,
       YogaMeasureMode widthMode,
       float height,


### PR DESCRIPTION
Summary:

Adds `Nullable` annotations to the `localData`, `props`, and `state` parameters in `ViewManager.java`'s `measure()` method to match the nullable Kotlin types (`ReadableMap?`) from `MountingManager.kt`.

Changelog: [Android][Changed] Corrected nullability of `ViewManager#measure`

Differential Revision: D107229856


