### PR TITLE
Make constructors of internal DOM, MutationObserver, and IntersectionObserver classes throw

### DIFF
--- a/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-Globals-IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-Globals-IntersectionObserver-itest.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @fantom_flags enableIntersectionObserverByDefault:*
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
+
+declare var IntersectionObserverEntry: unknown;
+
+// TODO: Merge into `setUpDefaultReactNativeEnvironment-Globals-itest.js` once
+// the `enableIntersectionObserverByDefault` feature flag is cleaned up and the
+// IntersectionObserver globals are exposed unconditionally.
+describe('setUpDefaultReactNativeEnvironment (IntersectionObserver globals)', () => {
+  if (ReactNativeFeatureFlags.enableIntersectionObserverByDefault()) {
+    describe('when enableIntersectionObserverByDefault is enabled', () => {
+      it('should provide IntersectionObserver', () => {
+        expect(typeof IntersectionObserver).toBe('function');
+      });
+
+      it('should provide IntersectionObserverEntry', () => {
+        expect(typeof IntersectionObserverEntry).toBe('function');
+      });
+    });
+  } else {
+    describe('when enableIntersectionObserverByDefault is disabled', () => {
+      it('should not provide IntersectionObserver', () => {
+        expect(typeof IntersectionObserver).toBe('undefined');
+      });
+
+      it('should not provide IntersectionObserverEntry', () => {
+        expect(typeof IntersectionObserverEntry).toBe('undefined');
+      });
+    });
+  }
+});

--- a/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-Globals-MutationObserver-itest.js
+++ b/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-Globals-MutationObserver-itest.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @fantom_flags enableMutationObserverByDefault:*
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
+
+declare var MutationRecord: unknown;
+
+// TODO: Merge into `setUpDefaultReactNativeEnvironment-Globals-itest.js` once
+// the `enableMutationObserverByDefault` feature flag is cleaned up and the
+// MutationObserver globals are exposed unconditionally.
+describe('setUpDefaultReactNativeEnvironment (MutationObserver globals)', () => {
+  if (ReactNativeFeatureFlags.enableMutationObserverByDefault()) {
+    describe('when enableMutationObserverByDefault is enabled', () => {
+      it('should provide MutationObserver', () => {
+        expect(typeof MutationObserver).toBe('function');
+      });
+
+      it('should provide MutationRecord', () => {
+        expect(typeof MutationRecord).toBe('function');
+      });
+    });
+  } else {
+    describe('when enableMutationObserverByDefault is disabled', () => {
+      it('should not provide MutationObserver', () => {
+        expect(typeof MutationObserver).toBe('undefined');
+      });
+
+      it('should not provide MutationRecord', () => {
+        expect(typeof MutationRecord).toBe('undefined');
+      });
+    });
+  }
+});

