### PR TITLE
Gate legacy view manager interop behind `RCT_REMOVE_LEGACY_COMPONENT_INTEROP` (#57071)

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -56,9 +56,11 @@ BOOL RCTTurboModuleInteropEnabled(void);
 void RCTEnableTurboModuleInterop(BOOL enabled);
 #endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 // Turn on the fabric interop layer
 BOOL RCTFabricInteropLayerEnabled(void);
 void RCTEnableFabricInteropLayer(BOOL enabled);
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void);
 void RCTUIManagerSetDispatchAccessibilityManagerInitOntoMain(BOOL enabled);

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -211,6 +211,7 @@ void RCTEnableTurboModuleInterop(BOOL enabled)
 }
 #endif // RCT_REMOVE_LEGACY_MODULE_INTEROP
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 static BOOL fabricInteropLayerEnabled = YES;
 BOOL RCTFabricInteropLayerEnabled()
 {
@@ -221,6 +222,7 @@ void RCTEnableFabricInteropLayer(BOOL enabled)
 {
   fabricInteropLayerEnabled = enabled;
 }
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 static RCTBridgeProxyLoggingLevel bridgeProxyLoggingLevel = kRCTBridgeProxyLoggingLevelNone;
 RCTBridgeProxyLoggingLevel RCTTurboModuleInteropBridgeProxyLogLevel(void)

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTViewComponentView.h>
@@ -30,3 +32,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -7,6 +7,8 @@
 
 #import "RCTLegacyViewManagerInteropComponentView.h"
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #import <React/RCTAssert.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTConstants.h>
@@ -299,3 +301,5 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 }
 
 @end
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #import <Foundation/Foundation.h>
 #import <react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h>
 
@@ -25,3 +27,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
@@ -6,6 +6,9 @@
  */
 
 #import "RCTLegacyViewManagerInteropCoordinatorAdapter.h"
+
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #import <React/UIView+React.h>
 #import <react/utils/FollyConvert.h>
 
@@ -146,3 +149,5 @@
 }
 
 @end
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -32,7 +32,9 @@
 #import <React/RCTComponentViewClassDescriptor.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTImageComponentView.h>
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 #import <React/RCTLegacyViewManagerInteropComponentView.h>
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 #import <React/RCTMountingTransactionObserving.h>
 #import <React/RCTParagraphComponentView.h>
 #import <React/RCTRootComponentView.h>
@@ -125,11 +127,6 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
     return;
   }
 
-  // Paper name: we prepare this variables to warn the user
-  // when the component is registered in both Fabric and in the
-  // interop layer, so they can remove that
-  NSString *componentNameString = RCTNSStringFromString(name);
-
   // Fallback 1: Call provider function for component view class.
   Class<RCTComponentViewProtocol> klass = RCTComponentViewClassWithName(name.c_str());
   if (klass != nullptr) {
@@ -149,6 +146,12 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
     }
   }
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+  // Paper name: we prepare this variables to warn the user
+  // when the component is registered in both Fabric and in the
+  // interop layer, so they can remove that
+  NSString *componentNameString = RCTNSStringFromString(name);
+
   // Fallback 3: Try to use Paper Interop.
   // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
   if (RCTFabricInteropLayerEnabled() && [RCTLegacyViewManagerInteropComponentView isSupported:componentNameString]) {
@@ -166,6 +169,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
     _registrationStatusMap.insert({provider.name, true});
     return;
   }
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
   // Fallback 4: use <UnimplementedView> if component doesn't exist.
   auto flavor = std::make_shared<const std::string>(name);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -758,6 +758,7 @@ Class getFallbackClassFromName(const char *name)
     return moduleClass;
   }
 
+#ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
   // fallback on modules registered throught RCT_EXPORT_MODULE with custom names
   NSString *objcModuleName = [NSString stringWithUTF8String:moduleName];
   NSArray<Class> *modules = RCTGetModuleClasses();
@@ -767,6 +768,7 @@ Class getFallbackClassFromName(const char *name)
       return current;
     }
   }
+#endif
 
   return moduleClass;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
@@ -6,6 +6,9 @@
  */
 
 #include "LegacyViewManagerInteropComponentDescriptor.h"
+
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <React/RCTBridge+Private.h>
 #include <React/RCTBridge.h>
 #include <React/RCTBridgeModuleDecorator.h>
@@ -175,3 +178,5 @@ void LegacyViewManagerInteropComponentDescriptor::adopt(ShadowNode &shadowNode) 
   legacyViewManagerInteropShadowNode.setStateData(std::move(state));
 }
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModuleDecorator.h>
 #import <UIKit/UIKit.h>
@@ -42,3 +44,5 @@ typedef void (^InterceptorBlock)(std::string eventName, folly::dynamic &&event);
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
@@ -6,6 +6,9 @@
  */
 
 #include "RCTLegacyViewManagerInteropCoordinator.h"
+
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <React/RCTBridge+Private.h>
 #include <React/RCTBridgeMethod.h>
 #include <React/RCTBridgeProxy.h>
@@ -220,3 +223,5 @@ using namespace facebook::react;
 }
 
 @end
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -48,7 +48,9 @@
 
 #import "ObjCTimerRegistry.h"
 #import "RCTJSThreadManager.h"
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 #import "RCTLegacyUIManagerConstantsProvider.h"
+#endif
 #import "RCTPerformanceLoggerUtils.h"
 
 #if RCT_DEV_MENU && __has_include(<React/RCTDevLoadingViewProtocol.h>)
@@ -447,9 +449,11 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     });
     RCTInstallNativeComponentRegistryBinding(runtime);
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
     if (ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode()) {
       installLegacyUIManagerConstantsProviderBinding(runtime);
     }
+#endif
 
     [strongSelf->_delegate instance:strongSelf didInitializeRuntime:runtime];
 


### PR DESCRIPTION
Summary:

Wraps the iOS legacy `RCTViewManager` ↔ Fabric component interop layer in `#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP` so that apps which opt into compile it out entirely. This enables dead-code elimination of the Paper view manager interop surface for apps that have fully migrated their custom views to Fabric Component Views.

Changes:

iOS (Objective-C / C++):
- `React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.{h,mm}`: Compile the entire translation unit only when the flag is undefined.
- `React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.{h,mm}`: Compile the entire translation unit only when the flag is undefined.
- `ReactCommon/.../platform/ios/.../RCTLegacyViewManagerInteropCoordinator.{h,mm}`: Compile the entire translation unit only when the flag is undefined.
- `ReactCommon/.../platform/ios/.../LegacyViewManagerInteropComponentDescriptor.mm`: Compile the entire translation unit only when the flag is undefined.
- `React/Base/RCTBridge.{h,mm}`: Hide `RCTFabricInteropLayerEnabled` / `RCTEnableFabricInteropLayer` API and the backing `fabricInteropLayerEnabled` static when the flag is defined.
- `React/Fabric/Mounting/RCTComponentViewFactory.mm`: Gate the `#import` of `RCTLegacyViewManagerInteropComponentView.h` and the legacy interop fallback branch in `_registerComponentIfPossible:`.

Default behavior is unchanged because `RCT_REMOVE_LEGACY_COMPONENT_INTEROP` is not defined unless the new constraint is selected.

Changelog:
[General][Added] Gate legacy view manager interop behind `RCT_REMOVE_LEGACY_COMPONENT_INTEROP`

Reviewed By: javache

Differential Revision: D107440358


