### PR TITLE
Always return true in RCTTurboModuleEnabled (#57092)

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -184,12 +184,6 @@ NSString *RCTBridgeModuleNameForClass(Class cls)
 
 BOOL RCTTurboModuleEnabled(void)
 {
-#if RCT_DEBUG
-  // TODO(T53341772): Allow TurboModule for test environment. Right now this breaks RNTester tests if enabled.
-  if (RCTRunningInTestEnvironment()) {
-    return NO;
-  }
-#endif
   return YES;
 }
 


### PR DESCRIPTION
Summary:

## Changelog:
[iOS][Fixed] Always return true in RCTTurboModuleEnabled

Differential Revision: D107686914


