### PR TITLE
Simplify `CSSDataTypeParser::consumeFunctionBlock` gradient parsing (#57158)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -565,6 +565,258 @@ inline void writeUpdateOverflowInsetMountItem(
           overflowInsetBottom});
 }
 
+// Bundles together the per-mutation-type output vectors so the mutation
+// handlers below can take a single reference. `maintainMutationOrder`
+// determines whether mount items are appended to `common` (preserving the
+// exact order produced by the differ) or to their type-specific bucket.
+struct MountItemBuffers {
+  bool maintainMutationOrder;
+  std::vector<CppMountItem>& common;
+  std::vector<CppMountItem>& deletes;
+  std::vector<CppMountItem>& updateProps;
+  std::vector<CppMountItem>& updateState;
+  std::vector<CppMountItem>& updatePadding;
+  std::vector<CppMountItem>& updateLayout;
+  std::vector<CppMountItem>& updateOverflowInset;
+  std::vector<CppMountItem>& updateEventEmitter;
+
+  std::vector<CppMountItem>& orderedOr(std::vector<CppMountItem>& bucket) {
+    return maintainMutationOrder ? common : bucket;
+  }
+};
+
+inline void handleCreateMutation(
+    const ShadowViewMutation& mutation,
+    MountItemBuffers& buffers,
+    std::unordered_set<Tag>& allocatedViewTags) {
+  const auto& newChildShadowView = mutation.newChildShadowView;
+  bool shouldCreateView = !allocatedViewTags.contains(newChildShadowView.tag);
+
+  if (shouldCreateView) {
+    buffers.common.push_back(CppMountItem::CreateMountItem(newChildShadowView));
+    allocatedViewTags.insert(newChildShadowView.tag);
+  }
+}
+
+inline void handleRemoveMutation(
+    const ShadowViewMutation& mutation,
+    bool isVirtual,
+    MountItemBuffers& buffers) {
+  if (!isVirtual) {
+    buffers.common.push_back(
+        CppMountItem::RemoveMountItem(
+            mutation.parentTag, mutation.oldChildShadowView, mutation.index));
+  }
+}
+
+inline void handleDeleteMutation(
+    const ShadowViewMutation& mutation,
+    MountItemBuffers& buffers,
+    std::unordered_set<Tag>& allocatedViewTags) {
+  const auto& oldChildShadowView = mutation.oldChildShadowView;
+  buffers.orderedOr(buffers.deletes)
+      .push_back(CppMountItem::DeleteMountItem(oldChildShadowView));
+  if (allocatedViewTags.erase(oldChildShadowView.tag) != 1) {
+    LOG(ERROR) << "Emitting delete for unallocated view "
+               << oldChildShadowView.tag;
+  }
+}
+
+inline void handleUpdateMutation(
+    const ShadowViewMutation& mutation,
+    bool isVirtual,
+    MountItemBuffers& buffers,
+    std::unordered_set<Tag>& allocatedViewTags) {
+  const auto& oldChildShadowView = mutation.oldChildShadowView;
+  const auto& newChildShadowView = mutation.newChildShadowView;
+  auto parentTag = mutation.parentTag;
+
+  if (!isVirtual) {
+    if (!allocatedViewTags.contains(newChildShadowView.tag)) {
+      LOG(ERROR) << "Emitting update for unallocated view "
+                 << newChildShadowView.tag;
+    }
+
+    if (oldChildShadowView.props != newChildShadowView.props) {
+      buffers.orderedOr(buffers.updateProps)
+          .push_back(
+              CppMountItem::UpdatePropsMountItem(
+                  oldChildShadowView, newChildShadowView));
+    }
+    if (oldChildShadowView.state != newChildShadowView.state) {
+      buffers.orderedOr(buffers.updateState)
+          .push_back(CppMountItem::UpdateStateMountItem(newChildShadowView));
+    }
+
+    // Padding: padding mountItems must be executed before layout props
+    // are updated in the view. This is necessary to ensure that events
+    // (resulting from layout changes) are dispatched with the correct
+    // padding information.
+    if (oldChildShadowView.layoutMetrics.contentInsets !=
+        newChildShadowView.layoutMetrics.contentInsets) {
+      buffers.orderedOr(buffers.updatePadding)
+          .push_back(CppMountItem::UpdatePaddingMountItem(newChildShadowView));
+    }
+
+    if (oldChildShadowView.layoutMetrics != newChildShadowView.layoutMetrics) {
+      buffers.orderedOr(buffers.updateLayout)
+          .push_back(
+              CppMountItem::UpdateLayoutMountItem(
+                  mutation.newChildShadowView, parentTag));
+    }
+
+    // OverflowInset: This is the values indicating boundaries including
+    // children of the current view. The layout of current view may not
+    // change, and we separate this part from layout mount items to not
+    // pack too much data there.
+    if ((oldChildShadowView.layoutMetrics.overflowInset !=
+         newChildShadowView.layoutMetrics.overflowInset)) {
+      buffers.orderedOr(buffers.updateOverflowInset)
+          .push_back(
+              CppMountItem::UpdateOverflowInsetMountItem(newChildShadowView));
+    }
+  }
+
+  if (oldChildShadowView.eventEmitter != newChildShadowView.eventEmitter) {
+    buffers.orderedOr(buffers.updateProps)
+        .push_back(
+            CppMountItem::UpdateEventEmitterMountItem(
+                mutation.newChildShadowView));
+  }
+}
+
+inline void handleInsertMutation(
+    const ShadowViewMutation& mutation,
+    bool isVirtual,
+    MountItemBuffers& buffers,
+    std::unordered_set<Tag>& allocatedViewTags) {
+  const auto& newChildShadowView = mutation.newChildShadowView;
+  auto parentTag = mutation.parentTag;
+  auto& index = mutation.index;
+
+  if (!isVirtual) {
+    // Insert item
+    buffers.common.push_back(
+        CppMountItem::InsertMountItem(parentTag, newChildShadowView, index));
+
+    bool shouldCreateView = !allocatedViewTags.contains(newChildShadowView.tag);
+    if (ReactNativeFeatureFlags::enableAccumulatedUpdatesInRawPropsAndroid()) {
+      if (shouldCreateView) {
+        LOG(ERROR) << "Emitting insert for unallocated view "
+                   << newChildShadowView.tag;
+      }
+      buffers.orderedOr(buffers.updateProps)
+          .push_back(
+              CppMountItem::UpdatePropsMountItem({}, newChildShadowView));
+    } else {
+      if (shouldCreateView) {
+        LOG(ERROR) << "Emitting insert for unallocated view "
+                   << newChildShadowView.tag;
+        buffers.orderedOr(buffers.updateProps)
+            .push_back(
+                CppMountItem::UpdatePropsMountItem({}, newChildShadowView));
+      }
+    }
+
+    // State
+    if (newChildShadowView.state) {
+      buffers.orderedOr(buffers.updateState)
+          .push_back(CppMountItem::UpdateStateMountItem(newChildShadowView));
+    }
+
+    // Padding: padding mountItems must be executed before layout props
+    // are updated in the view. This is necessary to ensure that events
+    // (resulting from layout changes) are dispatched with the correct
+    // padding information.
+    if (newChildShadowView.layoutMetrics.contentInsets != EdgeInsets::ZERO) {
+      buffers.orderedOr(buffers.updatePadding)
+          .push_back(CppMountItem::UpdatePaddingMountItem(newChildShadowView));
+    }
+
+    // Layout
+    buffers.orderedOr(buffers.updateLayout)
+        .push_back(
+            CppMountItem::UpdateLayoutMountItem(newChildShadowView, parentTag));
+
+    // OverflowInset: This is the values indicating boundaries including
+    // children of the current view. The layout of current view may not
+    // change, and we separate this part from layout mount items to not
+    // pack too much data there.
+    if (newChildShadowView.layoutMetrics.overflowInset != EdgeInsets::ZERO) {
+      buffers.orderedOr(buffers.updateOverflowInset)
+          .push_back(
+              CppMountItem::UpdateOverflowInsetMountItem(newChildShadowView));
+    }
+  }
+
+  // EventEmitter
+  // On insert we always update the event emitter, as we do not pass
+  // it in when preallocating views
+  buffers.orderedOr(buffers.updateEventEmitter)
+      .push_back(
+          CppMountItem::UpdateEventEmitterMountItem(
+              mutation.newChildShadowView));
+}
+
+// Dispatches a single mount item from the `common` vector to the matching
+// writer. Preserves the exact switch behavior, including the FATAL default.
+inline void writeCommonMountItem(
+    InstructionBuffer& buffer,
+    const CppMountItem& mountItem) {
+  const auto& mountItemType = mountItem.type;
+  switch (mountItemType) {
+    case CppMountItem::Type::Create:
+      writeCreateMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::Delete:
+      writeDeleteMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::Insert:
+      writeInsertMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::Remove:
+      writeRemoveMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::UpdateProps:
+      writeUpdatePropsMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::UpdateState:
+      writeUpdateStateMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::UpdateLayout:
+      writeUpdateLayoutMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::UpdateEventEmitter:
+      writeUpdateEventEmitterMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::UpdatePadding:
+      writeUpdatePaddingMountItem(buffer, mountItem);
+      break;
+    case CppMountItem::Type::UpdateOverflowInset:
+      writeUpdateOverflowInsetMountItem(buffer, mountItem);
+      break;
+    default:
+      LOG(FATAL) << "Unexpected CppMountItem type: " << mountItemType;
+  }
+}
+
+// Writes a homogeneous batch of mount items (preamble + each item via
+// `writeItem`). No-op for an empty batch, matching the original guards.
+template <typename WriteFn>
+inline void writeMountItemBatch(
+    InstructionBuffer& buffer,
+    CppMountItem::Type mountItemType,
+    const std::vector<CppMountItem>& mountItems,
+    WriteFn&& writeItem) {
+  if (mountItems.empty()) {
+    return;
+  }
+  writeMountItemPreamble(buffer, mountItemType, mountItems.size());
+  for (const auto& mountItem : mountItems) {
+    writeItem(buffer, mountItem);
+  }
+}
+
 } // namespace
 
 void FabricMountingManager::executeMount(
@@ -613,191 +865,38 @@ void FabricMountingManager::executeMount(
                  << " was stopped!";
     }
 
+    MountItemBuffers buffers{
+        maintainMutationOrder,
+        cppCommonMountItems,
+        cppDeleteMountItems,
+        cppUpdatePropsMountItems,
+        cppUpdateStateMountItems,
+        cppUpdatePaddingMountItems,
+        cppUpdateLayoutMountItems,
+        cppUpdateOverflowInsetMountItems,
+        cppUpdateEventEmitterMountItems};
+
     for (const auto& mutation : mutations) {
-      auto parentTag = mutation.parentTag;
-      const auto& oldChildShadowView = mutation.oldChildShadowView;
-      const auto& newChildShadowView = mutation.newChildShadowView;
-      auto& mutationType = mutation.type;
-      auto& index = mutation.index;
-
       bool isVirtual = mutation.mutatedViewIsVirtual();
-      switch (mutationType) {
+      switch (mutation.type) {
         case ShadowViewMutation::Create: {
-          bool shouldCreateView =
-              !allocatedViewTags.contains(newChildShadowView.tag);
-
-          if (shouldCreateView) {
-            cppCommonMountItems.push_back(
-                CppMountItem::CreateMountItem(newChildShadowView));
-            allocatedViewTags.insert(newChildShadowView.tag);
-          }
+          handleCreateMutation(mutation, buffers, allocatedViewTags);
           break;
         }
         case ShadowViewMutation::Remove: {
-          if (!isVirtual) {
-            cppCommonMountItems.push_back(
-                CppMountItem::RemoveMountItem(
-                    parentTag, oldChildShadowView, index));
-          }
+          handleRemoveMutation(mutation, isVirtual, buffers);
           break;
         }
         case ShadowViewMutation::Delete: {
-          (maintainMutationOrder ? cppCommonMountItems : cppDeleteMountItems)
-              .push_back(CppMountItem::DeleteMountItem(oldChildShadowView));
-          if (allocatedViewTags.erase(oldChildShadowView.tag) != 1) {
-            LOG(ERROR) << "Emitting delete for unallocated view "
-                       << oldChildShadowView.tag;
-          }
+          handleDeleteMutation(mutation, buffers, allocatedViewTags);
           break;
         }
         case ShadowViewMutation::Update: {
-          if (!isVirtual) {
-            if (!allocatedViewTags.contains(newChildShadowView.tag)) {
-              LOG(ERROR) << "Emitting update for unallocated view "
-                         << newChildShadowView.tag;
-            }
-
-            if (oldChildShadowView.props != newChildShadowView.props) {
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdatePropsMountItems)
-                  .push_back(
-                      CppMountItem::UpdatePropsMountItem(
-                          oldChildShadowView, newChildShadowView));
-            }
-            if (oldChildShadowView.state != newChildShadowView.state) {
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdateStateMountItems)
-                  .push_back(
-                      CppMountItem::UpdateStateMountItem(newChildShadowView));
-            }
-
-            // Padding: padding mountItems must be executed before layout props
-            // are updated in the view. This is necessary to ensure that events
-            // (resulting from layout changes) are dispatched with the correct
-            // padding information.
-            if (oldChildShadowView.layoutMetrics.contentInsets !=
-                newChildShadowView.layoutMetrics.contentInsets) {
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdatePaddingMountItems)
-                  .push_back(
-                      CppMountItem::UpdatePaddingMountItem(newChildShadowView));
-            }
-
-            if (oldChildShadowView.layoutMetrics !=
-                newChildShadowView.layoutMetrics) {
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdateLayoutMountItems)
-                  .push_back(
-                      CppMountItem::UpdateLayoutMountItem(
-                          mutation.newChildShadowView, parentTag));
-            }
-
-            // OverflowInset: This is the values indicating boundaries including
-            // children of the current view. The layout of current view may not
-            // change, and we separate this part from layout mount items to not
-            // pack too much data there.
-            if ((oldChildShadowView.layoutMetrics.overflowInset !=
-                 newChildShadowView.layoutMetrics.overflowInset)) {
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdateOverflowInsetMountItems)
-                  .push_back(
-                      CppMountItem::UpdateOverflowInsetMountItem(
-                          newChildShadowView));
-            }
-          }
-
-          if (oldChildShadowView.eventEmitter !=
-              newChildShadowView.eventEmitter) {
-            (maintainMutationOrder ? cppCommonMountItems
-                                   : cppUpdatePropsMountItems)
-                .push_back(
-                    CppMountItem::UpdateEventEmitterMountItem(
-                        mutation.newChildShadowView));
-          }
+          handleUpdateMutation(mutation, isVirtual, buffers, allocatedViewTags);
           break;
         }
         case ShadowViewMutation::Insert: {
-          if (!isVirtual) {
-            // Insert item
-            cppCommonMountItems.push_back(
-                CppMountItem::InsertMountItem(
-                    parentTag, newChildShadowView, index));
-
-            bool shouldCreateView =
-                !allocatedViewTags.contains(newChildShadowView.tag);
-            if (ReactNativeFeatureFlags::
-                    enableAccumulatedUpdatesInRawPropsAndroid()) {
-              if (shouldCreateView) {
-                LOG(ERROR) << "Emitting insert for unallocated view "
-                           << newChildShadowView.tag;
-              }
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdatePropsMountItems)
-                  .push_back(
-                      CppMountItem::UpdatePropsMountItem(
-                          {}, newChildShadowView));
-            } else {
-              if (shouldCreateView) {
-                LOG(ERROR) << "Emitting insert for unallocated view "
-                           << newChildShadowView.tag;
-                (maintainMutationOrder ? cppCommonMountItems
-                                       : cppUpdatePropsMountItems)
-                    .push_back(
-                        CppMountItem::UpdatePropsMountItem(
-                            {}, newChildShadowView));
-              }
-            }
-
-            // State
-            if (newChildShadowView.state) {
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdateStateMountItems)
-                  .push_back(
-                      CppMountItem::UpdateStateMountItem(newChildShadowView));
-            }
-
-            // Padding: padding mountItems must be executed before layout props
-            // are updated in the view. This is necessary to ensure that events
-            // (resulting from layout changes) are dispatched with the correct
-            // padding information.
-            if (newChildShadowView.layoutMetrics.contentInsets !=
-                EdgeInsets::ZERO) {
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdatePaddingMountItems)
-                  .push_back(
-                      CppMountItem::UpdatePaddingMountItem(newChildShadowView));
-            }
-
-            // Layout
-            (maintainMutationOrder ? cppCommonMountItems
-                                   : cppUpdateLayoutMountItems)
-                .push_back(
-                    CppMountItem::UpdateLayoutMountItem(
-                        newChildShadowView, parentTag));
-
-            // OverflowInset: This is the values indicating boundaries including
-            // children of the current view. The layout of current view may not
-            // change, and we separate this part from layout mount items to not
-            // pack too much data there.
-            if (newChildShadowView.layoutMetrics.overflowInset !=
-                EdgeInsets::ZERO) {
-              (maintainMutationOrder ? cppCommonMountItems
-                                     : cppUpdateOverflowInsetMountItems)
-                  .push_back(
-                      CppMountItem::UpdateOverflowInsetMountItem(
-                          newChildShadowView));
-            }
-          }
-
-          // EventEmitter
-          // On insert we always update the event emitter, as we do not pass
-          // it in when preallocating views
-          (maintainMutationOrder ? cppCommonMountItems
-                                 : cppUpdateEventEmitterMountItems)
-              .push_back(
-                  CppMountItem::UpdateEventEmitterMountItem(
-                      mutation.newChildShadowView));
-
+          handleInsertMutation(mutation, isVirtual, buffers, allocatedViewTags);
           break;
         }
         default: {
@@ -879,96 +978,39 @@ void FabricMountingManager::executeMount(
       prevMountItemType = mountItemType;
     }
 
-    switch (mountItemType) {
-      case CppMountItem::Type::Create:
-        writeCreateMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::Delete:
-        writeDeleteMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::Insert:
-        writeInsertMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::Remove:
-        writeRemoveMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::UpdateProps:
-        writeUpdatePropsMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::UpdateState:
-        writeUpdateStateMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::UpdateLayout:
-        writeUpdateLayoutMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::UpdateEventEmitter:
-        writeUpdateEventEmitterMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::UpdatePadding:
-        writeUpdatePaddingMountItem(buffer, mountItem);
-        break;
-      case CppMountItem::Type::UpdateOverflowInset:
-        writeUpdateOverflowInsetMountItem(buffer, mountItem);
-        break;
-      default:
-        LOG(FATAL) << "Unexpected CppMountItem type: " << mountItemType;
-    }
+    writeCommonMountItem(buffer, mountItem);
   }
 
-  if (!cppUpdatePropsMountItems.empty()) {
-    writeMountItemPreamble(
-        buffer,
-        CppMountItem::Type::UpdateProps,
-        cppUpdatePropsMountItems.size());
-    for (const auto& mountItem : cppUpdatePropsMountItems) {
-      writeUpdatePropsMountItem(buffer, mountItem);
-    }
-  }
-  if (!cppUpdateStateMountItems.empty()) {
-    writeMountItemPreamble(
-        buffer,
-        CppMountItem::Type::UpdateState,
-        cppUpdateStateMountItems.size());
-    for (const auto& mountItem : cppUpdateStateMountItems) {
-      writeUpdateStateMountItem(buffer, mountItem);
-    }
-  }
-  if (!cppUpdatePaddingMountItems.empty()) {
-    writeMountItemPreamble(
-        buffer,
-        CppMountItem::Type::UpdatePadding,
-        cppUpdatePaddingMountItems.size());
-    for (const auto& mountItem : cppUpdatePaddingMountItems) {
-      writeUpdatePaddingMountItem(buffer, mountItem);
-    }
-  }
-  if (!cppUpdateLayoutMountItems.empty()) {
-    writeMountItemPreamble(
-        buffer,
-        CppMountItem::Type::UpdateLayout,
-        cppUpdateLayoutMountItems.size());
-    for (const auto& mountItem : cppUpdateLayoutMountItems) {
-      writeUpdateLayoutMountItem(buffer, mountItem);
-    }
-  }
-  if (!cppUpdateOverflowInsetMountItems.empty()) {
-    writeMountItemPreamble(
-        buffer,
-        CppMountItem::Type::UpdateOverflowInset,
-        cppUpdateOverflowInsetMountItems.size());
-    for (const auto& mountItem : cppUpdateOverflowInsetMountItems) {
-      writeUpdateOverflowInsetMountItem(buffer, mountItem);
-    }
-  }
-  if (!cppUpdateEventEmitterMountItems.empty()) {
-    writeMountItemPreamble(
-        buffer,
-        CppMountItem::Type::UpdateEventEmitter,
-        cppUpdateEventEmitterMountItems.size());
-    for (const auto& mountItem : cppUpdateEventEmitterMountItems) {
-      writeUpdateEventEmitterMountItem(buffer, mountItem);
-    }
-  }
+  writeMountItemBatch(
+      buffer,
+      CppMountItem::Type::UpdateProps,
+      cppUpdatePropsMountItems,
+      writeUpdatePropsMountItem);
+  writeMountItemBatch(
+      buffer,
+      CppMountItem::Type::UpdateState,
+      cppUpdateStateMountItems,
+      writeUpdateStateMountItem);
+  writeMountItemBatch(
+      buffer,
+      CppMountItem::Type::UpdatePadding,
+      cppUpdatePaddingMountItems,
+      writeUpdatePaddingMountItem);
+  writeMountItemBatch(
+      buffer,
+      CppMountItem::Type::UpdateLayout,
+      cppUpdateLayoutMountItems,
+      writeUpdateLayoutMountItem);
+  writeMountItemBatch(
+      buffer,
+      CppMountItem::Type::UpdateOverflowInset,
+      cppUpdateOverflowInsetMountItems,
+      writeUpdateOverflowInsetMountItem);
+  writeMountItemBatch(
+      buffer,
+      CppMountItem::Type::UpdateEventEmitter,
+      cppUpdateEventEmitterMountItems,
+      writeUpdateEventEmitterMountItem);
 
   // Write deletes last - so that all prop updates, etc, for the tag in the same
   // batch don't fail. Without additional machinery, moving deletes here
