### PR TITLE
Add missing pointer event types to the TypeScript `PointerEvents` interface

### DIFF
--- a/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
@@ -265,4 +265,12 @@ export interface PointerEvents {
   onPointerDownCapture?: ((event: PointerEvent) => void) | undefined;
   onPointerUp?: ((event: PointerEvent) => void) | undefined;
   onPointerUpCapture?: ((event: PointerEvent) => void) | undefined;
+  onPointerOver?: ((event: PointerEvent) => void) | undefined;
+  onPointerOverCapture?: ((event: PointerEvent) => void) | undefined;
+  onPointerOut?: ((event: PointerEvent) => void) | undefined;
+  onPointerOutCapture?: ((event: PointerEvent) => void) | undefined;
+  onGotPointerCapture?: ((event: PointerEvent) => void) | undefined;
+  onGotPointerCaptureCapture?: ((event: PointerEvent) => void) | undefined;
+  onLostPointerCapture?: ((event: PointerEvent) => void) | undefined;
+  onLostPointerCaptureCapture?: ((event: PointerEvent) => void) | undefined;
 }

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -338,6 +338,18 @@ const lists = StyleSheet.create({
 
 const container = StyleSheet.compose(page.container, lists.listContainer);
 <View style={container} />;
+
+// Pointer events (W3C): all variants should be accepted on View.
+<View
+    onPointerOver={e => e.nativeEvent.pointerId}
+    onPointerOverCapture={e => e.nativeEvent.pointerId}
+    onPointerOut={e => e.nativeEvent.pointerId}
+    onPointerOutCapture={e => e.nativeEvent.pointerId}
+    onGotPointerCapture={e => e.nativeEvent.pointerId}
+    onGotPointerCaptureCapture={e => e.nativeEvent.pointerId}
+    onLostPointerCapture={e => e.nativeEvent.pointerId}
+    onLostPointerCaptureCapture={e => e.nativeEvent.pointerId}
+/>;
 const text = StyleSheet.compose(page.text, lists.listItem) as TextStyle;
 <Text style={text} />;
 


### PR DESCRIPTION
## Summary:

The hand-written TypeScript types declare only **12 of the 20** pointer event handlers that `ViewProps` actually exposes (per the Flow source and the generated `react-native-strict-api` types). The `PointerEvents` interface in `Libraries/Types/CoreEventTypes.d.ts` is missing:

- `onPointerOver` / `onPointerOverCapture`
- `onPointerOut` / `onPointerOutCapture`
- `onGotPointerCapture` / `onGotPointerCaptureCapture`
- `onLostPointerCapture` / `onLostPointerCaptureCapture`

These are part of the W3C Pointer Events API. They are declared in the Flow source — `Libraries/Components/View/ViewPropTypes.js` (all typed `(e: PointerEvent) => void`) — and in the generated `react-native-strict-api` types, but were missing from the hand-written TypeScript types, so TypeScript users get a type error using them on any built-in component:

```
Property 'onPointerOver' does not exist on type '... ViewProps'. Did you mean 'onPointerMove'?
```

This adds the 8 missing handlers to the `PointerEvents` interface (matching the existing 12) and a type test covering them.

## Changelog:

[GENERAL] [FIXED] - Add missing pointer event handler types (`onPointerOver`, `onPointerOut`, `onGotPointerCapture`, `onLostPointerCapture`, and their `*Capture` variants) to the TypeScript types

## Test Plan:

`yarn test-typescript` passes.

Verified before/after with `tsc -p packages/react-native/types/tsconfig.json`:
- **Before** (props absent): the added type test fails with `Property 'onPointerOver' does not exist on type '... ViewProps'`.
- **After**: passes — `<View onPointerOver={e => e.nativeEvent.pointerId} … />` type-checks for all 8 handlers, with the event correctly inferred as `PointerEvent`.
