### PR TITLE
Fix Android accessibility collection metadata handling

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.kt
@@ -19,6 +19,7 @@ import android.widget.EditText
 import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.CollectionInfoCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.CollectionItemInfoCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.RangeInfoCompat
 import androidx.core.view.accessibility.AccessibilityNodeProviderCompat
@@ -102,6 +103,18 @@ public open class ReactAccessibilityDelegate( // The View this delegate is attac
       setState(info, accessibilityState)
     }
     val accessibilityActions = host.getTag(R.id.accessibility_actions) as ReadableArray?
+
+    val accessibilityCollection = host.getTag(R.id.accessibility_collection) as ReadableMap?
+    if (accessibilityCollection != null) {
+      val rowCount = accessibilityCollection.getInt("rowCount")
+      val columnCount = accessibilityCollection.getInt("columnCount")
+      val hierarchical =
+          accessibilityCollection.hasKey("hierarchical") &&
+              accessibilityCollection.getBoolean("hierarchical")
+
+      val collectionInfoCompat = CollectionInfoCompat.obtain(rowCount, columnCount, hierarchical)
+      info.setCollectionInfo(collectionInfoCompat)
+    }
 
     val accessibilityCollectionItem =
         host.getTag(R.id.accessibility_collection_item) as ReadableMap?
@@ -597,6 +610,7 @@ public open class ReactAccessibilityDelegate( // The View this delegate is attac
                   view.getTag(R.id.accessibility_state) != null ||
                   view.getTag(R.id.accessibility_actions) != null ||
                   view.getTag(R.id.react_test_id) != null ||
+                  view.getTag(R.id.accessibility_collection) != null ||
                   view.getTag(R.id.accessibility_collection_item) != null ||
                   view.getTag(R.id.accessibility_links) != null ||
                   view.getTag(R.id.role) != null)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegate.kt
@@ -55,7 +55,9 @@ internal class ReactScrollViewAccessibilityDelegate : AccessibilityDelegateCompa
     val accessibilityCollection =
         view.getTag(R.id.accessibility_collection) as? ReadableMap ?: return
 
-    event.itemCount = accessibilityCollection.getInt("itemCount")
+    if (accessibilityCollection.hasKey("itemCount")) {
+      event.itemCount = accessibilityCollection.getInt("itemCount")
+    }
 
     val contentView = (view as? ViewGroup)?.getChildAt(0) as? ViewGroup ?: return
 
@@ -71,10 +73,10 @@ internal class ReactScrollViewAccessibilityDelegate : AccessibilityDelegateCompa
             return
           }
       var accessibilityCollectionItem: ReadableMap? =
-          nextChild.getTag(R.id.accessibility_collection_item) as ReadableMap
+          nextChild.getTag(R.id.accessibility_collection_item) as? ReadableMap
 
       if (nextChild !is ViewGroup) {
-        return
+        continue
       }
 
       // If this child's accessibilityCollectionItem is null, we'll check one more
