### PR TITLE
Make CustomEventNamesResolver a fun interface for SAM conversion

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.kt
@@ -85,7 +85,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 public open class UIManagerModule : ReactContextBaseJavaModule, LifecycleEventListener, UIManager {
 
   /** Resolves a name coming from native side to a name of the event that is exposed to JS. */
-  public interface CustomEventNamesResolver {
+  public fun interface CustomEventNamesResolver {
     /** Returns custom event name by the provided event name. */
     public fun resolveCustomEventName(eventName: String): String?
   }


### PR DESCRIPTION
Summary:
`UIManagerModule` was recently converted from Java to Kotlin. The nested
`CustomEventNamesResolver` interface has a single abstract method, but
was declared as a regular `interface` rather than `fun interface`.

In Java, single-method interfaces support SAM (Single Abstract Method)
conversion in Kotlin callers. After the Kotlin conversion, SAM conversion
no longer works unless the interface is declared as `fun interface`.

This breaks downstream libraries like `react-native-reanimated` that use
lambda syntax to instantiate `CustomEventNamesResolver`:
```
UIManagerModule.CustomEventNamesResolver { eventName -> ... }
```

Adding `fun` restores SAM conversion support. This is backward compatible
— existing `object : CustomEventNamesResolver { ... }` code continues to work.

Differential Revision: D107891295