@@ -977,13 +1019,11 @@ void FabricMountingManager::executeMount(
   // for space efficiency.
   // FIXME: this optimization is incorrect when multiple transactions are
   // merged together
-  if (!cppDeleteMountItems.empty()) {
-    writeMountItemPreamble(
-        buffer, CppMountItem::Type::Delete, cppDeleteMountItems.size());
-    for (const auto& mountItem : cppDeleteMountItems) {
-      writeDeleteMountItem(buffer, mountItem);
-    }
-  }
+  writeMountItemBatch(
+      buffer,
+      CppMountItem::Type::Delete,
+      cppDeleteMountItems,
+      writeDeleteMountItem);
 
   static auto createMountItemsIntBufferBatchContainer =
       JFabricUIManager::javaClassStatic()

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -77,6 +77,250 @@ interpolateFloats(Float coefficient, Float oldValue, Float newValue) {
   return oldValue + (newValue - oldValue) * coefficient;
 }
 
+// Sets up the "opacity 0" starting/ending props for a Create/Delete opacity
+// animation. Mutates `view.props` in place. This is the same logic for the
+// INSERT (Create animation) and REMOVE (Delete animation) cases; only the view
+// being mutated differs. `componentDescriptor` is null when there is no
+// component descriptor for the view, in which case nothing is done.
+static void setupOpacityAnimationProps(
+    const ComponentDescriptor* componentDescriptor,
+    const PropsParserContext& propsParserContext,
+    const AnimationConfig& mutationConfig,
+    const ShadowView& baselineShadowView,
+    ShadowView& view) {
+  if (mutationConfig.animationProperty == AnimationProperty::Opacity &&
+      componentDescriptor != nullptr) {
+    auto props =
+        componentDescriptor->cloneProps(propsParserContext, view.props, {});
+
+    if (baselineShadowView.traits.check(ShadowNodeTraits::Trait::ViewKind)) {
+      const auto& viewProps = static_cast<const ViewProps&>(*props);
+      const_cast<ViewProps&>(viewProps).opacity = 0;
+    }
+
+    react_native_assert(props != nullptr);
+    if (props != nullptr) {
+      view.props = props;
+    }
+  }
+}
+
+// Sets up the "scale 0" starting/ending props for a Create/Delete scale
+// animation. Mutates `view.props` in place. This is the same logic for the
+// INSERT (Create animation) and REMOVE (Delete animation) cases; only the view
+// being mutated differs. `componentDescriptor` is null when there is no
+// component descriptor for the view, in which case nothing is done.
+static void setupScaleAnimationProps(
+    const ComponentDescriptor* componentDescriptor,
+    const PropsParserContext& propsParserContext,
+    const AnimationConfig& mutationConfig,
+    const ShadowView& baselineShadowView,
+    ShadowView& view) {
+  bool isScaleX =
+      mutationConfig.animationProperty == AnimationProperty::ScaleX ||
+      mutationConfig.animationProperty == AnimationProperty::ScaleXY;
+  bool isScaleY =
+      mutationConfig.animationProperty == AnimationProperty::ScaleY ||
+      mutationConfig.animationProperty == AnimationProperty::ScaleXY;
+  if ((isScaleX || isScaleY) && componentDescriptor != nullptr) {
+    auto props =
+        componentDescriptor->cloneProps(propsParserContext, view.props, {});
+    if (baselineShadowView.traits.check(ShadowNodeTraits::Trait::ViewKind)) {
+      const auto& viewProps = static_cast<const ViewProps&>(*props);
+      const_cast<ViewProps&>(viewProps).transform =
+          Transform::Scale(isScaleX ? 0 : 1, isScaleY ? 0 : 1, 1);
+    }
+
+    react_native_assert(props != nullptr);
+    if (props != nullptr) {
+      view.props = props;
+    }
+  }
+}
+
+// Pre-process the mutation list to catch:
+//   - remove+reinsert (reorders): collected into `insertedTags`
+//   - delete+create (reparenting): collected into `reparentedTags`
+// Also collects deleted tags into `deletedTags` (used to detect reparenting).
+static void collectReorderAndReparentTags(
+    const ShadowViewMutationList& mutations,
+    std::unordered_set<Tag>& insertedTags,
+    std::unordered_set<Tag>& deletedTags,
+    std::unordered_set<Tag>& reparentedTags) {
+  for (const auto& mutation : mutations) {
+    if (mutation.type == ShadowViewMutation::Type::Insert) {
+      insertedTags.insert(mutation.newChildShadowView.tag);
+    }
+    if (mutation.type == ShadowViewMutation::Type::Delete) {
+      deletedTags.insert(mutation.oldChildShadowView.tag);
+    }
+    if (mutation.type == ShadowViewMutation::Type::Create) {
+      if (deletedTags.find(mutation.newChildShadowView.tag) !=
+          deletedTags.end()) {
+        reparentedTags.insert(mutation.newChildShadowView.tag);
+      }
+    }
+  }
+}
+
+// Special-case: if we have some (1) ongoing UPDATE animation, (2) it conflicted
+// with a new MOVE operation (REMOVE+INSERT) without another corresponding
+// UPDATE, re-queue the keyframe so its position/props don't suddenly "jump".
+// Returns true if the keyframe was re-queued (and the caller should skip
+// generating final mutations for it).
+static bool maybeRequeueConflictingUpdateKeyframe(
+    AnimationKeyFrame& keyFrame,
+    const std::unordered_map<Tag, ShadowViewMutation>& movedTags,
+    std::vector<AnimationKeyFrame>& keyFramesToAnimate,
+    ShadowViewMutation::List& immediateMutations) {
+  if (keyFrame.type != AnimationConfigurationType::Update) {
+    return false;
+  }
+  auto movedIt = movedTags.find(keyFrame.tag);
+  if (movedIt == movedTags.end()) {
+    return false;
+  }
+  auto newKeyFrameForUpdate = std::find_if(
+      keyFramesToAnimate.begin(),
+      keyFramesToAnimate.end(),
+      [&](const auto& newKeyFrame) {
+        return newKeyFrame.type == AnimationConfigurationType::Update &&
+            newKeyFrame.tag == keyFrame.tag;
+      });
+  if (newKeyFrameForUpdate != keyFramesToAnimate.end()) {
+    return false;
+  }
+  keyFrame.invalidated = false;
+
+  // The animation will continue from the current position - we
+  // restart viewStart to make sure there are no sudden jumps
+  keyFrame.viewStart = keyFrame.viewPrev;
+
+  // Find the insert mutation that conflicted with this update
+  for (auto& mutation : immediateMutations) {
+    if (mutation.newChildShadowView.tag == keyFrame.tag &&
+        (mutation.type == ShadowViewMutation::Insert ||
+         mutation.type == ShadowViewMutation::Create)) {
+      keyFrame.viewPrev = mutation.newChildShadowView;
+      keyFrame.viewEnd = mutation.newChildShadowView;
+    }
+  }
+  keyFramesToAnimate.push_back(keyFrame);
+  return true;
+}
+
+// If the freshly-built `keyFrame` conflicts with an existing in-flight
+// animation for the same tag, start the new animation from the conflicting
+// animation's current position so there are no sudden jumps.
+static void handleConflictingAnimationsForKeyFrame(
+    AnimationKeyFrame& keyFrame,
+    std::vector<AnimationKeyFrame>& conflictingAnimations,
+    Tag tag) {
+  for (auto& conflictingKeyFrame : conflictingAnimations) {
+    const auto& conflictingMutationBaselineShadowView =
+        conflictingKeyFrame.viewStart;
+
+    // We've found a conflict.
+    if (conflictingMutationBaselineShadowView.tag == tag) {
+      conflictingKeyFrame.generateFinalSyntheticMutations = false;
+
+      // Do NOT update viewStart for a CREATE animation.
+      if (keyFrame.type == AnimationConfigurationType::Create) {
+        break;
+      }
+
+#ifdef LAYOUT_ANIMATION_VERBOSE_LOGGING
+      LOG(ERROR)
+          << "Due to conflict, replacing 'viewStart' of animated keyframe: ["
+          << conflictingKeyFrame.viewPrev.tag << "] with ##"
+          << std::hash<ShadowView>{}(conflictingKeyFrame.viewPrev);
+#endif
+      // Pick a Prop or layout property, depending on the current
+      // animation configuration. Figure out how much progress we've
+      // already made in the current animation, and start the animation
+      // from this point.
+      keyFrame.viewPrev = conflictingKeyFrame.viewPrev;
+      keyFrame.viewStart = conflictingKeyFrame.viewPrev;
+      react_native_assert(keyFrame.viewStart.tag > 0);
+      keyFrame.initialProgress = 0;
+
+      // We're guaranteed that a tag only has one animation associated
+      // with it, so we can break here. If we support multiple
+      // animations and animation curves over the same tag in the
+      // future, this will need to be modified to support that.
+      break;
+    }
+  }
+}
+
+// When an Insert immediately follows an already-queued Update animation for the
+// same tag, adjust the queued keyframe's "previous" ShadowView (and parent tag)
+// so the Update animates to/from views consistent with the mounting layer.
+static void adjustQueuedUpdateKeyframesForInsert(
+    std::vector<AnimationKeyFrame>& keyFramesToAnimate,
+    const ShadowViewMutation& mutation,
+    const ShadowView& baselineShadowView) {
+  for (auto& keyframe : keyFramesToAnimate) {
+    if (keyframe.tag == baselineShadowView.tag) {
+      // If there's already an animation queued up, followed by this
+      // Insert, it *must* be an Update mutation animation. Other
+      // sequences should not be possible.
+      react_native_assert(keyframe.type == AnimationConfigurationType::Update);
+
+      // The mutation is an "insert", so it must have a
+      // "newChildShadowView"
+      react_native_assert(mutation.newChildShadowView.tag > 0);
+
+      // Those asserts don't run in prod. If there's some edge-case
+      // that we haven't caught yet, we'd crash in debug; make sure we
+      // don't mutate the prevView in prod.
+      if (keyframe.type == AnimationConfigurationType::Update &&
+          mutation.newChildShadowView.tag > 0) {
+        keyframe.viewPrev = mutation.newChildShadowView;
+        keyframe.parentTag = mutation.parentTag;
+        react_native_assert(keyframe.finalMutationsForKeyFrame.size() == 1);
+        keyframe.finalMutationsForKeyFrame[0].parentTag = mutation.parentTag;
+      }
+    }
+  }
+}
+
+// When a Remove immediately follows an already-queued Update animation for the
+// same tag, the deferred Update means the REMOVE must reference the keyframe's
+// "previous" ShadowView. Returns the adjusted Remove mutation to execute
+// immediately if a matching keyframe is found.
+static std::optional<ShadowViewMutation> adjustQueuedUpdateKeyframesForRemove(
+    std::vector<AnimationKeyFrame>& keyFramesToAnimate,
+    const ShadowViewMutation& mutation,
+    const ShadowView& baselineShadowView,
+    std::optional<ShadowViewMutation> executeMutationImmediately) {
+  for (auto& keyframe : keyFramesToAnimate) {
+    if (keyframe.tag == baselineShadowView.tag) {
+      // If there's already an animation queued up, followed by this
+      // Insert, it *must* be an Update mutation animation. Other
+      // sequences should not be possible.
+      react_native_assert(keyframe.type == AnimationConfigurationType::Update);
+
+      // The mutation is a "remove", so it must have a
+      // "oldChildShadowView"
+      react_native_assert(mutation.oldChildShadowView.tag > 0);
+
+      // Those asserts don't run in prod. If there's some edge-case
+      // that we haven't caught yet, we'd crash in debug; make sure we
+      // don't mutate the prevView in prod.
+      // Since normally the UPDATE would have been executed first and
+      // now it's deferred, we need to change the `oldChildShadowView`
+      // that is being referenced by the REMOVE mutation.
+      if (keyframe.type == AnimationConfigurationType::Update &&
+          mutation.oldChildShadowView.tag > 0) {
+        executeMutationImmediately = ShadowViewMutation::RemoveMutation(
+            mutation.parentTag, keyframe.viewPrev, mutation.index);
+      }
+    }
+  }
+  return executeMutationImmediately;
+}
+
 #pragma mark -
 
 LayoutAnimationKeyFrameManager::LayoutAnimationKeyFrameManager(
@@ -262,20 +506,8 @@ LayoutAnimationKeyFrameManager::pullTransaction(
       std::unordered_set<Tag>
           reparentedTags; // tags that are deleted and recreated
       std::unordered_map<Tag, ShadowViewMutation> movedTags;
-      for (const auto& mutation : mutations) {
-        if (mutation.type == ShadowViewMutation::Type::Insert) {
-          insertedTags.insert(mutation.newChildShadowView.tag);
-        }
-        if (mutation.type == ShadowViewMutation::Type::Delete) {
-          deletedTags.insert(mutation.oldChildShadowView.tag);
-        }
-        if (mutation.type == ShadowViewMutation::Type::Create) {
-          if (deletedTags.find(mutation.newChildShadowView.tag) !=
-              deletedTags.end()) {
-            reparentedTags.insert(mutation.newChildShadowView.tag);
-          }
-        }
-      }
+      collectReorderAndReparentTags(
+          mutations, insertedTags, deletedTags, reparentedTags);
 
       // Process mutations list into operations that can be sent to platform
       // immediately, and those that need to be animated Deletions, removals,
@@ -373,61 +605,14 @@ LayoutAnimationKeyFrameManager::pullTransaction(
           // any UPDATE animations already queued up for this tag, we adjust the
           // "previous" ShadowView.
           if (mutation.type == ShadowViewMutation::Type::Insert) {
-            for (auto& keyframe : keyFramesToAnimate) {
-              if (keyframe.tag == baselineShadowView.tag) {
-                // If there's already an animation queued up, followed by this
-                // Insert, it *must* be an Update mutation animation. Other
-                // sequences should not be possible.
-                react_native_assert(
-                    keyframe.type == AnimationConfigurationType::Update);
-
-                // The mutation is an "insert", so it must have a
-                // "newChildShadowView"
-                react_native_assert(mutation.newChildShadowView.tag > 0);
-
-                // Those asserts don't run in prod. If there's some edge-case
-                // that we haven't caught yet, we'd crash in debug; make sure we
-                // don't mutate the prevView in prod.
-                if (keyframe.type == AnimationConfigurationType::Update &&
-                    mutation.newChildShadowView.tag > 0) {
-                  keyframe.viewPrev = mutation.newChildShadowView;
-                  keyframe.parentTag = mutation.parentTag;
-                  react_native_assert(
-                      keyframe.finalMutationsForKeyFrame.size() == 1);
-                  keyframe.finalMutationsForKeyFrame[0].parentTag =
-                      mutation.parentTag;
-                }
-              }
-            }
+            adjustQueuedUpdateKeyframesForInsert(
+                keyFramesToAnimate, mutation, baselineShadowView);
           } else if (mutation.type == ShadowViewMutation::Type::Remove) {
-            for (auto& keyframe : keyFramesToAnimate) {
-              if (keyframe.tag == baselineShadowView.tag) {
-                // If there's already an animation queued up, followed by this
-                // Insert, it *must* be an Update mutation animation. Other
-                // sequences should not be possible.
-                react_native_assert(
-                    keyframe.type == AnimationConfigurationType::Update);
-
-                // The mutation is a "remove", so it must have a
-                // "oldChildShadowView"
-                react_native_assert(mutation.oldChildShadowView.tag > 0);
-
-                // Those asserts don't run in prod. If there's some edge-case
-                // that we haven't caught yet, we'd crash in debug; make sure we
-                // don't mutate the prevView in prod.
-                // Since normally the UPDATE would have been executed first and
-                // now it's deferred, we need to change the `oldChildShadowView`
-                // that is being referenced by the REMOVE mutation.
-                if (keyframe.type == AnimationConfigurationType::Update &&
-                    mutation.oldChildShadowView.tag > 0) {
-                  executeMutationImmediately =
-                      ShadowViewMutation::RemoveMutation(
-                          mutation.parentTag,
-                          keyframe.viewPrev,
-                          mutation.index);
-                }
-              }
-            }
+            executeMutationImmediately = adjustQueuedUpdateKeyframesForRemove(
+                keyFramesToAnimate,
+                mutation,
+                baselineShadowView,
+                executeMutationImmediately);
           }
         }
 
@@ -452,48 +637,25 @@ LayoutAnimationKeyFrameManager::pullTransaction(
               mutation.type == ShadowViewMutation::Type::Delete);
           Tag tag = viewStart.tag;
 
+          const ComponentDescriptor* componentDescriptor =
+              haveComponentDescriptor
+              ? &getComponentDescriptorForShadowView(baselineShadowView)
+              : nullptr;
+
           AnimationKeyFrame keyFrame{};
           if (mutation.type == ShadowViewMutation::Type::Insert) {
-            if (mutationConfig.animationProperty ==
-                    AnimationProperty::Opacity &&
-                haveComponentDescriptor) {
-              auto props =
-                  getComponentDescriptorForShadowView(baselineShadowView)
-                      .cloneProps(propsParserContext, viewStart.props, {});
-
-              if (baselineShadowView.traits.check(
-                      ShadowNodeTraits::Trait::ViewKind)) {
-                const auto& viewProps = static_cast<const ViewProps&>(*props);
-                const_cast<ViewProps&>(viewProps).opacity = 0;
-              }
-
-              react_native_assert(props != nullptr);
-              if (props != nullptr) {
-                viewStart.props = props;
-              }
-            }
-            bool isScaleX =
-                mutationConfig.animationProperty == AnimationProperty::ScaleX ||
-                mutationConfig.animationProperty == AnimationProperty::ScaleXY;
-            bool isScaleY =
-                mutationConfig.animationProperty == AnimationProperty::ScaleY ||
-                mutationConfig.animationProperty == AnimationProperty::ScaleXY;
-            if ((isScaleX || isScaleY) && haveComponentDescriptor) {
-              auto props =
-                  getComponentDescriptorForShadowView(baselineShadowView)
-                      .cloneProps(propsParserContext, viewStart.props, {});
-              if (baselineShadowView.traits.check(
-                      ShadowNodeTraits::Trait::ViewKind)) {
-                const auto& viewProps = static_cast<const ViewProps&>(*props);
-                const_cast<ViewProps&>(viewProps).transform =
-                    Transform::Scale(isScaleX ? 0 : 1, isScaleY ? 0 : 1, 1);
-              }
-
-              react_native_assert(props != nullptr);
-              if (props != nullptr) {
-                viewStart.props = props;
-              }
-            }
+            setupOpacityAnimationProps(
+                componentDescriptor,
+                propsParserContext,
+                mutationConfig,
+                baselineShadowView,
+                viewStart);
+            setupScaleAnimationProps(
+                componentDescriptor,
+                propsParserContext,
+                mutationConfig,
+                baselineShadowView,
+                viewStart);
 
             PrintMutationInstruction(
                 "Setting up animation KeyFrame for INSERT mutation (Create animation)",
@@ -577,49 +739,18 @@ LayoutAnimationKeyFrameManager::pullTransaction(
 
               auto deleteMutation = *correspondingDeleteIt;
 
-              if (mutationConfig.animationProperty ==
-                      AnimationProperty::Opacity &&
-                  haveComponentDescriptor) {
-                auto props =
-                    getComponentDescriptorForShadowView(baselineShadowView)
-                        .cloneProps(propsParserContext, viewFinal.props, {});
-
-                if (baselineShadowView.traits.check(
-                        ShadowNodeTraits::Trait::ViewKind)) {
-                  const auto& viewProps = static_cast<const ViewProps&>(*props);
-                  const_cast<ViewProps&>(viewProps).opacity = 0;
-                }
-
-                react_native_assert(props != nullptr);
-                if (props != nullptr) {
-                  viewFinal.props = props;
-                }
-              }
-              bool isScaleX = mutationConfig.animationProperty ==
-                      AnimationProperty::ScaleX ||
-                  mutationConfig.animationProperty ==
-                      AnimationProperty::ScaleXY;
-              bool isScaleY = mutationConfig.animationProperty ==
-                      AnimationProperty::ScaleY ||
-                  mutationConfig.animationProperty ==
-                      AnimationProperty::ScaleXY;
-              if ((isScaleX || isScaleY) && haveComponentDescriptor) {
-                auto props =
-                    getComponentDescriptorForShadowView(baselineShadowView)
-                        .cloneProps(propsParserContext, viewFinal.props, {});
-
-                if (baselineShadowView.traits.check(
-                        ShadowNodeTraits::Trait::ViewKind)) {
-                  const auto& viewProps = static_cast<const ViewProps&>(*props);
-                  const_cast<ViewProps&>(viewProps).transform =
-                      Transform::Scale(isScaleX ? 0 : 1, isScaleY ? 0 : 1, 1);
-                }
-
-                react_native_assert(props != nullptr);
-                if (props != nullptr) {
-                  viewFinal.props = props;
-                }
-              }
+              setupOpacityAnimationProps(
+                  componentDescriptor,
+                  propsParserContext,
+                  mutationConfig,
+                  baselineShadowView,
+                  viewFinal);
+              setupScaleAnimationProps(
+                  componentDescriptor,
+                  propsParserContext,
+                  mutationConfig,
+                  baselineShadowView,
+                  viewFinal);
 
               PrintMutationInstruction(
                   "Setting up animation KeyFrame for REMOVE mutation (Delete animation)",
@@ -645,41 +776,8 @@ LayoutAnimationKeyFrameManager::pullTransaction(
           }
 
           // Handle conflicting animations
-          for (auto& conflictingKeyFrame : conflictingAnimations) {
-            const auto& conflictingMutationBaselineShadowView =
-                conflictingKeyFrame.viewStart;
-
-            // We've found a conflict.
-            if (conflictingMutationBaselineShadowView.tag == tag) {
-              conflictingKeyFrame.generateFinalSyntheticMutations = false;
-
-              // Do NOT update viewStart for a CREATE animation.
-              if (keyFrame.type == AnimationConfigurationType::Create) {
-                break;
-              }
-
-#ifdef LAYOUT_ANIMATION_VERBOSE_LOGGING
-              LOG(ERROR)
-                  << "Due to conflict, replacing 'viewStart' of animated keyframe: ["
-                  << conflictingKeyFrame.viewPrev.tag << "] with ##"
-                  << std::hash<ShadowView>{}(conflictingKeyFrame.viewPrev);
-#endif
-              // Pick a Prop or layout property, depending on the current
-              // animation configuration. Figure out how much progress we've
-              // already made in the current animation, and start the animation
-              // from this point.
-              keyFrame.viewPrev = conflictingKeyFrame.viewPrev;
-              keyFrame.viewStart = conflictingKeyFrame.viewPrev;
-              react_native_assert(keyFrame.viewStart.tag > 0);
-              keyFrame.initialProgress = 0;
-
-              // We're guaranteed that a tag only has one animation associated
-              // with it, so we can break here. If we support multiple
-              // animations and animation curves over the same tag in the
-              // future, this will need to be modified to support that.
-              break;
-            }
-          }
+          handleConflictingAnimationsForKeyFrame(
+              keyFrame, conflictingAnimations, tag);
 
 #ifdef LAYOUT_ANIMATION_VERBOSE_LOGGING
           LOG(ERROR) << "Checking validity of keyframe: ["
@@ -735,37 +833,9 @@ LayoutAnimationKeyFrameManager::pullTransaction(
         // (2) it conflicted with a new MOVE operation (REMOVE+INSERT)
         // without another corresponding UPDATE, we should re-queue the
         // keyframe so that its position/props don't suddenly "jump".
-        if (keyFrame.type == AnimationConfigurationType::Update) {
-          auto movedIt = movedTags.find(keyFrame.tag);
-          if (movedIt != movedTags.end()) {
-            auto newKeyFrameForUpdate = std::find_if(
-                keyFramesToAnimate.begin(),
-                keyFramesToAnimate.end(),
-                [&](const auto& newKeyFrame) {
-                  return newKeyFrame.type ==
-                      AnimationConfigurationType::Update &&
-                      newKeyFrame.tag == keyFrame.tag;
-                });
-            if (newKeyFrameForUpdate == keyFramesToAnimate.end()) {
-              keyFrame.invalidated = false;
-
-              // The animation will continue from the current position - we
-              // restart viewStart to make sure there are no sudden jumps
-              keyFrame.viewStart = keyFrame.viewPrev;
-
-              // Find the insert mutation that conflicted with this update
-              for (auto& mutation : immediateMutations) {
-                if (mutation.newChildShadowView.tag == keyFrame.tag &&
-                    (mutation.type == ShadowViewMutation::Insert ||
-                     mutation.type == ShadowViewMutation::Create)) {
-                  keyFrame.viewPrev = mutation.newChildShadowView;
-                  keyFrame.viewEnd = mutation.newChildShadowView;
-                }
-              }
-              keyFramesToAnimate.push_back(keyFrame);
-              continue;
-            }
-          }
+        if (maybeRequeueConflictingUpdateKeyframe(
+                keyFrame, movedTags, keyFramesToAnimate, immediateMutations)) {
+          continue;
         }
 
         // If the "final" mutation is already accounted for, by previously

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -354,185 +354,225 @@ static folly::dynamic toDynamic(const Size& size) {
   return sizeResult;
 }
 
+// Behavior-preserving helpers extracted from appendTextAttributesProps below to
+// keep its cyclomatic complexity low. Each mirrors one of the recurring
+// compare-and-assign shapes used per text attribute, so the serialized output
+// (keys, values, and insertion order) is identical to the open-coded version.
+template <typename T>
+static void appendIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue) {
+  if (newValue != oldValue) {
+    result[propName] = newValue;
+  }
+}
+
+template <typename T>
+static void appendDerefIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue) {
+  if (newValue != oldValue) {
+    result[propName] = *newValue;
+  }
+}
+
+static void appendFloatIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    Float newValue,
+    Float oldValue) {
+  if (!floatEquality(newValue, oldValue)) {
+    result[propName] = newValue;
+  }
+}
+
+template <typename T, typename Convert>
+static void appendOptionalIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const std::optional<T>& newValue,
+    const std::optional<T>& oldValue,
+    Convert&& convert) {
+  if (newValue != oldValue) {
+    result[propName] = newValue.has_value()
+        ? folly::dynamic(convert(newValue.value()))
+        : folly::dynamic(nullptr);
+  }
+}
+
 void BaseTextProps::appendTextAttributesProps(
     folly::dynamic& result,
     const BaseTextProps* oldProps) const {
-  if (textAttributes.foregroundColor !=
-      oldProps->textAttributes.foregroundColor) {
-    result["color"] = *textAttributes.foregroundColor;
-  }
+  auto asString = [](const auto& value) { return toString(value); };
+  auto asIs = [](const auto& value) { return value; };
+  auto asDynamic = [](const auto& value) { return toDynamic(value); };
 
-  if (textAttributes.fontFamily != oldProps->textAttributes.fontFamily) {
-    result["fontFamily"] = textAttributes.fontFamily;
-  }
-
-  if (!floatEquality(
-          textAttributes.fontSize, oldProps->textAttributes.fontSize)) {
-    result["fontSize"] = textAttributes.fontSize;
-  }
-
-  if (!floatEquality(
-          textAttributes.fontSizeMultiplier,
-          oldProps->textAttributes.fontSizeMultiplier)) {
-    result["fontSizeMultiplier"] = textAttributes.fontSizeMultiplier;
-  }
-
-  if (textAttributes.fontWeight != oldProps->textAttributes.fontWeight) {
-    result["fontWeight"] = textAttributes.fontWeight.has_value()
-        ? toString(textAttributes.fontWeight.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.fontStyle != oldProps->textAttributes.fontStyle) {
-    result["fontStyle"] = textAttributes.fontStyle.has_value()
-        ? toString(textAttributes.fontStyle.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.fontVariant != oldProps->textAttributes.fontVariant) {
-    result["fontVariant"] = textAttributes.fontVariant.has_value()
-        ? toString(textAttributes.fontVariant.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.allowFontScaling !=
-      oldProps->textAttributes.allowFontScaling) {
-    result["allowFontScaling"] = textAttributes.allowFontScaling.has_value()
-        ? textAttributes.allowFontScaling.value()
-        : folly::dynamic(nullptr);
-  }
-
-  if (!floatEquality(
-          textAttributes.maxFontSizeMultiplier,
-          oldProps->textAttributes.maxFontSizeMultiplier)) {
-    result["maxFontSizeMultiplier"] = textAttributes.maxFontSizeMultiplier;
-  }
-
-  if (textAttributes.dynamicTypeRamp !=
-      oldProps->textAttributes.dynamicTypeRamp) {
-    result["dynamicTypeRamp"] = textAttributes.dynamicTypeRamp.has_value()
-        ? toString(textAttributes.dynamicTypeRamp.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (!floatEquality(
-          textAttributes.letterSpacing,
-          oldProps->textAttributes.letterSpacing)) {
-    result["letterSpacing"] = textAttributes.letterSpacing;
-  }
-
-  if (textAttributes.textTransform != oldProps->textAttributes.textTransform) {
-    result["textTransform"] = textAttributes.textTransform.has_value()
-        ? toString(textAttributes.textTransform.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (!floatEquality(
-          textAttributes.lineHeight, oldProps->textAttributes.lineHeight)) {
-    result["lineHeight"] = textAttributes.lineHeight;
-  }
-
-  if (textAttributes.alignment != oldProps->textAttributes.alignment) {
-    result["textAlign"] = textAttributes.alignment.has_value()
-        ? toString(textAttributes.alignment.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.baseWritingDirection !=
-      oldProps->textAttributes.baseWritingDirection) {
-    result["baseWritingDirection"] =
-        textAttributes.baseWritingDirection.has_value()
-        ? toString(textAttributes.baseWritingDirection.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.lineBreakStrategy !=
-      oldProps->textAttributes.lineBreakStrategy) {
-    result["lineBreakStrategyIOS"] =
-        textAttributes.lineBreakStrategy.has_value()
-        ? toString(textAttributes.lineBreakStrategy.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.lineBreakMode != oldProps->textAttributes.lineBreakMode) {
-    result["lineBreakModeIOS"] = textAttributes.lineBreakMode.has_value()
-        ? toString(textAttributes.lineBreakMode.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.textDecorationColor !=
-      oldProps->textAttributes.textDecorationColor) {
-    result["textDecorationColor"] = *textAttributes.textDecorationColor;
-  }
-
-  if (textAttributes.textDecorationLineType !=
-      oldProps->textAttributes.textDecorationLineType) {
-    result["textDecorationLine"] =
-        textAttributes.textDecorationLineType.has_value()
-        ? toString(textAttributes.textDecorationLineType.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.textDecorationStyle !=
-      oldProps->textAttributes.textDecorationStyle) {
-    result["textDecorationStyle"] =
-        textAttributes.textDecorationStyle.has_value()
-        ? toString(textAttributes.textDecorationStyle.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.textShadowOffset !=
-      oldProps->textAttributes.textShadowOffset) {
-    result["textShadowOffset"] = textAttributes.textShadowOffset.has_value()
-        ? toDynamic(textAttributes.textShadowOffset.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (!floatEquality(
-          textAttributes.textShadowRadius,
-          oldProps->textAttributes.textShadowRadius)) {
-    result["textShadowRadius"] = textAttributes.textShadowRadius;
-  }
-
-  if (textAttributes.textShadowColor !=
-      oldProps->textAttributes.textShadowColor) {
-    result["textShadowColor"] = *textAttributes.textShadowColor;
-  }
-
-  if (textAttributes.isHighlighted != oldProps->textAttributes.isHighlighted) {
-    result["isHighlighted"] = textAttributes.isHighlighted.has_value()
-        ? textAttributes.isHighlighted.value()
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.isPressable != oldProps->textAttributes.isPressable) {
-    result["isPressable"] = textAttributes.isPressable.has_value()
-        ? textAttributes.isPressable.value()
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.accessibilityRole !=
-      oldProps->textAttributes.accessibilityRole) {
-    result["accessibilityRole"] = textAttributes.accessibilityRole.has_value()
-        ? toString(textAttributes.accessibilityRole.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (textAttributes.role != oldProps->textAttributes.role) {
-    result["role"] = textAttributes.role.has_value()
-        ? toString(textAttributes.role.value())
-        : folly::dynamic(nullptr);
-  }
-
-  if (!floatEquality(
-          textAttributes.opacity, oldProps->textAttributes.opacity)) {
-    result["opacity"] = textAttributes.opacity;
-  }
-
-  if (textAttributes.backgroundColor !=
-      oldProps->textAttributes.backgroundColor) {
-    result["backgroundColor"] = *textAttributes.backgroundColor;
-  }
+  appendDerefIfChanged(
+      result,
+      "color",
+      textAttributes.foregroundColor,
+      oldProps->textAttributes.foregroundColor);
+  appendIfChanged(
+      result,
+      "fontFamily",
+      textAttributes.fontFamily,
+      oldProps->textAttributes.fontFamily);
+  appendFloatIfChanged(
+      result,
+      "fontSize",
+      textAttributes.fontSize,
+      oldProps->textAttributes.fontSize);
+  appendFloatIfChanged(
+      result,
+      "fontSizeMultiplier",
+      textAttributes.fontSizeMultiplier,
+      oldProps->textAttributes.fontSizeMultiplier);
+  appendOptionalIfChanged(
+      result,
+      "fontWeight",
+      textAttributes.fontWeight,
+      oldProps->textAttributes.fontWeight,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "fontStyle",
+      textAttributes.fontStyle,
+      oldProps->textAttributes.fontStyle,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "fontVariant",
+      textAttributes.fontVariant,
+      oldProps->textAttributes.fontVariant,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "allowFontScaling",
+      textAttributes.allowFontScaling,
+      oldProps->textAttributes.allowFontScaling,
+      asIs);
+  appendFloatIfChanged(
+      result,
+      "maxFontSizeMultiplier",
+      textAttributes.maxFontSizeMultiplier,
+      oldProps->textAttributes.maxFontSizeMultiplier);
+  appendOptionalIfChanged(
+      result,
+      "dynamicTypeRamp",
+      textAttributes.dynamicTypeRamp,
+      oldProps->textAttributes.dynamicTypeRamp,
+      asString);
+  appendFloatIfChanged(
+      result,
+      "letterSpacing",
+      textAttributes.letterSpacing,
+      oldProps->textAttributes.letterSpacing);
+  appendOptionalIfChanged(
+      result,
+      "textTransform",
+      textAttributes.textTransform,
+      oldProps->textAttributes.textTransform,
+      asString);
+  appendFloatIfChanged(
+      result,
+      "lineHeight",
+      textAttributes.lineHeight,
+      oldProps->textAttributes.lineHeight);
+  appendOptionalIfChanged(
+      result,
+      "textAlign",
+      textAttributes.alignment,
+      oldProps->textAttributes.alignment,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "baseWritingDirection",
+      textAttributes.baseWritingDirection,
+      oldProps->textAttributes.baseWritingDirection,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "lineBreakStrategyIOS",
+      textAttributes.lineBreakStrategy,
+      oldProps->textAttributes.lineBreakStrategy,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "lineBreakModeIOS",
+      textAttributes.lineBreakMode,
+      oldProps->textAttributes.lineBreakMode,
+      asString);
+  appendDerefIfChanged(
+      result,
+      "textDecorationColor",
+      textAttributes.textDecorationColor,
+      oldProps->textAttributes.textDecorationColor);
+  appendOptionalIfChanged(
+      result,
+      "textDecorationLine",
+      textAttributes.textDecorationLineType,
+      oldProps->textAttributes.textDecorationLineType,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "textDecorationStyle",
+      textAttributes.textDecorationStyle,
+      oldProps->textAttributes.textDecorationStyle,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "textShadowOffset",
+      textAttributes.textShadowOffset,
+      oldProps->textAttributes.textShadowOffset,
+      asDynamic);
+  appendFloatIfChanged(
+      result,
+      "textShadowRadius",
+      textAttributes.textShadowRadius,
+      oldProps->textAttributes.textShadowRadius);
+  appendDerefIfChanged(
+      result,
+      "textShadowColor",
+      textAttributes.textShadowColor,
+      oldProps->textAttributes.textShadowColor);
+  appendOptionalIfChanged(
+      result,
+      "isHighlighted",
+      textAttributes.isHighlighted,
+      oldProps->textAttributes.isHighlighted,
+      asIs);
+  appendOptionalIfChanged(
+      result,
+      "isPressable",
+      textAttributes.isPressable,
+      oldProps->textAttributes.isPressable,
+      asIs);
+  appendOptionalIfChanged(
+      result,
+      "accessibilityRole",
+      textAttributes.accessibilityRole,
+      oldProps->textAttributes.accessibilityRole,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "role",
+      textAttributes.role,
+      oldProps->textAttributes.role,
+      asString);
+  appendFloatIfChanged(
+      result,
+      "opacity",
+      textAttributes.opacity,
+      oldProps->textAttributes.opacity);
+  appendDerefIfChanged(
+      result,
+      "backgroundColor",
+      textAttributes.backgroundColor,
+      oldProps->textAttributes.backgroundColor);
 }
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -361,6 +361,69 @@ ComponentName AndroidTextInputProps::getDiffPropsImplementationTarget() const {
   return "TextInput";
 }
 
+// Behavior-preserving helpers extracted from getDiffProps below to keep its
+// cyclomatic complexity low. Each mirrors one of the recurring
+// compare-and-assign shapes used per prop, so the serialized output (keys,
+// values, conversions, and insertion order) is identical to the open-coded
+// version.
+template <typename T>
+static void appendIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue) {
+  if (newValue != oldValue) {
+    result[propName] = newValue;
+  }
+}
+
+template <typename T>
+static void appendDerefIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue) {
+  if (newValue != oldValue) {
+    result[propName] = *newValue;
+  }
+}
+
+static void appendFloatIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    Float newValue,
+    Float oldValue) {
+  if (!floatEquality(newValue, oldValue)) {
+    result[propName] = newValue;
+  }
+}
+
+template <typename T, typename Convert>
+static void appendConvertedIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue,
+    Convert&& convert) {
+  if (newValue != oldValue) {
+    result[propName] = convert(newValue);
+  }
+}
+
+template <typename T, typename Convert>
+static void appendOptionalIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const std::optional<T>& newValue,
+    const std::optional<T>& oldValue,
+    Convert&& convert) {
+  if (newValue != oldValue) {
+    result[propName] = newValue.has_value()
+        ? folly::dynamic(convert(newValue.value()))
+        : folly::dynamic(nullptr);
+  }
+}
+
 folly::dynamic AndroidTextInputProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = AndroidTextInputProps();
@@ -371,264 +434,201 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
 
   folly::dynamic result = ViewProps::getDiffProps(oldProps);
 
+  auto asString = [](const auto& value) { return toString(value); };
+  auto asDynamic = [](const auto& value) { return toDynamic(value); };
+
   // Base text input paragraph props
-  if (paragraphAttributes.maximumNumberOfLines !=
-      oldProps->paragraphAttributes.maximumNumberOfLines) {
-    result["numberOfLines"] = paragraphAttributes.maximumNumberOfLines;
-  }
-
-  if (paragraphAttributes.ellipsizeMode !=
-      oldProps->paragraphAttributes.ellipsizeMode) {
-    result["ellipsizeMode"] = toString(paragraphAttributes.ellipsizeMode);
-  }
-
-  if (paragraphAttributes.textBreakStrategy !=
-      oldProps->paragraphAttributes.textBreakStrategy) {
-    result["textBreakStrategy"] =
-        toString(paragraphAttributes.textBreakStrategy);
-  }
-
-  if (paragraphAttributes.adjustsFontSizeToFit !=
-      oldProps->paragraphAttributes.adjustsFontSizeToFit) {
-    result["adjustsFontSizeToFit"] = paragraphAttributes.adjustsFontSizeToFit;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.minimumFontSize,
-          oldProps->paragraphAttributes.minimumFontSize)) {
-    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.maximumFontSize,
-          oldProps->paragraphAttributes.maximumFontSize)) {
-    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
-  }
-
-  if (paragraphAttributes.includeFontPadding !=
-      oldProps->paragraphAttributes.includeFontPadding) {
-    result["includeFontPadding"] = paragraphAttributes.includeFontPadding;
-  }
-
-  if (paragraphAttributes.android_hyphenationFrequency !=
-      oldProps->paragraphAttributes.android_hyphenationFrequency) {
-    result["android_hyphenationFrequency"] =
-        toString(paragraphAttributes.android_hyphenationFrequency);
-  }
-
-  if (paragraphAttributes.textAlignVertical !=
-      oldProps->paragraphAttributes.textAlignVertical) {
-    if (!paragraphAttributes.textAlignVertical.has_value()) {
-      result["textAlignVertical"] = nullptr;
-    } else {
-      result["textAlignVertical"] =
-          toString(*paragraphAttributes.textAlignVertical);
-    }
-  }
+  appendIfChanged(
+      result,
+      "numberOfLines",
+      paragraphAttributes.maximumNumberOfLines,
+      oldProps->paragraphAttributes.maximumNumberOfLines);
+  appendConvertedIfChanged(
+      result,
+      "ellipsizeMode",
+      paragraphAttributes.ellipsizeMode,
+      oldProps->paragraphAttributes.ellipsizeMode,
+      asString);
+  appendConvertedIfChanged(
+      result,
+      "textBreakStrategy",
+      paragraphAttributes.textBreakStrategy,
+      oldProps->paragraphAttributes.textBreakStrategy,
+      asString);
+  appendIfChanged(
+      result,
+      "adjustsFontSizeToFit",
+      paragraphAttributes.adjustsFontSizeToFit,
+      oldProps->paragraphAttributes.adjustsFontSizeToFit);
+  appendFloatIfChanged(
+      result,
+      "minimumFontSize",
+      paragraphAttributes.minimumFontSize,
+      oldProps->paragraphAttributes.minimumFontSize);
+  appendFloatIfChanged(
+      result,
+      "maximumFontSize",
+      paragraphAttributes.maximumFontSize,
+      oldProps->paragraphAttributes.maximumFontSize);
+  appendIfChanged(
+      result,
+      "includeFontPadding",
+      paragraphAttributes.includeFontPadding,
+      oldProps->paragraphAttributes.includeFontPadding);
+  appendConvertedIfChanged(
+      result,
+      "android_hyphenationFrequency",
+      paragraphAttributes.android_hyphenationFrequency,
+      oldProps->paragraphAttributes.android_hyphenationFrequency,
+      asString);
+  appendOptionalIfChanged(
+      result,
+      "textAlignVertical",
+      paragraphAttributes.textAlignVertical,
+      oldProps->paragraphAttributes.textAlignVertical,
+      asString);
 
   // Base text input props
-  if (defaultValue != oldProps->defaultValue) {
-    result["defaultValue"] = defaultValue;
-  }
-
-  if (placeholder != oldProps->placeholder) {
-    result["placeholder"] = placeholder;
-  }
-
-  if (placeholderTextColor != oldProps->placeholderTextColor) {
-    result["placeholderTextColor"] = *placeholderTextColor;
-  }
-
-  if (cursorColor != oldProps->cursorColor) {
-    result["cursorColor"] = *cursorColor;
-  }
-
-  if (selectionColor != oldProps->selectionColor) {
-    result["selectionColor"] = *selectionColor;
-  }
-
-  if (selectionHandleColor != oldProps->selectionHandleColor) {
-    result["selectionHandleColor"] = *selectionHandleColor;
-  }
-
-  if (underlineColorAndroid != oldProps->underlineColorAndroid) {
-    result["underlineColorAndroid"] = *underlineColorAndroid;
-  }
-
-  if (maxLength != oldProps->maxLength) {
-    result["maxLength"] = maxLength;
-  }
-
-  if (text != oldProps->text) {
-    result["text"] = text;
-  }
-
-  if (mostRecentEventCount != oldProps->mostRecentEventCount) {
-    result["mostRecentEventCount"] = mostRecentEventCount;
-  }
-
-  if (autoFocus != oldProps->autoFocus) {
-    result["autoFocus"] = autoFocus;
-  }
-
-  if (autoCapitalize != oldProps->autoCapitalize) {
-    result["autoCapitalize"] = autoCapitalize;
-  }
-
-  if (editable != oldProps->editable) {
-    result["editable"] = editable;
-  }
-
-  if (readOnly != oldProps->readOnly) {
-    result["readOnly"] = readOnly;
-  }
-
-  if (submitBehavior != oldProps->submitBehavior) {
-    result["submitBehavior"] = toDynamic(submitBehavior);
-  }
-
-  if (multiline != oldProps->multiline) {
-    result["multiline"] = multiline;
-  }
-
-  if (disableKeyboardShortcuts != oldProps->disableKeyboardShortcuts) {
-    result["disableKeyboardShortcuts"] = disableKeyboardShortcuts;
-  }
-
-  if (acceptDragAndDropTypes != oldProps->acceptDragAndDropTypes) {
-    result["acceptDragAndDropTypes"] = acceptDragAndDropTypes.has_value()
-        ? toDynamic(acceptDragAndDropTypes.value())
-        : nullptr;
-  }
+  appendIfChanged(result, "defaultValue", defaultValue, oldProps->defaultValue);
+  appendIfChanged(result, "placeholder", placeholder, oldProps->placeholder);
+  appendDerefIfChanged(
+      result,
+      "placeholderTextColor",
+      placeholderTextColor,
+      oldProps->placeholderTextColor);
+  appendDerefIfChanged(
+      result, "cursorColor", cursorColor, oldProps->cursorColor);
+  appendDerefIfChanged(
+      result, "selectionColor", selectionColor, oldProps->selectionColor);
+  appendDerefIfChanged(
+      result,
+      "selectionHandleColor",
+      selectionHandleColor,
+      oldProps->selectionHandleColor);
+  appendDerefIfChanged(
+      result,
+      "underlineColorAndroid",
+      underlineColorAndroid,
+      oldProps->underlineColorAndroid);
+  appendIfChanged(result, "maxLength", maxLength, oldProps->maxLength);
+  appendIfChanged(result, "text", text, oldProps->text);
+  appendIfChanged(
+      result,
+      "mostRecentEventCount",
+      mostRecentEventCount,
+      oldProps->mostRecentEventCount);
+  appendIfChanged(result, "autoFocus", autoFocus, oldProps->autoFocus);
+  appendIfChanged(
+      result, "autoCapitalize", autoCapitalize, oldProps->autoCapitalize);
+  appendIfChanged(result, "editable", editable, oldProps->editable);
+  appendIfChanged(result, "readOnly", readOnly, oldProps->readOnly);
+  appendConvertedIfChanged(
+      result,
+      "submitBehavior",
+      submitBehavior,
+      oldProps->submitBehavior,
+      asDynamic);
+  appendIfChanged(result, "multiline", multiline, oldProps->multiline);
+  appendIfChanged(
+      result,
+      "disableKeyboardShortcuts",
+      disableKeyboardShortcuts,
+      oldProps->disableKeyboardShortcuts);
+  appendOptionalIfChanged(
+      result,
+      "acceptDragAndDropTypes",
+      acceptDragAndDropTypes,
+      oldProps->acceptDragAndDropTypes,
+      asDynamic);
 
   // Android text input props
-  if (autoComplete != oldProps->autoComplete) {
-    result["autoComplete"] = autoComplete;
-  }
-
-  if (returnKeyLabel != oldProps->returnKeyLabel) {
-    result["returnKeyLabel"] = returnKeyLabel;
-  }
-
-  if (numberOfLines != oldProps->numberOfLines) {
-    result["numberOfLines"] = numberOfLines;
-  }
-
-  if (disableFullscreenUI != oldProps->disableFullscreenUI) {
-    result["disableFullscreenUI"] = disableFullscreenUI;
-  }
-
-  if (textBreakStrategy != oldProps->textBreakStrategy) {
-    result["textBreakStrategy"] = textBreakStrategy;
-  }
-
-  if (inlineImageLeft != oldProps->inlineImageLeft) {
-    result["inlineImageLeft"] = inlineImageLeft;
-  }
-
-  if (inlineImagePadding != oldProps->inlineImagePadding) {
-    result["inlineImagePadding"] = inlineImagePadding;
-  }
-
-  if (importantForAutofill != oldProps->importantForAutofill) {
-    result["importantForAutofill"] = importantForAutofill;
-  }
-
-  if (showSoftInputOnFocus != oldProps->showSoftInputOnFocus) {
-    result["showSoftInputOnFocus"] = showSoftInputOnFocus;
-  }
-
-  if (autoCorrect != oldProps->autoCorrect) {
-    result["autoCorrect"] = autoCorrect;
-  }
-
-  if (allowFontScaling != oldProps->allowFontScaling) {
-    result["allowFontScaling"] = allowFontScaling;
-  }
-
-  if (maxFontSizeMultiplier != oldProps->maxFontSizeMultiplier) {
-    result["maxFontSizeMultiplier"] = maxFontSizeMultiplier;
-  }
-
-  if (keyboardType != oldProps->keyboardType) {
-    result["keyboardType"] = keyboardType;
-  }
-
-  if (returnKeyType != oldProps->returnKeyType) {
-    result["returnKeyType"] = returnKeyType;
-  }
-
-  if (secureTextEntry != oldProps->secureTextEntry) {
-    result["secureTextEntry"] = secureTextEntry;
-  }
-
-  if (value != oldProps->value) {
-    result["value"] = value;
-  }
-
-  if (selectTextOnFocus != oldProps->selectTextOnFocus) {
-    result["selectTextOnFocus"] = selectTextOnFocus;
-  }
-
-  if (caretHidden != oldProps->caretHidden) {
-    result["caretHidden"] = caretHidden;
-  }
-
-  if (contextMenuHidden != oldProps->contextMenuHidden) {
-    result["contextMenuHidden"] = contextMenuHidden;
-  }
-
-  if (textShadowColor != oldProps->textShadowColor) {
-    result["textShadowColor"] = *textShadowColor;
-  }
-
-  if (textShadowRadius != oldProps->textShadowRadius) {
-    result["textShadowRadius"] = textShadowRadius;
-  }
-
-  if (textDecorationLine != oldProps->textDecorationLine) {
-    result["textDecorationLine"] = textDecorationLine;
-  }
-
-  if (fontStyle != oldProps->fontStyle) {
-    result["fontStyle"] = fontStyle;
-  }
-
-  if (textShadowOffset != oldProps->textShadowOffset) {
-    result["textShadowOffset"] = toDynamic(textShadowOffset);
-  }
-
-  if (lineHeight != oldProps->lineHeight) {
-    result["lineHeight"] = lineHeight;
-  }
-
-  if (textTransform != oldProps->textTransform) {
-    result["textTransform"] = textTransform;
-  }
-
-  if (letterSpacing != oldProps->letterSpacing) {
-    result["letterSpacing"] = letterSpacing;
-  }
-
-  if (fontSize != oldProps->fontSize) {
-    result["fontSize"] = fontSize;
-  }
-
-  if (textAlign != oldProps->textAlign) {
-    result["textAlign"] = textAlign;
-  }
-
-  if (includeFontPadding != oldProps->includeFontPadding) {
-    result["includeFontPadding"] = includeFontPadding;
-  }
-
-  if (fontWeight != oldProps->fontWeight) {
-    result["fontWeight"] = fontWeight;
-  }
-
-  if (fontFamily != oldProps->fontFamily) {
-    result["fontFamily"] = fontFamily;
-  }
+  appendIfChanged(result, "autoComplete", autoComplete, oldProps->autoComplete);
+  appendIfChanged(
+      result, "returnKeyLabel", returnKeyLabel, oldProps->returnKeyLabel);
+  appendIfChanged(
+      result, "numberOfLines", numberOfLines, oldProps->numberOfLines);
+  appendIfChanged(
+      result,
+      "disableFullscreenUI",
+      disableFullscreenUI,
+      oldProps->disableFullscreenUI);
+  appendIfChanged(
+      result,
+      "textBreakStrategy",
+      textBreakStrategy,
+      oldProps->textBreakStrategy);
+  appendIfChanged(
+      result, "inlineImageLeft", inlineImageLeft, oldProps->inlineImageLeft);
+  appendIfChanged(
+      result,
+      "inlineImagePadding",
+      inlineImagePadding,
+      oldProps->inlineImagePadding);
+  appendIfChanged(
+      result,
+      "importantForAutofill",
+      importantForAutofill,
+      oldProps->importantForAutofill);
+  appendIfChanged(
+      result,
+      "showSoftInputOnFocus",
+      showSoftInputOnFocus,
+      oldProps->showSoftInputOnFocus);
+  appendIfChanged(result, "autoCorrect", autoCorrect, oldProps->autoCorrect);
+  appendIfChanged(
+      result, "allowFontScaling", allowFontScaling, oldProps->allowFontScaling);
+  appendIfChanged(
+      result,
+      "maxFontSizeMultiplier",
+      maxFontSizeMultiplier,
+      oldProps->maxFontSizeMultiplier);
+  appendIfChanged(result, "keyboardType", keyboardType, oldProps->keyboardType);
+  appendIfChanged(
+      result, "returnKeyType", returnKeyType, oldProps->returnKeyType);
+  appendIfChanged(
+      result, "secureTextEntry", secureTextEntry, oldProps->secureTextEntry);
+  appendIfChanged(result, "value", value, oldProps->value);
+  appendIfChanged(
+      result,
+      "selectTextOnFocus",
+      selectTextOnFocus,
+      oldProps->selectTextOnFocus);
+  appendIfChanged(result, "caretHidden", caretHidden, oldProps->caretHidden);
+  appendIfChanged(
+      result,
+      "contextMenuHidden",
+      contextMenuHidden,
+      oldProps->contextMenuHidden);
+  appendDerefIfChanged(
+      result, "textShadowColor", textShadowColor, oldProps->textShadowColor);
+  appendIfChanged(
+      result, "textShadowRadius", textShadowRadius, oldProps->textShadowRadius);
+  appendIfChanged(
+      result,
+      "textDecorationLine",
+      textDecorationLine,
+      oldProps->textDecorationLine);
+  appendIfChanged(result, "fontStyle", fontStyle, oldProps->fontStyle);
+  appendConvertedIfChanged(
+      result,
+      "textShadowOffset",
+      textShadowOffset,
+      oldProps->textShadowOffset,
+      asDynamic);
+  appendIfChanged(result, "lineHeight", lineHeight, oldProps->lineHeight);
+  appendIfChanged(
+      result, "textTransform", textTransform, oldProps->textTransform);
+  appendIfChanged(
+      result, "letterSpacing", letterSpacing, oldProps->letterSpacing);
+  appendIfChanged(result, "fontSize", fontSize, oldProps->fontSize);
+  appendIfChanged(result, "textAlign", textAlign, oldProps->textAlign);
+  appendIfChanged(
+      result,
+      "includeFontPadding",
+      includeFontPadding,
+      oldProps->includeFontPadding);
+  appendIfChanged(result, "fontWeight", fontWeight, oldProps->fontWeight);
+  appendIfChanged(result, "fontFamily", fontFamily, oldProps->fontFamily);
 
   return result;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -21,88 +21,37 @@ namespace facebook::react {
 
 inline void fromString(const std::string &string, AccessibilityTraits &result)
 {
-  if (string == "none") {
-    result = AccessibilityTraits::None;
-    return;
-  }
-  if (string == "button" || string == "togglebutton") {
-    result = AccessibilityTraits::Button;
-    return;
-  }
-  if (string == "link") {
-    result = AccessibilityTraits::Link;
-    return;
-  }
-  if (string == "image" || string == "img") {
-    result = AccessibilityTraits::Image;
-    return;
-  }
-  if (string == "selected") {
-    result = AccessibilityTraits::Selected;
-    return;
-  }
-  if (string == "plays") {
-    result = AccessibilityTraits::PlaysSound;
-    return;
-  }
-  if (string == "keyboardkey" || string == "key") {
-    result = AccessibilityTraits::KeyboardKey;
-    return;
-  }
-  if (string == "text") {
-    result = AccessibilityTraits::StaticText;
-    return;
-  }
-  if (string == "disabled") {
-    result = AccessibilityTraits::NotEnabled;
-    return;
-  }
-  if (string == "frequentUpdates") {
-    result = AccessibilityTraits::UpdatesFrequently;
-    return;
-  }
-  if (string == "search") {
-    result = AccessibilityTraits::SearchField;
-    return;
-  }
-  if (string == "startsMedia") {
-    result = AccessibilityTraits::StartsMediaSession;
-    return;
-  }
-  if (string == "adjustable") {
-    result = AccessibilityTraits::Adjustable;
-    return;
-  }
-  if (string == "allowsDirectInteraction") {
-    result = AccessibilityTraits::AllowsDirectInteraction;
-    return;
-  }
-  if (string == "pageTurn") {
-    result = AccessibilityTraits::CausesPageTurn;
-    return;
-  }
-  if (string == "header" || string == "heading") {
-    result = AccessibilityTraits::Header;
-    return;
-  }
-  if (string == "imagebutton") {
-    result = AccessibilityTraits::Image | AccessibilityTraits::Button;
-    return;
-  }
-  if (string == "summary") {
-    result = AccessibilityTraits::SummaryElement;
-    return;
-  }
-  if (string == "switch") {
-    result = AccessibilityTraits::Switch;
-    return;
-  }
-  if (string == "tabbar") {
-    result = AccessibilityTraits::TabBar;
-    return;
-  }
-  if (string == "progressbar") {
-    result = AccessibilityTraits::UpdatesFrequently;
+  static const std::unordered_map<std::string, AccessibilityTraits> traitsMap = {
+      {"none", AccessibilityTraits::None},
+      {"button", AccessibilityTraits::Button},
+      {"togglebutton", AccessibilityTraits::Button},
+      {"link", AccessibilityTraits::Link},
+      {"image", AccessibilityTraits::Image},
+      {"img", AccessibilityTraits::Image},
+      {"selected", AccessibilityTraits::Selected},
+      {"plays", AccessibilityTraits::PlaysSound},
+      {"keyboardkey", AccessibilityTraits::KeyboardKey},
+      {"key", AccessibilityTraits::KeyboardKey},
+      {"text", AccessibilityTraits::StaticText},
+      {"disabled", AccessibilityTraits::NotEnabled},
+      {"frequentUpdates", AccessibilityTraits::UpdatesFrequently},
+      {"search", AccessibilityTraits::SearchField},
+      {"startsMedia", AccessibilityTraits::StartsMediaSession},
+      {"adjustable", AccessibilityTraits::Adjustable},
+      {"allowsDirectInteraction", AccessibilityTraits::AllowsDirectInteraction},
+      {"pageTurn", AccessibilityTraits::CausesPageTurn},
+      {"header", AccessibilityTraits::Header},
+      {"heading", AccessibilityTraits::Header},
+      {"imagebutton", AccessibilityTraits::Image | AccessibilityTraits::Button},
+      {"summary", AccessibilityTraits::SummaryElement},
+      {"switch", AccessibilityTraits::Switch},
+      {"tabbar", AccessibilityTraits::TabBar},
+      {"progressbar", AccessibilityTraits::UpdatesFrequently},
+  };
+
+  auto it = traitsMap.find(string);
+  if (it != traitsMap.end()) {
+    result = it->second;
     return;
   }
   result = AccessibilityTraits::None;
@@ -380,87 +329,54 @@ inline std::string toString(const AccessibilityRole &accessibilityRole)
 
 inline void fromRawValue(const PropsParserContext &context, const RawValue &value, AccessibilityRole &result)
 {
+  static const std::unordered_map<std::string, AccessibilityRole> accessibilityRoleMap = {
+      {"none", AccessibilityRole::None},
+      {"button", AccessibilityRole::Button},
+      {"dropdownlist", AccessibilityRole::Dropdownlist},
+      {"togglebutton", AccessibilityRole::Togglebutton},
+      {"link", AccessibilityRole::Link},
+      {"search", AccessibilityRole::Search},
+      {"image", AccessibilityRole::Image},
+      {"keyboardkey", AccessibilityRole::Keyboardkey},
+      {"text", AccessibilityRole::Text},
+      {"adjustable", AccessibilityRole::Adjustable},
+      {"imagebutton", AccessibilityRole::Imagebutton},
+      {"header", AccessibilityRole::Header},
+      {"summary", AccessibilityRole::Summary},
+      {"alert", AccessibilityRole::Alert},
+      {"checkbox", AccessibilityRole::Checkbox},
+      {"combobox", AccessibilityRole::Combobox},
+      {"menu", AccessibilityRole::Menu},
+      {"menubar", AccessibilityRole::Menubar},
+      {"menuitem", AccessibilityRole::Menuitem},
+      {"progressbar", AccessibilityRole::Progressbar},
+      {"radio", AccessibilityRole::Radio},
+      {"radiogroup", AccessibilityRole::Radiogroup},
+      {"scrollbar", AccessibilityRole::Scrollbar},
+      {"spinbutton", AccessibilityRole::Spinbutton},
+      {"switch", AccessibilityRole::Switch},
+      {"tab", AccessibilityRole::Tab},
+      {"tabbar", AccessibilityRole::Tabbar},
+      {"tablist", AccessibilityRole::Tablist},
+      {"timer", AccessibilityRole::Timer},
+      {"toolbar", AccessibilityRole::Toolbar},
+      {"grid", AccessibilityRole::Grid},
+      {"pager", AccessibilityRole::Pager},
+      {"scrollview", AccessibilityRole::Scrollview},
+      {"horizontalscrollview", AccessibilityRole::Horizontalscrollview},
+      {"viewgroup", AccessibilityRole::Viewgroup},
+      {"webview", AccessibilityRole::Webview},
+      {"drawerlayout", AccessibilityRole::Drawerlayout},
+      {"slidingdrawer", AccessibilityRole::Slidingdrawer},
+      {"iconmenu", AccessibilityRole::Iconmenu},
+  };
+
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
-    if (string == "none") {
-      result = AccessibilityRole::None;
-    } else if (string == "button") {
-      result = AccessibilityRole::Button;
-    } else if (string == "dropdownlist") {
-      result = AccessibilityRole::Dropdownlist;
-    } else if (string == "togglebutton") {
-      result = AccessibilityRole::Togglebutton;
-    } else if (string == "link") {
-      result = AccessibilityRole::Link;
-    } else if (string == "search") {
-      result = AccessibilityRole::Search;
-    } else if (string == "image") {
-      result = AccessibilityRole::Image;
-    } else if (string == "keyboardkey") {
-      result = AccessibilityRole::Keyboardkey;
-    } else if (string == "text") {
-      result = AccessibilityRole::Text;
-    } else if (string == "adjustable") {
-      result = AccessibilityRole::Adjustable;
-    } else if (string == "imagebutton") {
-      result = AccessibilityRole::Imagebutton;
-    } else if (string == "header") {
-      result = AccessibilityRole::Header;
-    } else if (string == "summary") {
-      result = AccessibilityRole::Summary;
-    } else if (string == "alert") {
-      result = AccessibilityRole::Alert;
-    } else if (string == "checkbox") {
-      result = AccessibilityRole::Checkbox;
-    } else if (string == "combobox") {
-      result = AccessibilityRole::Combobox;
-    } else if (string == "menu") {
-      result = AccessibilityRole::Menu;
-    } else if (string == "menubar") {
-      result = AccessibilityRole::Menubar;
-    } else if (string == "menuitem") {
-      result = AccessibilityRole::Menuitem;
-    } else if (string == "progressbar") {
-      result = AccessibilityRole::Progressbar;
-    } else if (string == "radio") {
-      result = AccessibilityRole::Radio;
-    } else if (string == "radiogroup") {
-      result = AccessibilityRole::Radiogroup;
-    } else if (string == "scrollbar") {
-      result = AccessibilityRole::Scrollbar;
-    } else if (string == "spinbutton") {
-      result = AccessibilityRole::Spinbutton;
-    } else if (string == "switch") {
-      result = AccessibilityRole::Switch;
-    } else if (string == "tab") {
-      result = AccessibilityRole::Tab;
-    } else if (string == "tabbar") {
-      result = AccessibilityRole::Tabbar;
-    } else if (string == "tablist") {
-      result = AccessibilityRole::Tablist;
-    } else if (string == "timer") {
-      result = AccessibilityRole::Timer;
-    } else if (string == "toolbar") {
-      result = AccessibilityRole::Toolbar;
-    } else if (string == "grid") {
-      result = AccessibilityRole::Grid;
-    } else if (string == "pager") {
-      result = AccessibilityRole::Pager;
-    } else if (string == "scrollview") {
-      result = AccessibilityRole::Scrollview;
-    } else if (string == "horizontalscrollview") {
-      result = AccessibilityRole::Horizontalscrollview;
-    } else if (string == "viewgroup") {
-      result = AccessibilityRole::Viewgroup;
-    } else if (string == "webview") {
-      result = AccessibilityRole::Webview;
-    } else if (string == "drawerlayout") {
-      result = AccessibilityRole::Drawerlayout;
-    } else if (string == "slidingdrawer") {
-      result = AccessibilityRole::Slidingdrawer;
-    } else if (string == "iconmenu") {
-      result = AccessibilityRole::Iconmenu;
+    auto it = accessibilityRoleMap.find(string);
+    if (it != accessibilityRoleMap.end()) {
+      result = it->second;
     } else {
       LOG(ERROR) << "Unsupported AccessibilityRole value: " << string;
       react_native_expect(false);
@@ -619,139 +535,80 @@ inline std::string toString(const Role &role)
 
 inline void fromRawValue(const PropsParserContext &context, const RawValue &value, Role &result)
 {
+  static const std::unordered_map<std::string, Role> roleMap = {
+      {"alert", Role::Alert},
+      {"alertdialog", Role::Alertdialog},
+      {"application", Role::Application},
+      {"article", Role::Article},
+      {"banner", Role::Banner},
+      {"button", Role::Button},
+      {"cell", Role::Cell},
+      {"checkbox", Role::Checkbox},
+      {"columnheader", Role::Columnheader},
+      {"combobox", Role::Combobox},
+      {"complementary", Role::Complementary},
+      {"contentinfo", Role::Contentinfo},
+      {"definition", Role::Definition},
+      {"dialog", Role::Dialog},
+      {"directory", Role::Directory},
+      {"document", Role::Document},
+      {"feed", Role::Feed},
+      {"figure", Role::Figure},
+      {"form", Role::Form},
+      {"grid", Role::Grid},
+      {"group", Role::Group},
+      {"heading", Role::Heading},
+      {"img", Role::Img},
+      {"link", Role::Link},
+      {"list", Role::List},
+      {"listitem", Role::Listitem},
+      {"log", Role::Log},
+      {"main", Role::Main},
+      {"marquee", Role::Marquee},
+      {"math", Role::Math},
+      {"menu", Role::Menu},
+      {"menubar", Role::Menubar},
+      {"menuitem", Role::Menuitem},
+      {"meter", Role::Meter},
+      {"navigation", Role::Navigation},
+      {"none", Role::None},
+      {"note", Role::Note},
+      {"option", Role::Option},
+      {"presentation", Role::Presentation},
+      {"progressbar", Role::Progressbar},
+      {"radio", Role::Radio},
+      {"radiogroup", Role::Radiogroup},
+      {"region", Role::Region},
+      {"row", Role::Row},
+      {"rowgroup", Role::Rowgroup},
+      {"rowheader", Role::Rowheader},
+      {"scrollbar", Role::Scrollbar},
+      {"searchbox", Role::Searchbox},
+      {"separator", Role::Separator},
+      {"slider", Role::Slider},
+      {"spinbutton", Role::Spinbutton},
+      {"status", Role::Status},
+      {"summary", Role::Summary},
+      {"switch", Role::Switch},
+      {"tab", Role::Tab},
+      {"table", Role::Table},
+      {"tablist", Role::Tablist},
+      {"tabpanel", Role::Tabpanel},
+      {"term", Role::Term},
+      {"timer", Role::Timer},
+      {"toolbar", Role::Toolbar},
+      {"tooltip", Role::Tooltip},
+      {"tree", Role::Tree},
+      {"treegrid", Role::Treegrid},
+      {"treeitem", Role::Treeitem},
+  };
+
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
-    if (string == "alert") {
-      result = Role::Alert;
-    } else if (string == "alertdialog") {
-      result = Role::Alertdialog;
-    } else if (string == "application") {
-      result = Role::Application;
-    } else if (string == "article") {
-      result = Role::Article;
-    } else if (string == "banner") {
-      result = Role::Banner;
-    } else if (string == "button") {
-      result = Role::Button;
-    } else if (string == "cell") {
-      result = Role::Cell;
-    } else if (string == "checkbox") {
-      result = Role::Checkbox;
-    } else if (string == "columnheader") {
-      result = Role::Columnheader;
-    } else if (string == "combobox") {
-      result = Role::Combobox;
-    } else if (string == "complementary") {
-      result = Role::Complementary;
-    } else if (string == "contentinfo") {
-      result = Role::Contentinfo;
-    } else if (string == "definition") {
-      result = Role::Definition;
-    } else if (string == "dialog") {
-      result = Role::Dialog;
-    } else if (string == "directory") {
-      result = Role::Directory;
-    } else if (string == "document") {
-      result = Role::Document;
-    } else if (string == "feed") {
-      result = Role::Feed;
-    } else if (string == "figure") {
-      result = Role::Figure;
-    } else if (string == "form") {
-      result = Role::Form;
-    } else if (string == "grid") {
-      result = Role::Grid;
-    } else if (string == "group") {
-      result = Role::Group;
-    } else if (string == "heading") {
-      result = Role::Heading;
-    } else if (string == "img") {
-      result = Role::Img;
-    } else if (string == "link") {
-      result = Role::Link;
-    } else if (string == "list") {
-      result = Role::List;
-    } else if (string == "listitem") {
-      result = Role::Listitem;
-    } else if (string == "log") {
-      result = Role::Log;
-    } else if (string == "main") {
-      result = Role::Main;
-    } else if (string == "marquee") {
-      result = Role::Marquee;
-    } else if (string == "math") {
-      result = Role::Math;
-    } else if (string == "menu") {
-      result = Role::Menu;
-    } else if (string == "menubar") {
-      result = Role::Menubar;
-    } else if (string == "menuitem") {
-      result = Role::Menuitem;
-    } else if (string == "meter") {
-      result = Role::Meter;
-    } else if (string == "navigation") {
-      result = Role::Navigation;
-    } else if (string == "none") {
-      result = Role::None;
-    } else if (string == "note") {
-      result = Role::Note;
-    } else if (string == "option") {
-      result = Role::Option;
-    } else if (string == "presentation") {
-      result = Role::Presentation;
-    } else if (string == "progressbar") {
-      result = Role::Progressbar;
-    } else if (string == "radio") {
-      result = Role::Radio;
-    } else if (string == "radiogroup") {
-      result = Role::Radiogroup;
-    } else if (string == "region") {
-      result = Role::Region;
-    } else if (string == "row") {
-      result = Role::Row;
-    } else if (string == "rowgroup") {
-      result = Role::Rowgroup;
-    } else if (string == "rowheader") {
-      result = Role::Rowheader;
-    } else if (string == "scrollbar") {
-      result = Role::Scrollbar;
-    } else if (string == "searchbox") {
-      result = Role::Searchbox;
-    } else if (string == "separator") {
-      result = Role::Separator;
-    } else if (string == "slider") {
-      result = Role::Slider;
-    } else if (string == "spinbutton") {
-      result = Role::Spinbutton;
-    } else if (string == "status") {
-      result = Role::Status;
-    } else if (string == "summary") {
-      result = Role::Summary;
-    } else if (string == "switch") {
-      result = Role::Switch;
-    } else if (string == "tab") {
-      result = Role::Tab;
-    } else if (string == "table") {
-      result = Role::Table;
-    } else if (string == "tablist") {
-      result = Role::Tablist;
-    } else if (string == "tabpanel") {
-      result = Role::Tabpanel;
-    } else if (string == "term") {
-      result = Role::Term;
-    } else if (string == "timer") {
-      result = Role::Timer;
-    } else if (string == "toolbar") {
-      result = Role::Toolbar;
-    } else if (string == "tooltip") {
-      result = Role::Tooltip;
-    } else if (string == "tree") {
-      result = Role::Tree;
-    } else if (string == "treegrid") {
-      result = Role::Treegrid;
-    } else if (string == "treeitem") {
-      result = Role::Treeitem;
+    auto it = roleMap.find(string);
+    if (it != roleMap.end()) {
+      result = it->second;
     } else {
       LOG(ERROR) << "Unsupported Role value: " << string;
       react_native_expect(false);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -501,6 +501,389 @@ ComponentName HostPlatformViewProps::getDiffPropsImplementationTarget() const {
   return "View";
 }
 
+// Behavior-preserving helpers extracted from getDiffProps below to keep its
+// cyclomatic complexity low. Each mirrors one of the recurring
+// compare-and-assign shapes used per prop, so the serialized output (keys,
+// values, conversions, and insertion order) is identical to the open-coded
+// version.
+template <typename T>
+static void appendIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue) {
+  if (newValue != oldValue) {
+    result[propName] = newValue;
+  }
+}
+
+template <typename T>
+static void appendDerefIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue) {
+  if (newValue != oldValue) {
+    result[propName] = *newValue;
+  }
+}
+
+template <typename T, typename Convert>
+static void appendConvertedIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue,
+    Convert&& convert) {
+  if (newValue != oldValue) {
+    result[propName] = convert(newValue);
+  }
+}
+
+template <typename T, typename Convert>
+static void appendOptionalIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const std::optional<T>& newValue,
+    const std::optional<T>& oldValue,
+    Convert&& convert) {
+  if (newValue != oldValue) {
+    result[propName] = newValue.has_value()
+        ? folly::dynamic(convert(newValue.value()))
+        : folly::dynamic(nullptr);
+  }
+}
+
+static void appendOutlineStyleIfChanged(
+    folly::dynamic& result,
+    OutlineStyle outlineStyle,
+    OutlineStyle oldOutlineStyle) {
+  if (outlineStyle != oldOutlineStyle) {
+    switch (outlineStyle) {
+      case OutlineStyle::Solid:
+        result["outlineStyle"] = "solid";
+        break;
+      case OutlineStyle::Dotted:
+        result["outlineStyle"] = "dotted";
+        break;
+      case OutlineStyle::Dashed:
+        result["outlineStyle"] = "dashed";
+        break;
+    }
+  }
+}
+
+static void appendBackfaceVisibilityIfChanged(
+    folly::dynamic& result,
+    BackfaceVisibility backfaceVisibility,
+    BackfaceVisibility oldBackfaceVisibility) {
+  if (backfaceVisibility != oldBackfaceVisibility) {
+    switch (backfaceVisibility) {
+      case BackfaceVisibility::Auto:
+        result["backfaceVisibility"] = "auto";
+        break;
+      case BackfaceVisibility::Visible:
+        result["backfaceVisibility"] = "visible";
+        break;
+      case BackfaceVisibility::Hidden:
+        result["backfaceVisibility"] = "hidden";
+        break;
+    }
+  }
+}
+
+static void appendOverflowIfChanged(
+    folly::dynamic& result,
+    bool clipsContentToBounds,
+    bool oldClipsContentToBounds) {
+  if (clipsContentToBounds != oldClipsContentToBounds) {
+    result["overflow"] = clipsContentToBounds ? "hidden" : "visible";
+    result["scroll"] = result["overflow"];
+  }
+}
+
+template <typename T>
+static void appendNativeDrawableIfChanged(
+    folly::dynamic& result,
+    const char* propName,
+    const T& newValue,
+    const T& oldValue) {
+  if (newValue != oldValue) {
+    updateNativeDrawableProp(result, propName, newValue);
+  }
+}
+
+template <typename T>
+static void
+appendEventProps(folly::dynamic& result, const T& events, const T& oldEvents) {
+  if (events != oldEvents) {
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerEnter,
+        "onPointerEnter");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerEnterCapture,
+        "onPointerEnterCapture");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerMove,
+        "onPointerMove");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerMoveCapture,
+        "onPointerMoveCapture");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerLeave,
+        "onPointerLeave");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerLeaveCapture,
+        "onPointerLeaveCapture");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerOver,
+        "onPointerOver");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerOverCapture,
+        "onPointerOverCapture");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerOut,
+        "onPointerOut");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::PointerOutCapture,
+        "onPointerOutCapture");
+    updateEventProp(
+        result, events, oldEvents, ViewEvents::Offset::Click, "onClick");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ClickCapture,
+        "onClickCapture");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::MoveShouldSetResponder,
+        "onMoveShouldSetResponder");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::MoveShouldSetResponderCapture,
+        "onMoveShouldSetResponderCapture");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::StartShouldSetResponder,
+        "onStartShouldSetResponder");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::StartShouldSetResponderCapture,
+        "onStartShouldSetResponderCapture");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ResponderGrant,
+        "onResponderGrant");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ResponderReject,
+        "onResponderReject");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ResponderStart,
+        "onResponderStart");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ResponderEnd,
+        "onResponderEnd");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ResponderRelease,
+        "onResponderRelease");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ResponderMove,
+        "onResponderMove");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ResponderTerminate,
+        "onResponderTerminate");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ResponderTerminationRequest,
+        "onResponderTerminationRequest");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::ShouldBlockNativeResponder,
+        "onShouldBlockNativeResponder");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::TouchStart,
+        "onTouchStart");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::TouchMove,
+        "onTouchMove");
+    updateEventProp(
+        result, events, oldEvents, ViewEvents::Offset::TouchEnd, "onTouchEnd");
+    updateEventProp(
+        result,
+        events,
+        oldEvents,
+        ViewEvents::Offset::TouchCancel,
+        "onTouchCancel");
+  }
+}
+
+template <typename TTransform, typename TOrigin>
+static void appendTransformIfChanged(
+    folly::dynamic& result,
+    const TTransform& transform,
+    const TTransform& oldTransform,
+    const TOrigin& transformOrigin,
+    const TOrigin& oldTransformOrigin) {
+  if (transform != oldTransform || transformOrigin != oldTransformOrigin) {
+    folly::dynamic resultTranslateArray = folly::dynamic::array();
+    for (const auto& operation : transform.operations) {
+      updateTransformProps(transform, operation, resultTranslateArray);
+    }
+    result["transform"] = std::move(resultTranslateArray);
+  }
+}
+
+template <typename T>
+static void appendAccessibilityStateIfChanged(
+    folly::dynamic& result,
+    const T& accessibilityState,
+    const T& oldAccessibilityState) {
+  if (accessibilityState != oldAccessibilityState) {
+    updateAccessibilityStateProp(
+        result, accessibilityState, oldAccessibilityState);
+  }
+}
+
+template <typename T>
+static void appendAccessibilityLabelledByIfChanged(
+    folly::dynamic& result,
+    const T& accessibilityLabelledBy,
+    const T& oldAccessibilityLabelledBy) {
+  if (accessibilityLabelledBy != oldAccessibilityLabelledBy) {
+    auto accessibilityLabelledByValues = folly::dynamic::array();
+    for (const auto& accessibilityLabelledByValue :
+         accessibilityLabelledBy.value) {
+      accessibilityLabelledByValues.push_back(accessibilityLabelledByValue);
+    }
+    result["accessibilityLabelledBy"] = accessibilityLabelledByValues;
+  }
+}
+
+template <typename T>
+static void appendAccessibilityOrderIfChanged(
+    folly::dynamic& result,
+    const T& accessibilityOrder,
+    const T& oldAccessibilityOrder) {
+  if (accessibilityOrder != oldAccessibilityOrder) {
+    auto accessibilityChildrenIds = folly::dynamic::array();
+    for (const auto& accessibilityChildId : accessibilityOrder) {
+      accessibilityChildrenIds.push_back(accessibilityChildId);
+    }
+    result["experimental_accessibilityOrder"] = accessibilityChildrenIds;
+  }
+}
+
+template <typename T>
+static void appendAccessibilityValueIfChanged(
+    folly::dynamic& result,
+    const T& accessibilityValue,
+    const T& oldAccessibilityValue) {
+  if (accessibilityValue != oldAccessibilityValue) {
+    folly::dynamic accessibilityValueObject = folly::dynamic::object();
+    if (accessibilityValue.min.has_value()) {
+      accessibilityValueObject["min"] = accessibilityValue.min.value();
+    }
+    if (accessibilityValue.max.has_value()) {
+      accessibilityValueObject["max"] = accessibilityValue.max.value();
+    }
+    if (accessibilityValue.now.has_value()) {
+      accessibilityValueObject["now"] = accessibilityValue.now.value();
+    }
+    if (accessibilityValue.text.has_value()) {
+      accessibilityValueObject["text"] = accessibilityValue.text.value();
+    }
+    result["accessibilityValue"] = accessibilityValueObject;
+  }
+}
+
+template <typename T>
+static void appendAccessibilityActionsIfChanged(
+    folly::dynamic& result,
+    const T& accessibilityActions,
+    const T& oldAccessibilityActions) {
+  if (accessibilityActions != oldAccessibilityActions) {
+    auto accessibilityActionsArray = folly::dynamic::array();
+    for (const auto& accessibilityAction : accessibilityActions) {
+      folly::dynamic accessibilityActionObject = folly::dynamic::object();
+      accessibilityActionObject["name"] = accessibilityAction.name;
+      if (accessibilityAction.label.has_value()) {
+        accessibilityActionObject["label"] = accessibilityAction.label.value();
+      }
+      accessibilityActionsArray.push_back(accessibilityActionObject);
+    }
+    result["accessibilityActions"] = accessibilityActionsArray;
+  }
+}
+
 folly::dynamic HostPlatformViewProps::getDiffProps(
     const Props* prevProps) const {
   folly::dynamic result = folly::dynamic::object();
@@ -515,346 +898,103 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
     return result;
   }
 