@@ -93,10 +95,12 @@ internal class ReactScrollViewAccessibilityDelegate : AccessibilityDelegateCompa
       }
 
       if (isVisible && accessibilityCollectionItem != null) {
-        if (firstVisibleIndex == null) {
+        if (accessibilityCollectionItem.hasKey("itemIndex") && firstVisibleIndex == null) {
           firstVisibleIndex = accessibilityCollectionItem.getInt("itemIndex")
         }
-        lastVisibleIndex = accessibilityCollectionItem.getInt("itemIndex")
+        if (accessibilityCollectionItem.hasKey("itemIndex")) {
+          lastVisibleIndex = accessibilityCollectionItem.getInt("itemIndex")
+        }
       }
 
       if (firstVisibleIndex != null && lastVisibleIndex != null) {
@@ -121,7 +125,9 @@ internal class ReactScrollViewAccessibilityDelegate : AccessibilityDelegateCompa
     if (accessibilityCollection != null) {
       val rowCount = accessibilityCollection.getInt("rowCount")
       val columnCount = accessibilityCollection.getInt("columnCount")
-      val hierarchical = accessibilityCollection.getBoolean("hierarchical")
+      val hierarchical =
+          accessibilityCollection.hasKey("hierarchical") &&
+              accessibilityCollection.getBoolean("hierarchical")
 
       val collectionInfoCompat =
           AccessibilityNodeInfoCompat.CollectionInfoCompat.obtain(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -44,6 +44,7 @@ internal class ReactTextViewAccessibilityDelegate(
                   view.getTag(R.id.accessibility_state) != null ||
                   view.getTag(R.id.accessibility_actions) != null ||
                   view.getTag(R.id.react_test_id) != null ||
+                  view.getTag(R.id.accessibility_collection) != null ||
                   view.getTag(R.id.accessibility_collection_item) != null ||
                   view.getTag(R.id.accessibility_links) != null ||
                   view.getTag(R.id.role) != null)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactAccessibilityDelegateTest.kt
@@ -10,6 +10,7 @@
 package com.facebook.react.uimanager
 
 import android.os.Bundle
+import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import com.facebook.react.R
 import com.facebook.react.bridge.BridgeReactContext
@@ -121,6 +122,41 @@ class ReactAccessibilityDelegateTest {
     val result = accessibilityDelegate.performAccessibilityAction(view, customActionId, null)
 
     assertThat(result).isTrue()
+  }
+
+  @Test
+  fun testAccessibilityCollection_setsCollectionInfo() {
+    view.setTag(
+        R.id.accessibility_collection,
+        JavaOnlyMap().apply {
+          putInt("rowCount", 4)
+          putInt("columnCount", 2)
+          putBoolean("hierarchical", true)
+        },
+    )
+
+    val nodeInfo = AccessibilityNodeInfoCompat.obtain()
+    accessibilityDelegate.onInitializeAccessibilityNodeInfo(view, nodeInfo)
+
+    assertThat(nodeInfo.collectionInfo).isNotNull()
+    assertThat(nodeInfo.collectionInfo.rowCount).isEqualTo(4)
+    assertThat(nodeInfo.collectionInfo.columnCount).isEqualTo(2)
+    assertThat(nodeInfo.collectionInfo.isHierarchical).isTrue()
+  }
+
+  @Test
+  fun testSetDelegate_accessibilityCollection_installsAccessibilityDelegate() {
+    view.setTag(
+        R.id.accessibility_collection,
+        JavaOnlyMap().apply {
+          putInt("rowCount", 4)
+          putInt("columnCount", 2)
+        },
+    )
+
+    ReactAccessibilityDelegate.setDelegate(view, false, 0)
+
+    assertThat(ViewCompat.hasAccessibilityDelegate(view)).isTrue()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegateTest.kt
@@ -48,7 +48,7 @@ class ReactScrollViewAccessibilityDelegateTest {
     )
     contentView.addView(View(context))
 
-    val event = AccessibilityEvent.obtain()
+    val event = AccessibilityEvent()
     delegate.onInitializeAccessibilityEvent(scrollView, event)
 
     assertThat(event.itemCount).isEqualTo(-1)
@@ -82,7 +82,7 @@ class ReactScrollViewAccessibilityDelegateTest {
     wrapper.addView(item)
     contentView.addView(wrapper)
 
-    val event = AccessibilityEvent.obtain()
+    val event = AccessibilityEvent()
     delegate.onInitializeAccessibilityEvent(scrollView, event)
 
     assertThat(event.itemCount).isEqualTo(5)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegateTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.scroll
+
+import android.content.Context
+import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.widget.FrameLayout
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import com.facebook.react.R
+import com.facebook.react.bridge.JavaOnlyMap
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ReactScrollViewAccessibilityDelegateTest {
+  private lateinit var context: Context
+  private lateinit var scrollView: TestScrollView
+  private lateinit var contentView: FrameLayout
+  private lateinit var delegate: ReactScrollViewAccessibilityDelegate
+
+  @Before
+  fun setUp() {
+    context = RuntimeEnvironment.getApplication()
+    scrollView = TestScrollView(context)
+    contentView = FrameLayout(context)
+    scrollView.addView(contentView)
+    delegate = ReactScrollViewAccessibilityDelegate()
+  }
+
+  @Test
+  fun testOnInitializeAccessibilityEvent_allowsMissingOptionalCollectionFields() {
+    scrollView.setTag(
+        R.id.accessibility_collection,
+        JavaOnlyMap().apply {
+          putInt("rowCount", 3)
+          putInt("columnCount", 1)
+        },
+    )
+    contentView.addView(View(context))
+
+    val event = AccessibilityEvent.obtain()
+    delegate.onInitializeAccessibilityEvent(scrollView, event)
+
+    assertThat(event.itemCount).isEqualTo(-1)
+    assertThat(event.fromIndex).isEqualTo(-1)
+    assertThat(event.toIndex).isEqualTo(-1)
+  }
+
+  @Test
+  fun testOnInitializeAccessibilityEvent_readsNestedCollectionItemIndex() {
+    scrollView.setTag(
+        R.id.accessibility_collection,
+        JavaOnlyMap().apply {
+          putInt("itemCount", 5)
+          putInt("rowCount", 5)
+          putInt("columnCount", 1)
+        },
+    )
+    val wrapper = FrameLayout(context)
+    val item = View(context)
+    item.setTag(
+        R.id.accessibility_collection_item,
+        JavaOnlyMap().apply {
+          putInt("itemIndex", 2)
+          putInt("rowIndex", 2)
+          putInt("rowSpan", 1)
+          putInt("columnIndex", 0)
+          putInt("columnSpan", 1)
+          putBoolean("heading", false)
+        },
+    )
+    wrapper.addView(item)
+    contentView.addView(wrapper)
+
+    val event = AccessibilityEvent.obtain()
+    delegate.onInitializeAccessibilityEvent(scrollView, event)
+
+    assertThat(event.itemCount).isEqualTo(5)
+    assertThat(event.fromIndex).isEqualTo(2)
+    assertThat(event.toIndex).isEqualTo(2)
+  }
+
+  @Test
+  fun testOnInitializeAccessibilityNodeInfo_defaultsMissingHierarchicalToFalse() {
+    scrollView.setTag(
+        R.id.accessibility_collection,
+        JavaOnlyMap().apply {
+          putInt("rowCount", 3)
+          putInt("columnCount", 1)
+        },
+    )
+
+    val nodeInfo = AccessibilityNodeInfoCompat.obtain()
+    delegate.onInitializeAccessibilityNodeInfo(scrollView, nodeInfo)
+
+    assertThat(nodeInfo.collectionInfo).isNotNull()
+    assertThat(nodeInfo.collectionInfo.rowCount).isEqualTo(3)
+    assertThat(nodeInfo.collectionInfo.columnCount).isEqualTo(1)
+    assertThat(nodeInfo.collectionInfo.isHierarchical).isFalse()
+  }
+
+  private class TestScrollView(context: Context) : FrameLayout(context), ReactAccessibleScrollView {
+    override val scrollEnabled: Boolean = true
+
+    override fun isPartiallyScrolledInView(view: View): Boolean = true
+  }
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegateTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import com.facebook.react.R
+import com.facebook.react.bridge.JavaOnlyMap
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ReactTextViewAccessibilityDelegateTest {
+
+  @Test
+  fun testSetDelegate_accessibilityCollection_installsAccessibilityDelegate() {
+    val view =
+        View(RuntimeEnvironment.getApplication()).apply {
+          setTag(
+              R.id.accessibility_collection,
+              JavaOnlyMap().apply {
+                putInt("rowCount", 4)
+                putInt("columnCount", 2)
+              },
+          )
+        }
+
+    ReactTextViewAccessibilityDelegate.setDelegate(view, false, 0)
+
+    assertThat(ViewCompat.hasAccessibilityDelegate(view)).isTrue()
+  }
+}


### PR DESCRIPTION
## Summary

- Apply Android `accessibilityCollection` metadata in `ReactAccessibilityDelegate` so generic views receive `CollectionInfoCompat`.
- Install the accessibility delegate when `accessibilityCollection` is present, matching existing `accessibilityCollectionItem` behavior.
- Install the text accessibility delegate when `accessibilityCollection` is present so text-backed views honor collection metadata consistently.
- Harden `ReactScrollViewAccessibilityDelegate` so optional collection fields such as `itemCount`, `itemIndex`, and `hierarchical` can be absent without crashing.

## Changelog:

[ANDROID] [FIXED] - Fix Android accessibility collection metadata handling for generic and text views

## Motivation

The Android collection plumbing already exposes `accessibilityCollection` / `accessibilityCollectionItem`, but generic view delegates did not apply collection metadata and the scroll delegate assumed every collection field was present. This keeps the native plumbing useful for current and future list-level work without duplicating the open VirtualizedList/FlatList implementation in #56692.

## Test plan

- `PATH="/tmp/rn-yarn-bin:$HOME/.nvm/versions/node/v22.20.0/bin:$PATH" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew -Preact.internal.useHermesStable=true :packages:react-native:ReactAndroid:testDebugUnitTest --tests com.facebook.react.views.text.ReactTextViewAccessibilityDelegateTest --tests com.facebook.react.uimanager.ReactAccessibilityDelegateTest --tests com.facebook.react.views.scroll.ReactScrollViewAccessibilityDelegateTest`
- `PATH="/tmp/rn-yarn-bin:$HOME/.nvm/versions/node/v22.20.0/bin:$PATH" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew -Preact.internal.useHermesStable=true :packages:react-native:ReactAndroid:ktfmtCheck`