### PR TITLE
Remove getMapBuffer() from placeholder StateData

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/StateData.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StateData.h
@@ -11,8 +11,6 @@
 
 #ifdef RN_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
-#include <react/renderer/mapbuffer/MapBuffer.h>
-#include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
 namespace facebook::react {
@@ -27,8 +25,10 @@ struct StateData final {
 #ifdef RN_SERIALIZABLE_STATE
   StateData() = default;
   StateData(const StateData &previousState, folly::dynamic data) {}
-  folly::dynamic getDynamic() const;
-  MapBuffer getMapBuffer() const;
+  folly::dynamic getDynamic() const
+  {
+    return {};
+  }
 #endif
 };
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -7933,7 +7933,6 @@ struct facebook::react::Size {
 struct facebook::react::StateData {
   public StateData() = default;
   public StateData(const facebook::react::StateData& previousState, folly::dynamic data);
-  public facebook::react::MapBuffer getMapBuffer() const;
   public folly::dynamic getDynamic() const;
   public using Shared = std::shared_ptr<const void>;
 }

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -7697,7 +7697,6 @@ struct facebook::react::Size {
 struct facebook::react::StateData {
   public StateData() = default;
   public StateData(const facebook::react::StateData& previousState, folly::dynamic data);
-  public facebook::react::MapBuffer getMapBuffer() const;
   public folly::dynamic getDynamic() const;
   public using Shared = std::shared_ptr<const void>;
 }

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -7924,7 +7924,6 @@ struct facebook::react::Size {
 struct facebook::react::StateData {
   public StateData() = default;
   public StateData(const facebook::react::StateData& previousState, folly::dynamic data);
-  public facebook::react::MapBuffer getMapBuffer() const;
   public folly::dynamic getDynamic() const;
   public using Shared = std::shared_ptr<const void>;
 }


### PR DESCRIPTION
Summary:
`StateData` is the placeholder data type for shadow nodes that have no state. It declared `getMapBuffer()` but never defined it, which breaks the build under clang-22.

`ConcreteState<DataT>::getMapBuffer()` calls `getData().getMapBuffer()` only when the `StateDataWithMapBuffer` concept is satisfied, and otherwise returns `MapBufferBuilder::EMPTY()`. Because `StateData` declared `getMapBuffer()`, it satisfied the concept, so `ConcreteState<StateData>::getMapBuffer()` referenced the undefined `StateData::getMapBuffer()`. Whether a class template's virtual members are implicitly instantiated is unspecified ([temp.inst]/11); clang-22 instantiates this override, turning the missing definition into an undefined-symbol link error.

Remove `getMapBuffer()` from `StateData` so the concept is no longer satisfied and the `EMPTY()` fallback is used — the same way `getJNIReference()` is already handled for this placeholder type. `getDynamic()` stays, since `ConcreteState` calls it unconditionally.

Changelog:
[Internal]

Reviewed By: javache

Differential Revision: D95506209


