### PR TITLE
Gate shared C++ + Java/Kotlin legacy view manager interop behind `RCT_REMOVE_LEGACY_COMPONENT_INTEROP` (#57073)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1655,6 +1655,7 @@ public final class com/facebook/react/common/build/ReactBuildConfig {
 	public static final field IS_INTERNAL_BUILD Z
 	public static final field UNSTABLE_ENABLE_FUSEBOX_RELEASE Z
 	public static final field UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE Z
+	public static final field UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP Z
 }
 
 public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -561,6 +561,7 @@ android {
     buildConfigField("boolean", "UNSTABLE_ENABLE_FUSEBOX_RELEASE", "false")
     buildConfigField("boolean", "ENABLE_PERFETTO", "false")
     buildConfigField("boolean", "UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE", "false")
+    buildConfigField("boolean", "UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP", "false")
 
     resValue("integer", "react_native_dev_server_port", reactNativeDevServerPort())
     resValue("string", "react_native_dev_server_ip", "localhost")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -26,6 +26,7 @@ import com.facebook.react.bridge.interop.InteropModuleRegistry;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
+import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.interfaces.ExtraWindowEventListener;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import java.lang.ref.WeakReference;
@@ -110,6 +111,9 @@ public abstract class ReactContext extends ContextWrapper {
   }
 
   protected void initializeInteropModules() {
+    if (ReactBuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP) {
+      return;
+    }
     mInteropModuleRegistry = new InteropModuleRegistry();
   }
 
@@ -579,6 +583,9 @@ public abstract class ReactContext extends ContextWrapper {
    */
   public <T extends JavaScriptModule> void internal_registerInteropModule(
       Class<T> interopModuleInterface, Object interopModule) {
+    if (ReactBuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP) {
+      return;
+    }
     if (mInteropModuleRegistry != null) {
       mInteropModuleRegistry.registerInteropModule(interopModuleInterface, interopModule);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/build/ReactBuildConfig.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/build/ReactBuildConfig.kt
@@ -37,4 +37,8 @@ public object ReactBuildConfig {
   @JvmField
   public val UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE: Boolean =
       BuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
+
+  @JvmField
+  public val UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP: Boolean =
+      BuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -447,7 +447,8 @@ public class FabricUIManager
 
       ReactMarker.addFabricListener(mDevToolsReactPerfLogger);
     }
-    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
+    if (!ReactBuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP
+        && ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
       InteropEventEmitter interopEventEmitter = new InteropEventEmitter(mReactApplicationContext);
       mReactApplicationContext.internal_registerInteropModule(
           RCTEventEmitter.class, interopEventEmitter);
@@ -514,7 +515,8 @@ public class FabricUIManager
    * [addUiBlock] and [prependUiBlock] on UIManagerModule.
    */
   public void addUIBlock(UIBlock block) {
-    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
+    if (!ReactBuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP
+        && ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
       InteropUIBlockListener listener = getInteropUIBlockListener();
       listener.addUIBlock(block);
     }
@@ -525,7 +527,8 @@ public class FabricUIManager
    * [addUiBlock] and [prependUiBlock] on UIManagerModule.
    */
   public void prependUIBlock(UIBlock block) {
-    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
+    if (!ReactBuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP
+        && ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
       InteropUIBlockListener listener = getInteropUIBlockListener();
       listener.prependUIBlock(block);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
@@ -56,7 +56,10 @@ internal class BridgelessReactContext(context: Context, private val reactHost: R
     get() = reactHost.defaultBackButtonHandler
 
   init {
-    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
+    if (
+        !ReactBuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP &&
+            ReactNativeNewArchitectureFeatureFlags.useFabricInterop()
+    ) {
       initializeInteropModules()
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.kt
@@ -143,7 +143,7 @@ internal object UIManagerModuleConstantsHelper {
     var viewManagerBubblingEvents: MutableMap<String, Any>? =
         viewManager.exportedCustomBubblingEventTypeConstants
     if (viewManagerBubblingEvents != null) {
-      if (useFabricInterop()) {
+      if (!ReactBuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP && useFabricInterop()) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.
@@ -160,7 +160,7 @@ internal object UIManagerModuleConstantsHelper {
         viewManager.exportedCustomDirectEventTypeConstants
     validateDirectEventNames(viewManager.getName(), viewManagerDirectEvents)
     if (viewManagerDirectEvents != null) {
-      if (useFabricInterop()) {
+      if (!ReactBuildConfig.UNSTABLE_REMOVE_LEGACY_COMPONENT_INTEROP && useFabricInterop()) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
@@ -12,8 +12,10 @@
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h>
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/ShadowNodeFragment.h>
 #include <utility>
@@ -84,6 +86,7 @@ const ComponentDescriptor& ComponentDescriptorRegistry::at(
   }
 
   if (it == _registryByName.end()) {
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
     if (ReactNativeFeatureFlags::useFabricInterop()) {
       // When interop is enabled, if the component is not found we rely on
       // UnstableLegacyViewManagerAutomaticComponentDescriptor to support legacy
@@ -94,6 +97,7 @@ const ComponentDescriptor& ComponentDescriptorRegistry::at(
       registerComponentDescriptor(componentDescriptor);
       return *_registryByName.find(unifiedComponentName)->second;
     } else {
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP
       // When interop is disabled, if the component is not found we rely on
       // fallbackComponentDescriptor (default:
       // UnimplementedNativeViewComponentDescriptor).
@@ -107,7 +111,9 @@ const ComponentDescriptor& ComponentDescriptorRegistry::at(
       } else {
         return *_fallbackComponentDescriptor.get();
       }
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
     }
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP
   }
 
   return *it->second;

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.cpp
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 namespace facebook::react {
 
 extern const char LegacyViewManagerInteropComponentName[] =
     "LegacyViewManagerInterop";
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h>
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
@@ -22,3 +24,5 @@ using LegacyViewManagerInteropShadowNode = ConcreteViewShadowNode<
     LegacyViewManagerInteropState>;
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #import <memory>
 
 namespace facebook::react {
@@ -20,3 +22,5 @@ class LegacyViewManagerInteropState final {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "LegacyViewManagerInteropViewProps.h"
+
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <react/renderer/core/DynamicPropsUtilities.h>
 
 namespace facebook::react {
@@ -21,3 +24,5 @@ LegacyViewManagerInteropViewProps::LegacyViewManagerInteropViewProps(
           NullValueStrategy::Override)) {}
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <folly/dynamic.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -26,3 +28,5 @@ class LegacyViewManagerInteropViewProps final : public ViewProps {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "UnstableLegacyViewManagerAutomaticComponentDescriptor.h"
+
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/ReactPrimitives.h>
@@ -24,3 +27,5 @@ UnstableLegacyViewManagerAutomaticComponentDescriptor::getComponentHandle()
   return reinterpret_cast<ComponentHandle>(getComponentName());
 }
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/ReactPrimitives.h>
@@ -33,3 +35,5 @@ class UnstableLegacyViewManagerAutomaticComponentDescriptor final
   std::string legacyComponentName_;
 };
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.cpp
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 namespace facebook::react {
 
 extern const char LegacyViewManagerAndroidInteropComponentName[] =
     "LegacyViewManagerInterop";
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
@@ -18,3 +20,5 @@ using LegacyViewManagerAndroidInteropShadowNode =
     ConcreteViewShadowNode<LegacyViewManagerAndroidInteropComponentName, LegacyViewManagerInteropViewProps>;
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
@@ -33,3 +35,5 @@ class UnstableLegacyViewManagerInteropComponentDescriptor
 };
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP


### PR DESCRIPTION
Summary:

Changelog:
[General][Added] Gate shared C++ and Android Java/Kotlin legacy view manager interop behind `RCT_REMOVE_LEGACY_COMPONENT_INTEROP`

Reviewed By: cortinico, javache

Differential Revision: D107477086


