### PR TITLE
Deprecate Timing native module ahead of legacy-arch removal (#57081)

### DIFF
--- a/packages/react-native/React/Base/RCTDisplayLink.h
+++ b/packages/react-native/React/Base/RCTDisplayLink.h
@@ -21,7 +21,9 @@
 - (instancetype)init;
 - (void)invalidate;
 - (void)registerModuleForFrameUpdates:(id<RCTBridgeModule>)module
-                     withModuleHolder:(id<RCTDisplayLinkModuleHolder>)moduleHolder;
+                     withModuleHolder:(id<RCTDisplayLinkModuleHolder>)moduleHolder
+    __attribute__((deprecated(
+        "registerModuleForFrameUpdates is part of the legacy architecture and will be removed in a future React Native release.")));
 - (void)addToRunLoop:(NSRunLoop *)runLoop;
 
 @end

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/TimingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/TimingModule.kt
@@ -15,6 +15,9 @@ import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.module.annotations.ReactModule
 
 /** Native module for JS timer execution. Timers fire on frame boundaries. */
+@Deprecated(
+    "TimingModule is part of the legacy architecture and will be removed in a future React Native release."
+)
 @ReactModule(name = NativeTimingSpec.NAME)
 public class TimingModule(
     reactContext: ReactApplicationContext,

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -74,7 +74,9 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   sRuntimeDiagnosticFlags = [flags copy];
 }
 
-@interface RCTBridgelessDisplayLinkModuleHolder : NSObject <RCTDisplayLinkModuleHolder>
+__attribute__((deprecated(
+    "RCTBridgelessDisplayLinkModuleHolder is part of the legacy architecture and will be removed in a future React Native release.")))
+@interface RCTBridgelessDisplayLinkModuleHolder : NSObject<RCTDisplayLinkModuleHolder>
 - (instancetype)initWithModule:(id<RCTBridgeModule>)module;
 @end
 
@@ -457,9 +459,12 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
     [strongSelf->_delegate instance:strongSelf didInitializeRuntime:runtime];
 
-    // Set up Display Link
+// Set up Display Link
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     id<RCTDisplayLinkModuleHolder> moduleHolder = [[RCTBridgelessDisplayLinkModuleHolder alloc] initWithModule:timing];
     [strongSelf->_displayLink registerModuleForFrameUpdates:timing withModuleHolder:moduleHolder];
+#pragma clang diagnostic pop
     [strongSelf->_displayLink addToRunLoop:[NSRunLoop currentRunLoop]];
 
     // Attempt to load bundle synchronously, fallback to asynchronously.


### PR DESCRIPTION
Summary:

The legacy Timing native module (`RCTTiming` on iOS, `TimingModule` on Android) is scheduled for removal in a future React Native release as part of the legacy architecture cleanup.


Changelog:
[iOS][Deprecated] - Deprecate `RCTTiming Native Module usage`; will be removed in a future React Native release
[Android][Deprecated] - Deprecate `TimingModule`; will be removed in a future React Native release

Reviewed By: shwanton

Differential Revision: D107540262


