### PR TITLE
Add @Nullable to ScrollView getChildVisibleRect offset parameter

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -15,6 +15,7 @@ import static com.facebook.react.views.scroll.ReactScrollViewHelper.findNextFocu
 
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -1054,7 +1055,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   @Override
-  public boolean getChildVisibleRect(View child, Rect r, android.graphics.Point offset) {
+  @SuppressLint("NullsafeMismatch")
+  public boolean getChildVisibleRect(View child, Rect r, @Nullable android.graphics.Point offset) {
     return super.getChildVisibleRect(child, r, offset);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.java
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ee631e2aaec71e0722c894a07f4f7022>>
+ * @generated SignedSource<<73693667f092b5c8a9f5b10c479e8174>>
  */
 
 /**
@@ -23,6 +23,7 @@ import static com.facebook.react.views.scroll.ReactScrollViewHelper.findNextFocu
 
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -807,7 +808,8 @@ class ReactNestedScrollView extends NestedScrollView
   }
 
   @Override
-  public boolean getChildVisibleRect(View child, Rect r, android.graphics.Point offset) {
+  @SuppressLint("NullsafeMismatch")
+  public boolean getChildVisibleRect(View child, Rect r, @Nullable android.graphics.Point offset) {
     return super.getChildVisibleRect(child, r, offset);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -15,6 +15,7 @@ import static com.facebook.react.views.scroll.ReactScrollViewHelper.findNextFocu
 
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -799,7 +800,8 @@ public class ReactScrollView extends ScrollView
   }
 
   @Override
-  public boolean getChildVisibleRect(View child, Rect r, android.graphics.Point offset) {
+  @SuppressLint("NullsafeMismatch")
+  public boolean getChildVisibleRect(View child, Rect r, @Nullable android.graphics.Point offset) {
     return super.getChildVisibleRect(child, r, offset);
   }
 


### PR DESCRIPTION
Summary:
The `offset` parameter in `getChildVisibleRect` overrides was missing the
`Nullable` annotation. The Android framework contract for
`ViewGroup.getChildVisibleRect(View, Rect, Point)` allows `offset` to be null,
and `View.getGlobalVisibleRect(Rect)` legitimately passes null. The `Nullsafe`
instrumentation injected a non-null assertion that crashed when null was passed.

Changelog:
[Android][Fixed] - Fix NullPointerException in ScrollView `getChildVisibleRect` when `offset` is null

Reviewed By: javache

Differential Revision: D107507935


