### PR TITLE
fix: Metro inline-plugin doesn't support relative ES imports of Platform and it cause dead-code in production

### DIFF
--- a/packages/react-native/Libraries/Alert/Alert.js
+++ b/packages/react-native/Libraries/Alert/Alert.js
@@ -10,8 +10,9 @@
 
 import type {DialogOptions} from '../NativeModules/specs/NativeDialogManagerAndroid';
 
-import Platform from '../Utilities/Platform';
 import {alertWithArgs} from './RCTAlertManager';
+
+const Platform = require('../Utilities/Platform').default;
 
 /**
  * @platform ios

--- a/packages/react-native/Libraries/Animated/AnimatedExports.js
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js
@@ -15,9 +15,10 @@ import typeof AnimatedSectionList from './components/AnimatedSectionList';
 import typeof AnimatedText from './components/AnimatedText';
 import typeof AnimatedView from './components/AnimatedView';
 
-import Platform from '../Utilities/Platform';
 import AnimatedImplementation from './AnimatedImplementation';
 import AnimatedMock from './AnimatedMock';
+
+const Platform = require('../Utilities/Platform').default;
 
 const Animated: typeof AnimatedImplementation = Platform.isDisableAnimations
   ? AnimatedMock

--- a/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
@@ -21,12 +21,13 @@ import ScrollView, {
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import splitLayoutProps from '../../StyleSheet/splitLayoutProps';
 import StyleSheet from '../../StyleSheet/StyleSheet';
-import Platform from '../../Utilities/Platform';
 import useMergeRefs from '../../Utilities/useMergeRefs';
 import createAnimatedComponent from '../createAnimatedComponent';
 import useAnimatedProps from '../useAnimatedProps';
 import * as React from 'react';
 import {cloneElement, useMemo} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 type AnimatedScrollViewInstance = React.ElementRef<typeof ScrollView>;
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -13,11 +13,12 @@ import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import {validateStyles} from '../../../src/private/animated/NativeAnimatedValidation';
 import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
-import Platform from '../../Utilities/Platform';
 import AnimatedNode from './AnimatedNode';
 import AnimatedObject from './AnimatedObject';
 import AnimatedTransform from './AnimatedTransform';
 import AnimatedWithChildren from './AnimatedWithChildren';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export type AnimatedStyleAllowlist = Readonly<{[string]: true}>;
 

--- a/packages/react-native/Libraries/Animated/shouldUseTurboAnimatedModule.js
+++ b/packages/react-native/Libraries/Animated/shouldUseTurboAnimatedModule.js
@@ -9,7 +9,8 @@
  */
 
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
-import Platform from '../Utilities/Platform';
+
+const Platform = require('../Utilities/Platform').default;
 
 function shouldUseTurboAnimatedModule(): boolean {
   if (ReactNativeFeatureFlags.cxxNativeAnimatedEnabled()) {

--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -10,9 +10,10 @@
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
 import logError from '../Utilities/logError';
-import Platform from '../Utilities/Platform';
 import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import NativeAppState from './NativeAppState';
+
+const Platform = require('../Utilities/Platform').default;
 
 /**
  * active - The app is running in the foreground

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -13,10 +13,11 @@ import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
 
 import RCTDeviceEventEmitter from '../../EventEmitter/RCTDeviceEventEmitter';
 import {sendAccessibilityEvent} from '../../ReactNative/RendererProxy';
-import Platform from '../../Utilities/Platform';
 import legacySendAccessibilityEvent from './legacySendAccessibilityEvent';
 import NativeAccessibilityInfoAndroid from './NativeAccessibilityInfo';
 import NativeAccessibilityManagerIOS from './NativeAccessibilityManager';
+
+const Platform = require('../../Utilities/Platform').default;
 
 // Events that are only supported on Android.
 type AccessibilityEventDefinitionsAndroid = {

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -13,9 +13,10 @@ import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {ViewProps} from '../View/ViewPropTypes';
 
 import StyleSheet, {type ColorValue} from '../../StyleSheet/StyleSheet';
-import Platform from '../../Utilities/Platform';
 import View from '../View/View';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export type ActivityIndicatorInstance = HostInstance;
 

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -20,12 +20,13 @@ import type {
 
 import StyleSheet, {type ColorValue} from '../StyleSheet/StyleSheet';
 import Text from '../Text/Text';
-import Platform from '../Utilities/Platform';
 import TouchableNativeFeedback from './Touchable/TouchableNativeFeedback';
 import TouchableOpacity from './Touchable/TouchableOpacity';
 import View from './View/View';
 import invariant from 'invariant';
 import * as React from 'react';
+
+const Platform = require('../Utilities/Platform').default;
 
 /** @build-types emit-as-interface Uniwind compatibility */
 export type ButtonProps = Readonly<{

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -13,8 +13,9 @@ import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
 import NativeEventEmitter from '../../EventEmitter/NativeEventEmitter';
 import LayoutAnimation from '../../LayoutAnimation/LayoutAnimation';
 import dismissKeyboard from '../../Utilities/dismissKeyboard';
-import Platform from '../../Utilities/Platform';
 import NativeKeyboardObserver from './NativeKeyboardObserver';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export type KeyboardEventName = keyof KeyboardEventDefinitions;
 

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -18,13 +18,14 @@ import type {KeyboardEvent, KeyboardMetrics} from './Keyboard';
 
 import LayoutAnimation from '../../LayoutAnimation/LayoutAnimation';
 import StyleSheet from '../../StyleSheet/StyleSheet';
-import Platform from '../../Utilities/Platform';
 import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
 import AccessibilityInfo from '../AccessibilityInfo/AccessibilityInfo';
 import View from '../View/View';
 import Keyboard from './Keyboard';
 import * as React from 'react';
 import {createRef} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 /** @build-types emit-as-interface Uniwind compatibility */
 export type KeyboardAvoidingViewProps = Readonly<{

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
@@ -9,11 +9,12 @@
  */
 
 import {PlatformColor} from '../../../StyleSheet/PlatformColorValueTypes';
-import Platform from '../../../Utilities/Platform';
 import {expectRendersMatchingSnapshot} from '../../../Utilities/ReactNativeTestTools';
 import View from '../../View/View';
 import Pressable from '../Pressable';
 import * as React from 'react';
+
+const Platform = require('../../../Utilities/Platform').default;
 
 describe('<Pressable />', () => {
   it('should render as expected', async () => {

--- a/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -13,11 +13,12 @@ import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {GestureResponderEvent} from '../../Types/CoreEventTypes';
 
 import processColor from '../../StyleSheet/processColor';
-import Platform from '../../Utilities/Platform';
 import View from '../View/View';
 import {Commands} from '../View/ViewNativeComponent';
 import * as React from 'react';
 import {useMemo} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 type NativeBackgroundProp = Readonly<{
   type: 'RippleAndroid',

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js
@@ -13,7 +13,7 @@
 import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {ProgressBarAndroidProps} from './ProgressBarAndroidTypes';
 
-import Platform from '../../Utilities/Platform';
+const Platform = require('../../Utilities/Platform').default;
 
 export type ProgressBarAndroidInstance = HostInstance;
 

--- a/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -11,9 +11,10 @@
 import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {ViewProps} from '../View/ViewPropTypes';
 
-import Platform from '../../Utilities/Platform';
 import View from '../View/View';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export type SafeAreaViewInstance = HostInstance;
 

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -40,7 +40,6 @@ import splitLayoutProps from '../../StyleSheet/splitLayoutProps';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Dimensions from '../../Utilities/Dimensions';
 import dismissKeyboard from '../../Utilities/dismissKeyboard';
-import Platform from '../../Utilities/Platform';
 import Keyboard from '../Keyboard/Keyboard';
 import TextInputState from '../TextInput/TextInputState';
 import View from '../View/View';
@@ -53,6 +52,8 @@ import memoize from 'memoize-one';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {cloneElement} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 /*
  * iOS scroll event timing nuances:

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -14,8 +14,9 @@ import type {ScrollViewNativeProps as Props} from './ScrollViewNativeComponentTy
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';
 import {ConditionallyIgnoredEventHandlers} from '../../NativeComponent/ViewConfigIgnore';
-import Platform from '../../Utilities/Platform';
 import {colorAttribute} from '../View/ReactNativeStyleAttributes';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
   Platform.OS === 'android'

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -13,7 +13,6 @@ import type {LayoutChangeEvent} from '../../Types/CoreEventTypes';
 import Animated from '../../Animated/Animated';
 import {isPublicInstance as isFabricPublicInstance} from '../../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstanceUtils';
 import StyleSheet from '../../StyleSheet/StyleSheet';
-import Platform from '../../Utilities/Platform';
 import useMergeRefs from '../../Utilities/useMergeRefs';
 import * as React from 'react';
 import {
@@ -24,6 +23,8 @@ import {
   useRef,
   useState,
 } from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export type ScrollViewStickyHeaderProps = Readonly<{
   children?: React.Node,

--- a/packages/react-native/Libraries/Components/ScrollView/processDecelerationRate.js
+++ b/packages/react-native/Libraries/Components/ScrollView/processDecelerationRate.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import Platform from '../../Utilities/Platform';
+const Platform = require('../../Utilities/Platform').default;
 
 function processDecelerationRate(
   decelerationRate: number | 'normal' | 'fast',

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -13,11 +13,12 @@ import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
 
 import processColor from '../../StyleSheet/processColor';
 import * as Appearance from '../../Utilities/Appearance';
-import Platform from '../../Utilities/Platform';
 import NativeStatusBarManagerAndroid from './NativeStatusBarManagerAndroid';
 import NativeStatusBarManagerIOS from './NativeStatusBarManagerIOS';
 import invariant from 'invariant';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 /**
  * Status bar style

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -15,7 +15,6 @@ import type {AccessibilityState} from '../View/ViewAccessibility';
 import type {ViewProps} from '../View/ViewPropTypes';
 
 import StyleSheet from '../../StyleSheet/StyleSheet';
-import Platform from '../../Utilities/Platform';
 import useMergeRefs from '../../Utilities/useMergeRefs';
 import AndroidSwitchNativeComponent, {
   Commands as AndroidSwitchCommands,
@@ -25,6 +24,8 @@ import SwitchNativeComponent, {
 } from './SwitchNativeComponent';
 import * as React from 'react';
 import {useLayoutEffect, useRef, useState} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export type SwitchInstance = HostInstance;
 

--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
@@ -13,10 +13,11 @@ import StyleSheet, {
   type ColorValue,
   type ViewStyleProp,
 } from '../../StyleSheet/StyleSheet';
-import Platform from '../../Utilities/Platform';
 import useWindowDimensions from '../../Utilities/useWindowDimensions';
 import RCTInputAccessoryViewNativeComponent from './RCTInputAccessoryViewNativeComponent';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 /**
  * Note: iOS only

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -56,13 +56,14 @@ import flattenStyle from '../../StyleSheet/flattenStyle';
 import StyleSheet, {type TextStyleProp} from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
 import TextAncestorContext from '../../Text/TextAncestorContext';
-import Platform from '../../Utilities/Platform';
 import useMergeRefs from '../../Utilities/useMergeRefs';
 import TextInputState from './TextInputState';
 import invariant from 'invariant';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 let AndroidTextInput;
 let AndroidTextInputCommands;

--- a/packages/react-native/Libraries/Components/Touchable/Touchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/Touchable.js
@@ -18,11 +18,12 @@ import type {
 
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import UIManager from '../../ReactNative/UIManager';
-import Platform from '../../Utilities/Platform';
 import SoundManager from '../Sound/SoundManager';
 import BoundingDimensions from './BoundingDimensions';
 import Position from './Position';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 const extractSingleTouch = (nativeEvent: {
   readonly changedTouches: ReadonlyArray<GestureResponderEvent['nativeEvent']>,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -16,8 +16,9 @@ import Pressability, {
   type PressabilityConfig,
 } from '../../Pressability/Pressability';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
-import Platform from '../../Utilities/Platform';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 type TouchableBounceProps = Readonly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -19,10 +19,11 @@ import Pressability, {
 } from '../../Pressability/Pressability';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import StyleSheet, {type ViewStyleProp} from '../../StyleSheet/StyleSheet';
-import Platform from '../../Utilities/Platform';
 import warnOnce from '../../Utilities/warnOnce';
 import * as React from 'react';
 import {cloneElement} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export type TouchableHighlightInstance = HostInstance;
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -20,10 +20,11 @@ import Pressability, {
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import {findHostInstance_DEPRECATED} from '../../ReactNative/RendererProxy';
 import processColor from '../../StyleSheet/processColor';
-import Platform from '../../Utilities/Platform';
 import {Commands} from '../View/ViewNativeComponent';
 import * as React from 'react';
 import {cloneElement} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 type TouchableNativeFeedbackTVProps = {
   /**

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -19,8 +19,9 @@ import Pressability, {
 } from '../../Pressability/Pressability';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import flattenStyle from '../../StyleSheet/flattenStyle';
-import Platform from '../../Utilities/Platform';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 export type TouchableOpacityInstance = HostInstance;
 

--- a/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
@@ -8,8 +8,7 @@
  * @format
  */
 
-import Platform from '../Utilities/Platform';
-
+const Platform = require('../Utilities/Platform').default;
 const ReactNativeVersion = require('./ReactNativeVersion');
 
 /**

--- a/packages/react-native/Libraries/Core/setUpDeveloperTools.js
+++ b/packages/react-native/Libraries/Core/setUpDeveloperTools.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import Platform from '../Utilities/Platform';
+const Platform = require('../Utilities/Platform').default;
 
 declare var console: {[string]: $FlowFixMe};
 

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -15,9 +15,10 @@ import type {
   IEventEmitter,
 } from '../vendor/emitter/EventEmitter';
 
-import Platform from '../Utilities/Platform';
 import RCTDeviceEventEmitter from './RCTDeviceEventEmitter';
 import invariant from 'invariant';
+
+const Platform = require('../Utilities/Platform').default;
 
 interface NativeModule {
   addListener(eventType: string): void;

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -25,7 +25,8 @@ import {colorAttribute} from '../Components/View/ReactNativeStyleAttributes';
 import * as NativeComponentRegistry from '../NativeComponent/NativeComponentRegistry';
 import {ConditionallyIgnoredEventHandlers} from '../NativeComponent/ViewConfigIgnore';
 import codegenNativeCommands from '../Utilities/codegenNativeCommands';
-import Platform from '../Utilities/Platform';
+
+const Platform = require('../Utilities/Platform').default;
 
 type ImageHostComponentProps = Readonly<{
   ...ImageProps,

--- a/packages/react-native/Libraries/Image/nativeImageSource.js
+++ b/packages/react-native/Libraries/Image/nativeImageSource.js
@@ -10,7 +10,7 @@
 
 import type {ImageURISource} from './ImageSource';
 
-import Platform from '../Utilities/Platform';
+const Platform = require('../Utilities/Platform').default;
 
 type NativeImageSourceSpec = Readonly<{
   android?: string,

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -18,9 +18,9 @@ import type {
 
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import {getFabricUIManager} from '../ReactNative/FabricUIManager';
-import Platform from '../Utilities/Platform';
 
 const UIManager = require('../ReactNative/UIManager').default;
+const Platform = require('../Utilities/Platform').default;
 
 export type {
   LayoutAnimationType,

--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -11,11 +11,12 @@
 import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
-import Platform from '../Utilities/Platform';
 import NativeIntentAndroid from './NativeIntentAndroid';
 import NativeLinkingManager from './NativeLinkingManager';
 import invariant from 'invariant';
 import nullthrows from 'nullthrows';
+
+const Platform = require('../Utilities/Platform').default;
 
 type LinkingEventDefinitions = {
   url: [{url: string}],

--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -19,9 +19,10 @@ import type {
   VirtualizedSectionListProps,
 } from '@react-native/virtualized-lists';
 
-import Platform from '../Utilities/Platform';
 import VirtualizedLists from '@react-native/virtualized-lists';
 import * as React from 'react';
+
+const Platform = require('../Utilities/Platform').default;
 
 const VirtualizedSectionList = VirtualizedLists.VirtualizedSectionList;
 

--- a/packages/react-native/Libraries/Lists/SectionListModern.js
+++ b/packages/react-native/Libraries/Lists/SectionListModern.js
@@ -18,10 +18,11 @@ import type {
   VirtualizedSectionListProps,
 } from '@react-native/virtualized-lists';
 
-import Platform from '../Utilities/Platform';
 import VirtualizedLists from '@react-native/virtualized-lists';
 import * as React from 'react';
 import {useImperativeHandle, useRef} from 'react';
+
+const Platform = require('../Utilities/Platform').default;
 
 const VirtualizedSectionList = VirtualizedLists.VirtualizedSectionList;
 

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -13,9 +13,10 @@ import type {Stack} from './Data/LogBoxSymbolication';
 import type {ExtendedExceptionData} from './Data/parseLogBoxLog';
 
 import toExtendedError from '../../src/private/utilities/toExtendedError';
-import Platform from '../Utilities/Platform';
 import RCTLog from '../Utilities/RCTLog';
 import * as React from 'react';
+
+const Platform = require('../Utilities/Platform').default;
 
 // TODO: Remove support for LegacyComponentStackFrame in a future version.
 // This is kept for backward compatibility with external callers of LogBox.addLog.

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js
@@ -15,13 +15,14 @@ import View from '../../Components/View/View';
 import openFileInEditor from '../../Core/Devtools/openFileInEditor';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
-import Platform from '../../Utilities/Platform';
 import * as LogBoxData from '../Data/LogBoxData';
 import AnsiHighlight from './AnsiHighlight';
 import LogBoxButton from './LogBoxButton';
 import LogBoxInspectorSection from './LogBoxInspectorSection';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 component CodeFrameDisplay(codeFrame: CodeFrame) {
   function getFileName() {

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
@@ -15,10 +15,11 @@ import SafeAreaView from '../../Components/SafeAreaView/SafeAreaView';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
-import Platform from '../../Utilities/Platform';
 import LogBoxInspectorHeaderButton from './LogBoxInspectorHeaderButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 type Props = Readonly<{
   onSelectIndex: (selectedIndex: number) => void,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
@@ -14,12 +14,13 @@ import View from '../../Components/View/View';
 import openFileInEditor from '../../Core/Devtools/openFileInEditor';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
-import Platform from '../../Utilities/Platform';
 import LogBoxButton from './LogBoxButton';
 import LogBoxInspectorSection from './LogBoxInspectorSection';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 import {useState} from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 const BEFORE_SLASH_RE = /^(.*)[\\/]/;
 

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrame.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrame.js
@@ -14,10 +14,11 @@ import type {GestureResponderEvent} from '../../Types/CoreEventTypes';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
-import Platform from '../../Utilities/Platform';
 import LogBoxButton from './LogBoxButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
+
+const Platform = require('../../Utilities/Platform').default;
 
 const noop = () => {};
 

--- a/packages/react-native/Libraries/NativeComponent/ViewConfigIgnore.js
+++ b/packages/react-native/Libraries/NativeComponent/ViewConfigIgnore.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import Platform from '../Utilities/Platform';
+const Platform = require('../Utilities/Platform').default;
 
 const ignoredViewConfigProps = new WeakSet<{...}>();
 

--- a/packages/react-native/Libraries/Network/RCTNetworking.android.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.android.js
@@ -16,9 +16,10 @@ import type {NativeResponseType} from './XMLHttpRequest';
 // Do not require the native RCTNetworking module directly! Use this wrapper module instead.
 // It will add the necessary requestId, so that you don't have to generate it yourself.
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
-import Platform from '../Utilities/Platform';
 import convertRequestBody from './convertRequestBody';
 import NativeNetworkingAndroid from './NativeNetworkingAndroid';
+
+const Platform = require('../Utilities/Platform').default;
 
 type Header = [string, string];
 

--- a/packages/react-native/Libraries/Pressability/HoverState.js
+++ b/packages/react-native/Libraries/Pressability/HoverState.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import Platform from '../Utilities/Platform';
+const Platform = require('../Utilities/Platform').default;
 
 let isEnabled = false;
 

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -21,11 +21,12 @@ import SoundManager from '../Components/Sound/SoundManager';
 import UIManager from '../ReactNative/UIManager';
 import {type RectOrSize, normalizeRect} from '../StyleSheet/Rect';
 import {type PointerEvent} from '../Types/CoreEventTypes';
-import Platform from '../Utilities/Platform';
 import {isHoverEnabled} from './HoverState';
 import PressabilityPerformanceEventEmitter from './PressabilityPerformanceEventEmitter.js';
 import {type PressabilityTouchSignal as TouchSignal} from './PressabilityTypes.js';
 import invariant from 'invariant';
+
+const Platform = require('../Utilities/Platform').default;
 
 export type PressabilityConfig = Readonly<{
   /**

--- a/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -11,9 +11,10 @@
 import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
-import Platform from '../Utilities/Platform';
 import NativePushNotificationManagerIOS from './NativePushNotificationManagerIOS';
 import invariant from 'invariant';
+
+const Platform = require('../Utilities/Platform').default;
 
 export type PushNotificationPermissions = {
   alert: boolean,

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -15,9 +15,10 @@ import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
 import {unstable_hasComponent} from '../NativeComponent/NativeComponentRegistryUnstable';
 import defineLazyObjectProperty from '../Utilities/defineLazyObjectProperty';
-import Platform from '../Utilities/Platform';
 import {getFabricUIManager} from './FabricUIManager';
 import nullthrows from 'nullthrows';
+
+const Platform = require('../Utilities/Platform').default;
 
 function raiseSoftError(methodName: string, details?: string): void {
   console.error(

--- a/packages/react-native/Libraries/Settings/Settings.js
+++ b/packages/react-native/Libraries/Settings/Settings.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import Platform from '../Utilities/Platform';
+const Platform = require('../Utilities/Platform').default;
 
 let Settings: {
   get(key: string): any,

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -21,7 +21,6 @@ import usePressability from '../Pressability/usePressability';
 import flattenStyle from '../StyleSheet/flattenStyle';
 import processColor from '../StyleSheet/processColor';
 import StyleSheet from '../StyleSheet/StyleSheet';
-import Platform from '../Utilities/Platform';
 import TextAncestorContext from './TextAncestorContext';
 import {
   NativeSelectableText,
@@ -30,6 +29,8 @@ import {
 } from './TextNativeComponent';
 import * as React from 'react';
 import {useContext, useMemo, useState} from 'react';
+
+const Platform = require('../Utilities/Platform').default;
 
 export type TextInstance = HostInstance;
 

--- a/packages/react-native/Libraries/Utilities/DevSettings.js
+++ b/packages/react-native/Libraries/Utilities/DevSettings.js
@@ -12,7 +12,8 @@ import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
 import NativeDevSettings from '../NativeModules/specs/NativeDevSettings';
-import Platform from '../Utilities/Platform';
+
+const Platform = require('../Utilities/Platform').default;
 
 /**
  * The DevSettings module exposes methods for customizing settings for developers in development.

--- a/packages/react-native/Libraries/WebSocket/WebSocket.js
+++ b/packages/react-native/Libraries/WebSocket/WebSocket.js
@@ -24,10 +24,11 @@ import Blob from '../Blob/Blob';
 import BlobManager from '../Blob/BlobManager';
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
 import binaryToBase64 from '../Utilities/binaryToBase64';
-import Platform from '../Utilities/Platform';
 import NativeWebSocketModule from './NativeWebSocketModule';
 import base64 from 'base64-js';
 import invariant from 'invariant';
+
+const Platform = require('../Utilities/Platform').default;
 
 type ArrayBufferView =
   | Int8Array

--- a/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js
+++ b/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js
@@ -9,9 +9,10 @@
  */
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
-import Platform from '../Utilities/Platform';
 import NativeWebSocketModule from './NativeWebSocketModule';
 import base64 from 'base64-js';
+
+const Platform = require('../Utilities/Platform').default;
 
 const originalRCTWebSocketConnect = NativeWebSocketModule.connect;
 const originalRCTWebSocketSend = NativeWebSocketModule.send;

--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -25,10 +25,11 @@ import NativeAnimatedNonTurboModule from '../../../Libraries/Animated/NativeAnim
 import NativeAnimatedTurboModule from '../../../Libraries/Animated/NativeAnimatedTurboModule';
 import NativeEventEmitter from '../../../Libraries/EventEmitter/NativeEventEmitter';
 import RCTDeviceEventEmitter from '../../../Libraries/EventEmitter/RCTDeviceEventEmitter';
-import Platform from '../../../Libraries/Utilities/Platform';
 import * as ReactNativeFeatureFlags from '../featureflags/ReactNativeFeatureFlags';
 import invariant from 'invariant';
 import nullthrows from 'nullthrows';
+
+const Platform = require('../../../Libraries/Utilities/Platform').default;
 
 interface NativeAnimatedModuleSpec extends NativeAnimatedTurboModuleSpec {
   // connectAnimatedNodeToShadowNodeFamily is available only in NativeAnimatedNonTurboModule

--- a/packages/react-native/src/private/components/safeareaview/SafeAreaView_INTERNAL_DO_NOT_USE.js
+++ b/packages/react-native/src/private/components/safeareaview/SafeAreaView_INTERNAL_DO_NOT_USE.js
@@ -12,8 +12,9 @@ import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropType
 
 import View from '../../../../Libraries/Components/View/View';
 import UIManager from '../../../../Libraries/ReactNative/UIManager';
-import Platform from '../../../../Libraries/Utilities/Platform';
 import * as React from 'react';
+
+const Platform = require('../../../../Libraries/Utilities/Platform').default;
 
 const exported: component(
   ref?: React.RefSetter<React.ElementRef<typeof View>>,

--- a/packages/react-native/src/private/components/scrollview/HScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/scrollview/HScrollViewNativeComponents.js
@@ -15,8 +15,9 @@ import type {HostComponent} from '../../types/HostComponent';
 import AndroidHorizontalScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent';
 import ScrollContentViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';
 import ScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponent';
-import Platform from '../../../../Libraries/Utilities/Platform';
 import AndroidHorizontalScrollContentViewNativeComponent from '../../specs_DEPRECATED/components/AndroidHorizontalScrollContentViewNativeComponent';
+
+const Platform = require('../../../../Libraries/Utilities/Platform').default;
 
 export const HScrollViewNativeComponent: HostComponent<ScrollViewNativeProps> =
   Platform.OS === 'android'

--- a/packages/react-native/src/private/components/scrollview/VScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/scrollview/VScrollViewNativeComponents.js
@@ -15,7 +15,8 @@ import type {HostComponent} from '../../types/HostComponent';
 import ScrollContentViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';
 import ScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponent';
 import View from '../../../../Libraries/Components/View/View';
-import Platform from '../../../../Libraries/Utilities/Platform';
+
+const Platform = require('../../../../Libraries/Utilities/Platform').default;
 
 export const VScrollViewNativeComponent: HostComponent<ScrollViewNativeProps> =
   ScrollViewNativeComponent;


### PR DESCRIPTION

## Summary:

Metro [inline-plugin](https://github.com/retyui/metro/blob/main/packages/metro-transform-plugins/src/__tests__/inline-plugin-test.js) doesn't work when an Platform has relative ES import

```tsx
// source code
Platform.OS === 'android' 

// expected (when build for ios)
"ios" === "android" // <-- always false, so deadcode elimination algorithm can remove the code

// actual
"android" === r.default.OS
```

metro has own PR: https://github.com/facebook/metro/pull/1692#issuecomment-4657599279  but no lock it will be merged soon I think 

## Changelog:

[GENERAL] [FIXED] - No dead-code in production for internal usages of `Platform`


## Test Plan:




**Before:**

<img width="1370" height="709" alt="Screenshot 2026-04-20 at 17 45 12" src="https://github.com/user-attachments/assets/f530156c-8b26-4c17-89a6-6c41ee1d44d3" />


**After**


<img width="1420" height="870" alt="Screenshot 2026-06-09 at 10 36 53" src="https://github.com/user-attachments/assets/ee649b37-a9d8-4201-abeb-d296e32ad9d6" />