-  if (elevation != oldProps->elevation) {
-    result["elevation"] = elevation;
-  }
+  auto asString = [](const auto& value) { return toString(value); };
+  auto asDynamic = [](const auto& value) { return toDynamic(value); };
+  auto asIs = [](const auto& value) { return value; };
 
-  if (focusable != oldProps->focusable) {
-    result["focusable"] = focusable;
-  }
-
-  if (hasTVPreferredFocus != oldProps->hasTVPreferredFocus) {
-    result["hasTVPreferredFocus"] = hasTVPreferredFocus;
-  }
-
-  if (needsOffscreenAlphaCompositing !=
-      oldProps->needsOffscreenAlphaCompositing) {
-    result["needsOffscreenAlphaCompositing"] = needsOffscreenAlphaCompositing;
-  }
-
-  if (renderToHardwareTextureAndroid !=
-      oldProps->renderToHardwareTextureAndroid) {
-    result["renderToHardwareTextureAndroid"] = renderToHardwareTextureAndroid;
-  }
-
-  if (screenReaderFocusable != oldProps->screenReaderFocusable) {
-    result["screenReaderFocusable"] = screenReaderFocusable;
-  }
-
-  if (role != oldProps->role) {
-    result["role"] = toString(role);
-  }
-
-  if (opacity != oldProps->opacity) {
-    result["opacity"] = opacity;
-  }
-
-  if (backgroundColor != oldProps->backgroundColor) {
-    result["backgroundColor"] = *backgroundColor;
-  }
-
-  if (outlineColor != oldProps->outlineColor) {
-    result["outlineColor"] = *outlineColor;
-  }
-
-  if (outlineOffset != oldProps->outlineOffset) {
-    result["outlineOffset"] = outlineOffset;
-  }
-
-  if (outlineStyle != oldProps->outlineStyle) {
-    switch (outlineStyle) {
-      case OutlineStyle::Solid:
-        result["outlineStyle"] = "solid";
-        break;
-      case OutlineStyle::Dotted:
-        result["outlineStyle"] = "dotted";
-        break;
-      case OutlineStyle::Dashed:
-        result["outlineStyle"] = "dashed";
-        break;
-    }
-  }
-
-  if (outlineWidth != oldProps->outlineWidth) {
-    result["outlineWidth"] = outlineWidth;
-  }
-
-  if (shadowColor != oldProps->shadowColor) {
-    result["shadowColor"] = *shadowColor;
-  }
-
-  if (shadowOpacity != oldProps->shadowOpacity) {
-    result["shadowOpacity"] = shadowOpacity;
-  }
-
-  if (shadowRadius != oldProps->shadowRadius) {
-    result["shadowRadius"] = shadowRadius;
-  }
-
-  if (shouldRasterize != oldProps->shouldRasterize) {
-    result["shouldRasterize"] = shouldRasterize;
-  }
-
-  if (collapsable != oldProps->collapsable) {
-    result["collapsable"] = collapsable;
-  }
-
-  if (removeClippedSubviews != oldProps->removeClippedSubviews) {
-    result["removeClippedSubviews"] = removeClippedSubviews;
-  }
-
-  if (collapsableChildren != oldProps->collapsableChildren) {
-    result["collapsableChildren"] = collapsableChildren;
-  }
-
-  if (onLayout != oldProps->onLayout) {
-    result["onLayout"] = onLayout;
-  }
-
-  if (zIndex != oldProps->zIndex) {
-    result["zIndex"] =
-        zIndex.has_value() ? zIndex.value() : folly::dynamic(nullptr);
-  }
-
-  if (boxShadow != oldProps->boxShadow) {
-    result["boxShadow"] = toDynamic(boxShadow);
-  }
-
-  if (filter != oldProps->filter) {
-    result["filter"] = toDynamic(filter);
-  }
-
-  if (backgroundImage != oldProps->backgroundImage) {
-    result["experimental_backgroundImage"] = toDynamic(backgroundImage);
-  }
-
-  if (mixBlendMode != oldProps->mixBlendMode) {
-    result["mixBlendMode"] = toString(mixBlendMode);
-  }
-
-  if (pointerEvents != oldProps->pointerEvents) {
-    result["pointerEvents"] = toString(pointerEvents);
-  }
-
-  if (hitSlop != oldProps->hitSlop) {
-    result["hitSlop"] = toDynamic(hitSlop);
-  }
-
-  if (nativeId != oldProps->nativeId) {
-    result["nativeID"] = nativeId;
-  }
-
-  if (testId != oldProps->testId) {
-    result["testID"] = testId;
-  }
-
-  if (accessible != oldProps->accessible) {
-    result["accessible"] = accessible;
-  }
-
-  if (getClipsContentToBounds() != oldProps->getClipsContentToBounds()) {
-    result["overflow"] = getClipsContentToBounds() ? "hidden" : "visible";
-    result["scroll"] = result["overflow"];
-  }
-
-  if (backfaceVisibility != oldProps->backfaceVisibility) {
-    switch (backfaceVisibility) {
-      case BackfaceVisibility::Auto:
-        result["backfaceVisibility"] = "auto";
-        break;
-      case BackfaceVisibility::Visible:
-        result["backfaceVisibility"] = "visible";
-        break;
-      case BackfaceVisibility::Hidden:
-        result["backfaceVisibility"] = "hidden";
-        break;
-    }
-  }
-
-  if (nativeBackground != oldProps->nativeBackground) {
-    updateNativeDrawableProp(
-        result, "nativeBackgroundAndroid", nativeBackground);
-  }
-
-  if (nativeForeground != oldProps->nativeForeground) {
-    updateNativeDrawableProp(
-        result, "nativeForegroundAndroid", nativeForeground);
-  }
+  appendIfChanged(result, "elevation", elevation, oldProps->elevation);
+  appendIfChanged(result, "focusable", focusable, oldProps->focusable);
+  appendIfChanged(
+      result,
+      "hasTVPreferredFocus",
+      hasTVPreferredFocus,
+      oldProps->hasTVPreferredFocus);
+  appendIfChanged(
+      result,
+      "needsOffscreenAlphaCompositing",
+      needsOffscreenAlphaCompositing,
+      oldProps->needsOffscreenAlphaCompositing);
+  appendIfChanged(
+      result,
+      "renderToHardwareTextureAndroid",
+      renderToHardwareTextureAndroid,
+      oldProps->renderToHardwareTextureAndroid);
+  appendIfChanged(
+      result,
+      "screenReaderFocusable",
+      screenReaderFocusable,
+      oldProps->screenReaderFocusable);
+  appendConvertedIfChanged(result, "role", role, oldProps->role, asString);
+  appendIfChanged(result, "opacity", opacity, oldProps->opacity);
+  appendDerefIfChanged(
+      result, "backgroundColor", backgroundColor, oldProps->backgroundColor);
+  appendDerefIfChanged(
+      result, "outlineColor", outlineColor, oldProps->outlineColor);
+  appendIfChanged(
+      result, "outlineOffset", outlineOffset, oldProps->outlineOffset);
+  appendOutlineStyleIfChanged(result, outlineStyle, oldProps->outlineStyle);
+  appendIfChanged(result, "outlineWidth", outlineWidth, oldProps->outlineWidth);
+  appendDerefIfChanged(
+      result, "shadowColor", shadowColor, oldProps->shadowColor);
+  appendIfChanged(
+      result, "shadowOpacity", shadowOpacity, oldProps->shadowOpacity);
+  appendIfChanged(result, "shadowRadius", shadowRadius, oldProps->shadowRadius);
+  appendIfChanged(
+      result, "shouldRasterize", shouldRasterize, oldProps->shouldRasterize);
+  appendIfChanged(result, "collapsable", collapsable, oldProps->collapsable);
+  appendIfChanged(
+      result,
+      "removeClippedSubviews",
+      removeClippedSubviews,
+      oldProps->removeClippedSubviews);
+  appendIfChanged(
+      result,
+      "collapsableChildren",
+      collapsableChildren,
+      oldProps->collapsableChildren);
+  appendIfChanged(result, "onLayout", onLayout, oldProps->onLayout);
+  appendOptionalIfChanged(result, "zIndex", zIndex, oldProps->zIndex, asIs);
+  appendConvertedIfChanged(
+      result, "boxShadow", boxShadow, oldProps->boxShadow, asDynamic);
+  appendConvertedIfChanged(
+      result, "filter", filter, oldProps->filter, asDynamic);
+  appendConvertedIfChanged(
+      result,
+      "experimental_backgroundImage",
+      backgroundImage,
+      oldProps->backgroundImage,
+      asDynamic);
+  appendConvertedIfChanged(
+      result, "mixBlendMode", mixBlendMode, oldProps->mixBlendMode, asString);
+  appendConvertedIfChanged(
+      result,
+      "pointerEvents",
+      pointerEvents,
+      oldProps->pointerEvents,
+      asString);
+  appendConvertedIfChanged(
+      result, "hitSlop", hitSlop, oldProps->hitSlop, asDynamic);
+  appendIfChanged(result, "nativeID", nativeId, oldProps->nativeId);
+  appendIfChanged(result, "testID", testId, oldProps->testId);
+  appendIfChanged(result, "accessible", accessible, oldProps->accessible);
+  appendOverflowIfChanged(
+      result, getClipsContentToBounds(), oldProps->getClipsContentToBounds());
+  appendBackfaceVisibilityIfChanged(
+      result, backfaceVisibility, oldProps->backfaceVisibility);
+  appendNativeDrawableIfChanged(
+      result,
+      "nativeBackgroundAndroid",
+      nativeBackground,
+      oldProps->nativeBackground);
+  appendNativeDrawableIfChanged(
+      result,
+      "nativeForegroundAndroid",
+      nativeForeground,
+      oldProps->nativeForeground);
 
   // Events
   // TODO T212662692: pass events as std::bitset<64> to java
