### PR TITLE
Remove deprecated Instance type aliases (Flow)

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -171,9 +171,6 @@ export interface ScrollViewInstance
   extends HostInstance,
     ScrollViewImperativeMethods {}
 
-/** @deprecated Use ScrollViewInstance instead */
-export type PublicScrollViewInstance = ScrollViewInstance;
-
 type InnerViewInstance = React.ElementRef<typeof View>;
 
 export type ScrollViewPropsIOS = Readonly<{

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -38,9 +38,6 @@ type ModalEventDefinitions = {
 
 export type ModalInstance = HostInstance;
 
-/** @deprecated Use ModalInstance instead */
-export type PublicModalInstance = ModalInstance;
-
 const ModalEventEmitter =
   Platform.OS === 'ios' && NativeModalManager != null
     ? new NativeEventEmitter<ModalEventDefinitions>(

--- a/packages/rn-tester/js/examples/IntersectionObserver/IntersectionObserverExplicitRootScroll.js
+++ b/packages/rn-tester/js/examples/IntersectionObserver/IntersectionObserverExplicitRootScroll.js
@@ -8,8 +8,7 @@
  * @flow strict-local
  */
 
-import type {HostInstance} from 'react-native';
-import type {PublicScrollViewInstance} from 'react-native/Libraries/Components/ScrollView/ScrollView';
+import type {HostInstance, ScrollViewInstance} from 'react-native';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type IntersectionObserverType from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserver';
 
@@ -42,8 +41,8 @@ component IntersectionObserverExplicitRootScrollExample() {
   const [observationRoot, setObservationRoot] = useState<?HostInstance>(null);
 
   const [showMargin, setShowMargin] = useState(true);
-  const roofRef: React.RefSetter<PublicScrollViewInstance> = useCallback(
-    (rootNode: ?PublicScrollViewInstance) => {
+  const roofRef: React.RefSetter<ScrollViewInstance> = useCallback(
+    (rootNode: ?ScrollViewInstance) => {
       if (rootNode != null) {
         setObservationRoot(rootNode);
       }


### PR DESCRIPTION
Summary:
Remove the deprecated `PublicScrollViewInstance` and `PublicModalInstance` type aliases, replacing all remaining usages with the canonical `ScrollViewInstance` and `ModalInstance` types.

NOTE: Existing equivalent types are **left alone** in the manual `.d.ts` sources (current TS API), as this is covered by the existing breaking migration notes for ref types under the Strict API.

**Changes**

- Delete `PublicScrollViewInstance` alias (ScrollView.js)
- Delete `PublicModalInstance` alias (Modal.js)
- Update `IntersectionObserverExplicitRootScroll.js` rn-tester example

Changelog:
[General][Removed] - **Strict TypeScript API**: Remove deprecated `PublicScrollViewInstance` and `PublicModalInstance` types. Use `ScrollViewInstance` and `ModalInstance` instead.

Differential Revision: D107268481


