### PR TITLE
Make `setMaintainVisibleContentPosition` and `MaintainVisibleScrollPositionHelper` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5429,30 +5429,6 @@ public abstract interface class com/facebook/react/views/scroll/FpsListener {
 	public abstract fun isEnabled ()Z
 }
 
-public final class com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper : com/facebook/react/bridge/UIManagerListener {
-	public fun <init> (Landroid/view/ViewGroup;Z)V
-	public fun didDispatchMountItems (Lcom/facebook/react/bridge/UIManager;)V
-	public fun didMountItems (Lcom/facebook/react/bridge/UIManager;)V
-	public fun didScheduleMountItems (Lcom/facebook/react/bridge/UIManager;)V
-	public final fun getConfig ()Lcom/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config;
-	public final fun setConfig (Lcom/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config;)V
-	public final fun start ()V
-	public final fun stop ()V
-	public fun willDispatchViewUpdates (Lcom/facebook/react/bridge/UIManager;)V
-	public fun willMountItems (Lcom/facebook/react/bridge/UIManager;)V
-}
-
-public final class com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config {
-	public static final field Companion Lcom/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config$Companion;
-	public static final fun fromReadableMap (Lcom/facebook/react/bridge/ReadableMap;)Lcom/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config;
-	public final fun getAutoScrollToTopThreshold ()Ljava/lang/Integer;
-	public final fun getMinIndexForVisible ()I
-}
-
-public final class com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config$Companion {
-	public final fun fromReadableMap (Lcom/facebook/react/bridge/ReadableMap;)Lcom/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config;
-}
-
 public final class com/facebook/react/views/scroll/OnScrollDispatchHelper {
 	public fun <init> ()V
 	public final fun getXFlingVelocity ()F
@@ -5540,7 +5516,6 @@ public class com/facebook/react/views/scroll/ReactHorizontalScrollView : android
 	public fun setFadingEdgeLengthEnd (I)V
 	public fun setFadingEdgeLengthStart (I)V
 	public fun setLastScrollDispatchTime (J)V
-	public fun setMaintainVisibleContentPosition (Lcom/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config;)V
 	public fun setOverflow (Ljava/lang/String;)V
 	public fun setOverflowInset (IIII)V
 	public fun setPagingEnabled (Z)V
@@ -5685,7 +5660,6 @@ public class com/facebook/react/views/scroll/ReactScrollView : android/widget/Sc
 	public fun setFadingEdgeLengthEnd (I)V
 	public fun setFadingEdgeLengthStart (I)V
 	public fun setLastScrollDispatchTime (J)V
-	public fun setMaintainVisibleContentPosition (Lcom/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper$Config;)V
 	public fun setOverflow (Ljava/lang/String;)V
 	public fun setOverflowInset (IIII)V
 	public fun setPagingEnabled (Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.kt
@@ -28,12 +28,12 @@ import java.lang.ref.WeakReference
  * This uses UIManager to listen to updates and capture position of items before and after layout.
  */
 @OptIn(UnstableReactNativeAPI::class)
-public class MaintainVisibleScrollPositionHelper<ScrollViewT>(
+internal class MaintainVisibleScrollPositionHelper<ScrollViewT>(
     private val scrollView: ScrollViewT,
     private val horizontal: Boolean,
 ) : UIManagerListener where ScrollViewT : HasSmoothScroll?, ScrollViewT : ViewGroup? {
 
-  public var config: Config? = null
+  var config: Config? = null
   private var firstVisibleViewRef: WeakReference<View>? = null
   private var prevFirstVisibleFrame: Rect? = null
   private var isListening = false
@@ -50,14 +50,11 @@ public class MaintainVisibleScrollPositionHelper<ScrollViewT>(
             )
         )
 
-  public class Config
-  internal constructor(
-      public val minIndexForVisible: Int,
-      public val autoScrollToTopThreshold: Int?,
-  ) {
-    public companion object {
+  class Config
+  internal constructor(val minIndexForVisible: Int, val autoScrollToTopThreshold: Int?) {
+    companion object {
       @JvmStatic
-      public fun fromReadableMap(value: ReadableMap): Config {
+      fun fromReadableMap(value: ReadableMap): Config {
         val minIndexForVisible = value.getInt("minIndexForVisible")
         val autoScrollToTopThreshold =
             if (value.hasKey("autoscrollToTopThreshold")) value.getInt("autoscrollToTopThreshold")
@@ -68,7 +65,7 @@ public class MaintainVisibleScrollPositionHelper<ScrollViewT>(
   }
 
   /** Start listening to view hierarchy updates. Should be called when this is created. */
-  public fun start() {
+  fun start() {
     if (isListening) {
       return
     }
@@ -77,7 +74,7 @@ public class MaintainVisibleScrollPositionHelper<ScrollViewT>(
   }
 
   /** Stop listening to view hierarchy updates. Should be called before this is destroyed. */
-  public fun stop() {
+  fun stop() {
     if (!isListening) {
       return
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
@@ -422,7 +422,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     invalidate()
   }
 
-  public open fun setMaintainVisibleContentPosition(
+  internal open fun setMaintainVisibleContentPosition(
       config: MaintainVisibleScrollPositionHelper.Config?
   ) {
     if (config != null && maintainVisibleContentPositionHelper == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ef65f89c556fb0b391aace166349cebc>>
+ * @generated SignedSource<<2b0cbc5249ac34ae7f030a9c0fffd1f3>>
  */
 
 /**
@@ -392,7 +392,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     invalidate()
   }
 
-  public open fun setMaintainVisibleContentPosition(
+  internal open fun setMaintainVisibleContentPosition(
       config: MaintainVisibleScrollPositionHelper.Config?
   ) {
     if (config != null && maintainVisibleContentPositionHelper == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.kt
@@ -384,7 +384,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     invalidate()
   }
 
-  public open fun setMaintainVisibleContentPosition(
+  internal open fun setMaintainVisibleContentPosition(
       config: MaintainVisibleScrollPositionHelper.Config?
   ) {
     if (config != null && maintainVisibleContentPositionHelper == null) {


### PR DESCRIPTION
Summary:
`setMaintainVisibleContentPosition` takes a `MaintainVisibleScrollPositionHelper.Config` parameter whose constructor is `internal`, making the method uncallable by OSS consumers. This change makes both the method and the helper class `internal` to reflect that reality and reduce the public API surface.

Changelog: [Internal]

Differential Revision: D107530272
