### PR TITLE
fix: yoga crash with display:none

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -615,9 +615,18 @@ static float computeFlexBasisForChildren(
   for (auto child : children) {
     child->processDimensions();
     if (child->style().display() == Display::None) {
-      zeroOutLayoutRecursively(child);
-      child->setHasNewLayout(true);
-      child->setDirty(false);
+      // Only mutate display: none children during layout passes. Zeroing them
+      // out during measure-only passes contributes nothing to the measurement,
+      // but sets `hasNewLayout` on nodes the parent's layout pass may never
+      // visit (e.g. when its layout is restored from cache, skipping
+      // `cloneChildrenIfNeeded()`). Such a leaked flag survives the commit and
+      // is copied into lazily-shared clones, later tripping the ownership
+      // assertion in `YogaLayoutableShadowNode::layout`.
+      if (performLayout) {
+        zeroOutLayoutRecursively(child);
+        child->setHasNewLayout(true);
+        child->setDirty(false);
+      }
       continue;
     }
     if (performLayout) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

It fixes this issue: https://github.com/react/react-native/issues/52349
Basically, in some rare cases, having an element with `display:none` style caused the app to crash.

It was caused by a stale `hasNewLayout` flag on the hidden view
That flag was always set in `computeFlexBasisForChildren` for elements with `display:none` style, but could be never consumed/reset, because of a cache hit or something.
Since such elements contribute nothing to the layout sizes, I made the change to actually touch them only during actual layout passes

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Crash: YogaLayoutableShadowNode.cpp: function layout: assertion failed (YGNodeGetOwner(childYogaNode) == &yogaNode_) https://github.com/react/react-native/issues/52349

## Test Plan:

I created a reproduction repo: https://github.com/5ZYSZ3K/native-tabs-crash-repro, to see the issue
And to see, that my change fixes it, you can switch to `patch-yoga` branch there, and install it again (don't forget to install pods with `RCT_USE_PREBUILT_RNCORE=0 RCT_USE_RN_DEP=0` variables)
