### PR TITLE
Fix unused variable 'moduleClass' in RCTTurboModuleManager.mm

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -333,7 +333,6 @@ Class getFallbackClassFromName(const char *name)
    * Use respondsToSelector: below to infer conformance to @protocol(RCTTurboModule). Using conformsToProtocol: is
    * expensive.
    */
-  Class moduleClass = [module class];
   if ([module respondsToSelector:@selector(getTurboModule:)]) {
     ObjCTurboModule::InitParams params = {
         .moduleName = moduleName,
@@ -345,7 +344,7 @@ Class getFallbackClassFromName(const char *name)
 
     auto turboModule = [(id<RCTTurboModule>)module getTurboModule:params];
     if (turboModule == nullptr) {
-      RCTLogError(@"TurboModule \"%@\"'s getTurboModule: method returned nil.", moduleClass);
+      RCTLogError(@"TurboModule \"%@\"'s getTurboModule: method returned nil.", [module class]);
     }
     _turboModuleCache.insert({moduleName, turboModule});
 


### PR DESCRIPTION
Summary:
Pika 27 (LLVM 21 / Swift 6.4) flags `Class moduleClass = [module class];` as an unused variable (`-Werror,-Wunused-variable`) in `RCTTurboModuleManager.mm`. Its only reference is inside an `RCTLogError` call, which compiles to a no-op in release builds, leaving the variable unused.

This inlines `[module class]` directly into the `RCTLogError` call and removes the local declaration. The expression is now elided together with the log macro in release builds, eliminating the dangling unused variable. Debug logging behavior is identical.

No `#pragma` diagnostic suppression is used, per the task requirements.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=36a6fdd8-65cb-4fd8-bbc5-6d4afa5245dd)

Reviewed By: javache

Differential Revision: D108605640


