### PR TITLE
YGNodeFree: mark parent dirty when child is freed

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -44,6 +44,7 @@ void YGNodeFree(const YGNodeRef nodeRef) {
   if (auto owner = node->getOwner()) {
     owner->removeChild(node);
     node->setOwner(nullptr);
+    owner->markDirtyAndPropagate();
   }
 
   const size_t childCount = node->getChildCount();


### PR DESCRIPTION
Summary:
fixes https://github.com/facebook/yoga/issues/1659.

**problem:** `YGNodeFree` called `owner->removeChild(node)` to detach the node from its
parent, but never called `owner->markDirtyAndPropagate()`. the parent's layout stayed
stale after the free, so a subsequent `YGNodeCalculateLayout` wouldn't recompute it.
`YGNodeRemoveChild` has always called `markDirtyAndPropagate` — `YGNodeFree` was just
missing the same call.

`YGNodeFreeRecursive` was already correct for its recursive child removals (it calls
`YGNodeRemoveChild` internally), but the terminal `YGNodeFree(root)` inherited the bug.

**fix:** added `owner->markDirtyAndPropagate()` after `node->setOwner(nullptr)` in
`YGNodeFree`.

regression tests: `dirty_parent_when_child_freed` and `dirty_parent_when_subtree_freed_recursive`
in `YGDirtyMarkingTest.cpp`.

bypass-github-export-checks

X-link: https://github.com/facebook/yoga/pull/1969

Reviewed By: javache

Differential Revision: D107895988

Pulled By: cipolleschi


