### PR TITLE
Expose the bridgeless performance logger and post RCTJavaScriptDidLoadNotification (#57083)

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeProxy.h
+++ b/packages/react-native/React/Base/RCTBridgeProxy.h
@@ -14,12 +14,20 @@ NS_ASSUME_NONNULL_BEGIN
 @class RCTBundleManager;
 @class RCTCallableJSModules;
 @class RCTModuleRegistry;
+@class RCTPerformanceLogger;
 @class RCTViewRegistry;
 
 @interface RCTBridgeProxy : NSProxy
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
+
+/**
+ * The performance logger for this React instance. In bridgeless mode it is
+ * injected by RCTInstance so that consumers reading `[bridge performanceLogger]`
+ * on `RCTJavaScriptDidLoadNotification` keep working; previously it returned nil.
+ */
+@property (nonatomic, strong, nullable) RCTPerformanceLogger *performanceLogger;
 
 - (instancetype)initWithViewRegistry:(RCTViewRegistry *)viewRegistry
                       moduleRegistry:(RCTModuleRegistry *)moduleRegistry

--- a/packages/react-native/React/Base/RCTBridgeProxy.mm
+++ b/packages/react-native/React/Base/RCTBridgeProxy.mm
@@ -41,6 +41,8 @@ using namespace facebook;
   void *_runtime;
 }
 
+@synthesize performanceLogger = _performanceLogger;
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-designated-initializers"
 - (instancetype)initWithViewRegistry:(RCTViewRegistry *)viewRegistry
@@ -211,12 +213,6 @@ using namespace facebook;
 {
   [self logWarning:@"This method is not implemented. Returning NO." cmd:_cmd];
   return NO;
-}
-
-- (RCTPerformanceLogger *)performanceLogger
-{
-  [self logWarning:@"This method is not supported. Returning nil." cmd:_cmd];
-  return nil;
 }
 
 - (void)reload

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -115,6 +115,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   RCTPerformanceLogger *_performanceLogger;
   RCTDisplayLink *_displayLink;
   RCTTurboModuleManager *_turboModuleManager;
+  RCTBridgeProxy *_bridgeProxy;
   std::mutex _invalidationMutex;
   std::atomic<bool> _valid;
   RCTJSThreadManager *_jsThreadManager;
@@ -351,6 +352,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
           runtime:_reactInstance->getJavaScriptContext()
           launchOptions:_launchOptions];
   bridgeProxy.jsCallInvoker = jsCallInvoker;
+  bridgeProxy.performanceLogger = _performanceLogger;
+  _bridgeProxy = bridgeProxy;
   [RCTBridge setCurrentBridge:(RCTBridge *)bridgeProxy];
 
   // Set up TurboModules
@@ -606,8 +609,20 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       waitUntilModuleSetupComplete();
     }
   };
-  auto afterLoad = [](jsi::Runtime &_) {
+  __weak __typeof(self) weakSelf = self;
+  auto afterLoad = [weakSelf](jsi::Runtime &) {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTInstanceDidLoadBundle" object:nil];
+    __strong __typeof(weakSelf) strongSelf = weakSelf;
+    if (strongSelf) {
+      RCTBridgeProxy *bridgeProxy = strongSelf->_bridgeProxy;
+      // afterLoad runs on the JS thread; post on main like the legacy bridge so
+      // RCTJavaScriptDidLoadNotification observers aren't invoked off-main.
+      RCTExecuteOnMainQueue(^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidLoadNotification
+                                                            object:strongSelf
+                                                          userInfo:bridgeProxy ? @{@"bridge" : bridgeProxy} : @{}];
+      });
+    }
   };
   _reactInstance->loadScript(std::move(script), url, beforeLoad, afterLoad);
 }

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -725,6 +725,7 @@ interface RCTBridgeModuleDecorator : public NSObject {
 }
 
 interface RCTBridgeProxy : public NSProxy {
+  public @property (strong) RCTPerformanceLogger* performanceLogger;
   public virtual NSMethodSignature* methodSignatureForSelector:(SEL sel);
   public virtual id moduleForClass:(Class moduleClass);
   public virtual id moduleForName:lazilyLoadIfNecessary:(NSString* moduleName, BOOL lazilyLoad);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -723,6 +723,7 @@ interface RCTBridgeModuleDecorator : public NSObject {
 }
 
 interface RCTBridgeProxy : public NSProxy {
+  public @property (strong) RCTPerformanceLogger* performanceLogger;
   public virtual NSMethodSignature* methodSignatureForSelector:(SEL sel);
   public virtual id moduleForClass:(Class moduleClass);
   public virtual id moduleForName:lazilyLoadIfNecessary:(NSString* moduleName, BOOL lazilyLoad);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -725,6 +725,7 @@ interface RCTBridgeModuleDecorator : public NSObject {
 }
 
 interface RCTBridgeProxy : public NSProxy {
+  public @property (strong) RCTPerformanceLogger* performanceLogger;
   public virtual NSMethodSignature* methodSignatureForSelector:(SEL sel);
   public virtual id moduleForClass:(Class moduleClass);
   public virtual id moduleForName:lazilyLoadIfNecessary:(NSString* moduleName, BOOL lazilyLoad);


### PR DESCRIPTION
Summary:

In bridgeless mode, `RCTInstance` records native startup timings in a per-instance `RCTPerformanceLogger`, but that logger was never reachable from app code: `RCTBridgeProxy.performanceLogger` returned nil and `RCTJavaScriptDidLoadNotification` was never posted. Startup-perf consumers that follow the long-standing pattern of reading `[bridge performanceLogger]` on `RCTJavaScriptDidLoadNotification` were therefore silently inert under bridgeless, dropping all native startup timings.

This restores that pattern for bridgeless:
- `RCTBridgeProxy` now holds a real `performanceLogger` property, injected by `RCTInstance`, instead of returning nil.
- `RCTInstance` posts `RCTJavaScriptDidLoadNotification` (on the main thread, with the bridge proxy in `userInfo[@"bridge"]`) once the JS bundle has loaded, mirroring the legacy bridge.

No change to the legacy bridge path.

Changelog:
[iOS][Fixed] - Expose the bridgeless performance logger via `RCTBridgeProxy` and post `RCTJavaScriptDidLoadNotification`, so native startup-perf consumers work in bridgeless

Reviewed By: christophpurrer

Differential Revision: D107542363