--- a/packages/react-native/src/private/setup/setUpDOM.js
+++ b/packages/react-native/src/private/setup/setUpDOM.js
@@ -31,47 +31,57 @@ export default function setUpDOM() {
 
   polyfillGlobal(
     'DOMRectList',
-    () => require('../webapis/geometry/DOMRectList').default,
+    () => require('../webapis/geometry/DOMRectList').DOMRectList_public,
   );
 
   polyfillGlobal(
     'HTMLCollection',
-    () => require('../webapis/dom/oldstylecollections/HTMLCollection').default,
+    () =>
+      require('../webapis/dom/oldstylecollections/HTMLCollection')
+        .HTMLCollection_public,
   );
 
   polyfillGlobal(
     'NodeList',
-    () => require('../webapis/dom/oldstylecollections/NodeList').default,
+    () =>
+      require('../webapis/dom/oldstylecollections/NodeList').NodeList_public,
   );
 
   polyfillGlobal(
     'Node',
-    () => require('../webapis/dom/nodes/ReadOnlyNode').default,
+    () => require('../webapis/dom/nodes/ReadOnlyNode').ReadOnlyNode_public,
   );
 
   polyfillGlobal(
     'Document',
-    () => require('../webapis/dom/nodes/ReactNativeDocument').default,
+    () =>
+      require('../webapis/dom/nodes/ReactNativeDocument')
+        .ReactNativeDocument_public,
   );
 
   polyfillGlobal(
     'CharacterData',
-    () => require('../webapis/dom/nodes/ReadOnlyCharacterData').default,
+    () =>
+      require('../webapis/dom/nodes/ReadOnlyCharacterData')
+        .ReadOnlyCharacterData_public,
   );
 
   polyfillGlobal(
     'Text',
-    () => require('../webapis/dom/nodes/ReadOnlyText').default,
+    () => require('../webapis/dom/nodes/ReadOnlyText').ReadOnlyText_public,
   );
 
   polyfillGlobal(
     'Element',
-    () => require('../webapis/dom/nodes/ReadOnlyElement').default,
+    () =>
+      require('../webapis/dom/nodes/ReadOnlyElement').ReadOnlyElement_public,
   );
 
   polyfillGlobal(
     'HTMLElement',
-    () => require('../webapis/dom/nodes/ReactNativeElement').default,
+    () =>
+      require('../webapis/dom/nodes/ReactNativeElement')
+        .ReactNativeElement_public,
   );
 
   polyfillGlobal('Event', () => require('../webapis/dom/events/Event').default);

--- a/packages/react-native/src/private/setup/setUpIntersectionObserver.js
+++ b/packages/react-native/src/private/setup/setUpIntersectionObserver.js
@@ -24,4 +24,11 @@ export default function setUpIntersectionObserver() {
     () =>
       require('../webapis/intersectionobserver/IntersectionObserver').default,
   );
+
+  polyfillGlobal(
+    'IntersectionObserverEntry',
+    () =>
+      require('../webapis/intersectionobserver/IntersectionObserverEntry')
+        .IntersectionObserverEntry_public,
+  );
 }

--- a/packages/react-native/src/private/setup/setUpMutationObserver.js
+++ b/packages/react-native/src/private/setup/setUpMutationObserver.js
@@ -26,6 +26,8 @@ export default function setUpMutationObserver() {
 
   polyfillGlobal(
     'MutationRecord',
-    () => require('../webapis/mutationobserver/MutationRecord').default,
+    () =>
+      require('../webapis/mutationobserver/MutationRecord')
+        .MutationRecord_public,
   );
 }

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
@@ -139,3 +139,14 @@ export function createReactNativeDocument(
   const document = new ReactNativeDocument(rootTag, instanceHandle);
   return document;
 }
