### PR TITLE
Cleanup flowconfig options in react-native

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -43,15 +43,7 @@ packages/react-native/interface.js
 packages/react-native/flow/
 
 [options]
-enums=true
-experimental.pattern_matching=true
-experimental.allow_variance_keywords=true
-casting_syntax=both
-component_syntax=true
-
 emoji=true
-
-exact_by_default=true
 
 format.bracket_spacing=false
 


### PR DESCRIPTION
Summary:
- All legacy casting syntax has been converted, so we remove `casting_syntax=both` to use the default option of only allowing the new `as` casting syntax
- Removed all other options that are already the default value

Changelog: [Internal]

Differential Revision: D108281827