-  if (events != oldProps->events) {
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerEnter,
-        "onPointerEnter");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerEnterCapture,
-        "onPointerEnterCapture");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerMove,
-        "onPointerMove");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerMoveCapture,
-        "onPointerMoveCapture");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerLeave,
-        "onPointerLeave");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerLeaveCapture,
-        "onPointerLeaveCapture");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerOver,
-        "onPointerOver");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerOverCapture,
-        "onPointerOverCapture");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerOut,
-        "onPointerOut");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::PointerOutCapture,
-        "onPointerOutCapture");
-    updateEventProp(
-        result, events, oldProps->events, ViewEvents::Offset::Click, "onClick");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ClickCapture,
-        "onClickCapture");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::MoveShouldSetResponder,
-        "onMoveShouldSetResponder");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::MoveShouldSetResponderCapture,
-        "onMoveShouldSetResponderCapture");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::StartShouldSetResponder,
-        "onStartShouldSetResponder");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::StartShouldSetResponderCapture,
-        "onStartShouldSetResponderCapture");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ResponderGrant,
-        "onResponderGrant");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ResponderReject,
-        "onResponderReject");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ResponderStart,
-        "onResponderStart");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ResponderEnd,
-        "onResponderEnd");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ResponderRelease,
-        "onResponderRelease");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ResponderMove,
-        "onResponderMove");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ResponderTerminate,
-        "onResponderTerminate");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ResponderTerminationRequest,
-        "onResponderTerminationRequest");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::ShouldBlockNativeResponder,
-        "onShouldBlockNativeResponder");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::TouchStart,
-        "onTouchStart");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::TouchMove,
-        "onTouchMove");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::TouchEnd,
-        "onTouchEnd");
-    updateEventProp(
-        result,
-        events,
-        oldProps->events,
-        ViewEvents::Offset::TouchCancel,
-        "onTouchCancel");
-  }
+  appendEventProps(result, events, oldProps->events);
 
   // Borders
   auto borderWidths = getBorderWidths();
@@ -876,166 +1016,108 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
   }
 
   // Transforms
-  if (transform != oldProps->transform ||
-      transformOrigin != oldProps->transformOrigin) {
-    folly::dynamic resultTranslateArray = folly::dynamic::array();
-    for (const auto& operation : transform.operations) {
-      updateTransformProps(transform, operation, resultTranslateArray);
-    }
-    result["transform"] = std::move(resultTranslateArray);
-  }
-
-  if (transformOrigin != oldProps->transformOrigin) {
-    result["transformOrigin"] = transformOrigin;
-  }
+  appendTransformIfChanged(
+      result,
+      transform,
+      oldProps->transform,
+      transformOrigin,
+      oldProps->transformOrigin);
+  appendIfChanged(
+      result, "transformOrigin", transformOrigin, oldProps->transformOrigin);
 
   // Accessibility
 
-  if (accessibilityState != oldProps->accessibilityState) {
-    updateAccessibilityStateProp(
-        result, accessibilityState, oldProps->accessibilityState);
-  }
-
-  if (accessibilityLabel != oldProps->accessibilityLabel) {
-    result["accessibilityLabel"] = accessibilityLabel;
-  }
-
-  if (accessibilityLabelledBy != oldProps->accessibilityLabelledBy) {
-    auto accessibilityLabelledByValues = folly::dynamic::array();
-    for (const auto& accessibilityLabelledByValue :
-         accessibilityLabelledBy.value) {
-      accessibilityLabelledByValues.push_back(accessibilityLabelledByValue);
-    }
-    result["accessibilityLabelledBy"] = accessibilityLabelledByValues;
-  }
-
-  if (accessibilityOrder != oldProps->accessibilityOrder) {
-    auto accessibilityChildrenIds = folly::dynamic::array();
-    for (const auto& accessibilityChildId : accessibilityOrder) {
-      accessibilityChildrenIds.push_back(accessibilityChildId);
-    }
-    result["experimental_accessibilityOrder"] = accessibilityChildrenIds;
-  }
-
-  if (accessibilityLiveRegion != oldProps->accessibilityLiveRegion) {
-    result["accessibilityLiveRegion"] = toString(accessibilityLiveRegion);
-  }
-
-  if (accessibilityHint != oldProps->accessibilityHint) {
-    result["accessibilityHint"] = accessibilityHint;
-  }
-
-  if (accessibilityRole != oldProps->accessibilityRole) {
-    result["accessibilityRole"] = accessibilityRole;
-  }
-
-  if (accessibilityLanguage != oldProps->accessibilityLanguage) {
-    result["accessibilityLanguage"] = accessibilityLanguage;
-  }
-
-  if (accessibilityValue != oldProps->accessibilityValue) {
-    folly::dynamic accessibilityValueObject = folly::dynamic::object();
-    if (accessibilityValue.min.has_value()) {
-      accessibilityValueObject["min"] = accessibilityValue.min.value();
-    }
-    if (accessibilityValue.max.has_value()) {
-      accessibilityValueObject["max"] = accessibilityValue.max.value();
-    }
-    if (accessibilityValue.now.has_value()) {
-      accessibilityValueObject["now"] = accessibilityValue.now.value();
-    }
-    if (accessibilityValue.text.has_value()) {
-      accessibilityValueObject["text"] = accessibilityValue.text.value();
-    }
-    result["accessibilityValue"] = accessibilityValueObject;
-  }
-
-  if (accessibilityActions != oldProps->accessibilityActions) {
-    auto accessibilityActionsArray = folly::dynamic::array();
-    for (const auto& accessibilityAction : accessibilityActions) {
-      folly::dynamic accessibilityActionObject = folly::dynamic::object();
-      accessibilityActionObject["name"] = accessibilityAction.name;
-      if (accessibilityAction.label.has_value()) {
-        accessibilityActionObject["label"] = accessibilityAction.label.value();
-      }
-      accessibilityActionsArray.push_back(accessibilityActionObject);
-    }
-    result["accessibilityActions"] = accessibilityActionsArray;
-  }
-
-  if (accessibilityViewIsModal != oldProps->accessibilityViewIsModal) {
-    result["accessibilityViewIsModal"] = accessibilityViewIsModal;
-  }
-
-  if (accessibilityElementsHidden != oldProps->accessibilityElementsHidden) {
-    result["accessibilityElementsHidden"] = accessibilityElementsHidden;
-  }
-
-  if (accessibilityIgnoresInvertColors !=
-      oldProps->accessibilityIgnoresInvertColors) {
-    result["accessibilityIgnoresInvertColors"] =
-        accessibilityIgnoresInvertColors;
-  }
-
-  if (onAccessibilityTap != oldProps->onAccessibilityTap) {
-    result["onAccessibilityTap"] = onAccessibilityTap;
-  }
-
-  if (onAccessibilityMagicTap != oldProps->onAccessibilityMagicTap) {
-    result["onAccessibilityMagicTap"] = onAccessibilityMagicTap;
-  }
-
-  if (onAccessibilityEscape != oldProps->onAccessibilityEscape) {
-    result["onAccessibilityEscape"] = onAccessibilityEscape;
-  }
-
-  if (onAccessibilityAction != oldProps->onAccessibilityAction) {
-    result["onAccessibilityAction"] = onAccessibilityAction;
-  }
-
-  if (importantForAccessibility != oldProps->importantForAccessibility) {
-    result["importantForAccessibility"] = toString(importantForAccessibility);
-  }
-
-  if (nextFocusDown != oldProps->nextFocusDown) {
-    if (nextFocusDown.has_value()) {
-      result["nextFocusDown"] = nextFocusDown.value();
-    } else {
-      result["nextFocusDown"] = folly::dynamic(nullptr);
-    }
-  }
-
-  if (nextFocusForward != oldProps->nextFocusForward) {
-    if (nextFocusForward.has_value()) {
-      result["nextFocusForward"] = nextFocusForward.value();
-    } else {
-      result["nextFocusForward"] = folly::dynamic(nullptr);
-    }
-  }
-
-  if (nextFocusLeft != oldProps->nextFocusLeft) {
-    if (nextFocusLeft.has_value()) {
-      result["nextFocusLeft"] = nextFocusLeft.value();
-    } else {
-      result["nextFocusLeft"] = folly::dynamic(nullptr);
-    }
-  }
-
-  if (nextFocusRight != oldProps->nextFocusRight) {
-    if (nextFocusRight.has_value()) {
-      result["nextFocusRight"] = nextFocusRight.value();
-    } else {
-      result["nextFocusRight"] = folly::dynamic(nullptr);
-    }
-  }
-
-  if (nextFocusUp != oldProps->nextFocusUp) {
-    if (nextFocusUp.has_value()) {
-      result["nextFocusUp"] = nextFocusUp.value();
-    } else {
-      result["nextFocusUp"] = folly::dynamic(nullptr);
-    }
-  }
+  appendAccessibilityStateIfChanged(
+      result, accessibilityState, oldProps->accessibilityState);
+  appendIfChanged(
+      result,
+      "accessibilityLabel",
+      accessibilityLabel,
+      oldProps->accessibilityLabel);
+  appendAccessibilityLabelledByIfChanged(
+      result, accessibilityLabelledBy, oldProps->accessibilityLabelledBy);
+  appendAccessibilityOrderIfChanged(
+      result, accessibilityOrder, oldProps->accessibilityOrder);
+  appendConvertedIfChanged(
+      result,
+      "accessibilityLiveRegion",
+      accessibilityLiveRegion,
+      oldProps->accessibilityLiveRegion,
+      asString);
+  appendIfChanged(
+      result,
+      "accessibilityHint",
+      accessibilityHint,
+      oldProps->accessibilityHint);
+  appendIfChanged(
+      result,
+      "accessibilityRole",
+      accessibilityRole,
+      oldProps->accessibilityRole);
+  appendIfChanged(
+      result,
+      "accessibilityLanguage",
+      accessibilityLanguage,
+      oldProps->accessibilityLanguage);
+  appendAccessibilityValueIfChanged(
+      result, accessibilityValue, oldProps->accessibilityValue);
+  appendAccessibilityActionsIfChanged(
+      result, accessibilityActions, oldProps->accessibilityActions);
+  appendIfChanged(
+      result,
+      "accessibilityViewIsModal",
+      accessibilityViewIsModal,
+      oldProps->accessibilityViewIsModal);
+  appendIfChanged(
+      result,
+      "accessibilityElementsHidden",
+      accessibilityElementsHidden,
+      oldProps->accessibilityElementsHidden);
+  appendIfChanged(
+      result,
+      "accessibilityIgnoresInvertColors",
+      accessibilityIgnoresInvertColors,
+      oldProps->accessibilityIgnoresInvertColors);
+  appendIfChanged(
+      result,
+      "onAccessibilityTap",
+      onAccessibilityTap,
+      oldProps->onAccessibilityTap);
+  appendIfChanged(
+      result,
+      "onAccessibilityMagicTap",
+      onAccessibilityMagicTap,
+      oldProps->onAccessibilityMagicTap);
+  appendIfChanged(
+      result,
+      "onAccessibilityEscape",
+      onAccessibilityEscape,
+      oldProps->onAccessibilityEscape);
+  appendIfChanged(
+      result,
+      "onAccessibilityAction",
+      onAccessibilityAction,
+      oldProps->onAccessibilityAction);
+  appendConvertedIfChanged(
+      result,
+      "importantForAccessibility",
+      importantForAccessibility,
+      oldProps->importantForAccessibility,
+      asString);
+  appendOptionalIfChanged(
+      result, "nextFocusDown", nextFocusDown, oldProps->nextFocusDown, asIs);
+  appendOptionalIfChanged(
+      result,
+      "nextFocusForward",
+      nextFocusForward,
+      oldProps->nextFocusForward,
+      asIs);
+  appendOptionalIfChanged(
+      result, "nextFocusLeft", nextFocusLeft, oldProps->nextFocusLeft, asIs);
+  appendOptionalIfChanged(
+      result, "nextFocusRight", nextFocusRight, oldProps->nextFocusRight, asIs);
+  appendOptionalIfChanged(
+      result, "nextFocusUp", nextFocusUp, oldProps->nextFocusUp, asIs);
 
   return result;
 }

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
@@ -70,6 +70,69 @@ struct CSSLinearGradientDirection {
   bool operator==(const CSSLinearGradientDirection &rhs) const = default;
 };
 
+namespace detail {
+
+// Whether a secondary "to" direction keyword combines with the primary one
+// (e.g. "to top left" is valid, "to top bottom" is not).
+constexpr bool isCompatibleGradientDirection(CSSGradientDirectionKeyword primaryDir, CSSGradientDirectionKeyword kw)
+{
+  if (primaryDir == CSSGradientDirectionKeyword::Top || primaryDir == CSSGradientDirectionKeyword::Bottom) {
+    return (kw == CSSGradientDirectionKeyword::Left || kw == CSSGradientDirectionKeyword::Right);
+  } else if (primaryDir == CSSGradientDirectionKeyword::Left || primaryDir == CSSGradientDirectionKeyword::Right) {
+    return (kw == CSSGradientDirectionKeyword::Top || kw == CSSGradientDirectionKeyword::Bottom);
+  }
+  return false;
+}
+
+// Resolves a parsed primary/secondary "to" direction pair into a
+// CSSLinearGradientDirection.
+constexpr std::optional<CSSLinearGradientDirection> resolveLinearGradientDirection(
+    CSSGradientDirectionKeyword primaryDir,
+    std::optional<CSSGradientDirectionKeyword> secondaryDir)
+{
+  if (primaryDir == CSSGradientDirectionKeyword::Top) {
+    if (secondaryDir == CSSGradientDirectionKeyword::Left) {
+      return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToTopLeft};
+    } else if (secondaryDir == CSSGradientDirectionKeyword::Right) {
+      return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToTopRight};
+    } else {
+      // "to top" = 0 degrees
+      return CSSLinearGradientDirection{CSSAngle{0.0f}};
+    }
+  } else if (primaryDir == CSSGradientDirectionKeyword::Bottom) {
+    if (secondaryDir == CSSGradientDirectionKeyword::Left) {
+      return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToBottomLeft};
+    } else if (secondaryDir == CSSGradientDirectionKeyword::Right) {
+      return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToBottomRight};
+    } else {
+      // "to bottom" = 180 degrees
+      return CSSLinearGradientDirection{CSSAngle{180.0f}};
+    }
+  } else if (primaryDir == CSSGradientDirectionKeyword::Left) {
+    if (secondaryDir == CSSGradientDirectionKeyword::Top) {
+      return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToTopLeft};
+    } else if (secondaryDir == CSSGradientDirectionKeyword::Bottom) {
+      return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToBottomLeft};
+    } else {
+      // "to left" = 270 degrees
+      return CSSLinearGradientDirection{CSSAngle{270.0f}};
+    }
+  } else if (primaryDir == CSSGradientDirectionKeyword::Right) {
+    if (secondaryDir == CSSGradientDirectionKeyword::Top) {
+      return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToTopRight};
+    } else if (secondaryDir == CSSGradientDirectionKeyword::Bottom) {
+      return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToBottomRight};
+    } else {
+      // "to right" = 90 degrees
+      return CSSLinearGradientDirection{CSSAngle{90.0f}};
+    }
+  }
+
+  return {};
+}
+
+} // namespace detail
+
 template <>
 struct CSSDataTypeParser<CSSLinearGradientDirection> {
   static constexpr auto consume(CSSValueParser &parser) -> std::optional<CSSLinearGradientDirection>
@@ -104,57 +167,13 @@ struct CSSDataTypeParser<CSSLinearGradientDirection> {
     std::optional<CSSGradientDirectionKeyword> secondaryDir;
     if (std::holds_alternative<CSSGradientDirectionKeyword>(secondaryPeek)) {
       auto kw = std::get<CSSGradientDirectionKeyword>(secondaryPeek);
-      bool isCompatible = false;
-      if (primaryDir == CSSGradientDirectionKeyword::Top || primaryDir == CSSGradientDirectionKeyword::Bottom) {
-        isCompatible = (kw == CSSGradientDirectionKeyword::Left || kw == CSSGradientDirectionKeyword::Right);
-      } else if (primaryDir == CSSGradientDirectionKeyword::Left || primaryDir == CSSGradientDirectionKeyword::Right) {
-        isCompatible = (kw == CSSGradientDirectionKeyword::Top || kw == CSSGradientDirectionKeyword::Bottom);
-      }
-      if (isCompatible) {
+      if (detail::isCompatibleGradientDirection(primaryDir, kw)) {
         parser.parseNextValue<CSSGradientDirectionKeyword>();
         secondaryDir = kw;
       }
     }
 
-    if (primaryDir == CSSGradientDirectionKeyword::Top) {
-      if (secondaryDir == CSSGradientDirectionKeyword::Left) {
-        return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToTopLeft};
-      } else if (secondaryDir == CSSGradientDirectionKeyword::Right) {
-        return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToTopRight};
-      } else {
-        // "to top" = 0 degrees
-        return CSSLinearGradientDirection{CSSAngle{0.0f}};
-      }
-    } else if (primaryDir == CSSGradientDirectionKeyword::Bottom) {
-      if (secondaryDir == CSSGradientDirectionKeyword::Left) {
-        return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToBottomLeft};
-      } else if (secondaryDir == CSSGradientDirectionKeyword::Right) {
-        return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToBottomRight};
-      } else {
-        // "to bottom" = 180 degrees
-        return CSSLinearGradientDirection{CSSAngle{180.0f}};
-      }
-    } else if (primaryDir == CSSGradientDirectionKeyword::Left) {
-      if (secondaryDir == CSSGradientDirectionKeyword::Top) {
-        return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToTopLeft};
-      } else if (secondaryDir == CSSGradientDirectionKeyword::Bottom) {
-        return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToBottomLeft};
-      } else {
-        // "to left" = 270 degrees
-        return CSSLinearGradientDirection{CSSAngle{270.0f}};
-      }
-    } else if (primaryDir == CSSGradientDirectionKeyword::Right) {
-      if (secondaryDir == CSSGradientDirectionKeyword::Top) {
-        return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToTopRight};
-      } else if (secondaryDir == CSSGradientDirectionKeyword::Bottom) {
-        return CSSLinearGradientDirection{CSSLinearGradientDirectionKeyword::ToBottomRight};
-      } else {
-        // "to right" = 90 degrees
-        return CSSLinearGradientDirection{CSSAngle{90.0f}};
-      }
-    }
-
-    return {};
+    return detail::resolveLinearGradientDirection(primaryDir, secondaryDir);
   }
 };
 