+
+export const ReactNativeDocument_public: typeof ReactNativeDocument =
+  // $FlowExpectedError[incompatible-type]
+  function Document() {
+    throw new TypeError(
+      "Failed to construct 'Document': Nodes cannot be imperatively created in React Native",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+ReactNativeDocument_public.prototype = ReactNativeDocument.prototype;

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
@@ -292,3 +292,14 @@ function replaceConstructorWithoutSuper(
 export default replaceConstructorWithoutSuper(
   ReactNativeElement,
 ) as typeof ReactNativeElement;
+
+export const ReactNativeElement_public: typeof ReactNativeElement =
+  // $FlowExpectedError[incompatible-type]
+  function HTMLElement() {
+    throw new TypeError(
+      "Failed to construct 'HTMLElement': Nodes cannot be imperatively created in React Native",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+ReactNativeElement_public.prototype = ReactNativeElement.prototype;

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
@@ -70,3 +70,14 @@ export default class ReadOnlyCharacterData extends ReadOnlyNode {
     return data.slice(offset, offset + adjustedCount);
   }
 }
+
+export const ReadOnlyCharacterData_public: typeof ReadOnlyCharacterData =
+  // $FlowExpectedError[incompatible-type]
+  function CharacterData() {
+    throw new TypeError(
+      "Failed to construct 'CharacterData': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+ReadOnlyCharacterData_public.prototype = ReadOnlyCharacterData.prototype;

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
@@ -245,3 +245,12 @@ export function getBoundingClientRect(
   // Empty rect if any of the above failed
   return new DOMRect(0, 0, 0, 0);
 }
+
+export const ReadOnlyElement_public: typeof ReadOnlyElement =
+  // $FlowExpectedError[incompatible-type]
+  function Element() {
+    throw new TypeError("Failed to construct 'Element': Illegal constructor");
+  };
+
+// $FlowExpectedError[prop-missing]
+ReadOnlyElement_public.prototype = ReadOnlyElement.prototype;

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
@@ -371,6 +371,21 @@ export default replaceConstructorWithoutSuper(
   ReadOnlyNode,
 ) as typeof ReadOnlyNode;
 
+export const ReadOnlyNode_public: typeof ReadOnlyNode =
+  // $FlowExpectedError[incompatible-type]
+  function Node() {
+    throw new TypeError("Failed to construct 'Node': Illegal constructor");
+  };
+
+// $FlowExpectedError[prop-missing]
+ReadOnlyNode_public.prototype = ReadOnlyNode.prototype;
+// Copy static properties (ELEMENT_NODE, DOCUMENT_NODE, TEXT_NODE,
+// DOCUMENT_POSITION_*, etc.) so that callers accessing them via the public
+// constructor (e.g. `Node.ELEMENT_NODE`) still work.
+// $FlowFixMe[unsafe-object-assign]
+// $FlowFixMe[not-an-object]
+Object.assign(ReadOnlyNode_public, ReadOnlyNode);
+
 // Temporary type until we ship ReadOnlyNode extending EventTarget ungated.
 export type ReadOnlyNodeWithEventTarget = ReadOnlyNode & EventTarget;
 

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyText.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyText.js
@@ -28,3 +28,14 @@ export default class ReadOnlyText extends ReadOnlyCharacterData {
     return ReadOnlyNode.TEXT_NODE;
   }
 }
+
+export const ReadOnlyText_public: typeof ReadOnlyText =
+  // $FlowExpectedError[incompatible-type]
+  function Text() {
+    throw new TypeError(
+      "Failed to construct 'Text': Nodes cannot be imperatively created in React Native",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+ReadOnlyText_public.prototype = ReadOnlyText.prototype;

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -308,4 +308,12 @@ describe('ReactNativeDocument', () => {
       expect(document.getElementById('baz')).toBe(null);
     });
   });
+
+  describe('global constructor', () => {
+    it('throws when called', () => {
+      expect(() => new Document()).toThrow(
+        "Failed to construct 'Document': Nodes cannot be imperatively created in React Native",
+      );
+    });
+  });
 });

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -1631,4 +1631,18 @@ describe('ReactNativeElement', () => {
       });
     });
   });
+
+  describe('global constructors', () => {
+    it('throws when constructing HTMLElement', () => {
+      expect(() => new HTMLElement()).toThrow(
+        "Failed to construct 'HTMLElement': Nodes cannot be imperatively created in React Native",
+      );
+    });
+
+    it('throws when constructing Element', () => {
+      expect(() => new Element()).toThrow(
+        "Failed to construct 'Element': Illegal constructor",
+      );
+    });
+  });
 });

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
@@ -331,4 +331,69 @@ describe('ReadOnlyText', () => {
       });
     });
   });
