### PR TITLE
Remove RuntimeScheduler_Legacy.h/.cpp from react-native-github

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
@@ -143,8 +143,11 @@ void NativeMutationObserver::notifyMutationObserversIfNecessary() {
 
   if (dispatchNotification) {
     TraceSection s("NativeMutationObserver::notifyObservers");
+#ifndef RCT_REMOVE_LEGACY_ARCH
     if (ReactNativeFeatureFlags::enableBridgelessArchitecture()) {
+#endif
       runtime_->queueMicrotask(notifyMutationObservers_.value());
+#ifndef RCT_REMOVE_LEGACY_ARCH
     } else {
       jsInvoker_->invokeAsync([&](jsi::Runtime& runtime) {
         // It's possible that the last observer was disconnected before we could
@@ -154,6 +157,7 @@ void NativeMutationObserver::notifyMutationObserversIfNecessary() {
         }
       });
     }
+#endif
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -6,12 +6,16 @@
  */
 
 #include "RuntimeScheduler.h"
-#include "RuntimeScheduler_Legacy.h"
 #include "RuntimeScheduler_Modern.h"
+#ifndef RCT_REMOVE_LEGACY_ARCH
+#include "RuntimeScheduler_Legacy.h"
+#endif
 
 #include <cxxreact/ErrorUtils.h>
 #include <cxxreact/TraceSection.h>
+#ifndef RCT_REMOVE_LEGACY_ARCH
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#endif
 #include <utility>
 
 namespace facebook::react {
@@ -23,13 +27,17 @@ std::unique_ptr<RuntimeSchedulerBase> getRuntimeSchedulerImplementation(
     RuntimeExecutor runtimeExecutor,
     std::function<HighResTimeStamp()> now,
     RuntimeSchedulerTaskErrorHandler onTaskError) {
+#ifndef RCT_REMOVE_LEGACY_ARCH
   if (ReactNativeFeatureFlags::enableBridgelessArchitecture()) {
+#endif
     return std::make_unique<RuntimeScheduler_Modern>(
         std::move(runtimeExecutor), std::move(now), std::move(onTaskError));
+#ifndef RCT_REMOVE_LEGACY_ARCH
   } else {
     return std::make_unique<RuntimeScheduler_Legacy>(
         std::move(runtimeExecutor), std::move(now), std::move(onTaskError));
   }
+#endif
 }
 
 } // namespace

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "RuntimeScheduler_Legacy.h"
+
+#ifndef RCT_REMOVE_LEGACY_ARCH
+
 #include "SchedulerPriorityUtils.h"
 
 #include <ReactCommon/RuntimeExecutorSyncUIThreadUtils.h>
@@ -282,3 +285,5 @@ void RuntimeScheduler_Legacy::executeTask(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_ARCH

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_REMOVE_LEGACY_ARCH
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
@@ -172,3 +174,5 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_REMOVE_LEGACY_ARCH

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -17,7 +17,9 @@
 
 namespace facebook::react {
 
+#ifndef RCT_REMOVE_LEGACY_ARCH
 class RuntimeScheduler_Legacy;
+#endif
 class RuntimeScheduler_Modern;
 class TaskPriorityComparer;
 
@@ -29,7 +31,9 @@ struct Task final : public jsi::NativeState {
   Task(SchedulerPriority priority, RawCallback &&callback, HighResTimeStamp expirationTime);
 
  private:
+#ifndef RCT_REMOVE_LEGACY_ARCH
   friend RuntimeScheduler_Legacy;
+#endif
   friend RuntimeScheduler_Modern;
   friend TaskPriorityComparer;
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -1431,6 +1431,10 @@ TEST_P(RuntimeSchedulerTest, reportsLongTasksWithYielding) {
 INSTANTIATE_TEST_SUITE_P(
     UseModernRuntimeScheduler,
     RuntimeSchedulerTest,
+#ifdef RCT_REMOVE_LEGACY_ARCH
+    testing::Values(true));
+#else
     testing::Values(false, true));
+#endif
 
 } // namespace facebook::react

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -4264,30 +4264,6 @@ class facebook::react::RuntimeSchedulerIntersectionObserverDelegate {
   public virtual ~RuntimeSchedulerIntersectionObserverDelegate() = default;
 }
 
-class facebook::react::RuntimeScheduler_Legacy : public facebook::react::RuntimeSchedulerBase {
-  public RuntimeScheduler_Legacy(const facebook::react::RuntimeScheduler_Legacy&) = delete;
-  public RuntimeScheduler_Legacy(facebook::react::RuntimeExecutor runtimeExecutor, std::function<facebook::react::HighResTimeStamp()> now, facebook::react::RuntimeSchedulerTaskErrorHandler onTaskError);
-  public RuntimeScheduler_Legacy(facebook::react::RuntimeScheduler_Legacy&&) = delete;
-  public facebook::react::RuntimeScheduler_Legacy& operator=(const facebook::react::RuntimeScheduler_Legacy&) = delete;
-  public facebook::react::RuntimeScheduler_Legacy& operator=(facebook::react::RuntimeScheduler_Legacy&&) = delete;
-  public virtual bool getShouldYield() noexcept override;
-  public virtual facebook::react::HighResTimeStamp now() const noexcept override;
-  public virtual facebook::react::SchedulerPriority getCurrentPriorityLevel() const noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleIdleTask(facebook::jsi::Function&& callback, facebook::react::HighResDuration timeout = timeoutForSchedulerPriority(facebook::react::SchedulerPriority::IdlePriority)) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleIdleTask(facebook::react::RawCallback&& callback, facebook::react::HighResDuration timeout = timeoutForSchedulerPriority(facebook::react::SchedulerPriority::IdlePriority)) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleTask(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleTask(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback) noexcept override;
-  public virtual void callExpiredTasks(facebook::jsi::Runtime& runtime) override;
-  public virtual void cancelTask(facebook::react::Task& task) noexcept override;
-  public virtual void executeNowOnTheSameThread(facebook::react::RawCallback&& callback) override;
-  public virtual void scheduleRenderingUpdate(facebook::react::SurfaceId surfaceId, facebook::react::RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;
-  public virtual void scheduleWork(facebook::react::RawCallback&& callback) noexcept override;
-  public virtual void setEventTimingDelegate(facebook::react::RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) override;
-  public virtual void setIntersectionObserverDelegate(facebook::react::RuntimeSchedulerIntersectionObserverDelegate* intersectionObserverDelegate) override;
-  public virtual void setPerformanceEntryReporter(facebook::react::PerformanceEntryReporter* performanceEntryReporter) override;
-  public virtual void setShadowTreeRevisionConsistencyManager(facebook::react::ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager) override;
-}
-
 class facebook::react::RuntimeScheduler_Modern : public facebook::react::RuntimeSchedulerBase {
   public RuntimeScheduler_Modern(const facebook::react::RuntimeScheduler_Modern&) = delete;
   public RuntimeScheduler_Modern(facebook::react::RuntimeExecutor runtimeExecutor, std::function<facebook::react::HighResTimeStamp()> now, facebook::react::RuntimeSchedulerTaskErrorHandler onTaskError);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -6495,30 +6495,6 @@ class facebook::react::RuntimeSchedulerIntersectionObserverDelegate {
   public virtual ~RuntimeSchedulerIntersectionObserverDelegate() = default;
 }
 
-class facebook::react::RuntimeScheduler_Legacy : public facebook::react::RuntimeSchedulerBase {
-  public RuntimeScheduler_Legacy(const facebook::react::RuntimeScheduler_Legacy&) = delete;
-  public RuntimeScheduler_Legacy(facebook::react::RuntimeExecutor runtimeExecutor, std::function<facebook::react::HighResTimeStamp()> now, facebook::react::RuntimeSchedulerTaskErrorHandler onTaskError);
-  public RuntimeScheduler_Legacy(facebook::react::RuntimeScheduler_Legacy&&) = delete;
-  public facebook::react::RuntimeScheduler_Legacy& operator=(const facebook::react::RuntimeScheduler_Legacy&) = delete;
-  public facebook::react::RuntimeScheduler_Legacy& operator=(facebook::react::RuntimeScheduler_Legacy&&) = delete;
-  public virtual bool getShouldYield() noexcept override;
-  public virtual facebook::react::HighResTimeStamp now() const noexcept override;
-  public virtual facebook::react::SchedulerPriority getCurrentPriorityLevel() const noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleIdleTask(facebook::jsi::Function&& callback, facebook::react::HighResDuration timeout = timeoutForSchedulerPriority(facebook::react::SchedulerPriority::IdlePriority)) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleIdleTask(facebook::react::RawCallback&& callback, facebook::react::HighResDuration timeout = timeoutForSchedulerPriority(facebook::react::SchedulerPriority::IdlePriority)) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleTask(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleTask(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback) noexcept override;
-  public virtual void callExpiredTasks(facebook::jsi::Runtime& runtime) override;
-  public virtual void cancelTask(facebook::react::Task& task) noexcept override;
-  public virtual void executeNowOnTheSameThread(facebook::react::RawCallback&& callback) override;
-  public virtual void scheduleRenderingUpdate(facebook::react::SurfaceId surfaceId, facebook::react::RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;
-  public virtual void scheduleWork(facebook::react::RawCallback&& callback) noexcept override;
-  public virtual void setEventTimingDelegate(facebook::react::RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) override;
-  public virtual void setIntersectionObserverDelegate(facebook::react::RuntimeSchedulerIntersectionObserverDelegate* intersectionObserverDelegate) override;
-  public virtual void setPerformanceEntryReporter(facebook::react::PerformanceEntryReporter* performanceEntryReporter) override;
-  public virtual void setShadowTreeRevisionConsistencyManager(facebook::react::ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager) override;
-}
-
 class facebook::react::RuntimeScheduler_Modern : public facebook::react::RuntimeSchedulerBase {
   public RuntimeScheduler_Modern(const facebook::react::RuntimeScheduler_Modern&) = delete;
   public RuntimeScheduler_Modern(facebook::react::RuntimeExecutor runtimeExecutor, std::function<facebook::react::HighResTimeStamp()> now, facebook::react::RuntimeSchedulerTaskErrorHandler onTaskError);

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -2871,30 +2871,6 @@ class facebook::react::RuntimeSchedulerIntersectionObserverDelegate {
   public virtual ~RuntimeSchedulerIntersectionObserverDelegate() = default;
 }
 
-class facebook::react::RuntimeScheduler_Legacy : public facebook::react::RuntimeSchedulerBase {
-  public RuntimeScheduler_Legacy(const facebook::react::RuntimeScheduler_Legacy&) = delete;
-  public RuntimeScheduler_Legacy(facebook::react::RuntimeExecutor runtimeExecutor, std::function<facebook::react::HighResTimeStamp()> now, facebook::react::RuntimeSchedulerTaskErrorHandler onTaskError);
-  public RuntimeScheduler_Legacy(facebook::react::RuntimeScheduler_Legacy&&) = delete;
-  public facebook::react::RuntimeScheduler_Legacy& operator=(const facebook::react::RuntimeScheduler_Legacy&) = delete;
-  public facebook::react::RuntimeScheduler_Legacy& operator=(facebook::react::RuntimeScheduler_Legacy&&) = delete;
-  public virtual bool getShouldYield() noexcept override;
-  public virtual facebook::react::HighResTimeStamp now() const noexcept override;
-  public virtual facebook::react::SchedulerPriority getCurrentPriorityLevel() const noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleIdleTask(facebook::jsi::Function&& callback, facebook::react::HighResDuration timeout = timeoutForSchedulerPriority(facebook::react::SchedulerPriority::IdlePriority)) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleIdleTask(facebook::react::RawCallback&& callback, facebook::react::HighResDuration timeout = timeoutForSchedulerPriority(facebook::react::SchedulerPriority::IdlePriority)) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleTask(facebook::react::SchedulerPriority priority, facebook::jsi::Function&& callback) noexcept override;
-  public virtual std::shared_ptr<facebook::react::Task> scheduleTask(facebook::react::SchedulerPriority priority, facebook::react::RawCallback&& callback) noexcept override;
-  public virtual void callExpiredTasks(facebook::jsi::Runtime& runtime) override;
-  public virtual void cancelTask(facebook::react::Task& task) noexcept override;
-  public virtual void executeNowOnTheSameThread(facebook::react::RawCallback&& callback) override;
-  public virtual void scheduleRenderingUpdate(facebook::react::SurfaceId surfaceId, facebook::react::RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;
-  public virtual void scheduleWork(facebook::react::RawCallback&& callback) noexcept override;
-  public virtual void setEventTimingDelegate(facebook::react::RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) override;
-  public virtual void setIntersectionObserverDelegate(facebook::react::RuntimeSchedulerIntersectionObserverDelegate* intersectionObserverDelegate) override;
-  public virtual void setPerformanceEntryReporter(facebook::react::PerformanceEntryReporter* performanceEntryReporter) override;
-  public virtual void setShadowTreeRevisionConsistencyManager(facebook::react::ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager) override;
-}
-
 class facebook::react::RuntimeScheduler_Modern : public facebook::react::RuntimeSchedulerBase {
   public RuntimeScheduler_Modern(const facebook::react::RuntimeScheduler_Modern&) = delete;
   public RuntimeScheduler_Modern(facebook::react::RuntimeExecutor runtimeExecutor, std::function<facebook::react::HighResTimeStamp()> now, facebook::react::RuntimeSchedulerTaskErrorHandler onTaskError);


### PR DESCRIPTION
Summary:
## Changelog:
[General][Breaking] Remove RuntimeScheduler_Legacy.h/.cpp from react-native-github

Remove legacy RuntimeScheduler implementation and directly instantiate RuntimeScheduler_Modern instead. This eliminates the feature-flag-based selection between legacy and modern implementations, simplifying the codebase by removing ~400 lines of deprecated scheduling code.

Differential Revision: D107777881


