### PR TITLE
Error: android_crash:java.lang.IllegalArgumentException:com.facebook.react.views.view.WindowUtilKt.s (#57056)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt
@@ -151,6 +151,7 @@ internal class StatusBarModule(reactContext: ReactApplicationContext?) :
       return
     }
     UiThreadUtil.runOnUiThread {
+      if (activity.isFinishing || activity.isDestroyed) return@runOnUiThread
       activity.window?.setStatusBarVisibility(hidden)
       extraWindows.forEach { it.setStatusBarVisibility(hidden) }
     }
@@ -166,6 +167,7 @@ internal class StatusBarModule(reactContext: ReactApplicationContext?) :
       return
     }
     UiThreadUtil.runOnUiThread {
+      if (activity.isFinishing || activity.isDestroyed) return@runOnUiThread
       activity.window?.setStatusBarStyle(style)
       extraWindows.forEach { it.setStatusBarStyle(style) }
     }


### PR DESCRIPTION
Summary:

Fixed the crash (IllegalArgumentException: View not attached to window manager in `StatusBarModule`). The root cause is a lifecycle race condition where `StatusBarModule.setHidden()` and `setStyle()` post runnables to the UI thread that modify window attributes, but the activity can be destroyed before the runnable executes. Added `activity.isFinishing || activity.isDestroyed` guard checks inside both UI thread runnables in `StatusBarModule.kt` to prevent modifying window attributes on a destroyed activity.

Changelog: [Android][Fixed] - Prevent `IllegalArgumentException` crash in `StatusBarModule` when activity is destroyed before the UI thread runnable executes

Reviewed By: javache, cortinico

Differential Revision: D106202618


