### PR TITLE
feat: [TypeScript] Add missing methods types `Promise.try` + `Promise.withResolvers`

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -19,7 +19,9 @@
         "es2022.array",
         "es2022.error",
         "es2022.object",
-        "es2022.string"
+        "es2022.string",
+        "es2024.promise",
+        "esnext.promise"
       ],
       "allowJs": true,
       "jsx": "react-native",


### PR DESCRIPTION

## Summary:

New methods `Promise.try` and `Promise.withResolvers` were added to the Hermes V1 branch, see: https://github.com/facebook/hermes/pull/2020 

I tested them on the latest RN 0.86.0, and they are working:
```tsx
console.log({
  'ReactNativeVersion.getVersionString()':ReactNativeVersion.getVersionString(),
  'Promise.try': Promise.try,
  'Promise.withResolvers': Promise.withResolvers,
});
//{
//  "Promise.try": [Function anonymous], 
//  "Promise.withResolvers": [Function anonymous], 
//  "ReactNativeVersion.getVersionString()": "0.86.0"
// }
```


- `es2024.promise` - includes `Promise.withResolvers`
- `esnext.promise` - includes `Promise.try`

## Changelog:

[GENERAL] [ADDED] - Add `Promise.try` + `Promise.withResolvers` typescript types

## Test Plan:

```
edit `node_modules/@react-native/typescript-config/tsconfig.json`
add `es2024.promise` `esnext.promise`
try to use new methods in ts files 

// no error expected 
```
