### PR TITLE
codegen: ios platform extensions

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateSchemaInfos.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateSchemaInfos.js
@@ -18,9 +18,10 @@ const {globSync} = require('tinyglobby');
 
 function generateSchemaInfos(
   libraries /*: ReadonlyArray<$FlowFixMe> */,
+  platform /*: string */,
 ) /*: Array<$FlowFixMe> */ {
   // $FlowFixMe[incompatible-type]
-  return libraries.map(generateSchemaInfo);
+  return libraries.map(library => generateSchemaInfo(library, platform));
 }
 
 function generateSchemaInfo(

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
@@ -139,7 +139,7 @@ function execute(
           : path.join(outputPath, 'ReactCodegen');
 
       if (runReactNativeCodegen) {
-        const schemaInfos = generateSchemaInfos(libraries);
+        const schemaInfos = generateSchemaInfos(libraries, platform);
         generateNativeCode(
           reactCodegenOutputPath,
           schemaInfos.filter(schemaInfo =>


### PR DESCRIPTION
Currently codegen doesn't pass the platform file extension. This makes it possible to use `NativeModule.ios.ts` and will generate obj-c++ spec files