### PR TITLE
RCTReactNativeFactory remove RCTBridge methods and bridge property (#57067)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -10,7 +10,6 @@
 #import "RCTReactNativeFactory.h"
 #import "RCTRootViewFactory.h"
 
-@class RCTBridge;
 @protocol RCTBridgeDelegate;
 @protocol RCTComponentViewProtocol;
 @class RCTRootView;
@@ -41,10 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Overridable methods
  * Shared:
- *   - (RCTBridge *)createBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary
- *)launchOptions;
- *   - (UIView *)createRootViewWithBridge:(RCTBridge *)bridge moduleName:(NSString*)moduleName initProps:(NSDictionary
- *)initProps;
  *   - (UIViewController *)createRootViewController;
  *   - (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController;
  * New Architecture:

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -31,11 +31,6 @@
   return [UIViewController new];
 }
 
-- (RCTBridge *)createBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions
-{
-  return [[RCTBridge alloc] initWithDelegate:delegate launchOptions:launchOptions];
-}
-
 - (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController
 {
   rootViewController.view = rootView;
@@ -55,21 +50,6 @@
 - (void)customizeRootView:(RCTRootView *)rootView
 {
   // Override point for customization after application launch.
-}
-
-- (UIView *)createRootViewWithBridge:(RCTBridge *)bridge
-                          moduleName:(NSString *)moduleName
-                           initProps:(NSDictionary *)initProps
-{
-  UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, YES);
-
-#if TARGET_OS_TV
-  rootView.backgroundColor = [UIColor clearColor];
-#else
-  rootView.backgroundColor = [UIColor systemBackgroundColor];
-#endif
-
-  return rootView;
 }
 
 - (RCTColorSpace)defaultColorSpace

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
@@ -46,39 +46,6 @@ typedef NS_ENUM(NSInteger, RCTReleaseLevel) { Canary, Experimental, Stable };
 @property (nonatomic, strong) id<RCTDependencyProvider> dependencyProvider;
 
 @optional
-/**
- * It creates a `RCTBridge` using a delegate and some launch options.
- * By default, it is invoked passing `self` as a delegate.
- * You can override this function to customize the logic that creates the RCTBridge
- *
- * @parameter: delegate - an object that implements the `RCTBridgeDelegate` protocol.
- * @parameter: launchOptions - a dictionary with a set of options.
- *
- * @returns: a newly created instance of RCTBridge.
- */
-- (RCTBridge *)createBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate
-                          launchOptions:(NSDictionary *)launchOptions
-    __attribute__((deprecated(
-        "createBridgeWithDelegate:launchOptions: is deprecated and will be removed when removing the legacy architecture.")));
-
-/**
- * It creates a `UIView` starting from a bridge, a module name and a set of initial properties.
- * By default, it is invoked using the bridge created by `createBridgeWithDelegate:launchOptions` and
- * the name in the `self.moduleName` variable.
- * You can override this function to customize the logic that creates the Root View.
- *
- * @parameter: bridge - an instance of the `RCTBridge` object.
- * @parameter: moduleName - the name of the app, used by Metro to resolve the module.
- * @parameter: initProps - a set of initial properties.
- *
- * @returns: a UIView properly configured with a bridge for React Native.
- */
-- (UIView *)createRootViewWithBridge:(RCTBridge *)bridge
-                          moduleName:(NSString *)moduleName
-                           initProps:(NSDictionary *)initProps
-    __attribute__((deprecated(
-        "createRootViewWithBridge:moduleName:initProps is deprecated and will be removed when removing the legacy architecture.")));
-
 /// This method returns a map of Component Descriptors and Components classes that needs to be registered in the
 /// new renderer. The Component Descriptor is a string which represent the name used in JS to refer to the native
 /// component. The default implementation returns an empty dictionary. Subclasses can override this method to register
@@ -107,8 +74,6 @@ typedef NS_ENUM(NSInteger, RCTReleaseLevel) { Canary, Experimental, Stable };
                          launchOptions:(NSDictionary *_Nullable)launchOptions;
 
 #if !defined(RCT_REMOVE_LEGACY_ARCH)
-@property (nonatomic, nullable) RCTBridge *bridge
-    __attribute__((deprecated("The bridge is deprecated and will be removed when removing the legacy architecture.")));
 @property (nonatomic, nullable) RCTSurfacePresenterBridgeAdapter *bridgeAdapter __attribute__((
     deprecated("The bridgeAdapter is deprecated and will be removed when removing the legacy architecture.")));
 #endif

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -238,14 +238,6 @@ using namespace facebook::react;
                                                    turboModuleEnabled:YES
                                                     bridgelessEnabled:YES];
 
