### PR TITLE
chore: Mark UTFSequence as deprecated to remove in the future

### DIFF
--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -367,10 +367,13 @@ module.exports = {
   get useWindowDimensions() {
     return require('./Libraries/Utilities/useWindowDimensions').default;
   },
+  /**
+   * @deprecated UTFSequence will be removed in a future release. Please insert Unicode escape sequences directly
+   */
   get UTFSequence() {
     warnOnce(
-      'utfsequence-will-be-remove',
-      'UTFSequence will be removed in a future release.',
+      'utfsequence-deprecated',
+      "UTFSequence has been deprecated and will be removed in a future release. Please insert Unicode escape sequences directly, e.g. `'\\\ufeff'` (BOM)",
     );
     return require('./Libraries/UTFSequence').default;
   },


### PR DESCRIPTION


## Summary:

if you check the search results you won't find any usages of `UTFSequence` module. Also it wasn't documented.

So, it can be treated as dead-code and needs to be removed from RN package 

```bash
open https://github.com/search?q=%22UTFSequence.BOM%22&type=code
open https://github.com/search?q=%22UTFSequence.BULLET%22&type=code
open https://github.com/search?q=%22UTFSequence.BULLET_SP%22&type=code
open https://github.com/search?q=%22UTFSequence.MIDDOT%22&type=code
open https://github.com/search?q=%22UTFSequence.MIDDOT_SP%22&type=code
open https://github.com/search?q=%22UTFSequence.MIDDOT_KATAKANA%22&type=code
open https://github.com/search?q=%22UTFSequence.MDASH%22&type=code
open https://github.com/search?q=%22UTFSequence.MDASH_SP%22&type=code
open https://github.com/search?q=%22UTFSequence.NDASH%22&type=code
open https://github.com/search?q=%22UTFSequence.NDASH_SP%22&type=code
open https://github.com/search?q=%22UTFSequence.NEWLINE%22&type=code
open https://github.com/search?q=%22UTFSequence.NBSP%22&type=code
open https://github.com/search?q=%22UTFSequence.PIZZA%22&type=code
open https://github.com/search?q=%22UTFSequence.TRIANGLE_LEFT%22&type=code
open https://github.com/search?q=%22UTFSequence.TRIANGLE_RIGHT%22&type=code
```
In RN repo in used in one places and can be replaced with string litaral:  https://github.com/facebook/react-native/blob/8bcfb3ba1c16b1ba45058798bf43ecdc9bd42d3a/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js#L109

## Changelog:

[GENERAL] [DEPRECATED] - Mark undocumented `UTFSequence` module as deprecated

## Test Plan:

...
