### PR TITLE
Base64-encode binary response bodies in the C++ NetworkingModule

### DIFF
--- a/packages/react-native/ReactCommon/react/utils/tests/Base64Tests.cpp
+++ b/packages/react-native/ReactCommon/react/utils/tests/Base64Tests.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/utils/Base64.h>
+#include <string>
+
+namespace facebook::react {
+
+TEST(Base64Tests, encodesAsciiString) {
+  EXPECT_EQ(base64Encode("hello"), "aGVsbG8=");
+}
+
+TEST(Base64Tests, encodesEmptyString) {
+  EXPECT_EQ(base64Encode(""), "");
+}
+
+// Padding depends on input length modulo 3.
+TEST(Base64Tests, encodesWithCorrectPadding) {
+  EXPECT_EQ(base64Encode("a"), "YQ==");
+  EXPECT_EQ(base64Encode("ab"), "YWI=");
+  EXPECT_EQ(base64Encode("abc"), "YWJj");
+}
+
+// Binary safety: bytes that are invalid UTF-8 / contain NULs must round-trip.
+// This is the case that matters for binary ('base64'/arraybuffer) response
+// bodies in the NetworkingModule -- sending such bytes verbatim corrupts them.
+TEST(Base64Tests, encodesBinaryBytes) {
+  EXPECT_EQ(base64Encode(std::string("\x00\xff", 2)), "AP8=");
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/io/NetworkingModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/io/NetworkingModule.cpp
@@ -8,6 +8,7 @@
 #include "NetworkingModule.h"
 
 #include <react/debug/react_native_assert.h>
+#include <react/utils/Base64.h>
 
 namespace facebook::react {
 
@@ -270,15 +271,35 @@ int64_t NetworkingModule::didReceiveNetworkIncrementalData(
   return bytesRead;
 };
 
+namespace {
+// Encodes a response body for delivery to JS according to responseType.
+//
+// The JS XMLHttpRequest layer base64-decodes the delivered string for
+// 'base64'-type responses (responseType 'arraybuffer'), so binary bodies must
+// be base64-encoded here, matching the Android and iOS NetworkingModule
+// implementations. Without this, base64.toByteArray() on the JS side
+// mis-decodes the raw payload and corrupts the response (e.g. JSON.parse
+// failures on arraybuffer fetches). All other response types are delivered
+// unchanged.
+std::string encodeResponseBody(
+    const std::string& responseType,
+    std::string body) {
+  if (responseType == "base64") {
+    return base64Encode(body);
+  }
+  return body;
+}
+} // namespace
+
 void NetworkingModule::didReceiveNetworkData(
     uint32_t requestId,
-    const std::string& /*responseType*/,
+    const std::string& responseType,
     std::unique_ptr<folly::IOBuf> buf) {
   if (requests_.isStopped()) {
     return;
   }
 
-  auto responseData = buf->toString();
+  auto responseData = encodeResponseBody(responseType, buf->toString());
   emitDeviceEvent(
       "didReceiveNetworkData",
       [requestId,


### PR DESCRIPTION
Summary:
The ReactCxxPlatform `NetworkingModule` delivered response bodies to JS verbatim regardless of the requested `responseType`. For binary response types (`responseType` `arraybuffer`, which the JS `XMLHttpRequest` layer maps to the native `base64` type), JS calls `base64.toByteArray()` on the delivered string. Sending the raw bytes therefore caused the payload to be mis-decoded and corrupted — e.g. `JSON.parse` failures on responses fetched as `arraybuffer`.

Encode the body with base64 for `base64` responses, matching the existing Android (`NetworkingModule.kt` via `Base64.encodeToString(..., NO_WRAP)`) and iOS (`RCTNetworking.mm` via `base64EncodedStringWithOptions:0`) implementations. The encoding reuses the shared `react/utils` `base64Encode` helper already used by `jsinspector-modern`. All other response types are delivered unchanged. The per-`responseType` decision lives in a file-local (anonymous-namespace) `encodeResponseBody` helper in `NetworkingModule.cpp`, so it adds no surface to the public C++ API.

Changelog:
[General][Fixed] - Base64-encode binary (arraybuffer/blob) response bodies in the C++ NetworkingModule so they are not corrupted when delivered to JS

Differential Revision: D108440201


