### PR TITLE
fix(codegen): scan symlinked js source directories

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/__tests__/combine-js-to-schema-test.js
+++ b/packages/react-native-codegen/src/cli/combine/__tests__/combine-js-to-schema-test.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const {
+  combineSchemasInFileList,
+} = require('../combine-js-to-schema');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('combine-js-to-schema', () => {
+  let tmpdir;
+
+  beforeEach(() => {
+    tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegen-combine-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpdir, {recursive: true, force: true});
+  });
+
+  it('expands symlinked directories into source files', () => {
+    const sourceDir = path.join(tmpdir, 'source');
+    const symlinkDir = path.join(tmpdir, 'symlink');
+    fs.mkdirSync(sourceDir);
+    fs.symlinkSync(
+      sourceDir,
+      symlinkDir,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+
+    fs.writeFileSync(
+      path.join(sourceDir, 'NativeSample.ts'),
+      `
+        import type {TurboModule} from 'react-native';
+        import * as TurboModuleRegistry from 'TurboModuleRegistry';
+
+        export interface Spec extends TurboModule {
+          sampleMethod: () => void;
+        }
+
+        export default TurboModuleRegistry.get<Spec>('Sample');
+      `,
+    );
+
+    const schema = combineSchemasInFileList(
+      [symlinkDir],
+      null,
+      null,
+      'SampleSpec',
+    );
+
+    expect(Object.keys(schema.modules)).toEqual(['NativeSample']);
+  });
+});

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
@@ -63,7 +63,7 @@ function expandDirectoriesIntoFiles(
 ): Array<string> {
   return fileList
     .flatMap(file => {
-      if (!fs.lstatSync(file).isDirectory()) {
+      if (!fs.statSync(file).isDirectory()) {
         return [file];
       }
       return globSync('**/*{,.fb}.{js,ts,tsx}', {


### PR DESCRIPTION
## Summary:

Fix React Native codegen directory expansion when a configured JS source directory is a symlink.

`combine-js-to-schema` currently checks source entries with `fs.lstatSync(file).isDirectory()`. `lstatSync` does not follow symlinks, so a symlinked directory is treated as a file and codegen does not scan its contents.

This can happen with package managers such as pnpm when a library sets `codegenConfig.jsSrcsDir` to a symlinked package directory. Codegen can then emit an empty schema/header even though valid TurboModule or NativeComponent specs exist inside that directory.

This changes the directory check to `fs.statSync(file).isDirectory()`, which follows symlinks, and adds a regression test for symlinked source directories.

## Changelog:

[GENERAL] [FIXED] - Fix codegen scanning of symlinked JS source directories

## Test Plan:

Added a Jest regression test for `combine-js-to-schema` with a symlinked directory.

Ran:

```sh
git diff --check
```

Also verified the Node filesystem behavior locally:

```sh
node -e "const fs=require('fs'), os=require('os'), path=require('path'); const d=fs.mkdtempSync(path.join(os.tmpdir(),'rn-codegen-symlink-')); const real=path.join(d,'real'); const link=path.join(d,'link'); fs.mkdirSync(real); fs.symlinkSync(real, link, 'dir'); console.log({lstatIsDir: fs.lstatSync(link).isDirectory(), statIsDir: fs.statSync(link).isDirectory()}); fs.rmSync(d,{recursive:true,force:true});"
```

Output:

```sh
{ lstatIsDir: false, statIsDir: true }
```

Could not run Jest locally in this checkout because `yarn`/dependencies were not installed in the environment.