@@ -429,6 +448,411 @@ struct CSSRadialGradientFunction {
   bool operator==(const CSSRadialGradientFunction &rhs) const = default;
 };
 
+namespace detail {
+
+// Element type collected while parsing a radial-gradient "at <position>" list.
+using CSSRadialGradientPositionValue = std::variant<CSSLength, CSSPercentage, CSSKeyword>;
+
+// Returns true if either axis of an explicit size is negative (invalid).
+inline bool hasNegativeExplicitSize(const CSSRadialGradientExplicitSize &explicitSize)
+{
+  if (std::holds_alternative<CSSLength>(explicitSize.sizeX)) {
+    const auto &lengthX = std::get<CSSLength>(explicitSize.sizeX);
+    if (lengthX.value < 0) {
+      return true;
+    }
+  } else if (std::holds_alternative<CSSPercentage>(explicitSize.sizeX)) {
+    const auto &percentageX = std::get<CSSPercentage>(explicitSize.sizeX);
+    if (percentageX.value < 0) {
+      return true;
+    }
+  }
+  if (std::holds_alternative<CSSLength>(explicitSize.sizeY)) {
+    const auto &lengthY = std::get<CSSLength>(explicitSize.sizeY);
+    if (lengthY.value < 0) {
+      return true;
+    }
+  } else if (std::holds_alternative<CSSPercentage>(explicitSize.sizeY)) {
+    const auto &percentageY = std::get<CSSPercentage>(explicitSize.sizeY);
+    if (percentageY.value < 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// 1. [ left | center | right | top | bottom | <length-percentage> ]
+inline std::optional<CSSRadialGradientPosition> resolveSingleRadialGradientPosition(
+    const CSSRadialGradientPositionValue &value)
+{
+  CSSRadialGradientPosition position;
+  if (std::holds_alternative<CSSKeyword>(value)) {
+    auto keyword = std::get<CSSKeyword>(value);
+    if (keyword == CSSKeyword::Left) {
+      position.top = CSSPercentage{50.0f};
+      position.left = CSSPercentage{0.0f};
+    } else if (keyword == CSSKeyword::Right) {
+      position.top = CSSPercentage{50.0f};
+      position.left = CSSPercentage{100.0f};
+    } else if (keyword == CSSKeyword::Top) {
+      position.top = CSSPercentage{0.0f};
+      position.left = CSSPercentage{50.0f};
+    } else if (keyword == CSSKeyword::Bottom) {
+      position.top = CSSPercentage{100.0f};
+      position.left = CSSPercentage{50.0f};
+    } else if (keyword == CSSKeyword::Center) {
+      position.left = CSSPercentage{50.0f};
+      position.top = CSSPercentage{50.0f};
+    } else {
+      return {};
+    }
+  } else if ((std::holds_alternative<CSSLength>(value) || std::holds_alternative<CSSPercentage>(value))) {
+    if (std::holds_alternative<CSSLength>(value)) {
+      position.left = std::get<CSSLength>(value);
+    } else {
+      position.left = std::get<CSSPercentage>(value);
+    }
+    position.top = CSSPercentage{50.0f};
+  } else {
+    return {};
+  }
+  return position;
+}
+
+inline bool isHorizontalPositionKeyword(CSSKeyword kw)
+{
+  return kw == CSSKeyword::Left || kw == CSSKeyword::Center || kw == CSSKeyword::Right;
+}
+
+inline bool isVerticalPositionKeyword(CSSKeyword kw)
+{
+  return kw == CSSKeyword::Top || kw == CSSKeyword::Center || kw == CSSKeyword::Bottom;
+}
+
+// First horizontal, second vertical
+inline CSSRadialGradientPosition resolveHorizontalThenVerticalKeyword(CSSKeyword keyword1, CSSKeyword keyword2)
+{
+  CSSRadialGradientPosition position;
+  if (keyword1 == CSSKeyword::Left) {
+    position.left = CSSPercentage{0.0f};
+  } else if (keyword1 == CSSKeyword::Right) {
+    position.right = CSSPercentage{0.0f};
+  } else if (keyword1 == CSSKeyword::Center) {
+    position.left = CSSPercentage{50.0f};
+  }
+
+  if (keyword2 == CSSKeyword::Top) {
+    position.top = CSSPercentage{0.0f};
+  } else if (keyword2 == CSSKeyword::Bottom) {
+    position.bottom = CSSPercentage{0.0f};
+  } else if (keyword2 == CSSKeyword::Center) {
+    position.top = CSSPercentage{50.0f};
+  }
+  return position;
+}
+
+// First vertical, second horizontal
+inline CSSRadialGradientPosition resolveVerticalThenHorizontalKeyword(CSSKeyword keyword1, CSSKeyword keyword2)
+{
+  CSSRadialGradientPosition position;
+  if (keyword1 == CSSKeyword::Top) {
+    position.top = CSSPercentage{0.0f};
+  } else if (keyword1 == CSSKeyword::Bottom) {
+    position.bottom = CSSPercentage{0.0f};
+  } else if (keyword1 == CSSKeyword::Center) {
+    position.top = CSSPercentage{50.0f};
+  }
+
+  if (keyword2 == CSSKeyword::Left) {
+    position.left = CSSPercentage{0.0f};
+  } else if (keyword2 == CSSKeyword::Right) {
+    position.left = CSSPercentage{100.0f};
+  } else if (keyword2 == CSSKeyword::Center) {
+    position.left = CSSPercentage{50.0f};
+  }
+  return position;
+}
+
+// 2. [ left | center | right ] && [ top | center | bottom ]
+inline std::optional<CSSRadialGradientPosition> resolveDoubleKeywordPosition(CSSKeyword keyword1, CSSKeyword keyword2)
+{
+  if (isHorizontalPositionKeyword(keyword1) && isVerticalPositionKeyword(keyword2)) {
+    return resolveHorizontalThenVerticalKeyword(keyword1, keyword2);
+  } else if (isVerticalPositionKeyword(keyword1) && isHorizontalPositionKeyword(keyword2)) {
+    return resolveVerticalThenHorizontalKeyword(keyword1, keyword2);
+  } else {
+    return {};
+  }
+}
+
+// 3. [ left | center | right | <length-percentage> ] [ top | center |
+// bottom | <length-percentage> ]
+inline std::optional<CSSRadialGradientPosition> resolveMixedDoublePosition(
+    const CSSRadialGradientPositionValue &value1,
+    const CSSRadialGradientPositionValue &value2)
+{
+  CSSRadialGradientPosition position;
+  if (std::holds_alternative<CSSKeyword>(value1)) {
+    auto keyword1 = std::get<CSSKeyword>(value1);
+    if (keyword1 == CSSKeyword::Left) {
+      position.left = CSSPercentage{0.0f};
+    } else if (keyword1 == CSSKeyword::Right) {
+      position.right = CSSPercentage{0.0f};
+    } else if (keyword1 == CSSKeyword::Center) {
+      position.left = CSSPercentage{50.0f};
+    } else {
+      return {};
+    }
+  } else if ((std::holds_alternative<CSSLength>(value1) || std::holds_alternative<CSSPercentage>(value1))) {
+    if (std::holds_alternative<CSSLength>(value1)) {
+      position.left = std::get<CSSLength>(value1);
+    } else {
+      position.left = std::get<CSSPercentage>(value1);
+    }
+  } else {
+    return {};
+  }
+
+  if (std::holds_alternative<CSSKeyword>(value2)) {
+    auto keyword2 = std::get<CSSKeyword>(value2);
+    if (keyword2 == CSSKeyword::Top) {
+      position.top = CSSPercentage{0.0f};
+    } else if (keyword2 == CSSKeyword::Bottom) {
+      position.bottom = CSSPercentage{0.f};
+    } else if (keyword2 == CSSKeyword::Center) {
+      position.top = CSSPercentage{50.0f};
+    } else {
+      return {};
+    }
+  } else if ((std::holds_alternative<CSSLength>(value2) || std::holds_alternative<CSSPercentage>(value2))) {
+    if (std::holds_alternative<CSSLength>(value2)) {
+      position.top = std::get<CSSLength>(value2);
+    } else {
+      position.top = std::get<CSSPercentage>(value2);
+    }
+  } else {
+    return {};
+  }
+  return position;
+}
+
+inline std::optional<CSSRadialGradientPosition> resolveDoubleRadialGradientPosition(
+    const CSSRadialGradientPositionValue &value1,
+    const CSSRadialGradientPositionValue &value2)
+{
+  // 2. [ left | center | right ] && [ top | center | bottom ]
+  if (std::holds_alternative<CSSKeyword>(value1) && std::holds_alternative<CSSKeyword>(value2)) {
+    return resolveDoubleKeywordPosition(std::get<CSSKeyword>(value1), std::get<CSSKeyword>(value2));
+  }
+  // 3. [ left | center | right | <length-percentage> ] [ top | center |
+  // bottom | <length-percentage> ]
+  return resolveMixedDoublePosition(value1, value2);
+}
+
+// 4. [ [ left | right ] <length-percentage> ] && [ [ top | bottom ]
+// <length-percentage> ]
+inline std::optional<CSSRadialGradientPosition> resolveQuadRadialGradientPosition(
+    const CSSRadialGradientPositionValue &value1,
+    const CSSRadialGradientPositionValue &value2,
+    const CSSRadialGradientPositionValue &value3,
+    const CSSRadialGradientPositionValue &value4)
+{
+  CSSRadialGradientPosition position;
+
+  if (!std::holds_alternative<CSSKeyword>(value1)) {
+    return {};
+  }
+  if (!std::holds_alternative<CSSKeyword>(value3)) {
+    return {};
+  }
+  if ((!std::holds_alternative<CSSLength>(value2) && !std::holds_alternative<CSSPercentage>(value2))) {
+    return {};
+  }
+  if ((!std::holds_alternative<CSSLength>(value4) && !std::holds_alternative<CSSPercentage>(value4))) {
+    return {};
+  }
+
+  auto parsedValue2 = std::holds_alternative<CSSLength>(value2)
+      ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(value2)}
+      : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(value2)};
+  auto parsedValue4 = std::holds_alternative<CSSLength>(value4)
+      ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(value4)}
+      : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(value4)};
+  auto keyword1 = std::get<CSSKeyword>(value1);
+  auto keyword3 = std::get<CSSKeyword>(value3);
+
+  if (keyword1 == CSSKeyword::Left) {
+    position.left = parsedValue2;
+  } else if (keyword1 == CSSKeyword::Right) {
+    position.right = parsedValue2;
+  } else if (keyword1 == CSSKeyword::Top) {
+    position.top = parsedValue2;
+  } else if (keyword1 == CSSKeyword::Bottom) {
+    position.bottom = parsedValue2;
+  } else {
+    return {};
+  }
+
+  if (keyword3 == CSSKeyword::Left) {
+    position.left = parsedValue4;
+  } else if (keyword3 == CSSKeyword::Right) {
+    position.right = parsedValue4;
+  } else if (keyword3 == CSSKeyword::Top) {
+    position.top = parsedValue4;
+  } else if (keyword3 == CSSKeyword::Bottom) {
+    position.bottom = parsedValue4;
+  } else {
+    return {};
+  }
+  return position;
+}
+
+// Parses the shape and size portion of a radial-gradient, applying defaults and
+// validation. Returns false if the declaration is invalid (caller should bail).
+inline bool consumeRadialGradientShapeAndSize(CSSValueParser &parser, CSSRadialGradientFunction &gradient)
+{
+  auto hasExplicitShape = false;
+  auto hasExplicitSingleSize = false;
+  auto shapeResult = parser.parseNextValue<CSSRadialGradientShape>();
+  if (std::holds_alternative<CSSRadialGradientShape>(shapeResult)) {
+    parser.syntaxParser().consumeWhitespace();
+  }
+
+  std::optional<CSSRadialGradientSize> sizeResult;
+
+  auto sizeKeywordResult = parser.parseNextValue<CSSRadialGradientSizeKeyword>();
+
+  if (std::holds_alternative<CSSRadialGradientSizeKeyword>(sizeKeywordResult)) {
+    sizeResult = CSSRadialGradientSize{std::get<CSSRadialGradientSizeKeyword>(sizeKeywordResult)};
+    parser.syntaxParser().consumeWhitespace();
+  } else {
+    auto explicitSizeResult = parser.parseNextValue<CSSRadialGradientExplicitSize>();
+    if (std::holds_alternative<CSSRadialGradientExplicitSize>(explicitSizeResult)) {
+      auto explicitSize = std::get<CSSRadialGradientExplicitSize>(explicitSizeResult);
+      // negative value validation
+      if (hasNegativeExplicitSize(explicitSize)) {
+        return false;
+      }
+
+      // check if it's a single size (both X and Y are the same), we use it
+      // to set shape to circle
+      if (explicitSize.sizeX == explicitSize.sizeY) {
+        hasExplicitSingleSize = true;
+      }
+
+      sizeResult = CSSRadialGradientSize{explicitSize};
+      parser.syntaxParser().consumeWhitespace();
+    }
+  }
+
+  if (std::holds_alternative<CSSRadialGradientShape>(shapeResult)) {
+    gradient.shape = std::get<CSSRadialGradientShape>(shapeResult);
+    hasExplicitShape = true;
+  } else {
+    // default to ellipse
+    gradient.shape = CSSRadialGradientShape::Ellipse;
+  }
+
+  if (sizeResult.has_value()) {
+    gradient.size = *sizeResult;
+  } else {
+    // default to farthest corner
+    gradient.size = CSSRadialGradientSize{CSSRadialGradientSizeKeyword::FarthestCorner};
+  }
+
+  if (!hasExplicitShape && hasExplicitSingleSize) {
+    gradient.shape = CSSRadialGradientShape::Circle;
+  }
+
+  if (hasExplicitSingleSize && hasExplicitShape && gradient.shape.value() == CSSRadialGradientShape::Ellipse) {
+    // if a single size is explicitly set and the shape is an ellipse do not
+    // apply any gradient. Same as web.
+    return false;
+  }
+
+  return true;
+}
+
+// Collects the up-to-two position tokens following an "at" keyword. Returns
+// nullopt if an invalid (duplicate keyword) declaration is encountered.
+inline std::optional<std::vector<CSSRadialGradientPositionValue>> consumeRadialGradientPositionValues(
+    CSSValueParser &parser)
+{
+  std::vector<CSSRadialGradientPositionValue> positionKeywordValues;
+  for (int i = 0; i < 2; i++) {
+    auto keywordFound = false;
+    auto valueFound = false;
+
+    auto positionKeywordResult = parser.parseNextValue<CSSGradientPositionKeyword>();
+    std::optional<CSSKeyword> positionKeyword;
+    if (std::holds_alternative<CSSGradientPositionKeyword>(positionKeywordResult)) {
+      positionKeyword =
+          static_cast<CSSKeyword>(to_underlying(std::get<CSSGradientPositionKeyword>(positionKeywordResult)));
+    }
+
+    if (positionKeyword) {
+      // invalid position declaration of same keyword "at top 10% top 20%"
+      for (const auto &existingValue : positionKeywordValues) {
+        if (std::holds_alternative<CSSKeyword>(existingValue)) {
+          if (std::get<CSSKeyword>(existingValue) == positionKeyword) {
+            return {};
+          }
+        }
+      }
+      positionKeywordValues.emplace_back(*positionKeyword);
+      keywordFound = true;
+    }
+
+    parser.syntaxParser().consumeWhitespace();
+
+    auto lengthPercentageValue = parser.parseNextValue<CSSLengthPercentage>();
+
+    std::optional<decltype(positionKeywordValues)::value_type> value;
+    if (std::holds_alternative<CSSLength>(lengthPercentageValue)) {
+      value = std::get<CSSLength>(lengthPercentageValue);
+    } else if (std::holds_alternative<CSSPercentage>(lengthPercentageValue)) {
+      value = std::get<CSSPercentage>(lengthPercentageValue);
+    }
+    if (value.has_value()) {
+      positionKeywordValues.emplace_back(*value);
+      valueFound = true;
+    }
+
+    parser.syntaxParser().consumeWhitespace();
+
+    if (!keywordFound && !valueFound) {
+      break;
+    }
+  }
+  return positionKeywordValues;
+}
+
+// Resolves the collected "at <position>" values (1, 2, or 4 entries) into a
+// CSSRadialGradientPosition, or nullopt if the combination is invalid.
+inline std::optional<CSSRadialGradientPosition> resolveRadialGradientPosition(
+    const std::vector<CSSRadialGradientPositionValue> &positionKeywordValues)
+{
+  // 1. [ left | center | right | top | bottom | <length-percentage> ]
+  if (positionKeywordValues.size() == 1) {
+    return resolveSingleRadialGradientPosition(positionKeywordValues[0]);
+  }
+
+  else if (positionKeywordValues.size() == 2) {
+    return resolveDoubleRadialGradientPosition(positionKeywordValues[0], positionKeywordValues[1]);
+  }
+
+  // 4. [ [ left | right ] <length-percentage> ] && [ [ top | bottom ]
+  // <length-percentage> ]
+  else if (positionKeywordValues.size() == 4) {
+    return resolveQuadRadialGradientPosition(
+        positionKeywordValues[0], positionKeywordValues[1], positionKeywordValues[2], positionKeywordValues[3]);
+  } else {
+    return {};
+  }
+}
+
+} // namespace detail
+
 template <>
 struct CSSDataTypeParser<CSSRadialGradientFunction> {
   static auto consumeFunctionBlock(const CSSFunctionBlock &func, CSSValueParser &parser)
@@ -440,335 +864,33 @@ struct CSSDataTypeParser<CSSRadialGradientFunction> {
 
     CSSRadialGradientFunction gradient;
 
-    auto hasExplicitShape = false;
-    auto hasExplicitSingleSize = false;
-    auto shapeResult = parser.parseNextValue<CSSRadialGradientShape>();
-    if (std::holds_alternative<CSSRadialGradientShape>(shapeResult)) {
-      parser.syntaxParser().consumeWhitespace();
-    }
-
-    std::optional<CSSRadialGradientSize> sizeResult;
-
-    auto sizeKeywordResult = parser.parseNextValue<CSSRadialGradientSizeKeyword>();
-
-    if (std::holds_alternative<CSSRadialGradientSizeKeyword>(sizeKeywordResult)) {
-      sizeResult = CSSRadialGradientSize{std::get<CSSRadialGradientSizeKeyword>(sizeKeywordResult)};
-      parser.syntaxParser().consumeWhitespace();
-    } else {
-      auto explicitSizeResult = parser.parseNextValue<CSSRadialGradientExplicitSize>();
-      if (std::holds_alternative<CSSRadialGradientExplicitSize>(explicitSizeResult)) {
-        auto explicitSize = std::get<CSSRadialGradientExplicitSize>(explicitSizeResult);
-        // negative value validation
-        if (std::holds_alternative<CSSLength>(explicitSize.sizeX)) {
-          const auto &lengthX = std::get<CSSLength>(explicitSize.sizeX);
-          if (lengthX.value < 0) {
-            return {};
-          }
-        } else if (std::holds_alternative<CSSPercentage>(explicitSize.sizeX)) {
-          const auto &percentageX = std::get<CSSPercentage>(explicitSize.sizeX);
-          if (percentageX.value < 0) {
-            return {};
-          }
-        }
-        if (std::holds_alternative<CSSLength>(explicitSize.sizeY)) {
-          const auto &lengthY = std::get<CSSLength>(explicitSize.sizeY);
-          if (lengthY.value < 0) {
-            return {};
-          }
-        } else if (std::holds_alternative<CSSPercentage>(explicitSize.sizeY)) {
-          const auto &percentageY = std::get<CSSPercentage>(explicitSize.sizeY);
-          if (percentageY.value < 0) {
-            return {};
-          }
-        }
-
-        // check if it's a single size (both X and Y are the same), we use it
-        // to set shape to circle
-        if (explicitSize.sizeX == explicitSize.sizeY) {
-          hasExplicitSingleSize = true;
-        }
-
-        sizeResult = CSSRadialGradientSize{explicitSize};
-        parser.syntaxParser().consumeWhitespace();
-      }
-    }
-
-    if (std::holds_alternative<CSSRadialGradientShape>(shapeResult)) {
-      gradient.shape = std::get<CSSRadialGradientShape>(shapeResult);
-      hasExplicitShape = true;
-    } else {
-      // default to ellipse
-      gradient.shape = CSSRadialGradientShape::Ellipse;
-    }
-
-    if (sizeResult.has_value()) {
-      gradient.size = *sizeResult;
-    } else {
-      // default to farthest corner
-      gradient.size = CSSRadialGradientSize{CSSRadialGradientSizeKeyword::FarthestCorner};
-    }
-
-    if (!hasExplicitShape && hasExplicitSingleSize) {
-      gradient.shape = CSSRadialGradientShape::Circle;
-    }
-
-    if (hasExplicitSingleSize && hasExplicitShape && gradient.shape.value() == CSSRadialGradientShape::Ellipse) {
-      // if a single size is explicitly set and the shape is an ellipse do not
-      // apply any gradient. Same as web.
+    if (!detail::consumeRadialGradientShapeAndSize(parser, gradient)) {
       return {};
     }
 
     auto atResult = parser.parseNextValue<CSSGradientAtKeyword>();
     bool hasAtKeyword = std::holds_alternative<CSSGradientAtKeyword>(atResult);
 
-    CSSRadialGradientPosition position;
-
     if (hasAtKeyword) {
       parser.syntaxParser().consumeWhitespace();
-      std::vector<std::variant<CSSLength, CSSPercentage, CSSKeyword>> positionKeywordValues;
-      for (int i = 0; i < 2; i++) {
-        auto keywordFound = false;
-        auto valueFound = false;
-
-        auto positionKeywordResult = parser.parseNextValue<CSSGradientPositionKeyword>();
-        std::optional<CSSKeyword> positionKeyword;
-        if (std::holds_alternative<CSSGradientPositionKeyword>(positionKeywordResult)) {
-          positionKeyword =
-              static_cast<CSSKeyword>(to_underlying(std::get<CSSGradientPositionKeyword>(positionKeywordResult)));
-        }
-
-        if (positionKeyword) {
-          // invalid position declaration of same keyword "at top 10% top 20%"
-          for (const auto &existingValue : positionKeywordValues) {
-            if (std::holds_alternative<CSSKeyword>(existingValue)) {
-              if (std::get<CSSKeyword>(existingValue) == positionKeyword) {
-                return {};
-              }
-            }
-          }
-          positionKeywordValues.emplace_back(*positionKeyword);
-          keywordFound = true;
-        }
-
-        parser.syntaxParser().consumeWhitespace();
-
-        auto lengthPercentageValue = parser.parseNextValue<CSSLengthPercentage>();
-
-        std::optional<decltype(positionKeywordValues)::value_type> value;
-        if (std::holds_alternative<CSSLength>(lengthPercentageValue)) {
-          value = std::get<CSSLength>(lengthPercentageValue);
-        } else if (std::holds_alternative<CSSPercentage>(lengthPercentageValue)) {
-          value = std::get<CSSPercentage>(lengthPercentageValue);
-        }
-        if (value.has_value()) {
-          positionKeywordValues.emplace_back(*value);
-          valueFound = true;
-        }
-
-        parser.syntaxParser().consumeWhitespace();
-
-        if (!keywordFound && !valueFound) {
-          break;
-        }
-      }
-
-      if (positionKeywordValues.empty()) {
+      auto positionKeywordValues = detail::consumeRadialGradientPositionValues(parser);
+      if (!positionKeywordValues.has_value()) {
         return {};
       }
 
-      // 1. [ left | center | right | top | bottom | <length-percentage> ]
-      if (positionKeywordValues.size() == 1) {
-        auto value = positionKeywordValues[0];
-        if (std::holds_alternative<CSSKeyword>(value)) {
-          auto keyword = std::get<CSSKeyword>(value);
-          if (keyword == CSSKeyword::Left) {
-            position.top = CSSPercentage{50.0f};
-            position.left = CSSPercentage{0.0f};
-          } else if (keyword == CSSKeyword::Right) {
-            position.top = CSSPercentage{50.0f};
-            position.left = CSSPercentage{100.0f};
-          } else if (keyword == CSSKeyword::Top) {
-            position.top = CSSPercentage{0.0f};
-            position.left = CSSPercentage{50.0f};
-          } else if (keyword == CSSKeyword::Bottom) {
-            position.top = CSSPercentage{100.0f};
-            position.left = CSSPercentage{50.0f};
-          } else if (keyword == CSSKeyword::Center) {
-            position.left = CSSPercentage{50.0f};
-            position.top = CSSPercentage{50.0f};
-          } else {
-            return {};
-          }
-        } else if ((std::holds_alternative<CSSLength>(value) || std::holds_alternative<CSSPercentage>(value))) {
-          if (std::holds_alternative<CSSLength>(value)) {
-            position.left = std::get<CSSLength>(value);
-          } else {
-            position.left = std::get<CSSPercentage>(value);
-          }
-          position.top = CSSPercentage{50.0f};
-        } else {
-          return {};
-        }
-      }
-
-      else if (positionKeywordValues.size() == 2) {
-        auto value1 = positionKeywordValues[0];
-        auto value2 = positionKeywordValues[1];
-        // 2. [ left | center | right ] && [ top | center | bottom ]
-        if (std::holds_alternative<CSSKeyword>(value1) && std::holds_alternative<CSSKeyword>(value2)) {
-          auto keyword1 = std::get<CSSKeyword>(value1);
-          auto keyword2 = std::get<CSSKeyword>(value2);
-          auto isHorizontal = [](CSSKeyword kw) {
-            return kw == CSSKeyword::Left || kw == CSSKeyword::Center || kw == CSSKeyword::Right;
-          };
-          auto isVertical = [](CSSKeyword kw) {
-            return kw == CSSKeyword::Top || kw == CSSKeyword::Center || kw == CSSKeyword::Bottom;
-          };
-          if (isHorizontal(keyword1) && isVertical(keyword2)) {
-            // First horizontal, second vertical
-            if (keyword1 == CSSKeyword::Left) {
-              position.left = CSSPercentage{0.0f};
-            } else if (keyword1 == CSSKeyword::Right) {
-              position.right = CSSPercentage{0.0f};
-            } else if (keyword1 == CSSKeyword::Center) {
-              position.left = CSSPercentage{50.0f};
-            }
-
-            if (keyword2 == CSSKeyword::Top) {
-              position.top = CSSPercentage{0.0f};
-            } else if (keyword2 == CSSKeyword::Bottom) {
-              position.bottom = CSSPercentage{0.0f};
-            } else if (keyword2 == CSSKeyword::Center) {
-              position.top = CSSPercentage{50.0f};
-            }
-          } else if (isVertical(keyword1) && isHorizontal(keyword2)) {
-            // First vertical, second horizontal
-            if (keyword1 == CSSKeyword::Top) {
-              position.top = CSSPercentage{0.0f};
-            } else if (keyword1 == CSSKeyword::Bottom) {
-              position.bottom = CSSPercentage{0.0f};
-            } else if (keyword1 == CSSKeyword::Center) {
-              position.top = CSSPercentage{50.0f};
-            }
-
-            if (keyword2 == CSSKeyword::Left) {
-              position.left = CSSPercentage{0.0f};
-            } else if (keyword2 == CSSKeyword::Right) {
-              position.left = CSSPercentage{100.0f};
-            } else if (keyword2 == CSSKeyword::Center) {
-              position.left = CSSPercentage{50.0f};
-            }
-          } else {
-            return {};
-          }
-        }
-        // 3. [ left | center | right | <length-percentage> ] [ top | center |
-        // bottom | <length-percentage> ]
-        else {
-          if (std::holds_alternative<CSSKeyword>(value1)) {
-            auto keyword1 = std::get<CSSKeyword>(value1);
-            if (keyword1 == CSSKeyword::Left) {
-              position.left = CSSPercentage{0.0f};
-            } else if (keyword1 == CSSKeyword::Right) {
-              position.right = CSSPercentage{0.0f};
-            } else if (keyword1 == CSSKeyword::Center) {
-              position.left = CSSPercentage{50.0f};
-            } else {
-              return {};
-            }
-          } else if ((std::holds_alternative<CSSLength>(value1) || std::holds_alternative<CSSPercentage>(value1))) {
-            if (std::holds_alternative<CSSLength>(value1)) {
-              position.left = std::get<CSSLength>(value1);
-            } else {
-              position.left = std::get<CSSPercentage>(value1);
-            }
-          } else {
-            return {};
-          }
-
-          if (std::holds_alternative<CSSKeyword>(value2)) {
-            auto keyword2 = std::get<CSSKeyword>(value2);
-            if (keyword2 == CSSKeyword::Top) {
-              position.top = CSSPercentage{0.0f};
-            } else if (keyword2 == CSSKeyword::Bottom) {
-              position.bottom = CSSPercentage{0.f};
-            } else if (keyword2 == CSSKeyword::Center) {
-              position.top = CSSPercentage{50.0f};
-            } else {
-              return {};
-            }
-          } else if ((std::holds_alternative<CSSLength>(value2) || std::holds_alternative<CSSPercentage>(value2))) {
-            if (std::holds_alternative<CSSLength>(value2)) {
-              position.top = std::get<CSSLength>(value2);
-            } else {
-              position.top = std::get<CSSPercentage>(value2);
-            }
-          } else {
-            return {};
-          }
-        }
-      }
-
-      // 4. [ [ left | right ] <length-percentage> ] && [ [ top | bottom ]
-      // <length-percentage> ]
-      else if (positionKeywordValues.size() == 4) {
-        auto value1 = positionKeywordValues[0];
-        auto value2 = positionKeywordValues[1];
-        auto value3 = positionKeywordValues[2];
-        auto value4 = positionKeywordValues[3];
-
-        if (!std::holds_alternative<CSSKeyword>(value1)) {
-          return {};
-        }
-        if (!std::holds_alternative<CSSKeyword>(value3)) {
-          return {};
-        }
-        if ((!std::holds_alternative<CSSLength>(value2) && !std::holds_alternative<CSSPercentage>(value2))) {
-          return {};
-        }
-        if ((!std::holds_alternative<CSSLength>(value4) && !std::holds_alternative<CSSPercentage>(value4))) {
-          return {};
-        }
-
-        auto parsedValue2 = std::holds_alternative<CSSLength>(value2)
-            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(value2)}
-            : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(value2)};
-        auto parsedValue4 = std::holds_alternative<CSSLength>(value4)
-            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(value4)}
-            : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(value4)};
-        auto keyword1 = std::get<CSSKeyword>(value1);
-        auto keyword3 = std::get<CSSKeyword>(value3);
-
-        if (keyword1 == CSSKeyword::Left) {
-          position.left = parsedValue2;
-        } else if (keyword1 == CSSKeyword::Right) {
-          position.right = parsedValue2;
-        } else if (keyword1 == CSSKeyword::Top) {
-          position.top = parsedValue2;
-        } else if (keyword1 == CSSKeyword::Bottom) {
-          position.bottom = parsedValue2;
-        } else {
-          return {};
-        }
-
-        if (keyword3 == CSSKeyword::Left) {
-          position.left = parsedValue4;
-        } else if (keyword3 == CSSKeyword::Right) {
-          position.right = parsedValue4;
-        } else if (keyword3 == CSSKeyword::Top) {
-          position.top = parsedValue4;
-        } else if (keyword3 == CSSKeyword::Bottom) {
-          position.bottom = parsedValue4;
-        } else {
-          return {};
-        }
-      } else {
+      if (positionKeywordValues->empty()) {
         return {};
       }
 
-      gradient.position = position;
+      auto resolvedPosition = detail::resolveRadialGradientPosition(*positionKeywordValues);
+      if (!resolvedPosition.has_value()) {
+        return {};
+      }
+
+      gradient.position = *resolvedPosition;
     } else {
       // Default position
+      CSSRadialGradientPosition position;
       position.top = CSSPercentage{50.0f};
       position.left = CSSPercentage{50.0f};
       gradient.position = position;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -384,6 +384,613 @@ static void updateMatchedPair(
 }
 
 /**
+ * Remove all children (non-recursively) of tree being flattened, or insert
+ * children into parent tree if they're being unflattened. Caller will take
+ * care of the corresponding action in the other tree (caller will handle
+ * DELETE case if we REMOVE here; caller will handle CREATE case if we INSERT
+ * here).
+ *
+ * Extracted from `calculateShadowViewMutationsFlattener` to reduce its
+ * complexity; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsFlattenerRemoveOrInsertChild(
+    OrderedMutationInstructionContainer& mutationContainer,
+    ReparentMode reparentMode,
+    const ShadowViewNodePair& node,
+    const ShadowViewNodePair& treeChildPair,
+    bool existsInOtherTree) {
+  if (!treeChildPair.isConcreteView) {
+    return;
+  }
+  if (reparentMode == ReparentMode::Flatten) {
+    // treeChildPair.shadowView represents the "old" view in this case.
+    // If there's a "new" view, an UPDATE new -> old will be generated
+    // and will be executed before the REMOVE. Thus, we must actually
+    // perform a REMOVE (new view) FROM (old index) in this case so that
+    // we don't hit asserts in StubViewTree's REMOVE path.
+    // We also only do this if the "other" (newer) view is concrete. If
+    // it's not concrete, there will be no UPDATE mutation.
+    react_native_assert(existsInOtherTree == treeChildPair.inOtherTree());
+    if (treeChildPair.inOtherTree() &&
+        treeChildPair.otherTreePair->isConcreteView) {
+      mutationContainer.removeMutations.push_back(
+          ShadowViewMutation::RemoveMutation(
+              node.shadowView.tag,
+              treeChildPair.otherTreePair->shadowView,
+              static_cast<int>(treeChildPair.mountIndex)));
+    } else {
+      mutationContainer.removeMutations.push_back(
+          ShadowViewMutation::RemoveMutation(
+              node.shadowView.tag,
+              treeChildPair.shadowView,
+              static_cast<int>(treeChildPair.mountIndex)));
+    }
+  } else {
+    // treeChildParent represents the "new" version of the node, so
+    // we can safely insert it without checking in the other tree
+    mutationContainer.insertMutations.push_back(
+        ShadowViewMutation::InsertMutation(
+            node.shadowView.tag,
+            treeChildPair.shadowView,
+            static_cast<int>(treeChildPair.mountIndex)));
+  }
+}
+
+/**
+ * Update the grandchildren of a matched node pair when neither side is
+ * flattened. Extracted from `calculateShadowViewMutationsFlattener` to reduce
+ * its complexity; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsFlattenerUpdateMatchedGrandchildren(
+    OrderedMutationInstructionContainer& mutationContainer,
+    const ShadowViewNodePair& oldTreeNodePair,
+    const ShadowViewNodePair& newTreeNodePair,
+    const CullingContext& adjustedOldCullingContext,
+    const CullingContext& adjustedNewCullingContext) {
+  if (oldTreeNodePair.shadowNode != newTreeNodePair.shadowNode ||
+      adjustedOldCullingContext != adjustedNewCullingContext) {
+    ViewNodePairScope innerScope{};
+    auto oldGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
+        oldTreeNodePair, innerScope, false, adjustedOldCullingContext);
+    auto newGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
+        newTreeNodePair, innerScope, false, adjustedNewCullingContext);
+
+    calculateShadowViewMutations(
+        innerScope,
+        mutationContainer.downwardMutations,
+        newTreeNodePair.shadowView.tag,
+        std::move(oldGrandChildPairs),
+        std::move(newGrandChildPairs),
+        adjustedOldCullingContext,
+        adjustedNewCullingContext);
+  }
+}
+
+/**
+ * Handle the case where a child is being flattened/unflattened in the opposite
+ * direction to its parent (child reparent mode differs from parent reparent
+ * mode). Extracted from `calculateShadowViewMutationsFlattener` to reduce its
+ * complexity; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsFlattenerChildOppositeReparent(
+    ViewNodePairScope& scope,
+    ReparentMode reparentMode,
+    ReparentMode childReparentMode,
+    OrderedMutationInstructionContainer& mutationContainer,
+    Tag parentTag,
+    std::unordered_map<Tag, ShadowViewNodePair*>& unvisitedOtherNodes,
+    const ShadowViewNodePair& oldTreeNodePair,
+    const ShadowViewNodePair& newTreeNodePair,
+    Tag parentTagForUpdate,
+    std::unordered_map<Tag, ShadowViewNodePair*>* subVisitedNewMap,
+    std::unordered_map<Tag, ShadowViewNodePair*>* subVisitedOldMap,
+    const CullingContext& adjustedOldCullingContext,
+    const CullingContext& adjustedNewCullingContext,
+    std::unordered_map<Tag, const ShadowViewNodePair*>&
+        deletionCreationCandidatePairs) {
+  // Get flattened nodes from either new or old tree
+  auto flattenedNodes = sliceChildShadowNodeViewPairsFromViewNodePair(
+      (childReparentMode == ReparentMode::Flatten ? newTreeNodePair
+                                                  : oldTreeNodePair),
+      scope,
+      true,
+      childReparentMode == ReparentMode::Flatten ? adjustedNewCullingContext
+                                                 : adjustedOldCullingContext);
+  // Construct unvisited nodes map
+  std::unordered_map<Tag, ShadowViewNodePair*> unvisitedRecursiveChildPairs;
+  unvisitedRecursiveChildPairs.reserve(flattenedNodes.size());
+  for (auto& flattenedNode : flattenedNodes) {
+    auto& newChild = *flattenedNode;
+
+    auto unvisitedOtherNodesIt =
+        unvisitedOtherNodes.find(newChild.shadowView.tag);
+    if (unvisitedOtherNodesIt != unvisitedOtherNodes.end()) {
+      auto unvisitedItPair = *unvisitedOtherNodesIt->second;
+      unvisitedRecursiveChildPairs.insert(
+          {unvisitedItPair.shadowView.tag, &unvisitedItPair});
+    } else {
+      unvisitedRecursiveChildPairs.insert({newChild.shadowView.tag, &newChild});
+    }
+  }
+
+  if (childReparentMode == ReparentMode::Flatten) {
+    // Unflatten parent, flatten child
+    react_native_assert(reparentMode == ReparentMode::Unflatten);
+    auto fixedParentTagForUpdate = newTreeNodePair.shadowView.tag;
+    // Flatten old tree into new list
+    // At the end of this loop we still want to know which of these
+    // children are visited, so we reuse the `newRemainingPairs` map.
+    calculateShadowViewMutationsFlattener(
+        scope,
+        ReparentMode::Flatten,
+        mutationContainer,
+        newTreeNodePair.shadowView.tag,
+        unvisitedRecursiveChildPairs,
+        oldTreeNodePair,
+        fixedParentTagForUpdate,
+        subVisitedNewMap,
+        subVisitedOldMap,
+        adjustedNewCullingContext,
+        adjustedNewCullingContext);
+  } else {
+    // Flatten parent, unflatten child
+    react_native_assert(reparentMode == ReparentMode::Flatten);
+    // Unflatten old list into new tree
+    auto fixedParentTagForUpdate = parentTagForUpdate;
+    calculateShadowViewMutationsFlattener(
+        scope,
+        /* reparentMode */ ReparentMode::Unflatten,
+        mutationContainer,
+        parentTag,
+        /* unvisitedOtherNodes */ unvisitedRecursiveChildPairs,
+        /* node */ newTreeNodePair,
+        /* parentTagForUpdate */ fixedParentTagForUpdate,
+        /* parentSubVisitedOtherNewNodes */ subVisitedNewMap,
+        /* parentSubVisitedOtherOldNodes */ subVisitedOldMap,
+        /* cullingContextForUnvisitedOtherNodes */
+        adjustedOldCullingContext,
+        /* cullingContext */ adjustedOldCullingContext);
+
+    // If old nodes were not visited, we know that we can delete them
+    // now. They will be removed from the hierarchy by the outermost
+    // loop of this function.
+    for (auto& unvisitedRecursiveChildPair : unvisitedRecursiveChildPairs) {
+      auto& oldFlattenedNode = *unvisitedRecursiveChildPair.second;
+
+      // Node unvisited - mark the entire subtree for deletion
+      if (oldFlattenedNode.isConcreteView && !oldFlattenedNode.inOtherTree()) {
+        Tag tag = oldFlattenedNode.shadowView.tag;
+        auto deleteCreateIt = deletionCreationCandidatePairs.find(
+            oldFlattenedNode.shadowView.tag);
+        if (deleteCreateIt == deletionCreationCandidatePairs.end()) {
+          deletionCreationCandidatePairs.insert({tag, &oldFlattenedNode});
+        }
+      } else {
+        // Node was visited - make sure to remove it from
+        // "newRemainingPairs" map
+        auto newRemainingIt =
+            unvisitedOtherNodes.find(oldFlattenedNode.shadowView.tag);
+        if (newRemainingIt != unvisitedOtherNodes.end()) {
+          unvisitedOtherNodes.erase(newRemainingIt);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Final step of `calculateShadowViewMutationsFlattener`: go through
+ * creation/deletion candidates and delete/create subtrees if they were never
+ * visited during the execution of the main loop and recursions. Extracted to
+ * reduce complexity; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsFlattenerProcessCandidates(
+    OrderedMutationInstructionContainer& mutationContainer,
+    ReparentMode reparentMode,
+    const std::unordered_map<Tag, const ShadowViewNodePair*>&
+        deletionCreationCandidatePairs,
+    const CullingContext& cullingContext) {
+  for (auto& deletionCreationCandidatePair : deletionCreationCandidatePairs) {
+    auto& treeChildPair = *deletionCreationCandidatePair.second;
+
+    // If node was visited during a flattening/unflattening recursion,
+    // and the node in the other tree is concrete, that means it was
+    // already created/deleted and we don't need to do that here.
+    // It is always the responsibility of the matcher to update subtrees when
+    // nodes are matched.
+    if (treeChildPair.inOtherTree()) {
+      continue;
+    }
+
+    auto adjustedCullingContext =
+        cullingContext.adjustCullingContextIfNeeded(treeChildPair);
+
+    if (reparentMode == ReparentMode::Flatten) {
+      mutationContainer.deleteMutations.push_back(
+          ShadowViewMutation::DeleteMutation(treeChildPair.shadowView));
+
+      if (!treeChildPair.flattened) {
+        ViewNodePairScope innerScope{};
+        calculateShadowViewMutations(
+            innerScope,
+            mutationContainer.destructiveDownwardMutations,
+            treeChildPair.shadowView.tag,
+            sliceChildShadowNodeViewPairsFromViewNodePair(
+                treeChildPair, innerScope, false, adjustedCullingContext),
+            {},
+            adjustedCullingContext,
+            {});
+      }
+    } else {
+      mutationContainer.createMutations.push_back(
+          ShadowViewMutation::CreateMutation(treeChildPair.shadowView));
+
+      if (!treeChildPair.flattened) {
+        ViewNodePairScope innerScope{};
+        calculateShadowViewMutations(
+            innerScope,
+            mutationContainer.downwardMutations,
+            treeChildPair.shadowView.tag,
+            {},
+            sliceChildShadowNodeViewPairsFromViewNodePair(
+                treeChildPair, innerScope, false, adjustedCullingContext),
+            {},
+            adjustedCullingContext);
+      }
+    }
+  }
+}
+
+/**
+ * Handle the case where one of the children is flattened or unflattened, in the
+ * context of a parent flattening or unflattening. Dispatches to the same-mode
+ * recursion (child mode equals parent mode) or to the opposite-mode handler.
+ * Extracted from `calculateShadowViewMutationsFlattener` to reduce its
+ * complexity; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsFlattenerHandleChildReparent(
+    ViewNodePairScope& scope,
+    ReparentMode reparentMode,
+    OrderedMutationInstructionContainer& mutationContainer,
+    Tag parentTag,
+    std::unordered_map<Tag, ShadowViewNodePair*>& unvisitedOtherNodes,
+    ShadowViewNodePair& treeChildPair,
+    const ShadowViewNodePair& oldTreeNodePair,
+    const ShadowViewNodePair& newTreeNodePair,
+    Tag parentTagForUpdate,
+    std::unordered_map<Tag, ShadowViewNodePair*>* subVisitedNewMap,
+    std::unordered_map<Tag, ShadowViewNodePair*>* subVisitedOldMap,
+    const CullingContext& cullingContextForUnvisitedOtherNodes,
+    const CullingContext& cullingContext,
+    const CullingContext& adjustedOldCullingContext,
+    const CullingContext& adjustedNewCullingContext,
+    std::unordered_map<Tag, const ShadowViewNodePair*>&
+        deletionCreationCandidatePairs) {
+  ReparentMode childReparentMode =
+      (oldTreeNodePair.flattened ? ReparentMode::Unflatten
+                                 : ReparentMode::Flatten);
+
+  // Case 1: child mode is the same as parent.
+  // This is a flatten-flatten, or unflatten-unflatten.
+  if (childReparentMode == reparentMode) {
+    calculateShadowViewMutationsFlattener(
+        scope,
+        childReparentMode,
+        mutationContainer,
+        (reparentMode == ReparentMode::Flatten
+             ? parentTag
+             : newTreeNodePair.shadowView.tag),
+        unvisitedOtherNodes,
+        treeChildPair,
+        (reparentMode == ReparentMode::Flatten
+             ? oldTreeNodePair.shadowView.tag
+             : (ReactNativeFeatureFlags::
+                        fixDifferentiatorParentTagForUnflattenCase()
+                    ? parentTagForUpdate
+                    : parentTag)),
+        subVisitedNewMap,
+        subVisitedOldMap,
+        cullingContextForUnvisitedOtherNodes,
+        cullingContext.adjustCullingContextIfNeeded(treeChildPair));
+  } else {
+    calculateShadowViewMutationsFlattenerChildOppositeReparent(
+        scope,
+        reparentMode,
+        childReparentMode,
+        mutationContainer,
+        parentTag,
+        unvisitedOtherNodes,
+        oldTreeNodePair,
+        newTreeNodePair,
+        parentTagForUpdate,
+        subVisitedNewMap,
+        subVisitedOldMap,
+        adjustedOldCullingContext,
+        adjustedNewCullingContext,
+        deletionCreationCandidatePairs);
+  }
+}
+
+/**
+ * Mark that node exists in another tree, but only if the tree node is a
+ * concrete view. Removing the node from the unvisited list prevents the caller
+ * from taking further action on this node, so make sure to delete/create if the
+ * concreteness of the node has changed. Extracted from
+ * `calculateShadowViewMutationsFlattener`; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsFlattenerAppendConcretenessMutation(
+    OrderedMutationInstructionContainer& mutationContainer,
+    const ShadowViewNodePair& oldTreeNodePair,
+    const ShadowViewNodePair& newTreeNodePair) {
+  if (newTreeNodePair.isConcreteView != oldTreeNodePair.isConcreteView) {
+    if (newTreeNodePair.isConcreteView) {
+      mutationContainer.createMutations.push_back(
+          ShadowViewMutation::CreateMutation(newTreeNodePair.shadowView));
+    } else {
+      mutationContainer.deleteMutations.push_back(
+          ShadowViewMutation::DeleteMutation(oldTreeNodePair.shadowView));
+    }
+  }
+}
+
+/**
+ * Record a concrete tree child that does not exist in the other tree as a
+ * candidate for full subtree deletion/creation at the end of the flattener.
+ * Extracted from `calculateShadowViewMutationsFlattener`; behavior is
+ * unchanged.
+ */
+static void calculateShadowViewMutationsFlattenerMarkCandidate(
+    ShadowViewNodePair& treeChildPair,
+    std::unordered_map<Tag, const ShadowViewNodePair*>&
+        deletionCreationCandidatePairs) {
+  // Node does not in exist in other tree.
+  if (treeChildPair.isConcreteView && !treeChildPair.inOtherTree()) {
+    auto deletionCreationIt =
+        deletionCreationCandidatePairs.find(treeChildPair.shadowView.tag);
+    if (deletionCreationIt == deletionCreationCandidatePairs.end()) {
+      deletionCreationCandidatePairs.insert(
+          {treeChildPair.shadowView.tag, &treeChildPair});
+    }
+  }
+}
+
+/**
+ * Process a single tree child during (un)flattening: if the child is matched in
+ * the other tree, reconcile the pair and its subtree; otherwise mark it as a
+ * candidate for deletion/creation. Extracted from
+ * `calculateShadowViewMutationsFlattener` to reduce its complexity; behavior is
+ * unchanged. This is invoked as the last statement of the main loop body, so
+ * the early `return`s here are equivalent to the `continue`s they replaced.
+ */
+static void calculateShadowViewMutationsFlattenerMatchChild(
+    ViewNodePairScope& scope,
+    ReparentMode reparentMode,
+    OrderedMutationInstructionContainer& mutationContainer,
+    Tag parentTag,
+    std::unordered_map<Tag, ShadowViewNodePair*>& unvisitedOtherNodes,
+    ShadowViewNodePair& treeChildPair,
+    Tag parentTagForUpdate,
+    std::unordered_map<Tag, ShadowViewNodePair*>* subVisitedNewMap,
+    std::unordered_map<Tag, ShadowViewNodePair*>* subVisitedOldMap,
+    const CullingContext& cullingContextForUnvisitedOtherNodes,
+    const CullingContext& cullingContext,
+    std::unordered_map<Tag, const ShadowViewNodePair*>&
+        deletionCreationCandidatePairs,
+    bool existsInOtherTree,
+    ShadowViewNodePair* otherTreeNodePairPtr,
+    bool alreadyUpdated,
+    bool foundInUnvisited,
+    bool foundInSubVisitedNew,
+    bool foundInSubVisitedOld) {
+  // Find in other tree
+  if (existsInOtherTree) {
+    react_native_assert(otherTreeNodePairPtr != nullptr);
+    auto& otherTreeNodePair = *otherTreeNodePairPtr;
+
+    auto& newTreeNodePair =
+        (reparentMode == ReparentMode::Flatten ? otherTreeNodePair
+                                               : treeChildPair);
+    auto& oldTreeNodePair =
+        (reparentMode == ReparentMode::Flatten ? treeChildPair
+                                               : otherTreeNodePair);
+
+    react_native_assert(newTreeNodePair.shadowView.tag != 0);
+    react_native_assert(oldTreeNodePair.shadowView.tag != 0);
+    react_native_assert(
+        oldTreeNodePair.shadowView.tag == newTreeNodePair.shadowView.tag);
+
+    // If we've already done updates, don't repeat it.
+    if (alreadyUpdated) {
+      return;
+    }
+
+    // If we've already done updates on this node, don't repeat.
+    if (reparentMode == ReparentMode::Flatten && !foundInUnvisited &&
+        foundInSubVisitedOld) {
+      return;
+    } else if (
+        reparentMode == ReparentMode::Unflatten && !foundInUnvisited &&
+        foundInSubVisitedNew) {
+      return;
+    }
+
+    // TODO: compare ShadowNode pointer instead of ShadowView here?
+    // Or ShadowNode ptr comparison before comparing ShadowView, to allow for
+    // short-circuiting? ShadowView comparison is relatively expensive vs
+    // ShadowNode.
+    if (newTreeNodePair.shadowView != oldTreeNodePair.shadowView &&
+        newTreeNodePair.isConcreteView && oldTreeNodePair.isConcreteView) {
+      // We execute updates before creates, so pass the current parent in when
+      // unflattening.
+      // TODO: whenever we insert, we already update the relevant properties,
+      // so this update is redundant. We should remove this.
+      mutationContainer.updateMutations.push_back(
+          ShadowViewMutation::UpdateMutation(
+              oldTreeNodePair.shadowView,
+              newTreeNodePair.shadowView,
+              parentTagForUpdate));
+    }
+
+    auto adjustedOldCullingContext = reparentMode == ReparentMode::Flatten
+        ? cullingContext.adjustCullingContextIfNeeded(oldTreeNodePair)
+        : cullingContextForUnvisitedOtherNodes.adjustCullingContextIfNeeded(
+              oldTreeNodePair);
+    auto adjustedNewCullingContext = reparentMode == ReparentMode::Flatten
+        ? cullingContextForUnvisitedOtherNodes.adjustCullingContextIfNeeded(
+              newTreeNodePair)
+        : cullingContext.adjustCullingContextIfNeeded(newTreeNodePair);
+
+    // Update children if appropriate.
+    if (!oldTreeNodePair.flattened && !newTreeNodePair.flattened) {
+      calculateShadowViewMutationsFlattenerUpdateMatchedGrandchildren(
+          mutationContainer,
+          oldTreeNodePair,
+          newTreeNodePair,
+          adjustedOldCullingContext,
+          adjustedNewCullingContext);
+    } else if (oldTreeNodePair.flattened != newTreeNodePair.flattened) {
+      // We need to handle one of the children being flattened or
+      // unflattened, in the context of a parent flattening or unflattening.
+      calculateShadowViewMutationsFlattenerHandleChildReparent(
+          scope,
+          reparentMode,
+          mutationContainer,
+          parentTag,
+          unvisitedOtherNodes,
+          treeChildPair,
+          oldTreeNodePair,
+          newTreeNodePair,
+          parentTagForUpdate,
+          subVisitedNewMap,
+          subVisitedOldMap,
+          cullingContextForUnvisitedOtherNodes,
+          cullingContext,
+          adjustedOldCullingContext,
+          adjustedNewCullingContext,
+          deletionCreationCandidatePairs);
+    }
+
+    // Mark that node exists in another tree, but only if the tree node is a
+    // concrete view. Removing the node from the unvisited list prevents the
+    // caller from taking further action on this node, so make sure to
+    // delete/create if the Concreteness of the node has changed.
+    calculateShadowViewMutationsFlattenerAppendConcretenessMutation(
+        mutationContainer, oldTreeNodePair, newTreeNodePair);
+
+    subVisitedNewMap->insert(
+        {newTreeNodePair.shadowView.tag, &newTreeNodePair});
+    subVisitedOldMap->insert(
+        {oldTreeNodePair.shadowView.tag, &oldTreeNodePair});
+  } else {
+    calculateShadowViewMutationsFlattenerMarkCandidate(
+        treeChildPair, deletionCreationCandidatePairs);
+  }
+}
+
+/**
+ * Result of looking up a tree child in the "other" tree during (un)flattening.
+ * See `findFlattenerChildMatch`.
+ */
+struct FlattenerChildMatch {
+  bool existsInOtherTree{false};
+  ShadowViewNodePair* otherTreeNodePairPtr{nullptr};
+  bool alreadyUpdated{false};
+  bool foundInUnvisited{false};
+  bool foundInSubVisitedNew{false};
+  bool foundInSubVisitedOld{false};
+};
+
+/**
+ * Try to find a tree child in the other tree (across the unvisited, sub-visited
+ * new, and sub-visited old maps), and, if found, wire up the `otherTreePair`
+ * back-pointers. Extracted from `calculateShadowViewMutationsFlattener` to
+ * reduce its complexity; behavior is unchanged.
+ */
+static FlattenerChildMatch findFlattenerChildMatch(
+    ReparentMode reparentMode,
+    ShadowViewNodePair& treeChildPair,
+    std::unordered_map<Tag, ShadowViewNodePair*>& unvisitedOtherNodes,
+    std::unordered_map<Tag, ShadowViewNodePair*>* subVisitedNewMap,
+    std::unordered_map<Tag, ShadowViewNodePair*>* subVisitedOldMap) {
+  // Try to find node in other tree
+  auto unvisitedIt = unvisitedOtherNodes.find(treeChildPair.shadowView.tag);
+  auto subVisitedOtherNewIt =
+      (unvisitedIt == unvisitedOtherNodes.end()
+           ? subVisitedNewMap->find(treeChildPair.shadowView.tag)
+           : subVisitedNewMap->end());
+  auto subVisitedOtherOldIt =
+      (unvisitedIt == unvisitedOtherNodes.end() &&
+               subVisitedOtherNewIt == subVisitedNewMap->end()
+           ? subVisitedOldMap->find(treeChildPair.shadowView.tag)
+           : subVisitedOldMap->end());
+
+  bool existsInOtherTree = unvisitedIt != unvisitedOtherNodes.end() ||
+      subVisitedOtherNewIt != subVisitedNewMap->end() ||
+      subVisitedOtherOldIt != subVisitedOldMap->end();
+
+  auto otherTreeNodePairPtr =
+      (existsInOtherTree
+           ? (unvisitedIt != unvisitedOtherNodes.end()
+                  ? unvisitedIt->second
+                  : (subVisitedOtherNewIt != subVisitedNewMap->end()
+                         ? subVisitedOtherNewIt->second
+                         : subVisitedOtherOldIt->second))
+           : nullptr);
+
+  react_native_assert(
+      !existsInOtherTree ||
+      (unvisitedIt != unvisitedOtherNodes.end() ||
+       subVisitedOtherNewIt != subVisitedNewMap->end() ||
+       subVisitedOtherOldIt != subVisitedOldMap->end()));
+  react_native_assert(
+      unvisitedIt == unvisitedOtherNodes.end() ||
+      unvisitedIt->second->shadowView.tag == treeChildPair.shadowView.tag);
+  react_native_assert(
+      subVisitedOtherNewIt == subVisitedNewMap->end() ||
+      subVisitedOtherNewIt->second->shadowView.tag ==
+          treeChildPair.shadowView.tag);
+  react_native_assert(
+      subVisitedOtherOldIt == subVisitedOldMap->end() ||
+      subVisitedOtherOldIt->second->shadowView.tag ==
+          treeChildPair.shadowView.tag);
+
+  bool alreadyUpdated = false;
+
+  // Find in other tree and updated `otherTreePair` pointers
+  if (existsInOtherTree) {
+    react_native_assert(otherTreeNodePairPtr != nullptr);
+    auto newTreeNodePair =
+        (reparentMode == ReparentMode::Flatten ? otherTreeNodePairPtr
+                                               : &treeChildPair);
+    auto oldTreeNodePair =
+        (reparentMode == ReparentMode::Flatten ? &treeChildPair
+                                               : otherTreeNodePairPtr);
+
+    react_native_assert(newTreeNodePair->shadowView.tag != 0);
+    react_native_assert(oldTreeNodePair->shadowView.tag != 0);
+    react_native_assert(
+        oldTreeNodePair->shadowView.tag == newTreeNodePair->shadowView.tag);
+
+    alreadyUpdated =
+        newTreeNodePair->inOtherTree() || oldTreeNodePair->inOtherTree();
+
+    // We want to update these values unconditionally. Always do this
+    // before hitting any "continue" statements.
+    newTreeNodePair->otherTreePair = oldTreeNodePair;
+    oldTreeNodePair->otherTreePair = newTreeNodePair;
+    react_native_assert(treeChildPair.otherTreePair != nullptr);
+  }
+
+  return FlattenerChildMatch{
+      .existsInOtherTree = existsInOtherTree,
+      .otherTreeNodePairPtr = otherTreeNodePairPtr,
+      .alreadyUpdated = alreadyUpdated,
+      .foundInUnvisited = unvisitedIt != unvisitedOtherNodes.end(),
+      .foundInSubVisitedNew = subVisitedOtherNewIt != subVisitedNewMap->end(),
+      .foundInSubVisitedOld = subVisitedOtherOldIt != subVisitedOldMap->end()};
+}
+
+/**
  * Here we flatten or unflatten a subtree, given an unflattened node in either
  * the old or new tree, and a list of flattened nodes in the other tree.
  *
@@ -467,451 +1074,73 @@ static void calculateShadowViewMutationsFlattener(
        index++) {
     auto& treeChildPair = *treeChildren[index];
 
-    // Try to find node in other tree
-    auto unvisitedIt = unvisitedOtherNodes.find(treeChildPair.shadowView.tag);
-    auto subVisitedOtherNewIt =
-        (unvisitedIt == unvisitedOtherNodes.end()
-             ? subVisitedNewMap->find(treeChildPair.shadowView.tag)
-             : subVisitedNewMap->end());
-    auto subVisitedOtherOldIt =
-        (unvisitedIt == unvisitedOtherNodes.end() &&
-                 subVisitedOtherNewIt == subVisitedNewMap->end()
-             ? subVisitedOldMap->find(treeChildPair.shadowView.tag)
-             : subVisitedOldMap->end());
-
-    bool existsInOtherTree = unvisitedIt != unvisitedOtherNodes.end() ||
-        subVisitedOtherNewIt != subVisitedNewMap->end() ||
-        subVisitedOtherOldIt != subVisitedOldMap->end();
-
-    auto otherTreeNodePairPtr =
-        (existsInOtherTree
-             ? (unvisitedIt != unvisitedOtherNodes.end()
-                    ? unvisitedIt->second
-                    : (subVisitedOtherNewIt != subVisitedNewMap->end()
-                           ? subVisitedOtherNewIt->second
-                           : subVisitedOtherOldIt->second))
-             : nullptr);
-
-    react_native_assert(
-        !existsInOtherTree ||
-        (unvisitedIt != unvisitedOtherNodes.end() ||
-         subVisitedOtherNewIt != subVisitedNewMap->end() ||
-         subVisitedOtherOldIt != subVisitedOldMap->end()));
-    react_native_assert(
-        unvisitedIt == unvisitedOtherNodes.end() ||
-        unvisitedIt->second->shadowView.tag == treeChildPair.shadowView.tag);
-    react_native_assert(
-        subVisitedOtherNewIt == subVisitedNewMap->end() ||
-        subVisitedOtherNewIt->second->shadowView.tag ==
-            treeChildPair.shadowView.tag);
-    react_native_assert(
-        subVisitedOtherOldIt == subVisitedOldMap->end() ||
-        subVisitedOtherOldIt->second->shadowView.tag ==
-            treeChildPair.shadowView.tag);
-
-    bool alreadyUpdated = false;
-
-    // Find in other tree and updated `otherTreePair` pointers
-    if (existsInOtherTree) {
-      react_native_assert(otherTreeNodePairPtr != nullptr);
-      auto newTreeNodePair =
-          (reparentMode == ReparentMode::Flatten ? otherTreeNodePairPtr
-                                                 : &treeChildPair);
-      auto oldTreeNodePair =
-          (reparentMode == ReparentMode::Flatten ? &treeChildPair
-                                                 : otherTreeNodePairPtr);
-
-      react_native_assert(newTreeNodePair->shadowView.tag != 0);
-      react_native_assert(oldTreeNodePair->shadowView.tag != 0);
-      react_native_assert(
-          oldTreeNodePair->shadowView.tag == newTreeNodePair->shadowView.tag);
-
-      alreadyUpdated =
-          newTreeNodePair->inOtherTree() || oldTreeNodePair->inOtherTree();
-
-      // We want to update these values unconditionally. Always do this
-      // before hitting any "continue" statements.
-      newTreeNodePair->otherTreePair = oldTreeNodePair;
-      oldTreeNodePair->otherTreePair = newTreeNodePair;
-      react_native_assert(treeChildPair.otherTreePair != nullptr);
-    }
+    // Try to find node in other tree (and wire up `otherTreePair` pointers).
+    auto match = findFlattenerChildMatch(
+        reparentMode,
+        treeChildPair,
+        unvisitedOtherNodes,
+        subVisitedNewMap,
+        subVisitedOldMap);
 
     // Remove all children (non-recursively) of tree being flattened, or
     // insert children into parent tree if they're being unflattened.
     //  Caller will take care of the corresponding action in the other tree
     //  (caller will handle DELETE case if we REMOVE here; caller will handle
     //  CREATE case if we INSERT here).
-    if (treeChildPair.isConcreteView) {
-      if (reparentMode == ReparentMode::Flatten) {
-        // treeChildPair.shadowView represents the "old" view in this case.
-        // If there's a "new" view, an UPDATE new -> old will be generated
-        // and will be executed before the REMOVE. Thus, we must actually
-        // perform a REMOVE (new view) FROM (old index) in this case so that
-        // we don't hit asserts in StubViewTree's REMOVE path.
-        // We also only do this if the "other" (newer) view is concrete. If
-        // it's not concrete, there will be no UPDATE mutation.
-        react_native_assert(existsInOtherTree == treeChildPair.inOtherTree());
-        if (treeChildPair.inOtherTree() &&
-            treeChildPair.otherTreePair->isConcreteView) {
-          mutationContainer.removeMutations.push_back(
-              ShadowViewMutation::RemoveMutation(
-                  node.shadowView.tag,
-                  treeChildPair.otherTreePair->shadowView,
-                  static_cast<int>(treeChildPair.mountIndex)));
-        } else {
-          mutationContainer.removeMutations.push_back(
-              ShadowViewMutation::RemoveMutation(
-                  node.shadowView.tag,
-                  treeChildPair.shadowView,
-                  static_cast<int>(treeChildPair.mountIndex)));
-        }
-      } else {
-        // treeChildParent represents the "new" version of the node, so
-        // we can safely insert it without checking in the other tree
-        mutationContainer.insertMutations.push_back(
-            ShadowViewMutation::InsertMutation(
-                node.shadowView.tag,
-                treeChildPair.shadowView,
-                static_cast<int>(treeChildPair.mountIndex)));
-      }
-    }
+    calculateShadowViewMutationsFlattenerRemoveOrInsertChild(
+        mutationContainer,
+        reparentMode,
+        node,
+        treeChildPair,
+        match.existsInOtherTree);
 
-    // Find in other tree
-    if (existsInOtherTree) {
-      react_native_assert(otherTreeNodePairPtr != nullptr);
-      auto& otherTreeNodePair = *otherTreeNodePairPtr;
-
-      auto& newTreeNodePair =
-          (reparentMode == ReparentMode::Flatten ? otherTreeNodePair
-                                                 : treeChildPair);
-      auto& oldTreeNodePair =
-          (reparentMode == ReparentMode::Flatten ? treeChildPair
-                                                 : otherTreeNodePair);
-
-      react_native_assert(newTreeNodePair.shadowView.tag != 0);
-      react_native_assert(oldTreeNodePair.shadowView.tag != 0);
-      react_native_assert(
-          oldTreeNodePair.shadowView.tag == newTreeNodePair.shadowView.tag);
-
-      // If we've already done updates, don't repeat it.
-      if (alreadyUpdated) {
-        continue;
-      }
-
-      // If we've already done updates on this node, don't repeat.
-      if (reparentMode == ReparentMode::Flatten &&
-          unvisitedIt == unvisitedOtherNodes.end() &&
-          subVisitedOtherOldIt != subVisitedOldMap->end()) {
-        continue;
-      } else if (
-          reparentMode == ReparentMode::Unflatten &&
-          unvisitedIt == unvisitedOtherNodes.end() &&
-          subVisitedOtherNewIt != subVisitedNewMap->end()) {
-        continue;
-      }
-
-      // TODO: compare ShadowNode pointer instead of ShadowView here?
-      // Or ShadowNode ptr comparison before comparing ShadowView, to allow for
-      // short-circuiting? ShadowView comparison is relatively expensive vs
-      // ShadowNode.
-      if (newTreeNodePair.shadowView != oldTreeNodePair.shadowView &&
-          newTreeNodePair.isConcreteView && oldTreeNodePair.isConcreteView) {
-        // We execute updates before creates, so pass the current parent in when
-        // unflattening.
-        // TODO: whenever we insert, we already update the relevant properties,
-        // so this update is redundant. We should remove this.
-        mutationContainer.updateMutations.push_back(
-            ShadowViewMutation::UpdateMutation(
-                oldTreeNodePair.shadowView,
-                newTreeNodePair.shadowView,
-                parentTagForUpdate));
-      }
-
-      auto adjustedOldCullingContext = reparentMode == ReparentMode::Flatten
-          ? cullingContext.adjustCullingContextIfNeeded(oldTreeNodePair)
-          : cullingContextForUnvisitedOtherNodes.adjustCullingContextIfNeeded(
-                oldTreeNodePair);
-      auto adjustedNewCullingContext = reparentMode == ReparentMode::Flatten
-          ? cullingContextForUnvisitedOtherNodes.adjustCullingContextIfNeeded(
-                newTreeNodePair)
-          : cullingContext.adjustCullingContextIfNeeded(newTreeNodePair);
-
-      // Update children if appropriate.
-      if (!oldTreeNodePair.flattened && !newTreeNodePair.flattened) {
-        if (oldTreeNodePair.shadowNode != newTreeNodePair.shadowNode ||
-            adjustedOldCullingContext != adjustedNewCullingContext) {
-          ViewNodePairScope innerScope{};
-          auto oldGrandChildPairs =
-              sliceChildShadowNodeViewPairsFromViewNodePair(
-                  oldTreeNodePair,
-                  innerScope,
-                  false,
-                  adjustedOldCullingContext);
-          auto newGrandChildPairs =
-              sliceChildShadowNodeViewPairsFromViewNodePair(
-                  newTreeNodePair,
-                  innerScope,
-                  false,
-                  adjustedNewCullingContext);
-
-          calculateShadowViewMutations(
-              innerScope,
-              mutationContainer.downwardMutations,
-              newTreeNodePair.shadowView.tag,
-              std::move(oldGrandChildPairs),
-              std::move(newGrandChildPairs),
-              adjustedOldCullingContext,
-              adjustedNewCullingContext);
-        }
-      } else if (oldTreeNodePair.flattened != newTreeNodePair.flattened) {
-        // We need to handle one of the children being flattened or
-        // unflattened, in the context of a parent flattening or unflattening.
-        ReparentMode childReparentMode =
-            (oldTreeNodePair.flattened ? ReparentMode::Unflatten
-                                       : ReparentMode::Flatten);
-
-        // Case 1: child mode is the same as parent.
-        // This is a flatten-flatten, or unflatten-unflatten.
-        if (childReparentMode == reparentMode) {
-          calculateShadowViewMutationsFlattener(
-              scope,
-              childReparentMode,
-              mutationContainer,
-              (reparentMode == ReparentMode::Flatten
-                   ? parentTag
-                   : newTreeNodePair.shadowView.tag),
-              unvisitedOtherNodes,
-              treeChildPair,
-              (reparentMode == ReparentMode::Flatten
-                   ? oldTreeNodePair.shadowView.tag
-                   : (ReactNativeFeatureFlags::
-                              fixDifferentiatorParentTagForUnflattenCase()
-                          ? parentTagForUpdate
-                          : parentTag)),
-              subVisitedNewMap,
-              subVisitedOldMap,
-              cullingContextForUnvisitedOtherNodes,
-              cullingContext.adjustCullingContextIfNeeded(treeChildPair));
-        } else {
-          // Get flattened nodes from either new or old tree
-          auto flattenedNodes = sliceChildShadowNodeViewPairsFromViewNodePair(
-              (childReparentMode == ReparentMode::Flatten ? newTreeNodePair
-                                                          : oldTreeNodePair),
-              scope,
-              true,
-              childReparentMode == ReparentMode::Flatten
-                  ? adjustedNewCullingContext
-                  : adjustedOldCullingContext);
-          // Construct unvisited nodes map
-          std::unordered_map<Tag, ShadowViewNodePair*>
-              unvisitedRecursiveChildPairs;
-          unvisitedRecursiveChildPairs.reserve(flattenedNodes.size());
-          for (auto& flattenedNode : flattenedNodes) {
-            auto& newChild = *flattenedNode;
-
-            auto unvisitedOtherNodesIt =
-                unvisitedOtherNodes.find(newChild.shadowView.tag);
-            if (unvisitedOtherNodesIt != unvisitedOtherNodes.end()) {
-              auto unvisitedItPair = *unvisitedOtherNodesIt->second;
-              unvisitedRecursiveChildPairs.insert(
-                  {unvisitedItPair.shadowView.tag, &unvisitedItPair});
-            } else {
-              unvisitedRecursiveChildPairs.insert(
-                  {newChild.shadowView.tag, &newChild});
-            }
-          }
-
-          if (childReparentMode == ReparentMode::Flatten) {
-            // Unflatten parent, flatten child
-            react_native_assert(reparentMode == ReparentMode::Unflatten);
-            auto fixedParentTagForUpdate = newTreeNodePair.shadowView.tag;
-            // Flatten old tree into new list
-            // At the end of this loop we still want to know which of these
-            // children are visited, so we reuse the `newRemainingPairs` map.
-            calculateShadowViewMutationsFlattener(
-                scope,
-                ReparentMode::Flatten,
-                mutationContainer,
-                newTreeNodePair.shadowView.tag,
-                unvisitedRecursiveChildPairs,
-                oldTreeNodePair,
-                fixedParentTagForUpdate,
-                subVisitedNewMap,
-                subVisitedOldMap,
-                adjustedNewCullingContext,
-                adjustedNewCullingContext);
-          } else {
-            // Flatten parent, unflatten child
-            react_native_assert(reparentMode == ReparentMode::Flatten);
-            // Unflatten old list into new tree
-            auto fixedParentTagForUpdate = parentTagForUpdate;
-            calculateShadowViewMutationsFlattener(
-                scope,
-                /* reparentMode */ ReparentMode::Unflatten,
-                mutationContainer,
-                parentTag,
-                /* unvisitedOtherNodes */ unvisitedRecursiveChildPairs,
-                /* node */ newTreeNodePair,
-                /* parentTagForUpdate */ fixedParentTagForUpdate,
-                /* parentSubVisitedOtherNewNodes */ subVisitedNewMap,
-                /* parentSubVisitedOtherOldNodes */ subVisitedOldMap,
-                /* cullingContextForUnvisitedOtherNodes */
-                adjustedOldCullingContext,
-                /* cullingContext */ adjustedOldCullingContext);
-
-            // If old nodes were not visited, we know that we can delete them
-            // now. They will be removed from the hierarchy by the outermost
-            // loop of this function.
-            for (auto& unvisitedRecursiveChildPair :
-                 unvisitedRecursiveChildPairs) {
-              auto& oldFlattenedNode = *unvisitedRecursiveChildPair.second;
-
-              // Node unvisited - mark the entire subtree for deletion
-              if (oldFlattenedNode.isConcreteView &&
-                  !oldFlattenedNode.inOtherTree()) {
-                Tag tag = oldFlattenedNode.shadowView.tag;
-                auto deleteCreateIt = deletionCreationCandidatePairs.find(
-                    oldFlattenedNode.shadowView.tag);
-                if (deleteCreateIt == deletionCreationCandidatePairs.end()) {
-                  deletionCreationCandidatePairs.insert(
-                      {tag, &oldFlattenedNode});
-                }
-              } else {
-                // Node was visited - make sure to remove it from
-                // "newRemainingPairs" map
-                auto newRemainingIt =
-                    unvisitedOtherNodes.find(oldFlattenedNode.shadowView.tag);
-                if (newRemainingIt != unvisitedOtherNodes.end()) {
-                  unvisitedOtherNodes.erase(newRemainingIt);
-                }
-              }
-            }
-          }
-        }
-      }
-
-      // Mark that node exists in another tree, but only if the tree node is a
-      // concrete view. Removing the node from the unvisited list prevents the
-      // caller from taking further action on this node, so make sure to
-      // delete/create if the Concreteness of the node has changed.
-      if (newTreeNodePair.isConcreteView != oldTreeNodePair.isConcreteView) {
-        if (newTreeNodePair.isConcreteView) {
-          mutationContainer.createMutations.push_back(
-              ShadowViewMutation::CreateMutation(newTreeNodePair.shadowView));
-        } else {
-          mutationContainer.deleteMutations.push_back(
-              ShadowViewMutation::DeleteMutation(oldTreeNodePair.shadowView));
-        }
-      }
-
-      subVisitedNewMap->insert(
-          {newTreeNodePair.shadowView.tag, &newTreeNodePair});
-      subVisitedOldMap->insert(
-          {oldTreeNodePair.shadowView.tag, &oldTreeNodePair});
-    } else {
-      // Node does not in exist in other tree.
-      if (treeChildPair.isConcreteView && !treeChildPair.inOtherTree()) {
-        auto deletionCreationIt =
-            deletionCreationCandidatePairs.find(treeChildPair.shadowView.tag);
-        if (deletionCreationIt == deletionCreationCandidatePairs.end()) {
-          deletionCreationCandidatePairs.insert(
-              {treeChildPair.shadowView.tag, &treeChildPair});
-        }
-      }
-    }
+    // Find in other tree: reconcile the matched pair and its subtree, or mark
+    // the node as a deletion/creation candidate.
+    calculateShadowViewMutationsFlattenerMatchChild(
+        scope,
+        reparentMode,
+        mutationContainer,
+        parentTag,
+        unvisitedOtherNodes,
+        treeChildPair,
+        parentTagForUpdate,
+        subVisitedNewMap,
+        subVisitedOldMap,
+        cullingContextForUnvisitedOtherNodes,
+        cullingContext,
+        deletionCreationCandidatePairs,
+        match.existsInOtherTree,
+        match.otherTreeNodePairPtr,
+        match.alreadyUpdated,
+        match.foundInUnvisited,
+        match.foundInSubVisitedNew,
+        match.foundInSubVisitedOld);
   }
 
   // Final step: go through creation/deletion candidates and delete/create
   // subtrees if they were never visited during the execution of the above
   // loop and recursions.