+
+  describe('global constructors', () => {
+    it('throws when constructing Text', () => {
+      expect(() => new Text()).toThrow(
+        "Failed to construct 'Text': Nodes cannot be imperatively created in React Native",
+      );
+    });
+
+    it('throws when constructing CharacterData', () => {
+      expect(() => new CharacterData()).toThrow(
+        "Failed to construct 'CharacterData': Illegal constructor",
+      );
+    });
+
+    it('throws when constructing Node', () => {
+      expect(() => new Node()).toThrow(
+        "Failed to construct 'Node': Illegal constructor",
+      );
+    });
+
+    it('public stubs preserve `instanceof` against real instances', () => {
+      // The public stubs alias their prototype to the real class so that
+      // `instanceof` against the global still works for instances obtained
+      // from refs/observer callbacks.
+      const parentNodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+
+      Fantom.runTask(() => {
+        root.render(<NativeText ref={parentNodeRef}>Some text</NativeText>);
+      });
+
+      const parentNode = ensureReadOnlyNode(parentNodeRef.current);
+      const textNode = parentNode.childNodes[0];
+
+      expect(textNode instanceof Node).toBe(true);
+      expect(textNode instanceof CharacterData).toBe(true);
+      expect(textNode instanceof Text).toBe(true);
+    });
+  });
+
+  describe('Node static constants on the global', () => {
+    // The public `Node` stub also exposes the node-type and document-position
+    // constants from the spec so callers can read them off the global.
+    it('exposes node-type constants', () => {
+      expect(Node.ELEMENT_NODE).toBe(1);
+      expect(Node.ATTRIBUTE_NODE).toBe(2);
+      expect(Node.TEXT_NODE).toBe(3);
+      expect(Node.CDATA_SECTION_NODE).toBe(4);
+      expect(Node.PROCESSING_INSTRUCTION_NODE).toBe(7);
+      expect(Node.COMMENT_NODE).toBe(8);
+      expect(Node.DOCUMENT_NODE).toBe(9);
+      expect(Node.DOCUMENT_TYPE_NODE).toBe(10);
+      expect(Node.DOCUMENT_FRAGMENT_NODE).toBe(11);
+    });
+
+    it('exposes document-position constants', () => {
+      expect(Node.DOCUMENT_POSITION_DISCONNECTED).toBe(1);
+      expect(Node.DOCUMENT_POSITION_PRECEDING).toBe(2);
+      expect(Node.DOCUMENT_POSITION_FOLLOWING).toBe(4);
+      expect(Node.DOCUMENT_POSITION_CONTAINS).toBe(8);
+      expect(Node.DOCUMENT_POSITION_CONTAINED_BY).toBe(16);
+      expect(Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC).toBe(32);
+    });
+  });
 });

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection.js
@@ -86,3 +86,15 @@ export function createHTMLCollection<T>(
 ): HTMLCollection<T> {
   return new HTMLCollection(elements);
 }
