### PR TITLE
Unbreak android CI by moving to ubuntu-latest

### DIFF
--- a/.github/workflows/e2e-android-rntester.yml
+++ b/.github/workflows/e2e-android-rntester.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: 4-core-ubuntu
+    runs-on: ubuntu-latest
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     strategy:

--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: 4-core-ubuntu
+    runs-on: ubuntu-latest
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     strategy:

--- a/.github/workflows/fantom-tests.yml
+++ b/.github/workflows/fantom-tests.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: 8-core-ubuntu
+    runs-on: ubuntu-latest
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     container:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
     needs: [prebuild_apple_dependencies]
 
   build_android:
-    runs-on: 8-core-ubuntu
+    runs-on: ubuntu-latest
     if: github.repository == 'react/react-native'
     needs: [set_release_type]
     container:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   publish-react-native:
     if: inputs.mode == 'react-native'
-    runs-on: 8-core-ubuntu
+    runs-on: ubuntu-latest
     environment: npm-publish
     # `id-token: write` is required so the npm CLI can mint the OIDC
     # token that npm Trusted Publishing exchanges for a publish token.

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -220,7 +220,7 @@ jobs:
     secrets: inherit
 
   build_fantom_runner:
-    runs-on: 8-core-ubuntu
+    runs-on: ubuntu-latest
     needs: [set_release_type, check_code_changes, lint]
     if: needs.check_code_changes.outputs.any_code_change == 'true'
     container:
@@ -263,7 +263,7 @@ jobs:
     secrets: inherit
 
   build_android:
-    runs-on: 8-core-ubuntu
+    runs-on: ubuntu-latest
     needs: [set_release_type, check_code_changes]
     if: |
       needs.check_code_changes.outputs.any_code_change == 'true' &&
@@ -309,7 +309,7 @@ jobs:
     secrets: inherit
 
   build_npm_package:
-    runs-on: 8-core-ubuntu
+    runs-on: ubuntu-latest
     needs:
       [
         set_release_type,

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -342,7 +342,7 @@ jobs:
           skip-apple-prebuilts: ${{ needs.check_code_changes.outputs.should_test_ios == 'false' }}
 
   test_android_helloworld:
-    runs-on: 4-core-ubuntu
+    runs-on: ubuntu-latest
     needs: [build_npm_package, build_android]
     if: ${{ always() && needs.build_android.result == 'success' && needs.build_npm_package.result == 'success' }}
     container:


### PR DESCRIPTION
## Summary:

build_android is currently timing out - this should unblock it for now till we find a different solution.

## Changelog:

[INTERNAL] - 

## Test Plan:

CI