### PR TITLE
Remove unused legacy architecture RCTAppSetupUtils methods (#57068)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -38,22 +38,4 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
     RCTTurboModuleManager *turboModuleManager,
     const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler);
 
-std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactoryForOldArch(
-    RCTBridge *bridge,
-    const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler)
-    __attribute__((deprecated(
-        "RCTAppSetupJsExecutorFactoryForOldArch(RCTBridge *, RuntimeScheduler) is deprecated and will be removed when we remove the legacy architecture.")));
-;
-
 #endif // __cplusplus
-
-RCT_EXTERN_C_BEGIN
-
-void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled) __attribute__((deprecated(
-    "RCTAppSetupPrepareApp(UIApplication, BOOL) is deprecated and it's signature will change when we remove the legacy arch")));
-UIView *
-RCTAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary *initialProperties, BOOL fabricEnabled)
-    __attribute__((deprecated(
-        "RCTAppSetupDefaultRootView(RCTBridge *, NSString *, NSDictionary *, BOOL) is deprecated and it's signature will change when we remove the legacy arch")));
-
-RCT_EXTERN_C_END

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -28,28 +28,6 @@
 
 #import "RCTDependencyProvider.h"
 
-void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
-{
-  RCTEnableTurboModule(YES);
-
-#if DEBUG
-  // Disable idle timer in dev builds to avoid putting application in background and complicating
-  // Metro reconnection logic. Users only need this when running the application using our CLI tooling.
-  application.idleTimerDisabled = YES;
-#endif
-}
-
-UIView *
-RCTAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary *initialProperties, BOOL fabricEnabled)
-{
-  id<RCTSurfaceProtocol> surface = [[RCTFabricSurface alloc] initWithBridge:bridge
-                                                                 moduleName:moduleName
-                                                          initialProperties:initialProperties];
-  UIView *rootView = [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
-  [surface start];
-  return rootView;
-}
-
 NSArray<NSString *> *RCTAppSetupUnstableModulesRequiringMainQueueSetup(id<RCTDependencyProvider> dependencyProvider)
 {
   // For oss, insert core main queue setup modules here
@@ -117,13 +95,6 @@ id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass, id<RCTDe
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutorFactory(
     RCTBridge *bridge,
     RCTTurboModuleManager *turboModuleManager,
-    const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler)
-{
-  return nullptr;
-}
-
-std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactoryForOldArch(
-    RCTBridge *bridge,
     const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler)
 {
   return nullptr;


### PR DESCRIPTION
Summary:

## Changelog:
[iOS][Breaking] Remove unused legacy architecture RCTAppSetupUtils methods

Reviewed By: javache

Differential Revision: D107420863


