### PR TITLE
fix: add line break to gradle.properties for template testing

### DIFF
--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -66,7 +66,7 @@ jobs:
 
           echo "Feed maven local to gradle.properties"
           cd /tmp/RNTestProject
-          echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
+          echo "\nreact.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
 
           # Build
           cd android

--- a/scripts/release-testing/test-release-local.js
+++ b/scripts/release-testing/test-release-local.js
@@ -292,7 +292,7 @@ async function testRNTestProject(
 
   // need to do this here so that Android will be properly setup either way
   exec(
-    `echo "react.internal.mavenLocalRepo=${mavenLocalPath}" >> android/gradle.properties`,
+    `echo "\nreact.internal.mavenLocalRepo=${mavenLocalPath}" >> android/gradle.properties`,
   );
 
   // Only build the simulator architecture. CI is however generating only that one.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes the failing CI jobs on main for `template` testing. The job fails as they echo `react.internal.mavenLocalRepo=...` to the `gradle.properties` of template test project. As a result of which the `gradle.properties` look like below:

```properties
android.builtInKotlin=false
android.newDsl=falsereact.internal.mavenLocalRepo=...
```

To fix it we add a line break in the `echo` command.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - add line break to gradle.properties for template testing

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- CI Passing
- Verified Locally
