### PR TITLE
fix(inspector-proxy): prevent crash on malformed debugger messages

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -43,8 +43,6 @@ const WS_CLOSURE_CODE = {
   INTERNAL_ERROR: 1011,
 };
 
-// should be aligned with
-// https://github.com/facebook/react-native-devtools-frontend/blob/3d17e0fd462dc698db34586697cce2371b25e0d3/front_end/ui/legacy/components/utils/TargetDetachedDialog.ts#L50-L64
 export const WS_CLOSE_REASON = {
   PAGE_NOT_FOUND: '[PAGE_NOT_FOUND] Debugger page not found',
   CONNECTION_LOST: '[CONNECTION_LOST] Connection lost to corresponding device',
@@ -53,19 +51,15 @@ export const WS_CLOSE_REASON = {
     '[NEW_DEBUGGER_OPENED] New debugger opened for the same app instance',
 };
 
-// Prefix for script URLs that are alphanumeric IDs. See comment in #processMessageFromDeviceLegacy method for
-// more details.
 const FILE_PREFIX = 'file://';
 
 type DebuggerConnection = {
-  // Debugger web socket connection
   socket: WS,
   prependedFilePrefix: boolean,
   pageId: string,
   userAgent: string | null,
   customHandler: ?CustomMessageHandler,
   debuggerRelativeBaseUrl: ReadonlyURL,
-  // Session ID assigned by the proxy for multi-debugger support
   sessionId: string,
 };
 
@@ -84,60 +78,23 @@ export type DeviceOptions = Readonly<{
   experiments: Experiments,
 }>;
 
-/**
- * Device class represents single device connection to Inspector Proxy. Each device
- * can have multiple inspectable pages.
- */
 export default class Device {
-  // ID of the device.
   #id: string;
-
-  // Name of the device.
   #name: string;
-
-  // Package name of the app.
   #app: string;
-
-  // Stores socket connection between Inspector Proxy and device.
   #deviceSocket: WS;
-
-  // Stores the most recent listing of device's pages, keyed by the `id` field.
   #pages: ReadonlyMap<string, Page> = new Map();
-
-  // Stores information about currently connected debuggers, keyed by sessionId.
   #debuggerConnections: Map<string, DebuggerConnection> = new Map();
-
-  // Last known Page ID of the React Native page.
-  // This is used by debugger connections that don't have PageID specified
-  // (and will interact with the latest React Native page).
   #lastConnectedLegacyReactNativePage: ?Page = null;
-
-  // Whether we are in the middle of a reload in the REACT_NATIVE_RELOADABLE_PAGE.
   #isLegacyPageReloading: boolean = false;
-
-  // The previous "GetPages" message, for deduplication in debug logs.
   #lastGetPagesMessage: string = '';
-
-  // Mapping built from scriptParsed events and used to fetch file content in `Debugger.getScriptSource`.
   #scriptIdToSourcePathMapping: Map<string, string> = new Map();
-
   #deviceEventReporter: ?DeviceEventReporter;
-
   #pagesPollingIntervalId: ReturnType<typeof setInterval>;
-
-  // The device message middleware factory function allowing implementers to handle unsupported CDP messages.
   #createCustomMessageHandler: ?CreateCustomMessageHandlerFn;
-
-  // A base HTTP(S) URL to this server, reachable from the device. Derived from
-  // the http request that created the connection.
   #deviceRelativeBaseUrl: ReadonlyURL;
-
-  // A base HTTP(S) URL to the server, relative to this server.
   #serverRelativeBaseUrl: ReadonlyURL;
-
-  // Logging reporting batches of cdp messages
   #cdpDebugLogging: CdpDebugLogging;
-
   readonly #experiments: Experiments;
 
   constructor(deviceOptions: DeviceOptions) {
@@ -176,12 +133,10 @@ export default class Device {
       this.#deviceEventReporter?.logProfilingTargetRegistered();
     }
 
-    // $FlowFixMe[incompatible-type]
     this.#deviceSocket.on('message', (message: string) => {
       try {
         const parsedMessage = JSON.parse(message);
         if (parsedMessage.event === 'getPages') {
-          // There's a 'getPages' message every second, so only show them if they change
           if (message !== this.#lastGetPagesMessage) {
             debug('Device getPages ping has changed: %s', message);
             this.#lastGetPagesMessage = message;
@@ -207,7 +162,6 @@ export default class Device {
       }
     });
 
-    // Sends 'getPages' request to device every PAGES_POLLING_INTERVAL milliseconds.
     this.#pagesPollingIntervalId = setInterval(
       () => this.#sendMessageToDevice({event: 'getPages'}),
       PAGES_POLLING_INTERVAL,
@@ -215,7 +169,6 @@ export default class Device {
     this.#deviceSocket.on('close', () => {
       if (socket === this.#deviceSocket) {
         this.#deviceEventReporter?.logDisconnection('device');
-        // Device disconnected - close debugger connection.
         this.#terminateDebuggerConnection(
           WS_CLOSURE_CODE.NORMAL,
           WS_CLOSE_REASON.CONNECTION_LOST,
@@ -225,22 +178,14 @@ export default class Device {
     });
   }
 
-  /**
-   * Terminates debugger connection(s).
-   * If sessionId is provided, terminates only that session.
-   * If sessionId is not provided, terminates all sessions.
-   */
   #terminateDebuggerConnection(
     code?: number,
     reason?: string,
     sessionId?: string,
   ) {
     if (sessionId != null) {
-      // Terminate specific session
       const debuggerConnection = this.#debuggerConnections.get(sessionId);
       if (debuggerConnection) {
-        // Delete from map first so #sendDisconnectEventToDevice can correctly
-        // check if there are other debuggers connected to this page
         this.#debuggerConnections.delete(sessionId);
         this.#sendDisconnectEventToDevice(
           this.#mapToDevicePageId(debuggerConnection.pageId),
@@ -249,7 +194,6 @@ export default class Device {
         debuggerConnection.socket.close(code, reason);
       }
     } else {
-      // Terminate all sessions - collect connections first, then process
       const connections = Array.from(this.#debuggerConnections.entries());
       this.#debuggerConnections.clear();
       for (const [sid, debuggerConnection] of connections) {
@@ -262,22 +206,12 @@ export default class Device {
     }
   }
 
-  /**
-   * Used to recreate the device connection if there is a device ID collision.
-   * 1. Checks if the same device is attempting to reconnect for the same app.
-   * 2. If not, close both the device and debugger socket.
-   * 3. If the debugger connection can be reused, close the device socket only.
-   *
-   * This hack attempts to allow users to reload the app, either as result of a
-   * crash, or manually reloading, without having to restart the debugger.
-   */
   dangerouslyRecreateDevice(deviceOptions: DeviceOptions) {
     invariant(
       deviceOptions.id === this.#id,
       'dangerouslyRecreateDevice() can only be used for the same device ID',
     );
 
-    // Store existing debugger connections for potential reuse
     const oldDebuggerConnections = new Map(this.#debuggerConnections);
 
     if (this.#app !== deviceOptions.app || this.#name !== deviceOptions.name) {
@@ -293,7 +227,6 @@ export default class Device {
 
     this.#debuggerConnections.clear();
 
-    // Close the old device socket before reconstructing
     if (oldDebuggerConnections.size > 0) {
       this.#deviceSocket.close(
         WS_CLOSURE_CODE.NORMAL,
@@ -303,7 +236,6 @@ export default class Device {
 
     this.#dangerouslyConstruct(deviceOptions);
 
-    // Restore all debugger connections, not just the first one
     for (const oldDebugger of oldDebuggerConnections.values()) {
       oldDebugger.socket.removeAllListeners();
       this.handleDebuggerConnection(oldDebugger.socket, oldDebugger.pageId, {
@@ -329,10 +261,6 @@ export default class Device {
     }
   }
 
-  // Handles new debugger connection to this device:
-  // 1. Sends connect event to device
-  // 2. Forwards all messages from the debugger to device as wrappedEvent
-  // 3. Sends disconnect event to device when debugger connection socket closes.
   handleDebuggerConnection(
     socket: WS,
     pageId: string,
@@ -361,12 +289,8 @@ export default class Device {
       return;
     }
 
-    // Clear any commands we were waiting on.
     this.#deviceEventReporter?.logDisconnection('debugger');
 
-    // Check if this specific page supports multiple debuggers.
-    // If not (legacy mode), disconnect existing debuggers for THIS PAGE only
-    // before connecting the new one.
     if (!this.#pageHasCapability(page, 'supportsMultipleDebuggers')) {
       for (const [sid, conn] of this.#debuggerConnections) {
         if (conn.pageId === pageId) {
@@ -379,8 +303,6 @@ export default class Device {
       }
     }
 
-    // Generate a unique session ID for this debugger connection using UUID
-    // to minimize collision likelihood across device reconnections
     const sessionId = crypto.randomUUID();
 
     this.#deviceEventReporter?.logConnection('debugger', {
@@ -450,10 +372,15 @@ export default class Device {
 
     this.#sendConnectEventToDevice(this.#mapToDevicePageId(pageId), sessionId);
 
-    // $FlowFixMe[incompatible-type]
     socket.on('message', (message: string) => {
       this.#cdpDebugLogging.log('DebuggerToProxy', message);
-      const debuggerRequest = JSON.parse(message);
+      let debuggerRequest;
+      try {
+        debuggerRequest = JSON.parse(message);
+      } catch (error) {
+        debug('Failed to parse debugger message: %O', error);
+        return;
+      }
       this.#deviceEventReporter?.logRequest(debuggerRequest, 'debugger', {
         pageId: debuggerInfo.pageId,
         frontendUserAgent: userAgent,
@@ -495,9 +422,7 @@ export default class Device {
     });
 
     const cdpDebugLogging = this.#cdpDebugLogging;
-    // $FlowFixMe[method-unbinding]
     const sendFunc = socket.send;
-    // $FlowFixMe[cannot-write]
     socket.send = function (message: string) {
       cdpDebugLogging.log('ProxyToDebugger', message);
       return sendFunc.call(socket, message);
@@ -518,16 +443,10 @@ export default class Device {
     });
   }
 
-  /**
-   * Returns `true` if a page supports the given target capability flag.
-   */
   #pageHasCapability(page: Page, flag: keyof TargetCapabilityFlags): boolean {
     return page.capabilities[flag] === true;
   }
 
-  /**
-   * Returns the synthetic "React Native Experimental (Improved Chrome Reloads)" page.
-   */
   #createSyntheticPage(): Page {
     return {
       id: REACT_NATIVE_RELOADABLE_PAGE_ID,
@@ -538,16 +457,8 @@ export default class Device {
     };
   }
 
-  // Handles messages received from device:
-  // 1. For getPages responses updates local #pages list.
-  // 2. All other messages are forwarded to debugger as wrappedEvent.
-  //
-  // In the future more logic will be added to this method for modifying
-  // some of the messages (like updating messages with source maps and file
-  // locations).
   #handleMessageFromDevice(message: MessageFromDevice) {
     if (message.event === 'getPages') {
-      // Preserve ordering - getPages guarantees addition order.
       const shouldDisableMultipleDebuggers =
         !this.#experiments.enableStandaloneFuseboxShell;
       this.#pages = new Map(
@@ -583,11 +494,6 @@ export default class Device {
         );
       }
 
-      // Check if device has a new legacy React Native page.
-      // There is usually no more than 2-3 pages per device so this operation
-      // is not expensive.
-      // TODO(hypuk): It is better for VM to send update event when new page is
-      // created instead of manually checking this on every getPages result.
       for (const page of this.#pages.values()) {
         if (this.#pageHasCapability(page, 'nativePageReloads')) {
           continue;
@@ -601,22 +507,16 @@ export default class Device {
         }
       }
     } else if (message.event === 'disconnect') {
-      // Device sends disconnect events only when page is reloaded or
-      // if debugger socket was disconnected.
       const pageId = message.payload.pageId;
       const sessionId = message.payload.sessionId;
 
-      // TODO(moti): Handle null case explicitly, e.g. swallow disconnect events
-      // for unknown pages.
       const page: ?Page = this.#pages.get(pageId);
 
       if (page != null && this.#pageHasCapability(page, 'nativePageReloads')) {
         return;
       }
 
-      // Find the debugger connection(s) for this page
       if (sessionId != null) {
-        // Disconnect specific session
         const debuggerConnection = this.#debuggerConnections.get(sessionId);
         if (
           debuggerConnection &&
@@ -630,7 +530,6 @@ export default class Device {
           }
         }
       } else {
-        // Legacy mode: send to all connected debuggers for this page
         for (const debuggerConnection of this.#debuggerConnections.values()) {
           if (
             debuggerConnection.pageId !== REACT_NATIVE_RELOADABLE_PAGE_ID &&
@@ -644,13 +543,10 @@ export default class Device {
     } else if (message.event === 'wrappedEvent') {
       const sessionId = message.payload.sessionId;
 
-      // Route message to the correct debugger connection by sessionId
       let debuggerConnection: ?DebuggerConnection = null;
       if (sessionId != null) {
         debuggerConnection = this.#debuggerConnections.get(sessionId);
       } else {
-        // Legacy mode: route to the first (and only) debugger connection
-        // ASSERT: In legacy mode, there should be at most one debugger connected.
         if (this.#debuggerConnections.size > 1) {
           debug(
             'WARNING: Device sent message without sessionId but multiple debuggers are connected. ' +
@@ -667,7 +563,6 @@ export default class Device {
 
       const debuggerSocket = debuggerConnection.socket;
       if (debuggerSocket == null || debuggerSocket.readyState !== WS.OPEN) {
-        // TODO(hypuk): Send error back to device?
         return;
       }
 
@@ -697,7 +592,6 @@ export default class Device {
     }
   }
 
-  // Sends single message to device.
   #sendMessageToDevice(message: MessageToDevice) {
     try {
       const messageToSend = JSON.stringify(message);
@@ -708,11 +602,9 @@ export default class Device {
     } catch (error) {}
   }
 
-  // We received new React Native Page ID.
   #newLegacyReactNativePage(page: Page) {
     debug(`React Native page updated to ${page.id}`);
 
-    // Find the debugger connection that's connected to the reloadable page
     let reloadablePageDebugger: ?DebuggerConnection = null;
     for (const debuggerConnection of this.#debuggerConnections.values()) {
       if (debuggerConnection.pageId === REACT_NATIVE_RELOADABLE_PAGE_ID) {
@@ -722,20 +614,12 @@ export default class Device {
     }
 
     if (reloadablePageDebugger == null) {
-      // We can just remember new page ID without any further actions if no
-      // debugger is currently attached or attached debugger is not
-      // "Reloadable React Native" connection.
       this.#lastConnectedLegacyReactNativePage = page;
       return;
     }
     const oldPageId = this.#lastConnectedLegacyReactNativePage?.id;
     this.#lastConnectedLegacyReactNativePage = page;
     this.#isLegacyPageReloading = true;
-
-    // We already had a debugger connected to React Native page and a
-    // new one appeared - in this case we need to emulate execution context
-    // detroy and resend Debugger.enable and Runtime.enable commands to new
-    // page.
 
     if (oldPageId != null) {
       this.#sendDisconnectEventToDevice(
@@ -768,10 +652,6 @@ export default class Device {
     }
   }
 
-  /**
-   * Given a URL from the debugger frontend, returns the equivalent URL
-   * reachable from the device.
-   */
   #debuggerRelativeToDeviceRelativeUrl(
     debuggerRelativeUrl: URL,
     {debuggerRelativeBaseUrl}: DebuggerConnection,
@@ -785,10 +665,6 @@ export default class Device {
     return deviceRelativeUrl;
   }
 
-  /**
-   * Given a URL from the device, returns the equivalent URL reachable from
-   * the debugger frontend.
-   */
   #deviceRelativeUrlToDebuggerRelativeUrl(
     deviceRelativeUrl: URL,
     {debuggerRelativeBaseUrl}: DebuggerConnection,
@@ -802,10 +678,6 @@ export default class Device {
     return debuggerRelativeUrl;
   }
 
-  /**
-   * Given a URL from the device, returns the equivalent URL reachable from
-   * this proxy.
-   */
   #deviceRelativeUrlToServerRelativeUrl(deviceRelativeUrl: URL): URL {
     const debuggerRelativeUrl = new URL(deviceRelativeUrl.href);
     if (deviceRelativeUrl.origin === this.#deviceRelativeBaseUrl.origin) {
@@ -816,18 +688,13 @@ export default class Device {
     return debuggerRelativeUrl;
   }
 
-  // Allows to make changes in incoming message from device.
   #processMessageFromDeviceLegacy(
     payload: CDPServerMessage,
     debuggerInfo: DebuggerConnection,
     pageId: ?string,
   ) {
-    // TODO(moti): Handle null case explicitly, or ideally associate a copy
-    // of the page metadata object with the connection so this can never be
-    // null.
     const page: ?Page = pageId != null ? this.#pages.get(pageId) : null;
 
-    // Replace Android addresses for scriptParsed event.
     if (
       (!page || !this.#pageHasCapability(page, 'nativeSourceCodeFetching')) &&
       payload.method === 'Debugger.scriptParsed' &&
@@ -837,8 +704,6 @@ export default class Device {
       if ('sourceMapURL' in params) {
         const sourceMapURL = this.#tryParseHTTPURL(params.sourceMapURL);
         if (sourceMapURL) {
-          // Rewrite device-relative URLs to de debugger-relative URLs for the
-          // frontend.
           payload.params.sourceMapURL =
             this.#deviceRelativeUrlToDebuggerRelativeUrl(
               sourceMapURL,
@@ -850,30 +715,21 @@ export default class Device {
         let serverRelativeUrl = params.url;
         const parsedUrl = this.#tryParseHTTPURL(params.url);
         if (parsedUrl) {
-          // Rewrite device-relative URLs pointing to the server so that they're
-          // reachable from the frontend.
           payload.params.url = this.#deviceRelativeUrlToDebuggerRelativeUrl(
             parsedUrl,
             debuggerInfo,
           ).href;
 
-          // Determine the server-relative URL.
           serverRelativeUrl =
             this.#deviceRelativeUrlToServerRelativeUrl(parsedUrl).href;
         }
 
-        // Chrome doesn't download source maps if URL param is not a valid
-        // URL. Some frameworks pass alphanumeric script ID instead of URL which causes
-        // Chrome to not download source maps. In this case we want to prepend script ID
-        // with 'file://' prefix.
         if (payload.params.url.match(/^[0-9a-z]+$/)) {
           payload.params.url = FILE_PREFIX + payload.params.url;
           debuggerInfo.prependedFilePrefix = true;
         }
 
         if ('scriptId' in params && params.scriptId != null) {
-          // Set a server-relative URL to locally fetch source by script ID
-          // on Debugger.getScriptSource.
           this.#scriptIdToSourcePathMapping.set(
             params.scriptId,
             serverRelativeUrl,
@@ -883,25 +739,13 @@ export default class Device {
     }
 
     if (
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/4oq3zi07. */
       payload.method === 'Runtime.executionContextCreated' &&
       this.#isLegacyPageReloading
     ) {
-      // The new context is ready. First notify Chrome that we've reloaded so
-      // it'll resend its breakpoints. If we do this earlier, we may not be
-      // ready to receive them.
       debuggerInfo.socket.send(
         JSON.stringify({method: 'Runtime.executionContextsCleared'}),
       );
 
-      // The VM starts in a paused mode. Ask it to resume.
-      // Note that if setting breakpoints in early initialization functions,
-      // there's a currently race condition between these functions executing
-      // and Chrome re-applying the breakpoints due to the message above.
-      //
-      // This is not an issue in VSCode/Nuclide where the IDE knows to resume
-      // at its convenience.
       const resumeMessage = {method: 'Debugger.resume', id: 0};
       this.#deviceEventReporter?.logRequest(resumeMessage, 'proxy', {
         pageId: debuggerInfo.pageId,
@@ -925,8 +769,6 @@ export default class Device {
         if (callFrame.url) {
           const parsedUrl = this.#tryParseHTTPURL(callFrame.url);
           if (parsedUrl) {
-            // Rewrite device-relative URLs pointing to the server so that they're
-            // reachable from the frontend.
             callFrame.url = this.#deviceRelativeUrlToDebuggerRelativeUrl(
               parsedUrl,
               debuggerInfo,
@@ -937,11 +779,6 @@ export default class Device {
     }
   }
 
-  /**
-   * Intercept an incoming message from a connected debugger. Returns either an
-   * original/replacement CDP message object, or `null` (will forward nothing
-   * to the target).
-   */
   #interceptClientMessageForSourceFetching(
     req: CDPClientMessage,
     debuggerInfo: DebuggerConnection,
@@ -951,21 +788,12 @@ export default class Device {
       case 'Debugger.setBreakpointByUrl':
         return this.#processDebuggerSetBreakpointByUrl(req, debuggerInfo);
       case 'Debugger.getScriptSource':
-        // Sends response to debugger via side-effect
         void this.#processDebuggerGetScriptSource(req, socket, debuggerInfo);
         return null;
       case 'Network.loadNetworkResource':
-        // If we're rewriting URLs (to frontend-relative), we don't want to
-        // pass these URLs to the device, since it may try to fetch, return a
-        // CDP *result* (not error) with a network failure, and CDT
-        // will *not* then fall back to fetching locally.
-        //
-        // Instead, take the absence of a nativeSourceCodeFetching
-        // capability as a signal to never pass a loadNetworkResource request
-        // to the device. By returning a CDP error, the frontend should fetch.
         const result = {
           error: {
-            code: -32601, // Method not found
+            code: -32601,
             message:
               '[inspector-proxy]: Page lacks nativeSourceCodeFetching capability.',
           },
@@ -987,7 +815,6 @@ export default class Device {
     req: CDPRequest<'Debugger.setBreakpointByUrl'>,
     debuggerInfo: DebuggerConnection,
   ): CDPRequest<'Debugger.setBreakpointByUrl'> {
-    // If we replaced Android emulator's address to localhost we need to change it back.
     const {debuggerRelativeBaseUrl, prependedFilePrefix} = debuggerInfo;
 
     const processedReq = {...req, params: {...req.params}};
@@ -1003,24 +830,11 @@ export default class Device {
         originalUrlParam.startsWith(FILE_PREFIX) &&
         prependedFilePrefix
       ) {
-        // Remove fake URL prefix if we modified URL in #processMessageFromDeviceLegacy.
         processedReq.params.url = originalUrlParam.slice(FILE_PREFIX.length);
       }
     }
 
-    // Retain special case rewriting of localhost to device-relative IPs
-    // within regex patterns. We don't rewrite the protocol here because
-    // these patterns typically come from CDT reinterpreting the source URL
-    // `file://host/path` into the regex `host/path|file://host/path`. See:
-    //
-    // https://github.com/ChromeDevTools/devtools-frontend/blob/f913cc6d76f2e2639c05b11ba673fc880b5490dd/front_end/core/sdk/DebuggerModel.ts#L505
-    //
-    // This has always been fragile and probably unnecessary - we don't set
-    // `file://` source URLs. It can be removed when we drop support for
-    // legacy targets, if not sooner.
     if (
-      // Android's stock emulator and other emulators such as genymotion use a
-      // standard localhost alias.
       new Set(['10.0.2.2', '10.0.3.2']).has(
         this.#deviceRelativeBaseUrl.hostname,
       ) &&
@@ -1029,7 +843,6 @@ export default class Device {
     ) {
       processedReq.params.urlRegex = processedReq.params.urlRegex.replaceAll(
         'localhost',
-        // regex-escape IPv4
         this.#deviceRelativeBaseUrl.hostname.replaceAll('.', '\\.'),
       );
     }
@@ -1058,12 +871,10 @@ export default class Device {
       });
     };
     const sendErrorResponse = (error: string) => {
-      // Tell the client that the request failed
       const result = {error: {message: error}};
       const response = {id: req.id, result};
       socket.send(JSON.stringify(response));
 
-      // Send to the console as well, so the user can see it
       this.#sendErrorToDebugger(error, debuggerInfo);
       const pageId = debuggerInfo.pageId;
       this.#deviceEventReporter?.logResponse(response, 'proxy', {
@@ -1120,17 +931,12 @@ export default class Device {
     return parsedURL;
   }
 
-  // Fetch text, raising an exception if the text could not be fetched,
-  // or is too large.
   async #fetchText(url: URL): Promise<string> {
-    // $FlowFixMe[incompatible-call] Suppress arvr node-fetch flow error
     const response = await fetch(url);
     if (!response.ok) {
       throw new Error('HTTP ' + response.status + ' ' + response.statusText);
     }
     const text = await response.text();
-    // Restrict the length to well below the 500MB limit for nodejs (leaving
-    // room some some later manipulation, e.g. base64 or wrapping in JSON)
     if (text.length > 350000000) {
       throw new Error('file too large to fetch via HTTP');
     }


### PR DESCRIPTION
Added try-catch block for JSON.parse in handleDebuggerConnection to prevent the proxy from crashing when receiving invalid JSON messages from the debugger.

 