+
+export const HTMLCollection_public: typeof HTMLCollection =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function HTMLCollection() {
+    throw new TypeError(
+      "Failed to construct 'HTMLCollection': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+HTMLCollection_public.prototype = HTMLCollection.prototype;

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection.js.flow
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection.js.flow
@@ -27,3 +27,5 @@ declare export default class HTMLCollection<+T>
 declare export function createHTMLCollection<T>(
   elements: ReadonlyArray<T>,
 ): HTMLCollection<T>;
+
+declare export var HTMLCollection_public: typeof HTMLCollection;

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js
@@ -108,3 +108,13 @@ setPlatformObject(NodeList);
 export function createNodeList<T>(elements: ReadonlyArray<T>): NodeList<T> {
   return new NodeList(elements);
 }
+
+export const NodeList_public: typeof NodeList =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function NodeList() {
+    throw new TypeError("Failed to construct 'NodeList': Illegal constructor");
+  };
+
+// $FlowExpectedError[prop-missing]
+NodeList_public.prototype = NodeList.prototype;

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js.flow
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js.flow
@@ -32,3 +32,5 @@ declare export default class NodeList<+T> implements Iterable<T>, ArrayLike<T> {
 declare export function createNodeList<T>(
   elements: ReadonlyArray<T>,
 ): NodeList<T>;
+
+declare export var NodeList_public: typeof NodeList;

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/HTMLCollection-itest.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/HTMLCollection-itest.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
 import {createHTMLCollection} from '../HTMLCollection';
 
 describe('HTMLCollection', () => {
@@ -37,15 +39,23 @@ describe('HTMLCollection', () => {
 
     const collection = createHTMLCollection(['a', 'b', 'c']);
 
-    expect(() => {
+    let writeIndexError;
+    try {
       collection[0] = 'replacement';
-    }).toThrow(TypeError);
+    } catch (e) {
+      writeIndexError = e;
+    }
+    expect(writeIndexError).toBeInstanceOf(TypeError);
     expect(collection[0]).toBe('a');
 
-    expect(() => {
+    let writeLengthError;
+    try {
       // $FlowExpectedError[cannot-write]
       collection.length = 100;
-    }).toThrow(TypeError);
+    } catch (e) {
+      writeLengthError = e;
+    }
+    expect(writeLengthError).toBeInstanceOf(TypeError);
     expect(collection.length).toBe(3);
   });
 
@@ -74,6 +84,14 @@ describe('HTMLCollection', () => {
       expect(collection.item(1)).toBe('b');
       expect(collection.item(2)).toBe('c');
       expect(collection.item(3)).toBe(null);
+    });
+  });
+
+  describe('global constructor', () => {
+    it('throws when called', () => {
+      expect(() => new HTMLCollection()).toThrow(
+        "Failed to construct 'HTMLCollection': Illegal constructor",
+      );
     });
   });
 });

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/NodeList-itest.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/NodeList-itest.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
 import {createNodeList} from '../NodeList';
 
 describe('NodeList', () => {
@@ -46,15 +48,23 @@ describe('NodeList', () => {
 
     const collection = createNodeList(['a', 'b', 'c']);
 
-    expect(() => {
+    let writeIndexError;
+    try {
       collection[0] = 'replacement';
-    }).toThrow(TypeError);
+    } catch (e) {
+      writeIndexError = e;
+    }
+    expect(writeIndexError).toBeInstanceOf(TypeError);
     expect(collection[0]).toBe('a');
 
-    expect(() => {
+    let writeLengthError;
+    try {
       // $FlowExpectedError[cannot-write]
       collection.length = 100;
-    }).toThrow(TypeError);
+    } catch (e) {
+      writeLengthError = e;
+    }
+    expect(writeLengthError).toBeInstanceOf(TypeError);
     expect(collection.length).toBe(3);
   });
 
@@ -83,7 +93,7 @@ describe('NodeList', () => {
       expect(keys.next()).toEqual({value: 0, done: false});
       expect(keys.next()).toEqual({value: 1, done: false});
       expect(keys.next()).toEqual({value: 2, done: false});
-      expect(keys.next()).toEqual({done: true});
+      expect(keys.next()).toEqual({value: undefined, done: true});
 
       let i = 0;
       for (const key of collection.keys()) {
@@ -101,7 +111,7 @@ describe('NodeList', () => {
       expect(values.next()).toEqual({value: 'a', done: false});
       expect(values.next()).toEqual({value: 'b', done: false});
       expect(values.next()).toEqual({value: 'c', done: false});
-      expect(values.next()).toEqual({done: true});
+      expect(values.next()).toEqual({value: undefined, done: true});
 
       let i = 0;
       for (const value of collection.values()) {
@@ -119,7 +129,7 @@ describe('NodeList', () => {
       expect(entries.next()).toEqual({value: [0, 'a'], done: false});
       expect(entries.next()).toEqual({value: [1, 'b'], done: false});
       expect(entries.next()).toEqual({value: [2, 'c'], done: false});
-      expect(entries.next()).toEqual({done: true});
+      expect(entries.next()).toEqual({value: undefined, done: true});
 
       let i = 0;
       for (const entry of collection.entries()) {
@@ -155,6 +165,14 @@ describe('NodeList', () => {
         expect(this).toBe(explicitThis);
         i++;
       }, explicitThis);
+    });
+  });
+
+  describe('global constructor', () => {
+    it('throws when called', () => {
+      expect(() => new NodeList()).toThrow(
+        "Failed to construct 'NodeList': Illegal constructor",
+      );
     });
   });
 });

--- a/packages/react-native/src/private/webapis/geometry/DOMRectList.js
+++ b/packages/react-native/src/private/webapis/geometry/DOMRectList.js
@@ -77,3 +77,15 @@ export function createDOMRectList(
 ): DOMRectList {
   return new DOMRectList(elements);
 }
+
+export const DOMRectList_public: typeof DOMRectList =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function DOMRectList() {
+    throw new TypeError(
+      "Failed to construct 'DOMRectList': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+DOMRectList_public.prototype = DOMRectList.prototype;

--- a/packages/react-native/src/private/webapis/geometry/DOMRectList.js.flow
+++ b/packages/react-native/src/private/webapis/geometry/DOMRectList.js.flow
@@ -25,3 +25,5 @@ declare export default class DOMRectList
 declare export function createDOMRectList(
   domRects: ReadonlyArray<DOMRectReadOnly>,
 ): DOMRectList;
+
+declare export var DOMRectList_public: typeof DOMRectList;

--- a/packages/react-native/src/private/webapis/geometry/__tests__/DOMRectList-itest.js
+++ b/packages/react-native/src/private/webapis/geometry/__tests__/DOMRectList-itest.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
 import {createDOMRectList} from '../DOMRectList';
 import DOMRectReadOnly from '../DOMRectReadOnly';
 
@@ -42,15 +44,23 @@ describe('DOMRectList', () => {
 
     const collection = createDOMRectList([domRectA, domRectB, domRectC]);
 
-    expect(() => {
+    let writeIndexError;
+    try {
       collection[0] = new DOMRectReadOnly();
-    }).toThrow(TypeError);
+    } catch (e) {
+      writeIndexError = e;
+    }
+    expect(writeIndexError).toBeInstanceOf(TypeError);
     expect(collection[0]).toBe(domRectA);
 
-    expect(() => {
+    let writeLengthError;
+    try {
       // $FlowExpectedError[cannot-write]
       collection.length = 100;
-    }).toThrow(TypeError);
+    } catch (e) {
+      writeLengthError = e;
+    }
+    expect(writeLengthError).toBeInstanceOf(TypeError);
     expect(collection.length).toBe(3);
   });
 
@@ -79,6 +89,14 @@ describe('DOMRectList', () => {
       expect(collection.item(1)).toBe(domRectB);
       expect(collection.item(2)).toBe(domRectC);
       expect(collection.item(3)).toBe(null);
+    });
+  });
+
+  describe('global constructor', () => {
+    it('throws when called', () => {
+      expect(() => new DOMRectList()).toThrow(
+        "Failed to construct 'DOMRectList': Illegal constructor",
+      );
     });
   });
 });

--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry.js
@@ -168,3 +168,16 @@ export function createIntersectionObserverEntry(
 ): IntersectionObserverEntry {
   return new IntersectionObserverEntry(entry, target);
 }
+
+export const IntersectionObserverEntry_public: typeof IntersectionObserverEntry =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function IntersectionObserverEntry() {
+    throw new TypeError(
+      "Failed to construct 'IntersectionObserverEntry': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+IntersectionObserverEntry_public.prototype =
+  IntersectionObserverEntry.prototype;

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -12,6 +12,7 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 import type IntersectionObserverType from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserver';
+import type IntersectionObserverEntryType from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry';
 
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import {createShadowNodeReferenceCountingRef} from '../../../__tests__/utilities/ShadowNodeReferenceCounter';
@@ -22,9 +23,9 @@ import {ScrollView, View} from 'react-native';
 import setUpIntersectionObserver from 'react-native/src/private/setup/setUpIntersectionObserver';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 import DOMRectReadOnly from 'react-native/src/private/webapis/geometry/DOMRectReadOnly';
-import IntersectionObserverEntry from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry';
 
 declare const IntersectionObserver: Class<IntersectionObserverType>;
+declare const IntersectionObserverEntry: Class<IntersectionObserverEntryType>;
 
 setUpIntersectionObserver();
 
@@ -4275,6 +4276,20 @@ describe('IntersectionObserver', () => {
           expect(intersectionObserverCallback).toHaveBeenCalledTimes(0);
         });
       });
+    });
+  });
+
+  describe('IntersectionObserverEntry global constructor', () => {
+    it('throws when called', () => {
+      expect(
+        () =>
+          // The public stub throws regardless of arguments; the real class
+          // requires two so Flow needs a suppression here.
+          // $FlowExpectedError[incompatible-type]
+          new IntersectionObserverEntry(),
+      ).toThrow(
+        "Failed to construct 'IntersectionObserverEntry': Illegal constructor",
+      );
     });
   });
 });