-  for (auto& deletionCreationCandidatePair : deletionCreationCandidatePairs) {
-    auto& treeChildPair = *deletionCreationCandidatePair.second;
-
-    // If node was visited during a flattening/unflattening recursion,
-    // and the node in the other tree is concrete, that means it was
-    // already created/deleted and we don't need to do that here.
-    // It is always the responsibility of the matcher to update subtrees when
-    // nodes are matched.
-    if (treeChildPair.inOtherTree()) {
-      continue;
-    }
-
-    auto adjustedCullingContext =
-        cullingContext.adjustCullingContextIfNeeded(treeChildPair);
-
-    if (reparentMode == ReparentMode::Flatten) {
-      mutationContainer.deleteMutations.push_back(
-          ShadowViewMutation::DeleteMutation(treeChildPair.shadowView));
-
-      if (!treeChildPair.flattened) {
-        ViewNodePairScope innerScope{};
-        calculateShadowViewMutations(
-            innerScope,
-            mutationContainer.destructiveDownwardMutations,
-            treeChildPair.shadowView.tag,
-            sliceChildShadowNodeViewPairsFromViewNodePair(
-                treeChildPair, innerScope, false, adjustedCullingContext),
-            {},
-            adjustedCullingContext,
-            {});
-      }
-    } else {
-      mutationContainer.createMutations.push_back(
-          ShadowViewMutation::CreateMutation(treeChildPair.shadowView));
-
-      if (!treeChildPair.flattened) {
-        ViewNodePairScope innerScope{};
-        calculateShadowViewMutations(
-            innerScope,
-            mutationContainer.downwardMutations,
-            treeChildPair.shadowView.tag,
-            {},
-            sliceChildShadowNodeViewPairsFromViewNodePair(
-                treeChildPair, innerScope, false, adjustedCullingContext),
-            {},
-            adjustedCullingContext);
-      }
-    }
-  }
+  calculateShadowViewMutationsFlattenerProcessCandidates(
+      mutationContainer,
+      reparentMode,
+      deletionCreationCandidatePairs,
+      cullingContext);
 }
 
