### PR TITLE
Respect JS responder inside Fabric ScrollView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -572,8 +572,24 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
  * Returns whether or not the scroll view interaction should be blocked because
  * JavaScript was found to be the responder.
  */
-- (BOOL)_shouldDisableScrollInteraction
+- (BOOL)_shouldDisableScrollInteractionForContentView:(UIView *)contentView
 {
+  UIView *view = contentView;
+  while (view) {
+    if ([view respondsToSelector:@selector(isJSResponder)]) {
+      BOOL isJSResponder = ((UIView<RCTComponentViewProtocol> *)view).isJSResponder;
+      if (isJSResponder) {
+        return YES;
+      }
+    }
+
+    if (view == self) {
+      break;
+    }
+
+    view = view.superview;
+  }
+
   UIView *ancestorView = self.superview;
 
   while (ancestorView) {
@@ -736,11 +752,11 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScrollEndDrag(metrics);
 }
 
-- (BOOL)touchesShouldCancelInContentView:(__unused UIView *)view
+- (BOOL)touchesShouldCancelInContentView:(UIView *)view
 {
   // Historically, `UIScrollView`s in React Native do not cancel touches
   // started on `UIControl`-based views (as normal iOS `UIScrollView`s do).
-  return ![self _shouldDisableScrollInteraction];
+  return ![self _shouldDisableScrollInteractionForContentView:view];
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView


### PR DESCRIPTION
## Summary:

Fixes #51970.

Fabric ScrollView currently only checks whether one of its own ancestors is the active JS responder before allowing UIKit to cancel touches and start scrolling. When a `PanResponder` is attached to content inside the ScrollView, the responder marker is set on that touched content view, so the ancestor-only check can miss it and the ScrollView can keep handling the gesture.

This updates the Fabric iOS ScrollView cancellation path to also walk the touched content view's ancestry. If the touched view or one of its parents inside the ScrollView is the active JS responder, the ScrollView keeps the existing behavior of not cancelling those touches to begin scrolling.

## Changelog:

[IOS] [FIXED] - Respect active JS responders inside Fabric ScrollView content when deciding whether touches should start scrolling.

## Test Plan:

- `node_modules/.bin/clang-format --dry-run --Werror packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm`
- `git diff --check`
- `env RCT_NEW_ARCH_ENABLED=1 xcodebuild -workspace packages/rn-tester/RNTesterPods.xcworkspace -scheme RNTester -configuration Debug -destination 'id=4FEBA81F-F2FA-453A-A039-2A62750D88FD' -derivedDataPath /tmp/rn-rntester-51970-derived ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO build`
