### PR TITLE
Update repository references from facebook/react-native to react/react-native

### DIFF
--- a/.github/workflows/analyze-pr.yml
+++ b/.github/workflows/analyze-pr.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   analyze_pr:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - name: Check out main branch
         uses: actions/checkout@v6

--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   api_changes:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - name: Check out main branch
         uses: actions/checkout@v6

--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cache-cleaner:
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-for-reproducer.yml
+++ b/.github/workflows/check-for-reproducer.yml
@@ -8,7 +8,7 @@ jobs:
   check-for-reproducer:
     runs-on: ubuntu-latest
     if: |
-      github.repository == 'facebook/react-native' && github.event.issue.pull_request == null && github.event.issue.state == 'open' && !contains(github.event.issue.labels.*.name, ':open_umbrella: Umbrella')
+      github.repository == 'react/react-native' && github.event.issue.pull_request == null && github.event.issue.state == 'open' && !contains(github.event.issue.labels.*.name, ':open_umbrella: Umbrella')
     steps:
       - uses: actions/checkout@v6
       - uses: actions/github-script@v8

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   comment-and-label:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   create_release:
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/monitor-new-issues.yml
+++ b/.github/workflows/monitor-new-issues.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   monitor-issues:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -34,7 +34,7 @@ jobs:
           git_secret: ${{ secrets.GITHUB_TOKEN }}
           notifier: "discord"
           fetch_data_interval: 6
-          repo_owner: "facebook"
+          repo_owner: "react"
           repo_name: "react-native"
           discord_webhook_url: "${{ secrets.DISCORD_WEBHOOK_URL }}"
           discord_id_type: "user"

--- a/.github/workflows/needs-attention.yml
+++ b/.github/workflows/needs-attention.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write # for react-native-community/needs-attention to label issues
     name: Apply Needs Attention Label
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - uses: actions/checkout@v6
       - name: Apply Needs Attention Label

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   set_release_type:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     outputs:
       RELEASE_TYPE: ${{ steps.set_release_type.outputs.RELEASE_TYPE }}
     env:
@@ -25,7 +25,7 @@ jobs:
           echo "RELEASE_TYPE=nightly" >> $GITHUB_OUTPUT
 
   prebuild_apple_dependencies:
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     uses: ./.github/workflows/prebuild-ios-dependencies.yml
     secrets: inherit
 
@@ -39,7 +39,7 @@ jobs:
 
   build_android:
     runs-on: 8-core-ubuntu
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     needs: [set_release_type]
     container:
       image: reactnativecommunity/react-native-android:latest

--- a/.github/workflows/on-issue-labeled.yml
+++ b/.github/workflows/on-issue-labeled.yml
@@ -13,7 +13,7 @@ jobs:
   # then invokes actOnLabel to react to any added labels
   triage-issue:
     runs-on: ubuntu-latest
-    if: "${{ github.repository == 'facebook/react-native' && contains(github.event.label.name, 'Needs: Triage :mag:') }}"
+    if: "${{ github.repository == 'react/react-native' && contains(github.event.label.name, 'Needs: Triage :mag:') }}"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -49,7 +49,7 @@ jobs:
   # Reacts to the label that triggered this workflow (added manually or via other workflows)
   act-on-label:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/github-script@v8

--- a/.github/workflows/publish-bumped-packages.yml
+++ b/.github/workflows/publish-bumped-packages.yml
@@ -12,7 +12,7 @@ jobs:
   # Trusted Publishing only accepts one (org, repo, workflow_filename)
   # per package.
   publish_bumped_packages:
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     uses: ./.github/workflows/publish-npm.yml
     secrets: inherit
     with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   set_release_type:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     outputs:
       RELEASE_TYPE: ${{ steps.set_release_type.outputs.RELEASE_TYPE }}
     env:
@@ -21,7 +21,7 @@ jobs:
 
   set_hermes_version:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     outputs:
       HERMES_VERSION: ${{ steps.set_hermes_version.outputs.HERMES_VERSION }}
     steps:
@@ -34,7 +34,7 @@ jobs:
           echo "HERMES_VERSION=$hermes_version"
 
   prebuild_apple_dependencies:
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     uses: ./.github/workflows/prebuild-ios-dependencies.yml
     secrets: inherit
 

--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     rerun:
         runs-on: ubuntu-latest
-        if: github.repository == 'facebook/react-native'
+        if: github.repository == 'react/react-native'
         steps:
             - name: rerun ${{ inputs.run_id }}
               env:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     permissions:
       issues: write
       pull-requests: write
@@ -22,7 +22,7 @@ jobs:
           exempt-pr-labels: 'Help Wanted :octocat:, Never gets stale'
   stale-asc:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     permissions:
       issues: write
       pull-requests: write
@@ -40,7 +40,7 @@ jobs:
           exempt-pr-labels: 'Help Wanted :octocat:, Never gets stale'
   stale-needs-author-feedback:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     permissions:
       issues: write
       pull-requests: write
@@ -58,7 +58,7 @@ jobs:
           exempt-pr-labels: "Help Wanted :octocat:, Never gets stale"
   stale-needs-author-feedback-asc:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   set_release_type:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     outputs:
       RELEASE_TYPE: ${{ steps.set_release_type.outputs.RELEASE_TYPE }}
     env:
@@ -38,7 +38,7 @@ jobs:
 
   check_code_changes:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     outputs:
       any_code_change: ${{ steps.filter_exclusions.outputs.any_code_change == 'true' || github.event_name != 'pull_request' }}
       should_test_android: ${{ steps.filter_exclusions.outputs.should_test_android == 'true' || github.event_name != 'pull_request' }}
@@ -447,7 +447,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/validate-cxx-api-snapshots.yml
+++ b/.github/workflows/validate-cxx-api-snapshots.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   validate_cxx_api_snapshots:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/validate-dotslash-artifacts.yml
+++ b/.github/workflows/validate-dotslash-artifacts.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   validate-dotslash-artifacts:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'react/react-native'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Summary:
Update GitHub Actions workflow files to reflect React Native's migration from `facebook/react-native` to `react/react-native`.

Changes the fork-prevention guards (`github.repository == 'facebook/react-native'`) to use the new org across 17 workflow files (28 occurrences total), plus updates the `repo_owner` parameter in the issue monitoring workflow.

Changelog: [Internal]

Differential Revision: D108246445


