### PR TITLE
Add missing RCT_REMOVE_LEGACY_COMPONENT_INTEROP guard to LegacyViewManagerInteropComponentDescriptor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
+
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
@@ -33,3 +35,5 @@ class LegacyViewManagerInteropComponentDescriptor final
 };
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_COMPONENT_INTEROP


### PR DESCRIPTION
Summary:
The iOS `LegacyViewManagerInteropComponentDescriptor.h` was missing the `RCT_REMOVE_LEGACY_COMPONENT_INTEROP` guard that the rest of the `legacyviewmanagerinterop` library already uses, so enabling that flag failed to compile. Add the guard for consistency.

Changelog: [iOS][Fixed] - Add missing `RCT_REMOVE_LEGACY_COMPONENT_INTEROP` guard to `LegacyViewManagerInteropComponentDescriptor`

Differential Revision: D107717474


