### PR TITLE
Default fixDifferentiatorParentTagForUnflattenCase to true with MC opt-out

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<061d668cf04041f4d3d2f48f11dc739f>>
+ * @generated SignedSource<<ad505c0c71fa0c6e665a218606b596da>>
  */
 
 /**
@@ -127,7 +127,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableVirtualViewContainerStateExperimental(): Boolean = false
 
-  override fun fixDifferentiatorParentTagForUnflattenCase(): Boolean = false
+  override fun fixDifferentiatorParentTagForUnflattenCase(): Boolean = true
 
   override fun fixMappingOfEventPrioritiesBetweenFabricAndReact(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8dfc52502bd539e5e43d547f895a6d33>>
+ * @generated SignedSource<<f1921c6321439d8354f90ff261c15cd5>>
  */
 
 /**
@@ -236,7 +236,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool fixDifferentiatorParentTagForUnflattenCase() override {
-    return false;
+    return true;
   }
 
   bool fixMappingOfEventPrioritiesBetweenFabricAndReact() override {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/DifferentiatorUnflattenTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/DifferentiatorUnflattenTest.cpp
@@ -27,9 +27,14 @@ namespace {
 
 class TestFlagsWithUnflattenFix : public ReactNativeFeatureFlagsDefaults {
  public:
+  explicit TestFlagsWithUnflattenFix(bool enabled) : enabled_(enabled) {}
+
   bool fixDifferentiatorParentTagForUnflattenCase() override {
-    return true;
+    return enabled_;
   }
+
+ private:
+  bool enabled_;
 };
 
 } // namespace
@@ -164,6 +169,9 @@ class DifferentiatorUnflattenTest : public ::testing::Test {
 TEST_F(
     DifferentiatorUnflattenTest,
     withoutFix_updateMutationHasWrongParentTag) {
+  ReactNativeFeatureFlags::dangerouslyForceOverride(
+      std::make_unique<TestFlagsWithUnflattenFix>(false));
+
   applyUnflattenSetup_();
 
   auto mutations = calculateMutations_();
@@ -186,7 +194,7 @@ TEST_F(
 // as parentTag, and StubViewTree::mutate() succeeds without assertion failure.
 TEST_F(DifferentiatorUnflattenTest, withFix_updateMutationHasCorrectParentTag) {
   ReactNativeFeatureFlags::dangerouslyForceOverride(
-      std::make_unique<TestFlagsWithUnflattenFix>());
+      std::make_unique<TestFlagsWithUnflattenFix>(true));
 
   applyUnflattenSetup_();
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -605,7 +605,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     fixDifferentiatorParentTagForUnflattenCase: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2026-04-18',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<609451fd0a38e0f8eaf685e7cf534e27>>
+ * @generated SignedSource<<3304b4ee2c718dbf4d56b607ea09054d>>
  * @flow strict
  * @noformat
  */
@@ -424,7 +424,7 @@ export const enableVirtualViewContainerStateExperimental: Getter<boolean> = crea
 /**
  * Fix incorrect parentTag passed as parentTagForUpdate in the unflatten-unflatten branch of calculateShadowViewMutationsFlattener, which causes UPDATE mutations to reference a parent being created in the same batch.
  */
-export const fixDifferentiatorParentTagForUnflattenCase: Getter<boolean> = createNativeFlagGetter('fixDifferentiatorParentTagForUnflattenCase', false);
+export const fixDifferentiatorParentTagForUnflattenCase: Getter<boolean> = createNativeFlagGetter('fixDifferentiatorParentTagForUnflattenCase', true);
 /**
  * Uses the default event priority instead of the discreet event priority by default when dispatching events from Fabric to React.
  */


### PR DESCRIPTION
Summary:
Flip the React Native feature flag `fixDifferentiatorParentTagForUnflattenCase` default to `true` so the differentiator `parentTag` fix is on by default across all platforms

Changelog: [Internal]

Wire fbios + fb4a to MobileConfig params so we can opt out server-side if needed.

Because the MC defaults are `true`, the feature activates for all FB-app users on land; setting the param to `false` server-side is the kill switch.

Reviewed By: zeyap

Differential Revision: D108613362