-static void calculateShadowViewMutations(
-    ViewNodePairScope& scope,
-    ShadowViewMutation::List& mutations,
+/**
+ * Stage 1 of `calculateShadowViewMutations`: collect `Update` mutations for the
+ * common prefix where old/new children share tags and (un)flattening hasn't
+ * changed, recursing into their subtrees. Returns the index at which stage 1
+ * stopped. Extracted to reduce complexity; behavior is unchanged.
+ */
+static size_t calculateShadowViewMutationsStage1(
+    OrderedMutationInstructionContainer& mutationContainer,
     Tag parentTag,
-    std::vector<ShadowViewNodePair*>&& oldChildPairs,
-    std::vector<ShadowViewNodePair*>&& newChildPairs,
+    const std::vector<ShadowViewNodePair*>& oldChildPairs,
+    const std::vector<ShadowViewNodePair*>& newChildPairs,
     const CullingContext& oldCullingContext,
     const CullingContext& newCullingContext) {
-  if (oldChildPairs.empty() && newChildPairs.empty()) {
-    return;
-  }
-
   size_t index = 0;
-
-  // Lists of mutations
-  auto mutationContainer = OrderedMutationInstructionContainer{};
-
-  if (ReactNativeFeatureFlags::
-          enableDifferentiatorMutationVectorPreallocation()) {
-    // Pre-allocate mutation sub-vectors based on expected child count to avoid
-    // repeated reallocations during diffing.
-    size_t estimatedSize = std::max(oldChildPairs.size(), newChildPairs.size());
-    mutationContainer.createMutations.reserve(estimatedSize);
-    mutationContainer.deleteMutations.reserve(estimatedSize);
-    mutationContainer.insertMutations.reserve(estimatedSize);
-    mutationContainer.removeMutations.reserve(estimatedSize);
-    mutationContainer.updateMutations.reserve(estimatedSize);
-    mutationContainer.downwardMutations.reserve(estimatedSize);
-    mutationContainer.destructiveDownwardMutations.reserve(estimatedSize);
-  }
-
-  DEBUG_LOGS({
-    LOG(ERROR) << "Differ Entry: Child Pairs of node: [" << parentTag << "]";
-    LOG(ERROR) << "> Old Child Pairs: " << oldChildPairs;
-    LOG(ERROR) << "> New Child Pairs: " << newChildPairs;
-  });
-
   // Stage 1: Collecting `Update` mutations
   for (index = 0; index < oldChildPairs.size() && index < newChildPairs.size();
        index++) {
@@ -979,364 +1208,479 @@ static void calculateShadowViewMutations(
           adjustedNewCullingContext);
     }
   }
+  return index;
+}
+
+/**
+ * Branch 2 of `calculateShadowViewMutations`: we've reached the end of the new
+ * children, so delete+remove the remaining old children and their subtrees.
+ * Extracted to reduce complexity; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsRemoveRemaining(
+    OrderedMutationInstructionContainer& mutationContainer,
+    Tag parentTag,
+    const std::vector<ShadowViewNodePair*>& oldChildPairs,
+    size_t startIndex,
+    const CullingContext& oldCullingContext,
+    const CullingContext& newCullingContext) {
+  for (size_t index = startIndex; index < oldChildPairs.size(); index++) {
+    const auto& oldChildPair = *oldChildPairs[index];
+
+    DEBUG_LOGS({
+      LOG(ERROR) << "Differ Branch 2: Deleting Tag/Tree: " << oldChildPair
+                 << " with parent: [" << parentTag << "]";
+    });
+
+    if (!oldChildPair.isConcreteView) {
+      continue;
+    }
+
+    mutationContainer.deleteMutations.push_back(
+        ShadowViewMutation::DeleteMutation(oldChildPair.shadowView));
+    mutationContainer.removeMutations.push_back(
+        ShadowViewMutation::RemoveMutation(
+            parentTag,
+            oldChildPair.shadowView,
+            static_cast<int>(oldChildPair.mountIndex)));
+    auto oldCullingContextCopy =
+        oldCullingContext.adjustCullingContextIfNeeded(oldChildPair);
+
+    // We also have to call the algorithm recursively to clean up the entire
+    // subtree starting from the removed view.
+    ViewNodePairScope innerScope{};
+    calculateShadowViewMutations(
+        innerScope,
+        mutationContainer.destructiveDownwardMutations,
+        oldChildPair.shadowView.tag,
+        sliceChildShadowNodeViewPairsFromViewNodePair(
+            oldChildPair, innerScope, false, oldCullingContextCopy),
+        {},
+        oldCullingContextCopy,
+        newCullingContext);
+  }
+}
+
+/**
+ * Branch 3 of `calculateShadowViewMutations`: we have no more existing
+ * children, so create+insert the remaining new children and their subtrees.
+ * Extracted to reduce complexity; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsCreateRemaining(
+    OrderedMutationInstructionContainer& mutationContainer,
+    Tag parentTag,
+    const std::vector<ShadowViewNodePair*>& newChildPairs,
+    size_t startIndex,
+    const CullingContext& oldCullingContext,
+    const CullingContext& newCullingContext) {
+  for (size_t index = startIndex; index < newChildPairs.size(); index++) {
+    const auto& newChildPair = *newChildPairs[index];
+
+    DEBUG_LOGS({
+      LOG(ERROR) << "Differ Branch 3: Creating Tag/Tree: " << newChildPair
+                 << " with parent: [" << parentTag << "]";
+    });
+
+    if (!newChildPair.isConcreteView) {
+      continue;
+    }
+
+    mutationContainer.insertMutations.push_back(
+        ShadowViewMutation::InsertMutation(
+            parentTag,
+            newChildPair.shadowView,
+            static_cast<int>(newChildPair.mountIndex)));
+    mutationContainer.createMutations.push_back(
+        ShadowViewMutation::CreateMutation(newChildPair.shadowView));
+    auto newCullingContextCopy =
+        newCullingContext.adjustCullingContextIfNeeded(newChildPair);
+
+    ViewNodePairScope innerScope{};
+    calculateShadowViewMutations(
+        innerScope,
+        mutationContainer.downwardMutations,
+        newChildPair.shadowView.tag,
+        {},
+        sliceChildShadowNodeViewPairsFromViewNodePair(
+            newChildPair, innerScope, false, newCullingContextCopy),
+        oldCullingContext,
+        newCullingContextCopy);
+  }
+}
+
+/**
+ * Greedy Stage 4 of `calculateShadowViewMutations`: walk both remaining lists
+ * simultaneously, performing updates, create+insert, remove+delete, and
+ * remove+insert (move), then emit the deferred deletes and creates. Extracted
+ * to reduce complexity; behavior is unchanged.
+ */
+static void calculateShadowViewMutationsGreedyStage4(
+    ViewNodePairScope& scope,
+    OrderedMutationInstructionContainer& mutationContainer,
+    Tag parentTag,
+    std::vector<ShadowViewNodePair*>& oldChildPairs,
+    std::vector<ShadowViewNodePair*>& newChildPairs,
+    size_t lastIndexAfterFirstStage,
+    const CullingContext& oldCullingContext,
+    const CullingContext& newCullingContext) {
+  // Greedy Stage 4 algorithm.
+  // Collect map of tags in the new list
+  auto remainingCount = newChildPairs.size() - lastIndexAfterFirstStage;
+  std::unordered_map<Tag, ShadowViewNodePair*> newRemainingPairs;
+  newRemainingPairs.reserve(remainingCount);
+  std::unordered_map<Tag, ShadowViewNodePair*> newInsertedPairs;
+  newInsertedPairs.reserve(remainingCount);
+  std::unordered_map<Tag, const ShadowViewNodePair*> deletionCandidatePairs{};
+  for (size_t index = lastIndexAfterFirstStage; index < newChildPairs.size();
+       index++) {
+    auto& newChildPair = *newChildPairs[index];
+    newRemainingPairs.insert({newChildPair.shadowView.tag, &newChildPair});
+  }
+
+  // Walk through both lists at the same time
+  // We will perform updates, create+insert, remove+delete, remove+insert
+  // (move) here.
+  size_t oldIndex = lastIndexAfterFirstStage;
+  size_t newIndex = lastIndexAfterFirstStage;
+  size_t newSize = newChildPairs.size();
+  size_t oldSize = oldChildPairs.size();
+  while (newIndex < newSize || oldIndex < oldSize) {
+    bool haveNewPair = newIndex < newSize;
+    bool haveOldPair = oldIndex < oldSize;
+
+    // Advance both pointers if pointing to the same element
+    if (haveNewPair && haveOldPair) {
+      const auto& oldChildPair = *oldChildPairs[oldIndex];
+      const auto& newChildPair = *newChildPairs[newIndex];
+
+      Tag newTag = newChildPair.shadowView.tag;
+      Tag oldTag = oldChildPair.shadowView.tag;
+
+      if (newTag == oldTag) {
+        DEBUG_LOGS({
+          LOG(ERROR) << "Differ Branch 4: Matched Tags at indices: " << oldIndex
+                     << " and " << newIndex << ": " << oldChildPair << " and "
+                     << newChildPair << " with parent: [" << parentTag << "]";
+        });
+
+        updateMatchedPair(
+            mutationContainer,
+            true,
+            true,
+            parentTag,
+            oldChildPair,
+            newChildPair);
+
+        updateMatchedPairSubtrees(
+            scope,
+            mutationContainer,
+            newRemainingPairs,
+            oldChildPairs,
+            parentTag,
+            oldChildPair,
+            newChildPair,
+            oldCullingContext,
+            newCullingContext);
+
+        newIndex++;
+        oldIndex++;
+        continue;
+      }
+    }
+
+    // We have an old pair, but we either don't have any remaining new pairs
+    // or we have one but it's not matched up with the old pair
+    if (haveOldPair) {
+      const auto& oldChildPair = *oldChildPairs[oldIndex];
+
+      Tag oldTag = oldChildPair.shadowView.tag;
+
+      // Was oldTag already inserted? This indicates a reordering, not just
+      // a move. The new node has already been inserted, we just need to
+      // remove the node from its old position now, and update the node's
+      // subtree.
+      const auto insertedIt = newInsertedPairs.find(oldTag);
+      if (insertedIt != newInsertedPairs.end()) {
+        const auto& newChildPair = *insertedIt->second;
+
+        DEBUG_LOGS({
+          LOG(ERROR) << "Differ Branch 5: Founded reordered tags at indices: "
+                     << oldIndex << ": " << oldChildPair << " and "
+                     << newChildPair << " with parent: [" << parentTag << "]";
+        });
+
+        updateMatchedPair(
+            mutationContainer,
+            true,
+            false,
+            parentTag,
+            oldChildPair,
+            newChildPair);
+
+        updateMatchedPairSubtrees(
+            scope,
+            mutationContainer,
+            newRemainingPairs,
+            oldChildPairs,
+            parentTag,
+            oldChildPair,
+            newChildPair,
+            oldCullingContext,
+            newCullingContext);
+
+        newInsertedPairs.erase(insertedIt);
+        oldIndex++;
+        continue;
+      }
+
+      // Should we generate a delete+remove instruction for the old node?
+      // If there's an old node and it's not found in the "new" list, we
+      // generate remove+delete for this node and its subtree.
+      const auto newIt = newRemainingPairs.find(oldTag);
+      if (newIt == newRemainingPairs.end()) {
+        oldIndex++;
+
+        if (!oldChildPair.isConcreteView) {
+          continue;
+        }
+
+        // From here, we know the oldChildPair is concrete.
+        // We *probably* need to generate a REMOVE mutation (see edge-case
+        // notes below).
+
+        DEBUG_LOGS({
+          LOG(ERROR)
+              << "Differ Branch 6: Removing tag that was not re-inserted: "
+              << oldChildPair << " with parent: [" << parentTag
+              << "], which is " << (oldChildPair.inOtherTree() ? "" : "not ")
+              << "in other tree";
+        });
+
+        // Edge case: node is not found in `newRemainingPairs`, due to
+        // complex (un)flattening cases, but exists in other tree *and* is
+        // concrete.
+        if (oldChildPair.inOtherTree() &&
+            oldChildPair.otherTreePair->isConcreteView) {
+          const ShadowView& otherTreeView =
+              oldChildPair.otherTreePair->shadowView;
+
+          // Remove, but remove using the *new* node, since we know
+          // an UPDATE mutation from old -> new has been generated.
+          // Practically this shouldn't matter for most mounting layer
+          // implementations, but helps adhere to the invariant that
+          // for all mutation instructions, "oldViewShadowNode" == "current
+          // node on mounting layer / stubView".
+          // Here we do *not" need to generate a potential DELETE mutation
+          // because we know the view is concrete, and still in the new
+          // hierarchy.
+          mutationContainer.removeMutations.push_back(
+              ShadowViewMutation::RemoveMutation(
+                  parentTag,
+                  otherTreeView,
+                  static_cast<int>(oldChildPair.mountIndex)));
+          continue;
+        }
+
+        mutationContainer.removeMutations.push_back(
+            ShadowViewMutation::RemoveMutation(
+                parentTag,
+                oldChildPair.shadowView,
+                static_cast<int>(oldChildPair.mountIndex)));
+
+        deletionCandidatePairs.insert(
+            {oldChildPair.shadowView.tag, &oldChildPair});
+
+        continue;
+      }
+    }
+
+    // At this point, oldTag is -1 or is in the new list, and hasn't been
+    // inserted or matched yet. We're not sure yet if the new node is in the
+    // old list - generate an insert instruction for the new node.
+    auto& newChildPair = *newChildPairs[newIndex];
+    DEBUG_LOGS({
+      LOG(ERROR)
+          << "Differ Branch 7: Inserting tag/tree that was not (yet?) removed from hierarchy: "
+          << newChildPair << " @ " << newIndex << "/" << newSize
+          << " with parent: [" << parentTag << "]";
+    });
+    if (newChildPair.isConcreteView) {
+      mutationContainer.insertMutations.push_back(
+          ShadowViewMutation::InsertMutation(
+              parentTag,
+              newChildPair.shadowView,
+              static_cast<int>(newChildPair.mountIndex)));
+    }
+
+    // `inOtherTree` is only set to true during flattening/unflattening of
+    // parent. If the parent isn't (un)flattened, this will always be
+    // `false`, even if the node is in the other (old) tree. In this case,
+    // we expect the node to be removed from `newInsertedPairs` when we
+    // later encounter it in this loop.
+    if (!newChildPair.inOtherTree()) {
+      newInsertedPairs.insert({newChildPair.shadowView.tag, &newChildPair});
+    }
+
+    newIndex++;
+  }
+
+  // Penultimate step: generate Delete instructions for entirely deleted
+  // subtrees/nodes. We do this here because we need to traverse the entire
+  // list to make sure that a node was not reparented into an unflattened
+  // node that occurs *after* it in the hierarchy, due to zIndex ordering.
+  for (auto& deletionCandidatePair : deletionCandidatePairs) {
+    const auto& oldChildPair = *deletionCandidatePair.second;
+
+    DEBUG_LOGS({
+      LOG(ERROR)
+          << "Differ Branch 8: Deleting tag/tree that was not in new hierarchy: "
+          << oldChildPair
+          << (oldChildPair.inOtherTree() ? "(in other tree)" : "")
+          << " with parent: [" << parentTag << "] ##"
+          << std::hash<ShadowView>{}(oldChildPair.shadowView);
+    });
+
+    // This can happen when the parent is unflattened
+    if (!oldChildPair.inOtherTree() && oldChildPair.isConcreteView) {
+      mutationContainer.deleteMutations.push_back(
+          ShadowViewMutation::DeleteMutation(oldChildPair.shadowView));
+      auto oldCullingContextCopy =
+          oldCullingContext.adjustCullingContextIfNeeded(oldChildPair);
+
+      // We also have to call the algorithm recursively to clean up the
+      // entire subtree starting from the removed view.
+      ViewNodePairScope innerScope{};
+
+      auto newGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
+          oldChildPair, innerScope, false, oldCullingContextCopy);
+      calculateShadowViewMutations(
+          innerScope,
+          mutationContainer.destructiveDownwardMutations,
+          oldChildPair.shadowView.tag,
+          std::move(newGrandChildPairs),
+          {},
+          oldCullingContextCopy,
+          newCullingContext);
+    }
+  }
+
+  // Final step: generate Create instructions for entirely new
+  // subtrees/nodes that are not the result of flattening or unflattening.
+  for (auto& newInsertedPair : newInsertedPairs) {
+    const auto& newChildPair = *newInsertedPair.second;
+
+    DEBUG_LOGS({
+      LOG(ERROR)
+          << "Differ Branch 9: Inserting tag/tree that was not in old hierarchy: "
+          << newChildPair
+          << (newChildPair.inOtherTree() ? "(in other tree)" : "")
+          << " with parent: [" << parentTag << "]";
+    });
+
+    if (!newChildPair.isConcreteView) {
+      continue;
+    }
+    if (newChildPair.inOtherTree()) {
+      continue;
+    }
+
+    mutationContainer.createMutations.push_back(
+        ShadowViewMutation::CreateMutation(newChildPair.shadowView));
+
+    auto newCullingContextCopy =
+        newCullingContext.adjustCullingContextIfNeeded(newChildPair);
+
+    ViewNodePairScope innerScope{};
+
+    calculateShadowViewMutations(
+        innerScope,
+        mutationContainer.downwardMutations,
+        newChildPair.shadowView.tag,
+        {},
+        sliceChildShadowNodeViewPairsFromViewNodePair(
+            newChildPair, innerScope, false, newCullingContextCopy),
+        oldCullingContext,
+        newCullingContextCopy);
+  }
+}
+
+static void calculateShadowViewMutations(
+    ViewNodePairScope& scope,
+    ShadowViewMutation::List& mutations,
+    Tag parentTag,
+    std::vector<ShadowViewNodePair*>&& oldChildPairs,
+    std::vector<ShadowViewNodePair*>&& newChildPairs,
+    const CullingContext& oldCullingContext,
+    const CullingContext& newCullingContext) {
+  if (oldChildPairs.empty() && newChildPairs.empty()) {
+    return;
+  }
+
+  size_t index = 0;
+
+  // Lists of mutations
+  auto mutationContainer = OrderedMutationInstructionContainer{};
+
+  if (ReactNativeFeatureFlags::
+          enableDifferentiatorMutationVectorPreallocation()) {
+    // Pre-allocate mutation sub-vectors based on expected child count to avoid
+    // repeated reallocations during diffing.
+    size_t estimatedSize = std::max(oldChildPairs.size(), newChildPairs.size());
+    mutationContainer.createMutations.reserve(estimatedSize);
+    mutationContainer.deleteMutations.reserve(estimatedSize);
+    mutationContainer.insertMutations.reserve(estimatedSize);
+    mutationContainer.removeMutations.reserve(estimatedSize);
+    mutationContainer.updateMutations.reserve(estimatedSize);
+    mutationContainer.downwardMutations.reserve(estimatedSize);
+    mutationContainer.destructiveDownwardMutations.reserve(estimatedSize);
+  }
+
+  DEBUG_LOGS({
+    LOG(ERROR) << "Differ Entry: Child Pairs of node: [" << parentTag << "]";
+    LOG(ERROR) << "> Old Child Pairs: " << oldChildPairs;
+    LOG(ERROR) << "> New Child Pairs: " << newChildPairs;
+  });
+
+  // Stage 1: Collecting `Update` mutations
+  index = calculateShadowViewMutationsStage1(
+      mutationContainer,
+      parentTag,
+      oldChildPairs,
+      newChildPairs,
+      oldCullingContext,
+      newCullingContext);
 
   size_t lastIndexAfterFirstStage = index;
 
   if (index == newChildPairs.size()) {
     // We've reached the end of the new children. We can delete+remove the
     // rest.
-    for (; index < oldChildPairs.size(); index++) {
-      const auto& oldChildPair = *oldChildPairs[index];
-
-      DEBUG_LOGS({
-        LOG(ERROR) << "Differ Branch 2: Deleting Tag/Tree: " << oldChildPair
-                   << " with parent: [" << parentTag << "]";
-      });
-
-      if (!oldChildPair.isConcreteView) {
-        continue;
-      }
-
-      mutationContainer.deleteMutations.push_back(
-          ShadowViewMutation::DeleteMutation(oldChildPair.shadowView));
-      mutationContainer.removeMutations.push_back(
-          ShadowViewMutation::RemoveMutation(
-              parentTag,
-              oldChildPair.shadowView,
-              static_cast<int>(oldChildPair.mountIndex)));
-      auto oldCullingContextCopy =
-          oldCullingContext.adjustCullingContextIfNeeded(oldChildPair);
-
-      // We also have to call the algorithm recursively to clean up the entire
-      // subtree starting from the removed view.
-      ViewNodePairScope innerScope{};
-      calculateShadowViewMutations(
-          innerScope,
-          mutationContainer.destructiveDownwardMutations,
-          oldChildPair.shadowView.tag,
-          sliceChildShadowNodeViewPairsFromViewNodePair(
-              oldChildPair, innerScope, false, oldCullingContextCopy),
-          {},
-          oldCullingContextCopy,
-          newCullingContext);
-    }
+    calculateShadowViewMutationsRemoveRemaining(
+        mutationContainer,
+        parentTag,
+        oldChildPairs,
+        index,
+        oldCullingContext,
+        newCullingContext);
   } else if (index == oldChildPairs.size()) {
     // If we don't have any more existing children we can choose a fast path
     // since the rest will all be create+insert.
-    for (; index < newChildPairs.size(); index++) {
-      const auto& newChildPair = *newChildPairs[index];
-
-      DEBUG_LOGS({
-        LOG(ERROR) << "Differ Branch 3: Creating Tag/Tree: " << newChildPair
-                   << " with parent: [" << parentTag << "]";
-      });
-
-      if (!newChildPair.isConcreteView) {
-        continue;
-      }
-
-      mutationContainer.insertMutations.push_back(
-          ShadowViewMutation::InsertMutation(
-              parentTag,
-              newChildPair.shadowView,
-              static_cast<int>(newChildPair.mountIndex)));
-      mutationContainer.createMutations.push_back(
-          ShadowViewMutation::CreateMutation(newChildPair.shadowView));
-      auto newCullingContextCopy =
-          newCullingContext.adjustCullingContextIfNeeded(newChildPair);
-
-      ViewNodePairScope innerScope{};
-      calculateShadowViewMutations(
-          innerScope,
-          mutationContainer.downwardMutations,
-          newChildPair.shadowView.tag,
-          {},
-          sliceChildShadowNodeViewPairsFromViewNodePair(
-              newChildPair, innerScope, false, newCullingContextCopy),
-          oldCullingContext,
-          newCullingContextCopy);
-    }
+    calculateShadowViewMutationsCreateRemaining(
+        mutationContainer,
+        parentTag,
+        newChildPairs,
+        index,
+        oldCullingContext,
+        newCullingContext);
   } else {
-    // Greedy Stage 4 algorithm.
-    // Collect map of tags in the new list
-    auto remainingCount = newChildPairs.size() - lastIndexAfterFirstStage;
-    std::unordered_map<Tag, ShadowViewNodePair*> newRemainingPairs;
-    newRemainingPairs.reserve(remainingCount);
-    std::unordered_map<Tag, ShadowViewNodePair*> newInsertedPairs;
-    newInsertedPairs.reserve(remainingCount);
-    std::unordered_map<Tag, const ShadowViewNodePair*> deletionCandidatePairs{};
-    for (index = lastIndexAfterFirstStage; index < newChildPairs.size();
-         index++) {
-      auto& newChildPair = *newChildPairs[index];
-      newRemainingPairs.insert({newChildPair.shadowView.tag, &newChildPair});
-    }
-
-    // Walk through both lists at the same time
-    // We will perform updates, create+insert, remove+delete, remove+insert
-    // (move) here.
-    size_t oldIndex = lastIndexAfterFirstStage;
-    size_t newIndex = lastIndexAfterFirstStage;
-    size_t newSize = newChildPairs.size();
-    size_t oldSize = oldChildPairs.size();
-    while (newIndex < newSize || oldIndex < oldSize) {
-      bool haveNewPair = newIndex < newSize;
-      bool haveOldPair = oldIndex < oldSize;
-
-      // Advance both pointers if pointing to the same element
-      if (haveNewPair && haveOldPair) {
-        const auto& oldChildPair = *oldChildPairs[oldIndex];
-        const auto& newChildPair = *newChildPairs[newIndex];
-
-        Tag newTag = newChildPair.shadowView.tag;
-        Tag oldTag = oldChildPair.shadowView.tag;
-
-        if (newTag == oldTag) {
-          DEBUG_LOGS({
-            LOG(ERROR) << "Differ Branch 4: Matched Tags at indices: "
-                       << oldIndex << " and " << newIndex << ": "
-                       << oldChildPair << " and " << newChildPair
-                       << " with parent: [" << parentTag << "]";
-          });
-
-          updateMatchedPair(
-              mutationContainer,
-              true,
-              true,
-              parentTag,
-              oldChildPair,
-              newChildPair);
-
-          updateMatchedPairSubtrees(
-              scope,
-              mutationContainer,
-              newRemainingPairs,
-              oldChildPairs,
-              parentTag,
-              oldChildPair,
-              newChildPair,
-              oldCullingContext,
-              newCullingContext);
-
-          newIndex++;
-          oldIndex++;
-          continue;
-        }
-      }
-
-      // We have an old pair, but we either don't have any remaining new pairs
-      // or we have one but it's not matched up with the old pair
-      if (haveOldPair) {
-        const auto& oldChildPair = *oldChildPairs[oldIndex];
-
-        Tag oldTag = oldChildPair.shadowView.tag;
-
-        // Was oldTag already inserted? This indicates a reordering, not just
-        // a move. The new node has already been inserted, we just need to
-        // remove the node from its old position now, and update the node's
-        // subtree.
-        const auto insertedIt = newInsertedPairs.find(oldTag);
-        if (insertedIt != newInsertedPairs.end()) {
-          const auto& newChildPair = *insertedIt->second;
-
-          DEBUG_LOGS({
-            LOG(ERROR) << "Differ Branch 5: Founded reordered tags at indices: "
-                       << oldIndex << ": " << oldChildPair << " and "
-                       << newChildPair << " with parent: [" << parentTag << "]";
-          });
-
-          updateMatchedPair(
-              mutationContainer,
-              true,
-              false,
-              parentTag,
-              oldChildPair,
-              newChildPair);
-
-          updateMatchedPairSubtrees(
-              scope,
-              mutationContainer,
-              newRemainingPairs,
-              oldChildPairs,
-              parentTag,
-              oldChildPair,
-              newChildPair,
-              oldCullingContext,
-              newCullingContext);
-
-          newInsertedPairs.erase(insertedIt);
-          oldIndex++;
-          continue;
-        }
-
-        // Should we generate a delete+remove instruction for the old node?
-        // If there's an old node and it's not found in the "new" list, we
-        // generate remove+delete for this node and its subtree.
-        const auto newIt = newRemainingPairs.find(oldTag);
-        if (newIt == newRemainingPairs.end()) {
-          oldIndex++;
-
-          if (!oldChildPair.isConcreteView) {
-            continue;
-          }
-
-          // From here, we know the oldChildPair is concrete.
-          // We *probably* need to generate a REMOVE mutation (see edge-case
-          // notes below).
-
-          DEBUG_LOGS({
-            LOG(ERROR)
-                << "Differ Branch 6: Removing tag that was not re-inserted: "
-                << oldChildPair << " with parent: [" << parentTag
-                << "], which is " << (oldChildPair.inOtherTree() ? "" : "not ")
-                << "in other tree";
-          });
-
-          // Edge case: node is not found in `newRemainingPairs`, due to
-          // complex (un)flattening cases, but exists in other tree *and* is
-          // concrete.
-          if (oldChildPair.inOtherTree() &&
-              oldChildPair.otherTreePair->isConcreteView) {
-            const ShadowView& otherTreeView =
-                oldChildPair.otherTreePair->shadowView;
-
-            // Remove, but remove using the *new* node, since we know
-            // an UPDATE mutation from old -> new has been generated.
-            // Practically this shouldn't matter for most mounting layer
-            // implementations, but helps adhere to the invariant that
-            // for all mutation instructions, "oldViewShadowNode" == "current
-            // node on mounting layer / stubView".
-            // Here we do *not" need to generate a potential DELETE mutation
-            // because we know the view is concrete, and still in the new
-            // hierarchy.
-            mutationContainer.removeMutations.push_back(
-                ShadowViewMutation::RemoveMutation(
-                    parentTag,
-                    otherTreeView,
-                    static_cast<int>(oldChildPair.mountIndex)));
-            continue;
-          }
-
-          mutationContainer.removeMutations.push_back(
-              ShadowViewMutation::RemoveMutation(
-                  parentTag,
-                  oldChildPair.shadowView,
-                  static_cast<int>(oldChildPair.mountIndex)));
-
-          deletionCandidatePairs.insert(
-              {oldChildPair.shadowView.tag, &oldChildPair});
-
-          continue;
-        }
-      }
-
-      // At this point, oldTag is -1 or is in the new list, and hasn't been
-      // inserted or matched yet. We're not sure yet if the new node is in the
-      // old list - generate an insert instruction for the new node.
-      auto& newChildPair = *newChildPairs[newIndex];
-      DEBUG_LOGS({
-        LOG(ERROR)
-            << "Differ Branch 7: Inserting tag/tree that was not (yet?) removed from hierarchy: "
-            << newChildPair << " @ " << newIndex << "/" << newSize
-            << " with parent: [" << parentTag << "]";
-      });
-      if (newChildPair.isConcreteView) {
-        mutationContainer.insertMutations.push_back(
-            ShadowViewMutation::InsertMutation(
-                parentTag,
-                newChildPair.shadowView,
-                static_cast<int>(newChildPair.mountIndex)));
-      }
-
-      // `inOtherTree` is only set to true during flattening/unflattening of
-      // parent. If the parent isn't (un)flattened, this will always be
-      // `false`, even if the node is in the other (old) tree. In this case,
-      // we expect the node to be removed from `newInsertedPairs` when we
-      // later encounter it in this loop.
-      if (!newChildPair.inOtherTree()) {
-        newInsertedPairs.insert({newChildPair.shadowView.tag, &newChildPair});
-      }
-
-      newIndex++;
-    }
-
-    // Penultimate step: generate Delete instructions for entirely deleted
-    // subtrees/nodes. We do this here because we need to traverse the entire
-    // list to make sure that a node was not reparented into an unflattened
-    // node that occurs *after* it in the hierarchy, due to zIndex ordering.
-    for (auto& deletionCandidatePair : deletionCandidatePairs) {
-      const auto& oldChildPair = *deletionCandidatePair.second;
-
-      DEBUG_LOGS({
-        LOG(ERROR)
-            << "Differ Branch 8: Deleting tag/tree that was not in new hierarchy: "
-            << oldChildPair
-            << (oldChildPair.inOtherTree() ? "(in other tree)" : "")
-            << " with parent: [" << parentTag << "] ##"
-            << std::hash<ShadowView>{}(oldChildPair.shadowView);
-      });
-
-      // This can happen when the parent is unflattened
-      if (!oldChildPair.inOtherTree() && oldChildPair.isConcreteView) {
-        mutationContainer.deleteMutations.push_back(
-            ShadowViewMutation::DeleteMutation(oldChildPair.shadowView));
-        auto oldCullingContextCopy =
-            oldCullingContext.adjustCullingContextIfNeeded(oldChildPair);
-
-        // We also have to call the algorithm recursively to clean up the
-        // entire subtree starting from the removed view.
-        ViewNodePairScope innerScope{};
-
-        auto newGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
-            oldChildPair, innerScope, false, oldCullingContextCopy);
-        calculateShadowViewMutations(
-            innerScope,
-            mutationContainer.destructiveDownwardMutations,
-            oldChildPair.shadowView.tag,
-            std::move(newGrandChildPairs),
-            {},
-            oldCullingContextCopy,
-            newCullingContext);
-      }
-    }
-
-    // Final step: generate Create instructions for entirely new
-    // subtrees/nodes that are not the result of flattening or unflattening.
-    for (auto& newInsertedPair : newInsertedPairs) {
-      const auto& newChildPair = *newInsertedPair.second;
-
-      DEBUG_LOGS({
-        LOG(ERROR)
-            << "Differ Branch 9: Inserting tag/tree that was not in old hierarchy: "
-            << newChildPair
-            << (newChildPair.inOtherTree() ? "(in other tree)" : "")
-            << " with parent: [" << parentTag << "]";
-      });
-
-      if (!newChildPair.isConcreteView) {
-        continue;
-      }
-      if (newChildPair.inOtherTree()) {
-        continue;
-      }
-
-      mutationContainer.createMutations.push_back(
-          ShadowViewMutation::CreateMutation(newChildPair.shadowView));
-
-      auto newCullingContextCopy =
-          newCullingContext.adjustCullingContextIfNeeded(newChildPair);
-
-      ViewNodePairScope innerScope{};
-
-      calculateShadowViewMutations(
-          innerScope,
-          mutationContainer.downwardMutations,
-          newChildPair.shadowView.tag,
-          {},
-          sliceChildShadowNodeViewPairsFromViewNodePair(
-              newChildPair, innerScope, false, newCullingContextCopy),
-          oldCullingContext,
-          newCullingContextCopy);
-    }
+    calculateShadowViewMutationsGreedyStage4(
+        scope,
+        mutationContainer,
+        parentTag,
+        oldChildPairs,
+        newChildPairs,
+        lastIndexAfterFirstStage,
+        oldCullingContext,
+        newCullingContext);
   }
 
   if (ReactNativeFeatureFlags::

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -17,6 +17,7 @@
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 #include <react/renderer/uimanager/primitives.h>
 
+#include <optional>
 #include <utility>
 
 namespace facebook::react {
@@ -181,40 +182,18 @@ static void validateArgumentCount(
   }
 }
 
-jsi::Value UIManagerBinding::get(
+// The following `get*Methods` free functions each handle a contiguous group of
+// the JSI host-function methods exposed by `UIManagerBinding::get`. They return
+// `std::nullopt` when `methodName` is not one they handle, allowing `get` to be
+// a flat dispatch sequence. Splitting the original monolithic function this way
+// keeps behavior identical (same method names, arity, captures and bodies)
+// while lowering its cyclomatic complexity.
+
+static std::optional<jsi::Value> getNodeManagementMethods(
+    UIManager* uiManager,
     jsi::Runtime& runtime,
-    const jsi::PropNameID& name) {
-  auto methodName = name.utf8(runtime);
-
-  // Convert shared_ptr<UIManager> to a raw ptr
-  // Why? Because:
-  // 1) UIManagerBinding strongly retains UIManager. The JS VM
-  //    strongly retains UIManagerBinding (through the JSI).
-  //    These functions are JSI functions and are only called via
-  //    the JS VM; if the JS VM is torn down, those functions can't
-  //    execute and these lambdas won't execute.
-  // 2) The UIManager is only deallocated when all references to it
-  //    are deallocated, including the UIManagerBinding. That only
-  //    happens when the JS VM is deallocated. So, the raw pointer
-  //    is safe.
-  //
-  // Even if it's safe, why not just use shared_ptr anyway as
-  //  extra insurance?
-  // 1) Using shared_ptr or weak_ptr when they're not needed is
-  //    a pessimisation. It's more instructions executed without
-  //    any additional value in this case.
-  // 2) How and when exactly these lambdas is deallocated is
-  //    complex. Adding shared_ptr to them which causes the UIManager
-  //    to potentially live longer is unnecessary, complicated cognitive
-  //    overhead.
-  // 3) There is a strong suspicion that retaining UIManager from
-  //    these C++ lambdas, which are retained by an object that is held onto
-  //    by the JSI, caused some crashes upon deallocation of the
-  //    Scheduler and JS VM. This could happen if, for instance, C++
-  //    semantics cause these lambda to not be deallocated until
-  //    a CPU tick (or more) after the JS VM is deallocated.
-  UIManager* uiManager = uiManager_.get();
-
+    const jsi::PropNameID& name,
+    const std::string& methodName) {
   // Semantic: Creates a new node with given pieces.
   if (methodName == "createNode") {
     auto paramCount = 5;
@@ -271,46 +250,6 @@ jsi::Value UIManagerBinding::get(
               arguments[1].getBool(),
               arguments[2].getBool());
 
-          return jsi::Value::undefined();
-        });
-  }
-
-  if (methodName == "findNodeAtPoint") {
-    auto paramCount = 4;
-    return jsi::Function::createFromHostFunction(
-        runtime,
-        name,
-        paramCount,
-        [uiManager, methodName, paramCount](
-            jsi::Runtime& runtime,
-            const jsi::Value& /*thisValue*/,
-            const jsi::Value* arguments,
-            size_t count) {
-          validateArgumentCount(runtime, methodName, paramCount, count);
-
-          auto node = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
-              runtime, arguments[0]);
-          auto locationX = (Float)arguments[1].getNumber();
-          auto locationY = (Float)arguments[2].getNumber();
-          auto onSuccessFunction =
-              arguments[3].getObject(runtime).getFunction(runtime);
-          auto targetNode = uiManager->findNodeAtPoint(
-              node, Point{.x = locationX, .y = locationY});
-
-          if (!targetNode) {
-            onSuccessFunction.call(runtime, jsi::Value::null());
-            return jsi::Value::undefined();
-          }
-
-          auto& eventTarget = targetNode->getEventEmitter()->eventTarget_;
-
-          EventEmitter::DispatchMutex().lock();
-          eventTarget->retain(runtime);
-          auto instanceHandle = eventTarget->getInstanceHandle(runtime);
-          eventTarget->release(runtime);
-          EventEmitter::DispatchMutex().unlock();
-
-          onSuccessFunction.call(runtime, std::move(instanceHandle));
           return jsi::Value::undefined();
         });
   }
