### PR TITLE
Mark loaderRequest __unused in RCTSyncImageManager to fix release-build unused-variable error

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
@@ -78,7 +78,7 @@ using namespace facebook::react;
     observerCoordinator->nativeImageResponseProgress((float)progress / (float)total, progress, total);
   };
 
-  RCTImageURLLoaderRequest *loaderRequest =
+  RCTImageURLLoaderRequest *__unused loaderRequest =
       [self->_imageLoader loadImageWithURLRequest:request
                                              size:CGSizeMake(imageSource.size.width, imageSource.size.height)
                                             scale:imageSource.scale


### PR DESCRIPTION
Summary:
WARNING: Generated by Autopilot (alpha) — review carefully, verify the underlying claim before accepting.
Agent: Default: IROC Investigator | Trajectory: https://www.internalfb.com/intern/devai/devmate/inspector/e67dfb9b-9e79-4eb6-b114-2346948d1358/ | SC job: https://www.internalfb.com/intern/sandcastle/instance/4503602361875877/

---

In `-[RCTSyncImageManager requestImage:surfaceId:priority:]` the local `loaderRequest` is read only inside an `RCTLogWarn` call on the image-timeout path. In release/profile builds the logging macros compile down to a no-op (`do {} while (0)` when `RCTLOG_ENABLED == 0`), so the binding is never read and a stricter `-Werror,-Wunused-variable` check in the newer toolchain (LLVM 21) flags it as a hard compilation error.

Mark the variable `__unused`, the established idiom already used throughout this codebase, so it is accepted whether or not logging is compiled in, while keeping the side-effecting loader call and the timeout-path log intact. This is not diagnostic suppression — `__unused` precisely documents that the binding is legitimately read only in builds where logging is enabled, and it does not hide unused-variable issues anywhere else in the file.

Changelog: [Internal]

Differential Revision: D108445102


