### PR TITLE
Optimize nested style array flattening

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-benchmark-itest.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-benchmark-itest.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import flattenStyle from '../flattenStyle';
+import * as Fantom from '@react-native/fantom';
+
+const baseStyle = {
+  width: 100,
+  height: 40,
+  opacity: 0.8,
+  backgroundColor: 'blue',
+  borderRadius: 8,
+};
+
+const overrideStyle = {
+  height: 44,
+  opacity: 1,
+  borderWidth: 1,
+  borderColor: 'red',
+};
+
+const accentStyle = {
+  borderRadius: 12,
+  transform: [{scale: 1.1}],
+};
+
+const objectStyle = baseStyle;
+const singleArrayStyle = [baseStyle];
+const singleEffectiveArrayStyle: $FlowFixMe = [
+  null,
+  false,
+  undefined,
+  baseStyle,
+];
+const nestedSingleArrayStyle: $FlowFixMe = [
+  null,
+  [undefined, baseStyle],
+  false,
+];
+const nestedMergedArrayStyle = [baseStyle, [null, overrideStyle, accentStyle]];
+const mergedArrayStyle = [baseStyle, overrideStyle];
+
+Fantom.unstable_benchmark
+  .suite('flattenStyle', {minTestExecutionTimeMs: 500})
+  .test('flatten object style', () => {
+    flattenStyle(objectStyle);
+  })
+  .test('flatten array with one style', () => {
+    flattenStyle(singleArrayStyle);
+  })
+  .test('flatten array with one effective style', () => {
+    flattenStyle(singleEffectiveArrayStyle);
+  })
+  .test('flatten nested array with one effective style', () => {
+    flattenStyle(nestedSingleArrayStyle);
+  })
+  .test('flatten nested array with merged styles', () => {
+    // $FlowFixMe[incompatible-call]
+    flattenStyle(nestedMergedArrayStyle);
+  })
+  .test('flatten array with merged styles', () => {
+    flattenStyle(mergedArrayStyle);
+  });

--- a/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js
@@ -94,6 +94,37 @@ describe('flattenStyle', () => {
     });
   });
 
+  it('should allocate an object when an array contains one style', () => {
+    const style = {a: 'b'};
+    const singleStyle = flattenStyle([style]);
+
+    expect(singleStyle).not.toBe(style);
+    expect(singleStyle).toEqual(style);
+  });
+
+  it('should allocate an object when an array contains one effective style', () => {
+    const style = {a: 'b'};
+    const singleStyle = flattenStyle([null, false, undefined, style]);
+    const singleStyleAgain = flattenStyle([null, [undefined, style], false]);
+
+    expect(singleStyle).not.toBe(style);
+    expect(singleStyleAgain).not.toBe(style);
+    expect(singleStyle).toEqual(style);
+    expect(singleStyleAgain).toEqual(style);
+  });
+
+  it('should allocate an object when merging multiple styles', () => {
+    const style1 = {width: 10};
+    const style2 = {height: 20};
+    const flatStyle = flattenStyle([style1, style2]);
+
+    expect(flatStyle).not.toBe(style1);
+    expect(flatStyle).not.toBe(style2);
+    expect(style1).toEqual({width: 10});
+    expect(style2).toEqual({height: 20});
+    expect(flatStyle).toEqual({width: 10, height: 20});
+  });
+
   it('should merge single class and style properly', () => {
     const fixture = getFixture();
     const style = {styleA: 'overrideA', styleC: 'overrideC'};

--- a/packages/react-native/Libraries/StyleSheet/flattenStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/flattenStyle.js
@@ -20,6 +20,31 @@ type NonAnimatedNodeObject<TStyleProp> = TStyleProp extends AnimatedNode
   ? empty
   : TStyleProp;
 
+function flattenStyleArrayInto<
+  TStyleProp extends ____DangerouslyImpreciseAnimatedStyleProp_Internal,
+>(result: {[string]: $FlowFixMe}, styles: ReadonlyArray<?TStyleProp>) {
+  for (let i = 0, styleLength = styles.length; i < styleLength; ++i) {
+    const style = styles[i];
+    if (style === null || typeof style !== 'object') {
+      continue;
+    }
+
+    if (Array.isArray(style)) {
+      // $FlowFixMe[underconstrained-implicit-instantiation]
+      flattenStyleArrayInto(result, style);
+      continue;
+    }
+
+    // $FlowFixMe[invalid-in-rhs]
+    for (const key in style) {
+      // $FlowFixMe[incompatible-use]
+      // $FlowFixMe[invalid-computed-prop]
+      // $FlowFixMe[prop-missing]
+      result[key] = style[key];
+    }
+  }
+}
+
 function flattenStyle<
   TStyleProp extends ____DangerouslyImpreciseAnimatedStyleProp_Internal,
 >(
@@ -36,19 +61,9 @@ function flattenStyle<
   }
 
   const result: {[string]: $FlowFixMe} = {};
-  for (let i = 0, styleLength = style.length; i < styleLength; ++i) {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
-    const computedStyle = flattenStyle(style[i]);
-    if (computedStyle) {
-      // $FlowFixMe[invalid-in-rhs]
-      for (const key in computedStyle) {
-        // $FlowFixMe[incompatible-use]
-        // $FlowFixMe[invalid-computed-prop]
-        // $FlowFixMe[prop-missing]
-        result[key] = computedStyle[key];
-      }
-    }
-  }
+  // $FlowFixMe[underconstrained-implicit-instantiation]
+  flattenStyleArrayInto(result, style);
+
   // $FlowFixMe[incompatible-type]
   return result;
 }


### PR DESCRIPTION
## Summary

Flatten nested style arrays directly into the final result object instead of recursively allocating intermediate flattened objects and copying their keys again.

This preserves the existing public behavior:

- non-array style objects still return by reference
- array inputs still allocate a fresh flattened object
- merge order for nested arrays is unchanged

Nested style arrays can show up when style props are composed across component boundaries. Avoiding the intermediate object reduces allocation and duplicate key-copy work for those paths.

## Local benchmark

Node v24.15.0 side-by-side microbenchmark, 9-run median, 5,000,000 iterations per run:

| Case | Before | After | Delta |
| --- | ---: | ---: | ---: |
| array with one style | 71.14 ns/op | 72.52 ns/op | -1.9% |
| array with one effective style | 84.39 ns/op | 76.33 ns/op | 9.5% faster |
| nested array with one effective style | 163.90 ns/op | 83.43 ns/op | 49.1% faster |
| nested array with merged styles | 254.62 ns/op | 161.43 ns/op | 36.6% faster |
| array with merged styles | 129.32 ns/op | 119.59 ns/op | 7.5% faster |

## Changelog:

[GENERAL][CHANGED] - Improve flattening performance for nested style arrays.

## Test Plan:

- `./node_modules/.bin/eslint --max-warnings 0 packages/react-native/Libraries/StyleSheet/flattenStyle.js packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-benchmark-itest.js`
- `yarn jest packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js --runInBand`
- `yarn flow check`
- `git diff --check`
- `yarn fantom packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-benchmark-itest.js --benchmarks` exits successfully in OSS, but the benchmark suite is skipped by the OSS Fantom optimized-mode gate.
