### PR TITLE
Gate Metro connectivity on RCT_DEV_MENU instead of RCT_DEV

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -19,7 +19,7 @@ NSString *const RCTBundleURLProviderUpdatedNotification = @"RCTBundleURLProvider
 
 const NSUInteger kRCTBundleURLProviderDefaultPort = RCT_METRO_PORT;
 
-#if RCT_DEV | RCT_PACKAGER_LOADING_FUNCTIONALITY
+#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
 static BOOL kRCTAllowPackagerAccess = YES;
 void RCTBundleURLProviderAllowPackagerServerAccess(BOOL allowed)
 {
@@ -81,7 +81,7 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                                                          (unsigned long)kRCTBundleURLProviderDefaultPort]];
 }
 
-#if RCT_DEV | RCT_PACKAGER_LOADING_FUNCTIONALITY
+#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
 + (BOOL)isPackagerRunning:(NSString *)hostPort
 {
   return [RCTBundleURLProvider isPackagerRunning:hostPort scheme:nil];
@@ -258,14 +258,14 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
 
 - (NSString *)packagerServerHostPort
 {
-#if RCT_DEV | RCT_PACKAGER_LOADING_FUNCTIONALITY
+#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
   if (!kRCTAllowPackagerAccess) {
     RCTLogInfo(@"Packager server access is disabled in this environment");
     return nil;
   }
 #endif
   NSString *location = [self jsLocation];
-#if RCT_DEV
+#if RCT_DEV_MENU
   NSString *scheme = [self packagerScheme];
   if ([location length] && ![RCTBundleURLProvider isPackagerRunning:location scheme:scheme]) {
     location = nil;


### PR DESCRIPTION
Summary:
When an iOS app is built with the React Native dev menu enabled (`RCT_DEV_MENU=1`) but `RCT_DEV=0`, the "Change Bundle Location" option can be visible while the Metro connection path remains compiled out. This makes the setting ineffective.

This gates the Metro host override path on `RCT_DEV_MENU` instead of `RCT_DEV`, matching the flag that controls whether the dev menu exists. Auto-discovery via `guessPackagerHost` remains behind `RCT_DEV` because it is a development convenience for full dev builds. Builds that do not set `RCT_DEV_MENU=1` keep the same preprocessor output because `RCT_DEV_MENU` defaults to `RCT_DEV`.

Changelog:
[iOS][Fixed] - Allow iOS apps with the dev menu enabled (`RCT_DEV_MENU`) to connect to Metro via "Change Bundle Location"

Differential Revision: D107524388


