### PR TITLE
Localize keyboard return-key labels on numeric-keypad input accessory view (#57168)

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -13,6 +13,7 @@
 #import <react/renderer/textlayoutmanager/TextLayoutManager.h>
 
 #import <React/RCTBackedTextInputViewProtocol.h>
+#import <React/RCTLocalizedString.h>
 #import <React/RCTScrollViewComponentView.h>
 #import <React/RCTUITextField.h>
 #import <React/RCTUITextView.h>
@@ -603,25 +604,25 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 {
   switch (returnKeyType) {
     case UIReturnKeyGo:
-      return @"Go";
+      return RCTLocalizedString("Go", "keyboard return key button label for go action");
     case UIReturnKeyNext:
-      return @"Next";
+      return RCTLocalizedString("Next", "keyboard return key button label for next action");
     case UIReturnKeySearch:
-      return @"Search";
+      return RCTLocalizedString("Search", "keyboard return key button label for search action");
     case UIReturnKeySend:
-      return @"Send";
+      return RCTLocalizedString("Send", "keyboard return key button label for send action");
     case UIReturnKeyYahoo:
-      return @"Yahoo";
+      return RCTLocalizedString("Yahoo", "keyboard return key button label for Yahoo");
     case UIReturnKeyGoogle:
-      return @"Google";
+      return RCTLocalizedString("Google", "keyboard return key button label for Google");
     case UIReturnKeyRoute:
-      return @"Route";
+      return RCTLocalizedString("Route", "keyboard return key button label for route action");
     case UIReturnKeyJoin:
-      return @"Join";
+      return RCTLocalizedString("Join", "keyboard return key button label for join action");
     case UIReturnKeyEmergencyCall:
-      return @"Emergency Call";
+      return RCTLocalizedString("Emergency Call", "keyboard return key button label for emergency call action");
     default:
-      return @"Done";
+      return RCTLocalizedString("Done", "keyboard return key button label for done action");
   }
 }
 


### PR DESCRIPTION
Summary:

The "Next", "Done", and other return-key button labels on the iOS numeric-keypad input accessory view render in English regardless of device locale.

Root cause: `returnKeyTypeToString:` in `RCTTextInputComponentView.mm` returns hardcoded English string literals. These strings are passed directly to `UIBarButtonItem` as the button title, so they never go through the localization pipeline.

Fix: Wrap each literal in the `RCTLocalizedString` macro, which registers the strings for translation. This follows the established React Native pattern used elsewhere in the codebase.

Changelog:
[iOS][Changed] - Adds localization for Text Input default return key types

Reviewed By: javache

Differential Revision: D108270298