@@ -398,6 +337,14 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
+  return std::nullopt;
+}
+
+static std::optional<jsi::Value> getChildSetMethods(
+    UIManager* uiManager,
+    jsi::Runtime& runtime,
+    const jsi::PropNameID& name,
+    const std::string& methodName) {
   if (methodName == "appendChild") {
     auto paramCount = 2;
     return jsi::Function::createFromHostFunction(
@@ -488,27 +435,14 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
-  if (methodName == "registerEventHandler") {
-    auto paramCount = 1;
-    return jsi::Function::createFromHostFunction(
-        runtime,
-        name,
-        paramCount,
-        [this, methodName, paramCount](
-            jsi::Runtime& runtime,
-            const jsi::Value& /*thisValue*/,
-            const jsi::Value* arguments,
-            size_t count) -> jsi::Value {
-          validateArgumentCount(runtime, methodName, paramCount, count);
+  return std::nullopt;
+}
 
-          auto eventHandler =
-              arguments[0].getObject(runtime).getFunction(runtime);
-          eventHandler_ =
-              std::make_unique<jsi::Function>(std::move(eventHandler));
-          return jsi::Value::undefined();
-        });
-  }
-
+static std::optional<jsi::Value> getLayoutAndCommandMethods(
+    UIManager* uiManager,
+    jsi::Runtime& runtime,
+    const jsi::PropNameID& name,
+    const std::string& methodName) {
   if (methodName == "getRelativeLayoutMetrics") {
     auto paramCount = 2;
     return jsi::Function::createFromHostFunction(
@@ -639,6 +573,14 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
+  return std::nullopt;
+}
+
+static std::optional<jsi::Value> getMeasurementMethods(
+    UIManager* uiManager,
+    jsi::Runtime& runtime,
+    const jsi::PropNameID& name,
+    const std::string& methodName) {
   if (methodName == "measure") {
     auto paramCount = 2;
     return jsi::Function::createFromHostFunction(
@@ -739,43 +681,11 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
-  if (methodName == "configureNextLayoutAnimation") {
-    auto paramCount = 3;
-    return jsi::Function::createFromHostFunction(
-        runtime,
-        name,
-        paramCount,
-        [uiManager, methodName, paramCount](
-            jsi::Runtime& runtime,
-            const jsi::Value& /*thisValue*/,
-            const jsi::Value* arguments,
-            size_t count) -> jsi::Value {
-          validateArgumentCount(runtime, methodName, paramCount, count);
+  return std::nullopt;
+}
 
-          uiManager->configureNextLayoutAnimation(
-              runtime,
-              // TODO: pass in JSI value instead of folly::dynamic to RawValue
-              RawValue(commandArgsFromValue(runtime, arguments[0])),
-              arguments[1],
-              arguments[2]);
-          return jsi::Value::undefined();
-        });
-  }
-
-  if (methodName == "unstable_getCurrentEventPriority") {
-    return jsi::Function::createFromHostFunction(
-        runtime,
-        name,
-        0,
-        [this](
-            jsi::Runtime& /*runtime*/,
-            const jsi::Value& /*thisValue*/,
-            const jsi::Value* /*arguments*/,
-            size_t /*count*/) -> jsi::Value {
-          return {serialize(currentEventPriority_)};
-        });
-  }
-
+static std::optional<jsi::Value> getEventPriorityConstants(
+    const std::string& methodName) {
   if (methodName == "unstable_DefaultEventPriority") {
     return {serialize(ReactEventPriority::Default)};
   }
@@ -792,6 +702,14 @@ jsi::Value UIManagerBinding::get(
     return {serialize(ReactEventPriority::Idle)};
   }
 
+  return std::nullopt;
+}
+
+static std::optional<jsi::Value> getDomCompatMethods(
+    UIManager* uiManager,
+    jsi::Runtime& runtime,
+    const jsi::PropNameID& name,
+    const std::string& methodName) {
   if (methodName == "findShadowNodeByTag_DEPRECATED") {
     auto paramCount = 1;
     return jsi::Function::createFromHostFunction(
@@ -944,6 +862,14 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
+  return std::nullopt;
+}
+
+static std::optional<jsi::Value> getViewTransitionMethods(
+    UIManager* uiManager,
+    jsi::Runtime& runtime,
+    const jsi::PropNameID& name,
+    const std::string& methodName) {
   if (methodName == "applyViewTransitionName") {
     auto paramCount = 3;
     return jsi::Function::createFromHostFunction(
@@ -1046,6 +972,14 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
+  return std::nullopt;
+}
+
+static std::optional<jsi::Value> getViewTransitionLifecycleMethods(
+    UIManager* uiManager,
+    jsi::Runtime& runtime,
+    const jsi::PropNameID& name,
+    const std::string& methodName) {
   if (methodName == "restoreViewTransitionName") {
     auto paramCount = 1;
     return jsi::Function::createFromHostFunction(
@@ -1110,6 +1044,186 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
+  return std::nullopt;
+}
+
+jsi::Value UIManagerBinding::get(
+    jsi::Runtime& runtime,
+    const jsi::PropNameID& name) {
+  auto methodName = name.utf8(runtime);
+
+  // Convert shared_ptr<UIManager> to a raw ptr
+  // Why? Because:
+  // 1) UIManagerBinding strongly retains UIManager. The JS VM
+  //    strongly retains UIManagerBinding (through the JSI).
+  //    These functions are JSI functions and are only called via
+  //    the JS VM; if the JS VM is torn down, those functions can't
+  //    execute and these lambdas won't execute.
+  // 2) The UIManager is only deallocated when all references to it
+  //    are deallocated, including the UIManagerBinding. That only
+  //    happens when the JS VM is deallocated. So, the raw pointer
+  //    is safe.
+  //
+  // Even if it's safe, why not just use shared_ptr anyway as
+  //  extra insurance?
+  // 1) Using shared_ptr or weak_ptr when they're not needed is
+  //    a pessimisation. It's more instructions executed without
+  //    any additional value in this case.
+  // 2) How and when exactly these lambdas is deallocated is
+  //    complex. Adding shared_ptr to them which causes the UIManager
+  //    to potentially live longer is unnecessary, complicated cognitive
+  //    overhead.
+  // 3) There is a strong suspicion that retaining UIManager from
+  //    these C++ lambdas, which are retained by an object that is held onto
+  //    by the JSI, caused some crashes upon deallocation of the
+  //    Scheduler and JS VM. This could happen if, for instance, C++
+  //    semantics cause these lambda to not be deallocated until
+  //    a CPU tick (or more) after the JS VM is deallocated.
+  UIManager* uiManager = uiManager_.get();
+
+  if (auto result =
+          getNodeManagementMethods(uiManager, runtime, name, methodName)) {
+    return std::move(*result);
+  }
+
+  // Kept inline because the lambda accesses `EventEmitter::eventTarget_`, which
+  // is only reachable through `UIManagerBinding`'s `friend` access.
+  if (methodName == "findNodeAtPoint") {
+    auto paramCount = 4;
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        paramCount,
+        [uiManager, methodName, paramCount](
+            jsi::Runtime& runtime,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* arguments,
+            size_t count) {
+          validateArgumentCount(runtime, methodName, paramCount, count);
+
+          auto node = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[0]);
+          auto locationX = (Float)arguments[1].getNumber();
+          auto locationY = (Float)arguments[2].getNumber();
+          auto onSuccessFunction =
+              arguments[3].getObject(runtime).getFunction(runtime);
+          auto targetNode = uiManager->findNodeAtPoint(
+              node, Point{.x = locationX, .y = locationY});
+
+          if (!targetNode) {
+            onSuccessFunction.call(runtime, jsi::Value::null());
+            return jsi::Value::undefined();
+          }
+
+          auto& eventTarget = targetNode->getEventEmitter()->eventTarget_;
+
+          EventEmitter::DispatchMutex().lock();
+          eventTarget->retain(runtime);
+          auto instanceHandle = eventTarget->getInstanceHandle(runtime);
+          eventTarget->release(runtime);
+          EventEmitter::DispatchMutex().unlock();
+
+          onSuccessFunction.call(runtime, std::move(instanceHandle));
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (auto result = getChildSetMethods(uiManager, runtime, name, methodName)) {
+    return std::move(*result);
+  }
+
+  if (methodName == "registerEventHandler") {
+    auto paramCount = 1;
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        paramCount,
+        [this, methodName, paramCount](
+            jsi::Runtime& runtime,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* arguments,
+            size_t count) -> jsi::Value {
+          validateArgumentCount(runtime, methodName, paramCount, count);
+
+          auto eventHandler =
+              arguments[0].getObject(runtime).getFunction(runtime);
+          eventHandler_ =
+              std::make_unique<jsi::Function>(std::move(eventHandler));
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (auto result =
+          getLayoutAndCommandMethods(uiManager, runtime, name, methodName)) {
+    return std::move(*result);
+  }
+
+  if (auto result =
+          getMeasurementMethods(uiManager, runtime, name, methodName)) {
+    return std::move(*result);
+  }
+
+  // Kept inline because the lambda calls the private
+  // `UIManager::configureNextLayoutAnimation` and constructs a `RawValue`, both
+  // of which are only reachable through `UIManagerBinding`'s `friend` access.
+  if (methodName == "configureNextLayoutAnimation") {
+    auto paramCount = 3;
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        paramCount,
+        [uiManager, methodName, paramCount](
+            jsi::Runtime& runtime,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* arguments,
+            size_t count) -> jsi::Value {
+          validateArgumentCount(runtime, methodName, paramCount, count);
+
+          uiManager->configureNextLayoutAnimation(
+              runtime,
+              // TODO: pass in JSI value instead of folly::dynamic to RawValue
+              RawValue(commandArgsFromValue(runtime, arguments[0])),
+              arguments[1],
+              arguments[2]);
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (methodName == "unstable_getCurrentEventPriority") {
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        0,
+        [this](
+            jsi::Runtime& /*runtime*/,
+            const jsi::Value& /*thisValue*/,
+            const jsi::Value* /*arguments*/,
+            size_t /*count*/) -> jsi::Value {
+          return {serialize(currentEventPriority_)};
+        });
+  }
+
+  if (auto result = getEventPriorityConstants(methodName)) {
+    return std::move(*result);
+  }
+
+  if (auto result = getDomCompatMethods(uiManager, runtime, name, methodName)) {
+    return std::move(*result);
+  }
+
+  if (auto result =
+          getViewTransitionMethods(uiManager, runtime, name, methodName)) {
+    return std::move(*result);
+  }
+
+  if (auto result = getViewTransitionLifecycleMethods(
+          uiManager, runtime, name, methodName)) {
+    return std::move(*result);
+  }
+
+  // Kept inline because the lambda captures the private
+  // `UIManager::runtimeExecutor_`, which is only reachable through
+  // `UIManagerBinding`'s `friend` access.
   if (methodName == "startViewTransition") {
     auto paramCount = 1;
     return jsi::Function::createFromHostFunction(


### PR DESCRIPTION
Summary:

`CSSDataTypeParser<CSSRadialGradientFunction>::consumeFunctionBlock` (CCN 100) and `parseLinearGradientDirection` (CCN 24) parse CSS gradient syntax through deeply nested conditionals. This is a pure, behavior-preserving refactor: the recurring parsing steps (direction/position keyword resolution, shape-and-size, position-value lists) are extracted into focused helpers in `namespace facebook::react::detail`, matching the existing convention in this file, turning the two entry points into flat sequences. Parsing results are unchanged.

Changelog: [Internal]

Differential Revision: D108027809


