### PR TITLE
Add tight lineHeight descender example to TextExample.android.js

### DIFF
--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -1123,6 +1123,19 @@ function LineHeightExample(props: {}): React.Node {
         style={[
           {
             fontSize: 24,
+            lineHeight: 24,
+            borderColor: 'black',
+            borderWidth: 1,
+          },
+          styles.wrappedText,
+        ]}
+        testID="line-height-matches-font-size-descenders">
+        gjpqy
+      </RNTesterText>
+      <RNTesterText
+        style={[
+          {
+            fontSize: 24,
             lineHeight: 8,
             borderColor: 'black',
             borderWidth: 1,


### PR DESCRIPTION
Summary:
Adds a `gjpqy` example to the Text > lineHeight RNTester section that exercises `fontSize: 24, lineHeight: 24`. Pure example addition for the upcoming `CustomLineHeightSpan` descender-clipping fix, providing the surface for a jest-e2e screenshot regression test.

Changelog:
[Internal]

Reviewed By: cortinico

Differential Revision: D108409230


