### PR TITLE
fix(iOS): release previous UIImage on source prop change to prevent memory leak (#12220)

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -140,6 +140,12 @@ static NSString *RCTImageRequestPriorityDebugLabel(ImageRequestPriority priority
     observerCoordinator.removeObserver(_imageResponseObserverProxy);
   }
 
+  // Release the previous image to prevent memory accumulation
+  // when the source prop changes rapidly (e.g., in animations/slideshows).
+  // The UIImageView retains the UIImage, preventing deallocation until
+  // the next image arrives, which can cause significant memory growth.
+  _imageView.image = nil;
+
   _state = state;
 
   if (_state) {


### PR DESCRIPTION
## Summary

Fixes #12220 — Memory leak when programmatically changing `source` prop of Image on iOS.

## Problem

When the Image component's `source` prop changes, the `UIImageView` retains the previous `UIImage` until the new image loads. On rapid source changes (e.g., image carousels, slideshows), this causes unbounded memory accumulation.

## Fix

Added `_imageView.image = nil` in `_setStateAndResubscribeImageResponseObserver:` to explicitly release the previous UIImage when the state changes. This is consistent with the existing cleanup in `prepareForRecycle`.

## Changelog

[iOS][Fixed] - Release previous UIImage on source prop change to prevent memory leak

## Test Plan

1. Render an `<Image>` with a source that changes on each button press
2. Run in Release mode on iOS
3. Profile with Xcode Memory Graph — memory should not grow unboundedly
4. Verify images still display correctly after source changes