--- a/packages/react-native/src/private/webapis/mutationobserver/MutationRecord.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/MutationRecord.js
@@ -83,3 +83,15 @@ export function createMutationRecord(
 ): MutationRecord {
   return new MutationRecord(entry);
 }
+
+export const MutationRecord_public: typeof MutationRecord =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function MutationRecord() {
+    throw new TypeError(
+      "Failed to construct 'MutationRecord': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+MutationRecord_public.prototype = MutationRecord.prototype;

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -928,4 +928,16 @@ describe('MutationObserver', () => {
       }).not.toThrow();
     });
   });
+
+  describe('MutationRecord global constructor', () => {
+    it('throws when called', () => {
+      expect(
+        () =>
+          // The public stub throws regardless of arguments; the real class
+          // requires one so Flow needs a suppression here.
+          // $FlowExpectedError[incompatible-type]
+          new MutationRecord(),
+      ).toThrow("Failed to construct 'MutationRecord': Illegal constructor");
+    });
+  });
 });


### PR DESCRIPTION
Summary:
Several Web API classes exposed globally by React Native are not meant to be constructed from userland. They fall into two groups:

- Classes whose web spec constructors are illegal regardless of platform: `Node`, `Element`, `CharacterData`, `HTMLCollection`, `NodeList`, `DOMRectList`, `IntersectionObserverEntry`, `MutationRecord`. The web platform itself throws an "Illegal constructor" `TypeError` for these.
- Classes whose web spec constructors are public, but whose React Native implementations cannot be constructed from userland because nodes cannot be imperatively created in React Native — only React can create them during rendering. These are `Document`, `Text`, and `HTMLElement`.

