### PR TITLE
Override shouldDelayChildPressedState in Android containers

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5403,6 +5403,7 @@ public final class com/facebook/react/views/modal/ReactModalHostView : android/v
 	public final fun setStateWrapper (Lcom/facebook/react/uimanager/StateWrapper;)V
 	public final fun setStatusBarTranslucent (Z)V
 	public final fun setTransparent (Z)V
+	public fun shouldDelayChildPressedState ()Z
 	public final fun showOrUpdate ()V
 }
 
@@ -6445,6 +6446,7 @@ public class com/facebook/react/views/view/ReactViewGroup : android/view/ViewGro
 	public fun setPointerEvents (Lcom/facebook/react/uimanager/PointerEvents;)V
 	public fun setRemoveClippedSubviews (Z)V
 	public final fun setTranslucentBackgroundDrawable (Landroid/graphics/drawable/Drawable;)V
+	public fun shouldDelayChildPressedState ()Z
 	public fun updateClippingRect ()V
 	public fun updateClippingRect (Ljava/util/Set;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -134,6 +134,8 @@ public class ReactModalHostView(context: ThemedReactContext) :
     dialogRootViewGroup.dispatchProvideStructure(structure)
   }
 
+  override fun shouldDelayChildPressedState(): Boolean = false
+
   protected override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     // Do nothing as we are laid out by UIManager
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaView.kt
@@ -39,6 +39,8 @@ internal class ReactSafeAreaView(val reactContext: ThemedReactContext) : ViewGro
 
   override fun onLayout(p0: Boolean, p1: Int, p2: Int, p3: Int, p4: Int): Unit = Unit
 
+  override fun shouldDelayChildPressedState(): Boolean = false
+
   @Suppress("DEPRECATION")
   @UiThread
   private fun updateState(insets: Insets) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -402,6 +402,8 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
     }
   }
 
+  override fun shouldDelayChildPressedState(): Boolean = false
+
   public override fun dispatchHoverEvent(event: MotionEvent): Boolean =
       super.dispatchHoverEvent(event)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -650,6 +650,8 @@ public open class ReactViewGroup public constructor(context: Context?) :
     }
   }
 
+  override fun shouldDelayChildPressedState(): Boolean = false
+
   override fun dispatchSetPressed(pressed: Boolean) {
     // Prevents the ViewGroup from dispatching the pressed state
     // to it's children.


### PR DESCRIPTION
Summary:
Changelog: [Android][Fixed] Prevent React Native containers from delaying native touches

[`shouldDelayChildPressedState`](https://developer.android.com/reference/android/view/ViewGroup#shouldDelayChildPressedState%28%29) returns `true` for compatibility reasons and non-scrollable containers should override it and return `false` to prevent the press feedback from being delayed.

Differential Revision: D108003374


