### PR TITLE
Deprecate RCTTurboModuleEnabled() and RCTEnableTurboModule() (#57082)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -58,7 +58,6 @@ using namespace facebook::react;
     [self _setUpFeatureFlags:releaseLevel];
 
     [RCTColorSpaceUtils applyDefaultColorSpace:[self defaultColorSpace]];
-    RCTEnableTurboModule(YES);
 
     self.rootViewFactory = [self createRCTRootViewFactory];
 

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -44,11 +44,13 @@ NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
 NSMutableArray<NSString *> *getModulesLoadedWithOldArch(void);
 
 /**
- * Experimental.
- * Check/set if JSI-bound NativeModule is enabled. By default it's off.
+ * The New Architecture is enabled by default. These APIs are no-ops and will
+ * be removed in a future release.
  */
-BOOL RCTTurboModuleEnabled(void);
-void RCTEnableTurboModule(BOOL enabled);
+BOOL RCTTurboModuleEnabled(void)
+    __attribute__((deprecated("TurboModules are always enabled; this always returns YES (NO in test env).")));
+void RCTEnableTurboModule(BOOL enabled)
+    __attribute__((deprecated("No-op. The New Architecture is enabled by default.")));
 
 #ifndef RCT_REMOVE_LEGACY_MODULE_INTEROP
 // Turn on TurboModule interop

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -182,7 +182,6 @@ NSString *RCTBridgeModuleNameForClass(Class cls)
   return RCTDropReactPrefixes(name);
 }
 
-static const BOOL turboModuleEnabled = YES;
 BOOL RCTTurboModuleEnabled(void)
 {
 #if RCT_DEBUG
@@ -191,7 +190,7 @@ BOOL RCTTurboModuleEnabled(void)
     return NO;
   }
 #endif
-  return turboModuleEnabled;
+  return YES;
 }
 
 void RCTEnableTurboModule(BOOL enabled)


### PR DESCRIPTION
Summary:

## Changelog:
[iOS][Fixed] Deprecate RCTTurboModuleEnabled() and RCTEnableTurboModule()

Differential Revision: D107548130