-  configuration.createRootViewWithBridge = ^UIView *(RCTBridge *bridge, NSString *moduleName, NSDictionary *initProps) {
-    return [weakSelf.delegate createRootViewWithBridge:bridge moduleName:moduleName initProps:initProps];
-  };
-
-  configuration.createBridgeWithDelegate = ^RCTBridge *(id<RCTBridgeDelegate> delegate, NSDictionary *launchOptions) {
-    return [weakSelf.delegate createBridgeWithDelegate:delegate launchOptions:launchOptions];
-  };
-
   configuration.customizeRootView = ^(UIView *_Nonnull rootView) {
     [weakSelf.delegate customizeRootView:(RCTRootView *)rootView];
   };

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -1583,7 +1583,6 @@ interface RCTRadialGradient : public NSObject {
 }
 
 interface RCTReactNativeFactory : public NSObject {
-  public @property (assign) RCTBridge* bridge;
   public @property (assign) RCTDevMenuConfiguration* devMenuConfiguration;
   public @property (assign) RCTSurfacePresenterBridgeAdapter* bridgeAdapter;
   public @property (strong) RCTBundleConfiguration* bundleConfiguration;
@@ -2980,8 +2979,6 @@ protocol RCTReactNativeFactoryDelegate : public RCTBridgeDelegate, public RCTUIC
   public @property (strong) id<RCTDependencyProvider> dependencyProvider;
   public virtual NSDictionary<NSString*, Class<RCTComponentViewProtocol>>* thirdPartyFabricComponents();
   public virtual NSURL* _Nullable bundleURL();
-  public virtual RCTBridge* createBridgeWithDelegate:launchOptions:(id<RCTBridgeDelegate> delegate, NSDictionary* launchOptions);
-  public virtual UIView* createRootViewWithBridge:moduleName:initProps:(RCTBridge* bridge, NSString* moduleName, NSDictionary* initProps);
 }
 
 protocol RCTRedBoxExtraDataActionDelegate : public NSObject {

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -2967,8 +2967,6 @@ protocol RCTReactNativeFactoryDelegate : public RCTBridgeDelegate, public RCTUIC
   public @property (strong) id<RCTDependencyProvider> dependencyProvider;
   public virtual NSDictionary<NSString*, Class<RCTComponentViewProtocol>>* thirdPartyFabricComponents();
   public virtual NSURL* _Nullable bundleURL();
-  public virtual RCTBridge* createBridgeWithDelegate:launchOptions:(id<RCTBridgeDelegate> delegate, NSDictionary* launchOptions);
-  public virtual UIView* createRootViewWithBridge:moduleName:initProps:(RCTBridge* bridge, NSString* moduleName, NSDictionary* initProps);
 }
 
 protocol RCTRedBoxExtraDataActionDelegate : public NSObject {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -1583,7 +1583,6 @@ interface RCTRadialGradient : public NSObject {
 }
 
 interface RCTReactNativeFactory : public NSObject {
-  public @property (assign) RCTBridge* bridge;
   public @property (assign) RCTDevMenuConfiguration* devMenuConfiguration;
   public @property (assign) RCTSurfacePresenterBridgeAdapter* bridgeAdapter;
   public @property (strong) RCTBundleConfiguration* bundleConfiguration;
@@ -2980,8 +2979,6 @@ protocol RCTReactNativeFactoryDelegate : public RCTBridgeDelegate, public RCTUIC
   public @property (strong) id<RCTDependencyProvider> dependencyProvider;
   public virtual NSDictionary<NSString*, Class<RCTComponentViewProtocol>>* thirdPartyFabricComponents();
   public virtual NSURL* _Nullable bundleURL();
-  public virtual RCTBridge* createBridgeWithDelegate:launchOptions:(id<RCTBridgeDelegate> delegate, NSDictionary* launchOptions);
-  public virtual UIView* createRootViewWithBridge:moduleName:initProps:(RCTBridge* bridge, NSString* moduleName, NSDictionary* initProps);
 }
 
 protocol RCTRedBoxExtraDataActionDelegate : public NSObject {


### PR DESCRIPTION
Summary:

Removes `RCTBridge`-related functions from `RCTReactNativeFactory` protocol and default delegate implementation as part of cleaning up legacy architecture APIs.

Removes `createBridgeWithDelegate:launchOptions:`, `createRootViewWithBridge:moduleName:initProps:`, and the `bridge` property. The `bridgeAdapter` property is preserved as it returns `RCTSurfacePresenterBridgeAdapter`, not `RCTBridge`. Updates documentation in `RCTAppDelegate.h` to reflect the removed overridable methods.

## Changelog: 
[iOS][Breaking] Remove RCTBridge Functions from RCTReactNativeFactory Header

Differential Revision: D107417684


