### PR TITLE
Unify bridge and bridgeless ReactMarker implementations (#57040)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
@@ -13,13 +13,14 @@
 
 namespace facebook::react {
 
+namespace {
+const int kInstanceKey = 1;
+}
+
 void JReactMarker::setLogPerfMarkerIfNeeded() {
   static std::once_flag flag{};
   std::call_once(flag, []() {
-    std::unique_lock lock(ReactMarker::logTaggedMarkerImplMutex);
     ReactMarker::logTaggedMarkerImpl = JReactMarker::logPerfMarker;
-    ReactMarker::logTaggedMarkerBridgelessImpl =
-        JReactMarker::logPerfMarkerBridgeless;
   });
 }
 
@@ -51,21 +52,6 @@ void JReactMarker::logMarker(
 void JReactMarker::logPerfMarker(
     const ReactMarker::ReactMarkerId markerId,
     const char* tag) {
-  const int bridgeInstanceKey = 0;
-  logPerfMarkerWithInstanceKey(markerId, tag, bridgeInstanceKey);
-}
-
-void JReactMarker::logPerfMarkerBridgeless(
-    const ReactMarker::ReactMarkerId markerId,
-    const char* tag) {
-  const int bridgelessInstanceKey = 1;
-  logPerfMarkerWithInstanceKey(markerId, tag, bridgelessInstanceKey);
-}
-
-void JReactMarker::logPerfMarkerWithInstanceKey(
-    const ReactMarker::ReactMarkerId markerId,
-    const char* tag,
-    const int instanceKey) {
   switch (markerId) {
     case ReactMarker::APP_STARTUP_START:
       JReactMarker::logMarker("APP_STARTUP_START");
@@ -80,10 +66,10 @@ void JReactMarker::logPerfMarkerWithInstanceKey(
       JReactMarker::logMarker("INIT_REACT_RUNTIME_END");
       break;
     case ReactMarker::RUN_JS_BUNDLE_START:
-      JReactMarker::logMarker("RUN_JS_BUNDLE_START", tag, instanceKey);
+      JReactMarker::logMarker("RUN_JS_BUNDLE_START", tag, kInstanceKey);
       break;
     case ReactMarker::RUN_JS_BUNDLE_STOP:
-      JReactMarker::logMarker("RUN_JS_BUNDLE_END", tag, instanceKey);
+      JReactMarker::logMarker("RUN_JS_BUNDLE_END", tag, kInstanceKey);
       break;
     case ReactMarker::CREATE_REACT_CONTEXT_STOP:
       JReactMarker::logMarker("CREATE_REACT_CONTEXT_END");
@@ -95,16 +81,16 @@ void JReactMarker::logPerfMarkerWithInstanceKey(
       JReactMarker::logMarker("loadApplicationScript_endStringConvert");
       break;
     case ReactMarker::NATIVE_MODULE_SETUP_START:
-      JReactMarker::logMarker("NATIVE_MODULE_SETUP_START", tag, instanceKey);
+      JReactMarker::logMarker("NATIVE_MODULE_SETUP_START", tag, kInstanceKey);
       break;
     case ReactMarker::NATIVE_MODULE_SETUP_STOP:
-      JReactMarker::logMarker("NATIVE_MODULE_SETUP_END", tag, instanceKey);
+      JReactMarker::logMarker("NATIVE_MODULE_SETUP_END", tag, kInstanceKey);
       break;
     case ReactMarker::REGISTER_JS_SEGMENT_START:
-      JReactMarker::logMarker("REGISTER_JS_SEGMENT_START", tag, instanceKey);
+      JReactMarker::logMarker("REGISTER_JS_SEGMENT_START", tag, kInstanceKey);
       break;
     case ReactMarker::REGISTER_JS_SEGMENT_STOP:
-      JReactMarker::logMarker("REGISTER_JS_SEGMENT_STOP", tag, instanceKey);
+      JReactMarker::logMarker("REGISTER_JS_SEGMENT_STOP", tag, kInstanceKey);
       break;
     case ReactMarker::NATIVE_REQUIRE_START:
     case ReactMarker::NATIVE_REQUIRE_STOP:

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
@@ -25,8 +25,6 @@ class JReactMarker : public facebook::jni::JavaClass<JReactMarker> {
   static void logMarker(const std::string &marker, const std::string &tag);
   static void logMarker(const std::string &marker, const std::string &tag, int instanceKey);
   static void logPerfMarker(ReactMarker::ReactMarkerId markerId, const char *tag);
-  static void logPerfMarkerBridgeless(ReactMarker::ReactMarkerId markerId, const char *tag);
-  static void logPerfMarkerWithInstanceKey(ReactMarker::ReactMarkerId markerId, const char *tag, int instanceKey);
   static void nativeLogMarker(jni::alias_ref<jclass> /* unused */, const std::string &markerNameStr, jlong markerTime);
 };
 

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
@@ -9,40 +9,22 @@
 
 namespace facebook::react::ReactMarker {
 
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wglobal-constructors"
-#endif
-
-LogTaggedMarker logTaggedMarkerBridgelessImpl = nullptr;
-LogTaggedMarker logTaggedMarkerImpl = nullptr;
-std::shared_mutex logTaggedMarkerImplMutex;
-
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+AtomicLogTaggedMarker logTaggedMarkerImpl;
 
 void logMarker(const ReactMarkerId markerId) {
   logTaggedMarker(markerId, nullptr);
 }
 
 void logTaggedMarker(const ReactMarkerId markerId, const char* tag) {
-  LogTaggedMarker marker = nullptr;
-  {
-    std::shared_lock lock(logTaggedMarkerImplMutex);
-    marker = logTaggedMarkerImpl;
-  }
-  if (marker != nullptr) {
-    marker(markerId, tag);
-  }
+  logTaggedMarkerImpl(markerId, tag);
 }
 
 void logMarkerBridgeless(const ReactMarkerId markerId) {
-  logTaggedMarkerBridgeless(markerId, nullptr);
+  logTaggedMarker(markerId, nullptr);
 }
 
 void logTaggedMarkerBridgeless(const ReactMarkerId markerId, const char* tag) {
-  logTaggedMarkerBridgelessImpl(markerId, tag);
+  logTaggedMarker(markerId, tag);
 }
 
 void logMarkerDone(const ReactMarkerId markerId, double markerTime) {

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
@@ -8,11 +8,9 @@
 #pragma once
 
 #include <cmath>
-#include <shared_mutex>
-
-#ifdef __APPLE__
 #include <functional>
-#endif
+#include <mutex>
+#include <shared_mutex>
 
 namespace facebook::react::ReactMarker {
 
@@ -36,28 +34,49 @@ enum ReactMarkerId {
   REACT_INSTANCE_INIT_STOP
 };
 
-#ifdef __APPLE__
-using LogTaggedMarker = std::function<void(const ReactMarkerId, const char *tag)>; // Bridge only
-using LogTaggedMarkerBridgeless = std::function<void(const ReactMarkerId, const char *tag)>;
-#else
-typedef void (*LogTaggedMarker)(const ReactMarkerId, const char *tag); // Bridge only
-typedef void (*LogTaggedMarkerBridgeless)(const ReactMarkerId, const char *tag);
-#endif
+using LogTaggedMarker = std::function<void(ReactMarkerId, const char *tag)>;
+using LogTaggedMarkerBridgeless = LogTaggedMarker;
 
 #ifndef RN_EXPORT
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-extern RN_EXPORT std::shared_mutex logTaggedMarkerImplMutex;
-/// - important: To ensure this gets read and written to in a thread safe
-/// manner, make use of `logTaggedMarkerImplMutex`.
-extern RN_EXPORT LogTaggedMarker logTaggedMarkerImpl;
-extern RN_EXPORT LogTaggedMarker logTaggedMarkerBridgelessImpl;
+/// Thread-safe holder for a LogTaggedMarker callback. Reads and writes are
+/// internally synchronized, so callers do not need external locking.
+struct RN_EXPORT AtomicLogTaggedMarker {
+  AtomicLogTaggedMarker &operator=(LogTaggedMarker marker)
+  {
+    std::unique_lock lock(mutex_);
+    impl_ = std::move(marker);
+    return *this;
+  }
 
-extern RN_EXPORT void logMarker(ReactMarkerId markerId); // Bridge only
-extern RN_EXPORT void logTaggedMarker(ReactMarkerId markerId,
-                                      const char *tag); // Bridge only
+  explicit operator bool() const noexcept
+  {
+    std::shared_lock lock(mutex_);
+    return static_cast<bool>(impl_);
+  }
+
+  void operator()(ReactMarkerId markerId, const char *tag) const
+  {
+    std::shared_lock lock(mutex_);
+    if (impl_) {
+      impl_(markerId, tag);
+    }
+  }
+
+ private:
+  LogTaggedMarker impl_;
+  mutable std::shared_mutex mutex_;
+};
+
+extern RN_EXPORT AtomicLogTaggedMarker logTaggedMarkerImpl;
+
+extern RN_EXPORT void logMarker(ReactMarkerId markerId);
+extern RN_EXPORT void logTaggedMarker(ReactMarkerId markerId, const char *tag);
+[[deprecated("Use logMarker instead")]]
 extern RN_EXPORT void logMarkerBridgeless(ReactMarkerId markerId);
+[[deprecated("Use logTaggedMarker instead")]]
 extern RN_EXPORT void logTaggedMarkerBridgeless(ReactMarkerId markerId, const char *tag);
 
 struct ReactMarkerEvent {

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -144,25 +144,14 @@ void JSIExecutor::initializeRuntime() {
   if (runtimeInstaller_) {
     runtimeInstaller_(*runtime_);
   }
-  bool hasLogger = false;
-  {
-    std::shared_lock lock(ReactMarker::logTaggedMarkerImplMutex);
-    hasLogger = ReactMarker::logTaggedMarkerImpl != nullptr;
-  }
-  if (hasLogger) {
-    ReactMarker::logMarker(ReactMarker::CREATE_REACT_CONTEXT_STOP);
-  }
+  ReactMarker::logMarker(ReactMarker::CREATE_REACT_CONTEXT_STOP);
 }
 
 void JSIExecutor::loadBundle(
     std::unique_ptr<const JSBigString> script,
     std::string sourceURL) {
   TraceSection s("JSIExecutor::loadBundle");
-  bool hasLogger = false;
-  {
-    std::shared_lock lock(ReactMarker::logTaggedMarkerImplMutex);
-    hasLogger = ReactMarker::logTaggedMarkerImpl != nullptr;
-  }
+  bool hasLogger(ReactMarker::logTaggedMarkerImpl);
   std::string scriptName = simpleBasename(sourceURL);
   if (hasLogger) {
     ReactMarker::logTaggedMarker(

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
@@ -70,15 +70,8 @@ void JSINativeModules::reset() {
 std::optional<Object> JSINativeModules::createModule(
     Runtime& rt,
     const std::string& name) {
-  bool hasLogger = false;
-  {
-    std::shared_lock lock(ReactMarker::logTaggedMarkerImplMutex);
-    hasLogger = ReactMarker::logTaggedMarkerImpl != nullptr;
-  }
-  if (hasLogger) {
-    ReactMarker::logTaggedMarker(
-        ReactMarker::NATIVE_MODULE_SETUP_START, name.c_str());
-  }
+  ReactMarker::logTaggedMarker(
+      ReactMarker::NATIVE_MODULE_SETUP_START, name.c_str());
 
   auto result = m_moduleRegistry->getConfig(name);
   if (!result.has_value()) {
@@ -101,10 +94,8 @@ std::optional<Object> JSINativeModules::createModule(
   std::optional<Object> module(
       moduleInfo.asObject(rt).getPropertyAsObject(rt, "module"));
 
-  if (hasLogger) {
-    ReactMarker::logTaggedMarker(
-        ReactMarker::NATIVE_MODULE_SETUP_STOP, name.c_str());
-  }
+  ReactMarker::logTaggedMarker(
+      ReactMarker::NATIVE_MODULE_SETUP_STOP, name.c_str());
 
   return module;
 }

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -235,62 +235,63 @@ void ReactInstance::loadScript(
   std::shared_ptr<const jsi::Buffer> buffer(std::move(script));
   std::string scriptName = simpleBasename(sourceURL);
 
-  runtimeScheduler_->scheduleWork([jsErrorHandler = jsErrorHandler_,
-                                   scriptName,
-                                   sourceURL,
-                                   buffer = std::move(buffer),
-                                   weakBufferedRuntimeExecuter =
-                                       std::weak_ptr<BufferedRuntimeExecutor>(
-                                           bufferedRuntimeExecutor_),
-                                   beforeLoad,
-                                   afterLoad](jsi::Runtime& runtime) mutable {
-    if (beforeLoad) {
-      beforeLoad(runtime);
-    }
-    TraceSection s("ReactInstance::loadScript");
-    bool hasLogger(ReactMarker::logTaggedMarkerBridgelessImpl != nullptr);
-    if (hasLogger) {
-      ReactMarker::logTaggedMarkerBridgeless(
-          ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());
-      ReactMarker::logMarkerBridgeless(ReactMarker::INIT_REACT_RUNTIME_START);
-      ReactMarker::logMarkerBridgeless(ReactMarker::APP_STARTUP_START);
-    }
+  runtimeScheduler_->scheduleWork(
+      [jsErrorHandler = jsErrorHandler_,
+       scriptName,
+       sourceURL = sourceURL,
+       buffer = std::move(buffer),
+       weakBufferedRuntimeExecuter =
+           std::weak_ptr<BufferedRuntimeExecutor>(bufferedRuntimeExecutor_),
+       beforeLoad,
+       afterLoad](jsi::Runtime& runtime) mutable {
+        if (beforeLoad) {
+          beforeLoad(runtime);
+        }
+        TraceSection s("ReactInstance::loadScript");
+        bool hasLogger(ReactMarker::logTaggedMarkerImpl);
+        if (hasLogger) {
+          ReactMarker::logTaggedMarker(
+              ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());
+          ReactMarker::logMarker(ReactMarker::INIT_REACT_RUNTIME_START);
+          ReactMarker::logMarker(ReactMarker::APP_STARTUP_START);
+        }
 
-    // Check if the shermes unit is avaliable.
-    auto* shUnitAPI = jsi::castInterface<hermes::IHermesSHUnit>(&runtime);
-    auto* shUnitCreator = shUnitAPI ? shUnitAPI->getSHUnitCreator() : nullptr;
-    if (shUnitCreator) {
-      LOG(WARNING) << "ReactInstance: evaluateSHUnit";
-      auto* hermesAPI = jsi::castInterface<hermes::IHermes>(&runtime);
-      hermesAPI->evaluateSHUnit(shUnitCreator);
-    } else {
-      LOG(WARNING) << "ReactInstance: evaluateJavaScript() with JS bundle";
-      runtime.evaluateJavaScript(buffer, sourceURL);
-    }
+        // Check if the shermes unit is avaliable.
+        auto* shUnitAPI = jsi::castInterface<hermes::IHermesSHUnit>(&runtime);
+        auto* shUnitCreator =
+            shUnitAPI ? shUnitAPI->getSHUnitCreator() : nullptr;
+        if (shUnitCreator) {
+          LOG(WARNING) << "ReactInstance: evaluateSHUnit";
+          auto* hermesAPI = jsi::castInterface<hermes::IHermes>(&runtime);
+          hermesAPI->evaluateSHUnit(shUnitCreator);
+        } else {
+          LOG(WARNING) << "ReactInstance: evaluateJavaScript() with JS bundle";
+          runtime.evaluateJavaScript(buffer, sourceURL);
+        }
 
-    /**
-     * TODO(T183610671): We need a safe/reliable way to enable the js
-     * pipeline from javascript. Remove this after we figure that out, or
-     * after we just remove the js pipeline.
-     */
-    if (!jsErrorHandler->hasHandledFatalError()) {
-      jsErrorHandler->setRuntimeReady();
-    }
+        /**
+         * TODO(T183610671): We need a safe/reliable way to enable the js
+         * pipeline from javascript. Remove this after we figure that out, or
+         * after we just remove the js pipeline.
+         */
+        if (!jsErrorHandler->hasHandledFatalError()) {
+          jsErrorHandler->setRuntimeReady();
+        }
 
-    if (hasLogger) {
-      ReactMarker::logTaggedMarkerBridgeless(
-          ReactMarker::RUN_JS_BUNDLE_STOP, scriptName.c_str());
-      ReactMarker::logMarkerBridgeless(ReactMarker::INIT_REACT_RUNTIME_STOP);
-      ReactMarker::logMarkerBridgeless(ReactMarker::APP_STARTUP_STOP);
-    }
-    if (auto strongBufferedRuntimeExecuter =
-            weakBufferedRuntimeExecuter.lock()) {
-      strongBufferedRuntimeExecuter->flush();
-    }
-    if (afterLoad) {
-      afterLoad(runtime);
-    }
-  });
+        if (hasLogger) {
+          ReactMarker::logTaggedMarker(
+              ReactMarker::RUN_JS_BUNDLE_STOP, scriptName.c_str());
+          ReactMarker::logMarker(ReactMarker::INIT_REACT_RUNTIME_STOP);
+          ReactMarker::logMarker(ReactMarker::APP_STARTUP_STOP);
+        }
+        if (auto strongBufferedRuntimeExecuter =
+                weakBufferedRuntimeExecuter.lock()) {
+          strongBufferedRuntimeExecuter->flush();
+        }
+        if (afterLoad) {
+          afterLoad(runtime);
+        }
+      });
 }
 
 /*
@@ -369,21 +370,16 @@ void ReactInstance::registerSegment(
           "Empty segment registered with ID " + tag + " from " + segmentPath);
     }
 
-    bool hasLogger(ReactMarker::logTaggedMarkerBridgelessImpl != nullptr);
-    if (hasLogger) {
-      ReactMarker::logTaggedMarkerBridgeless(
-          ReactMarker::REGISTER_JS_SEGMENT_START, tag.c_str());
-    }
+    ReactMarker::logTaggedMarker(
+        ReactMarker::REGISTER_JS_SEGMENT_START, tag.c_str());
     LOG(WARNING) << "Starting to evaluate segment " << segmentId
                  << " in ReactInstance::registerSegment";
     runtime.evaluateJavaScript(
         std::move(script), getSyntheticBundlePath(segmentId));
     LOG(WARNING) << "Finished evaluating segment " << segmentId
                  << " in ReactInstance::registerSegment";
-    if (hasLogger) {
-      ReactMarker::logTaggedMarkerBridgeless(
-          ReactMarker::REGISTER_JS_SEGMENT_STOP, tag.c_str());
-    }
+    ReactMarker::logTaggedMarker(
+        ReactMarker::REGISTER_JS_SEGMENT_STOP, tag.c_str());
   });
 }
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTPerformanceLoggerUtils.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTPerformanceLoggerUtils.mm
@@ -67,8 +67,9 @@ static void mapReactMarkerToPerformanceLogger(
 void registerPerformanceLoggerHooks(RCTPerformanceLogger *performanceLogger)
 {
   __weak RCTPerformanceLogger *weakPerformanceLogger = performanceLogger;
-  ReactMarker::logTaggedMarkerBridgelessImpl = [weakPerformanceLogger](
-                                                   const ReactMarker::ReactMarkerId markerId, const char *tag) {
+  ReactMarker::logTaggedMarkerImpl = [weakPerformanceLogger](
+                                         const ReactMarker::ReactMarkerId markerId, const char *tag) {
+    (void)tag;
     mapReactMarkerToPerformanceLogger(markerId, weakPerformanceLogger);
   };
 }

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -11709,16 +11709,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -11752,15 +11754,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -11347,16 +11347,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -11390,15 +11392,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -11562,16 +11562,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -11605,15 +11607,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -13541,16 +13541,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -13584,15 +13586,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -13241,16 +13241,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -13284,15 +13286,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -13404,16 +13404,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -13447,15 +13449,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -8694,16 +8694,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -8737,15 +8739,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -8534,16 +8534,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -8577,15 +8579,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -8685,16 +8685,18 @@ struct facebook::react::map_detail::Bridging {
 }
 
 
-typedef void(*facebook::react::ReactMarker::LogTaggedMarker)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
-typedef void(*facebook::react::ReactMarker::LogTaggedMarkerBridgeless)(const facebook::react::ReactMarker::ReactMarkerId, const char *tag);
+uint64_t facebook::react::oscompat::getCurrentProcessId();
+uint64_t facebook::react::oscompat::getCurrentThreadId();
+
+
+using facebook::react::ReactMarker::LogTaggedMarker = std::function<void(facebook::react::ReactMarker::ReactMarkerId, const char* tag)>;
+using facebook::react::ReactMarker::LogTaggedMarkerBridgeless = facebook::react::ReactMarker::LogTaggedMarker;
 void facebook::react::ReactMarker::logMarker(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId);
 void facebook::react::ReactMarker::logMarkerDone(facebook::react::ReactMarker::ReactMarkerId markerId, double markerTime);
 void facebook::react::ReactMarker::logTaggedMarker(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
 void facebook::react::ReactMarker::logTaggedMarkerBridgeless(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag);
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerBridgelessImpl;
-facebook::react::ReactMarker::LogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
-std::shared_mutex facebook::react::ReactMarker::logTaggedMarkerImplMutex;
+facebook::react::ReactMarker::AtomicLogTaggedMarker facebook::react::ReactMarker::logTaggedMarkerImpl;
 
 class facebook::react::ReactMarker::StartupLogger {
   public double getAppStartupEndTime();
@@ -8728,15 +8730,17 @@ enum facebook::react::ReactMarker::ReactMarkerId {
   RUN_JS_BUNDLE_STOP,
 }
 
+struct facebook::react::ReactMarker::AtomicLogTaggedMarker {
+  public facebook::react::ReactMarker::AtomicLogTaggedMarker& operator=(facebook::react::ReactMarker::LogTaggedMarker marker);
+  public operator bool() const noexcept;
+  public void operator()(facebook::react::ReactMarker::ReactMarkerId markerId, const char* tag) const;
+}
+
 struct facebook::react::ReactMarker::ReactMarkerEvent {
   public const char* tag;
   public const facebook::react::ReactMarker::ReactMarkerId markerId;
   public double time;
 }
-
-
-uint64_t facebook::react::oscompat::getCurrentProcessId();
-uint64_t facebook::react::oscompat::getCurrentThreadId();
 
 
 void facebook::react::BridgeNativeModulePerfLogger::asyncMethodCallArgConversionEnd(const char* moduleName, const char* methodName);


### PR DESCRIPTION
Summary:

The split between `logTaggedMarkerImpl` and `logTaggedMarkerBridgelessImpl` no longer earns its keep — bridgeless callers always pass the same instance key, and the bridge mode is on its way out. Collapse the two paths into a single hook so platform code only has to wire up one slot.

`LogTaggedMarkerBridgeless` becomes a type alias for `LogTaggedMarker`. The free `logMarkerBridgeless` / `logTaggedMarkerBridgeless` functions stay around as `[[deprecated]]` shims that forward to the unified path, but the `logTaggedMarkerBridgelessImpl` registration slot is removed entirely — external writers should assign to `logTaggedMarkerImpl` instead. Call-sites in `ReactInstance` switch to the unified `logMarker` / `logTaggedMarker`. On the Android side, `logPerfMarkerBridgeless` and the `logPerfMarkerWithInstanceKey` indirection go away — there's only one instance key now.

`logTaggedMarkerImpl` is also reshaped into a small `AtomicLogTaggedMarker` wrapper so reads and writes synchronize internally and callers no longer need to lock around it; the standalone `logTaggedMarkerImplMutex` goes away.

Changelog:
[General][Breaking] - Remove `logTaggedMarkerBridgelessImpl`; assign callbacks to `logTaggedMarkerImpl` instead
[General][Deprecated] - Deprecate `logMarkerBridgeless` and `logTaggedMarkerBridgeless` in favor of `logMarker` and `logTaggedMarker`

Reviewed By: mdvacca

Differential Revision: D88068665


