### PR TITLE
Register Android pointer capture events

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -112,6 +112,18 @@ const bubblingEventTypes = {
       bubbled: 'onPointerOver',
     },
   },
+  topGotPointerCapture: {
+    phasedRegistrationNames: {
+      captured: 'onGotPointerCaptureCapture',
+      bubbled: 'onGotPointerCapture',
+    },
+  },
+  topLostPointerCapture: {
+    phasedRegistrationNames: {
+      captured: 'onLostPointerCaptureCapture',
+      bubbled: 'onLostPointerCapture',
+    },
+  },
   topClick: {
     phasedRegistrationNames: {
       captured: 'onClickCapture',
@@ -424,6 +436,10 @@ const validAttributesForEventProps = {
   onPointerOutCapture: true,
   onPointerOver: true,
   onPointerOverCapture: true,
+  onGotPointerCapture: true,
+  onGotPointerCaptureCapture: true,
+  onLostPointerCapture: true,
+  onLostPointerCaptureCapture: true,
 } as const;
 
 /**

--- a/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
+++ b/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
@@ -157,6 +157,58 @@ describe('Event Dispatching', () => {
     expect(onPointerUpPriority).toBe(UIManager.unstable_DiscreteEventPriority);
   });
 
+  it('dispatches pointer capture events', () => {
+    const root = Fantom.createRoot();
+
+    const ref = React.createRef<React.ElementRef<typeof View>>();
+    const order: Array<string> = [];
+
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={ref}
+          onGotPointerCaptureCapture={() => {
+            order.push('got-capture');
+          }}
+          onGotPointerCapture={() => {
+            order.push('got-bubble');
+          }}
+          onLostPointerCaptureCapture={() => {
+            order.push('lost-capture');
+          }}
+          onLostPointerCapture={() => {
+            order.push('lost-bubble');
+          }}
+        />,
+      );
+    });
+
+    Fantom.dispatchNativeEvent(
+      ref,
+      'onGotPointerCapture',
+      {pointerId: 1},
+      {
+        category: Fantom.NativeEventCategory.Discrete,
+      },
+    );
+
+    Fantom.dispatchNativeEvent(
+      ref,
+      'onLostPointerCapture',
+      {pointerId: 1},
+      {
+        category: Fantom.NativeEventCategory.Discrete,
+      },
+    );
+
+    expect(order).toEqual([
+      'got-capture',
+      'got-bubble',
+      'lost-capture',
+      'lost-bubble',
+    ]);
+  });
+
   it('dispatches events with continuous priority', () => {
     const root = Fantom.createRoot();
 


### PR DESCRIPTION
## Summary:

The `PointerEventsProcessor` C++ pointer-events implementation already supports pointer capture and can emit `topGotPointerCapture` and `topLostPointerCapture`. `TouchEventEmitter` has handlers for both events.

Android base view config was not registering the events:

- `onGotPointerCapture` / `onGotPointerCaptureCapture`
- `onLostPointerCapture` / `onLostPointerCaptureCapture`

This adds the missing Android registrations and adds an EventDispatching integration test covering capture and bubble dispatch for both pointer capture events.

## Changelog:

[Android] [Fixed] - Register pointer capture event handlers in the Android base view config

## Test Plan:

Added coverage in `EventDispatching-itest.js` for `onGotPointerCapture`, `onGotPointerCaptureCapture`, `onLostPointerCapture`, and `onLostPointerCaptureCapture`.

`git diff --check main...HEAD`