Apply the same `_public` pattern already in use under `setUpPerformanceModern` to these classes: export a constructor stub that throws a `TypeError`, with its `prototype` aliased to the real class so that `instanceof` checks against the global still work. Internal code continues to use the real class via the default export.

For the first group the thrown message follows the web convention, e.g.:

  TypeError: Failed to construct 'Node': Illegal constructor

For the second group the message clarifies the React-Native-specific reason, e.g.:

  TypeError: Failed to construct 'Document': Nodes cannot be imperatively created in React Native

The following classes get a `_public` export and are now polyfilled through it in their corresponding setup file:

- `setUpDOM`: `DOMRectList`, `HTMLCollection`, `NodeList`, `Node` (`ReadOnlyNode`), `Document` (`ReactNativeDocument`), `CharacterData` (`ReadOnlyCharacterData`), `Text` (`ReadOnlyText`), `Element` (`ReadOnlyElement`), `HTMLElement` (`ReactNativeElement`).
- `setUpMutationObserver`: `MutationRecord`.
- `setUpIntersectionObserver`: `IntersectionObserverEntry` (also newly added to the setup file — it was not being exposed globally before).

For `Node`, the public stub also copies the static node-type and document-position constants (`ELEMENT_NODE`, `TEXT_NODE`, `DOCUMENT_POSITION_*`, etc.) so that consumers can keep reading them from the global (`Node.ELEMENT_NODE`, …).

Classes whose web-spec constructors are legitimately public (`DOMRect`, `DOMRectReadOnly`, `Event`, `EventTarget`, `CustomEvent`, `MutationObserver`, `IntersectionObserver`) are unchanged.

For the three collection classes whose public Flow types live in a `.js.flow` declaration file (`DOMRectList`, `HTMLCollection`, `NodeList`), the new `_public` export is also declared in the `.js.flow` companion so Flow can see it.

Changelog:
[General][Changed] - Throw "Illegal constructor" `TypeError` when constructing `Node` from JavaScript
[General][Changed] - Throw "Illegal constructor" `TypeError` when constructing `Element` from JavaScript
[General][Changed] - Throw "Illegal constructor" `TypeError` when constructing `CharacterData` from JavaScript
[General][Changed] - Throw "Illegal constructor" `TypeError` when constructing `HTMLCollection` from JavaScript
[General][Changed] - Throw "Illegal constructor" `TypeError` when constructing `NodeList` from JavaScript
[General][Changed] - Throw "Illegal constructor" `TypeError` when constructing `DOMRectList` from JavaScript
[General][Changed] - Throw "Illegal constructor" `TypeError` when constructing `IntersectionObserverEntry` from JavaScript
[General][Changed] - Throw "Illegal constructor" `TypeError` when constructing `MutationRecord` from JavaScript
[General][Changed] - Throw "Nodes cannot be imperatively created in React Native" `TypeError` when constructing `Document` from JavaScript
[General][Changed] - Throw "Nodes cannot be imperatively created in React Native" `TypeError` when constructing `Text` from JavaScript
[General][Changed] - Throw "Nodes cannot be imperatively created in React Native" `TypeError` when constructing `HTMLElement` from JavaScript
[General][Added] - Expose `IntersectionObserverEntry` as a global

Reviewed By: huntie

Differential Revision: D107227212
