### PR TITLE
Remove useOptimizedViewRegistryOnAndroid feature flag

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
@@ -55,7 +55,6 @@ import com.facebook.systrace.Systrace
 import java.util.ArrayDeque
 import java.util.LinkedList
 import java.util.Queue
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.read
@@ -87,19 +86,8 @@ internal constructor(
   public var context: ThemedReactContext? = reactContext
     private set
 
-  private val tagToViewState: ConcurrentHashMap<Int, ViewState>?
-  private val optimizedTagToViewState: MutableIntObjectMap<ViewState>?
+  private val tagToViewState: MutableIntObjectMap<ViewState> = MutableIntObjectMap()
   private val registryLock = ReentrantReadWriteLock()
-
-  init {
-    if (ReactNativeFeatureFlags.useOptimizedViewRegistryOnAndroid()) {
-      tagToViewState = null
-      optimizedTagToViewState = MutableIntObjectMap()
-    } else {
-      tagToViewState = ConcurrentHashMap()
-      optimizedTagToViewState = null
-    }
-  }
 
   private val onViewAttachMountItems: Queue<MountItem> = ArrayDeque()
 
@@ -142,7 +130,9 @@ internal constructor(
       return
     }
 
-    registryPut(surfaceId, ViewState(surfaceId, rootView, rootViewManager, true))
+    registryLock.write {
+      tagToViewState[surfaceId] = ViewState(surfaceId, rootView, rootViewManager, true)
+    }
 
     val runnable: Runnable =
         object : GuardedRunnable(checkNotNull(context)) {
@@ -206,7 +196,7 @@ internal constructor(
     if (tagSetForStoppedSurface?.containsKey(tag) == true) {
       return true
     }
-    return registryContains(tag)
+    return registryLock.read { tagToViewState.containsKey(tag) }
   }
 
   @UiThread
@@ -252,12 +242,14 @@ internal constructor(
     // Reset all StateWrapper objects
     // Since this can happen on any thread, is it possible to race between StateWrapper destruction
     // and some accesses from View classes in the UI thread?
-    registryForEachValue { viewState ->
-      viewState.stateWrapper?.destroyState()
-      viewState.stateWrapper = null
+    registryLock.read {
+      tagToViewState.forEachValue { viewState ->
+        viewState.stateWrapper?.destroyState()
+        viewState.stateWrapper = null
 
-      viewState.eventEmitter?.destroy()
-      viewState.eventEmitter = null
+        viewState.eventEmitter?.destroy()
+        viewState.eventEmitter = null
+      }
     }
 
     val runnable = Runnable {
@@ -265,29 +257,23 @@ internal constructor(
         viewManagerRegistry?.onSurfaceStopped(surfaceId)
       }
 
-      if (optimizedTagToViewState != null) {
-        val viewStatesToDelete: ArrayList<ViewState>
-        registryLock.write {
-          val tagSetForStoppedSurface =
-              SparseArrayCompat<Any>().also { this.tagSetForStoppedSurface = it }
-          viewStatesToDelete = ArrayList(optimizedTagToViewState.size)
-          optimizedTagToViewState.forEach { key, value ->
-            tagSetForStoppedSurface[key] = this@SurfaceMountingManager
-            viewStatesToDelete.add(value)
-          }
-          optimizedTagToViewState.clear()
+      // Using this as a placeholder value in the map. We're using SparseArrayCompat
+      // since it can efficiently represent the list of pending tags
+      val tagSetForStoppedSurface =
+          SparseArrayCompat<Any>().also { this.tagSetForStoppedSurface = it }
+
+      val viewStatesToDelete: ArrayList<ViewState>
+      registryLock.write {
+        viewStatesToDelete = ArrayList(tagToViewState.size)
+        tagToViewState.forEach { key, value ->
+          tagSetForStoppedSurface[key] = this@SurfaceMountingManager
+          viewStatesToDelete.add(value)
         }
-        for (viewState in viewStatesToDelete) {
-          onViewStateDeleted(viewState)
-        }
-      } else {
-        val tagSetForStoppedSurface =
-            SparseArrayCompat<Any>().also { this.tagSetForStoppedSurface = it }
-        for ((key, value) in tagToViewState!!) {
-          tagSetForStoppedSurface[key] = this
-          onViewStateDeleted(value)
-        }
-        tagToViewState!!.clear()
+        tagToViewState.clear()
+      }
+      for (viewState in viewStatesToDelete) {
+        // We must call `onDropViewInstance` on all remaining Views
+        onViewStateDeleted(viewState)
       }
 
       // Evict all views from cache and memory
@@ -602,7 +588,7 @@ internal constructor(
             this.stateWrapper = stateWrapper
             this.eventEmitter = eventEmitterWrapper
           }
-      registryPut(reactTag, viewState)
+      registryLock.write { tagToViewState[reactTag] = viewState }
 
       if (isLayoutable) {
         @Suppress("UNCHECKED_CAST")
@@ -977,17 +963,9 @@ internal constructor(
 
     // TODO T62717437 - Use a flag to determine that these event emitters belong to virtual nodes
     // only.
-    val viewState: ViewState =
-        if (optimizedTagToViewState != null) {
-          registryLock.write { optimizedTagToViewState.getOrPut(reactTag) { ViewState(reactTag) } }
-        } else {
-          var vs = tagToViewState!![reactTag]
-          if (vs == null) {
-            vs = ViewState(reactTag)
-            tagToViewState!![reactTag] = vs
-          }
-          vs
-        }
+    val viewState: ViewState = registryLock.write {
+      tagToViewState.getOrPut(reactTag) { ViewState(reactTag) }
+    }
 
     val previousEventEmitterWrapper = viewState.eventEmitter
     synchronized(viewState) {
@@ -1096,7 +1074,7 @@ internal constructor(
       // To delete we simply remove the tag from the registry.
       // We want to rely on the correct set of MountInstructions being sent to the platform,
       // or StopSurface being called, so we do not handle deleting descendants of the View.
-      registryRemove(reactTag)
+      registryLock.write { tagToViewState.remove(reactTag) }
 
       onViewStateDeleted(viewState)
     }
@@ -1141,51 +1119,13 @@ internal constructor(
   }
 
   private fun getViewState(reactTag: Int): ViewState =
-      registryGet(reactTag)
+      getNullableViewState(reactTag)
           ?: throw RetryableMountingLayerException(
               "Unable to find viewState for tag $reactTag. Surface stopped: $isStopped"
           )
 
-  private fun getNullableViewState(reactTag: Int): ViewState? = registryGet(reactTag)
-
-  private fun registryGet(tag: Int): ViewState? {
-    return if (optimizedTagToViewState != null) {
-      registryLock.read { optimizedTagToViewState[tag] }
-    } else {
-      tagToViewState!![tag]
-    }
-  }
-
-  private fun registryPut(tag: Int, state: ViewState) {
-    if (optimizedTagToViewState != null) {
-      registryLock.write { optimizedTagToViewState[tag] = state }
-    } else {
-      tagToViewState!![tag] = state
-    }
-  }
-
-  private fun registryRemove(tag: Int) {
-    if (optimizedTagToViewState != null) {
-      registryLock.write { optimizedTagToViewState.remove(tag) }
-    } else {
-      tagToViewState!!.remove(tag)
-    }
-  }
-
-  private fun registryContains(tag: Int): Boolean {
-    return if (optimizedTagToViewState != null) {
-      registryLock.read { optimizedTagToViewState.containsKey(tag) }
-    } else {
-      tagToViewState!!.containsKey(tag)
-    }
-  }
-
-  private inline fun registryForEachValue(action: (ViewState) -> Unit) {
-    if (optimizedTagToViewState != null) {
-      registryLock.read { optimizedTagToViewState.forEachValue(action) }
-    } else {
-      tagToViewState!!.values.forEach(action)
-    }
+  private inline fun getNullableViewState(reactTag: Int): ViewState? = registryLock.read {
+    tagToViewState[reactTag]
   }
 
   /** Applies a bitmap as the background of the view with the given tag, if it exists. */
@@ -1197,16 +1137,18 @@ internal constructor(
 
   public fun printSurfaceState(): Unit {
     FLog.e(TAG, "Views created for surface $surfaceId:")
-    registryForEachValue { viewState ->
-      val viewManagerName = viewState.viewManager?.name
-      val view = viewState.view
-      val parent = if (view != null) view.parent as View? else null
-      val parentTag = parent?.id
+    registryLock.read {
+      tagToViewState.forEachValue { viewState ->
+        val viewManagerName = viewState.viewManager?.name
+        val view = viewState.view
+        val parent = if (view != null) view.parent as View? else null
+        val parentTag = parent?.id
 
-      FLog.e(
-          TAG,
-          "<$viewManagerName id=${viewState.reactTag} parentTag=$parentTag isRoot=${viewState.isRoot} />",
-      )
+        FLog.e(
+            TAG,
+            "<$viewManagerName id=${viewState.reactTag} parentTag=$parentTag isRoot=${viewState.isRoot} />",
+        )
+      }
     }
   }
 
@@ -1219,7 +1161,7 @@ internal constructor(
       @EventCategoryDef eventCategory: Int,
       eventTimestamp: Long,
   ) {
-    val viewState = registryGet(reactTag)
+    val viewState = getNullableViewState(reactTag)
     if (viewState == null) {
       FLog.i(TAG, "Unable to invoke event: %s for reactTag: %d", eventName, reactTag)
       return

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7e91da9df64ce42424101d7d72356c4a>>
+ * @generated SignedSource<<1167623751686dc836ff8209fe55cbb1>>
  */
 
 /**
@@ -509,12 +509,6 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useNestedScrollViewAndroid(): Boolean = accessor.useNestedScrollViewAndroid()
-
-  /**
-   * Use MutableIntObjectMap with ReadWriteLock instead of ConcurrentHashMap for the view registry in SurfaceMountingManager to reduce memory overhead and GC pressure.
-   */
-  @JvmStatic
-  public fun useOptimizedViewRegistryOnAndroid(): Boolean = accessor.useOptimizedViewRegistryOnAndroid()
 
   /**
    * Use shared animation backend in C++ Animated

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3c0e10dee93b76f3e66ca79d26f2b4f2>>
+ * @generated SignedSource<<4203cfc47d90d9d11b3ae97d932e8200>>
  */
 
 /**
@@ -100,7 +100,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var useFabricInteropCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
   private var useNestedScrollViewAndroidCache: Boolean? = null
-  private var useOptimizedViewRegistryOnAndroidCache: Boolean? = null
   private var useSharedAnimatedBackendCache: Boolean? = null
   private var useTraitHiddenOnAndroidCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
@@ -825,15 +824,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useNestedScrollViewAndroid()
       useNestedScrollViewAndroidCache = cached
-    }
-    return cached
-  }
-
-  override fun useOptimizedViewRegistryOnAndroid(): Boolean {
-    var cached = useOptimizedViewRegistryOnAndroidCache
-    if (cached == null) {
-      cached = ReactNativeFeatureFlagsCxxInterop.useOptimizedViewRegistryOnAndroid()
-      useOptimizedViewRegistryOnAndroidCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e9cc7d01ac1884710f131fbf375f3502>>
+ * @generated SignedSource<<7f472ecf6b1cacee2087a6df862c5274>>
  */
 
 /**
@@ -187,8 +187,6 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun useNativeViewConfigsInBridgelessMode(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useNestedScrollViewAndroid(): Boolean
-
-  @DoNotStrip @JvmStatic public external fun useOptimizedViewRegistryOnAndroid(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useSharedAnimatedBackend(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<061d668cf04041f4d3d2f48f11dc739f>>
+ * @generated SignedSource<<f0c68f41f2be4c283965970413bb7d31>>
  */
 
 /**
@@ -182,8 +182,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = false
 
   override fun useNestedScrollViewAndroid(): Boolean = false
-
-  override fun useOptimizedViewRegistryOnAndroid(): Boolean = false
 
   override fun useSharedAnimatedBackend(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fa85d53197cbdce6b1373fbadf3cf2b9>>
+ * @generated SignedSource<<f40636a4203d5741bb9a034f1a1a482b>>
  */
 
 /**
@@ -104,7 +104,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var useFabricInteropCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
   private var useNestedScrollViewAndroidCache: Boolean? = null
-  private var useOptimizedViewRegistryOnAndroidCache: Boolean? = null
   private var useSharedAnimatedBackendCache: Boolean? = null
   private var useTraitHiddenOnAndroidCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
@@ -909,16 +908,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.useNestedScrollViewAndroid()
       accessedFeatureFlags.add("useNestedScrollViewAndroid")
       useNestedScrollViewAndroidCache = cached
-    }
-    return cached
-  }
-
-  override fun useOptimizedViewRegistryOnAndroid(): Boolean {
-    var cached = useOptimizedViewRegistryOnAndroidCache
-    if (cached == null) {
-      cached = currentProvider.useOptimizedViewRegistryOnAndroid()
-      accessedFeatureFlags.add("useOptimizedViewRegistryOnAndroid")
-      useOptimizedViewRegistryOnAndroidCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a460b28871fc3f928dcc2d1a3bf66422>>
+ * @generated SignedSource<<527607482377488c5d5126dcb78a16a1>>
  */
 
 /**
@@ -182,8 +182,6 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun useNativeViewConfigsInBridgelessMode(): Boolean
 
   @DoNotStrip public fun useNestedScrollViewAndroid(): Boolean
-
-  @DoNotStrip public fun useOptimizedViewRegistryOnAndroid(): Boolean
 
   @DoNotStrip public fun useSharedAnimatedBackend(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ea8284ad906ae89281a3fbd849e88c19>>
+ * @generated SignedSource<<eb07e9f1971aea80f7a437dcb5bcc64e>>
  */
 
 /**
@@ -519,12 +519,6 @@ class ReactNativeFeatureFlagsJavaProvider
     return method(javaProvider_);
   }
 
-  bool useOptimizedViewRegistryOnAndroid() override {
-    static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useOptimizedViewRegistryOnAndroid");
-    return method(javaProvider_);
-  }
-
   bool useSharedAnimatedBackend() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useSharedAnimatedBackend");
@@ -971,11 +965,6 @@ bool JReactNativeFeatureFlagsCxxInterop::useNestedScrollViewAndroid(
   return ReactNativeFeatureFlags::useNestedScrollViewAndroid();
 }
 
-bool JReactNativeFeatureFlagsCxxInterop::useOptimizedViewRegistryOnAndroid(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
-  return ReactNativeFeatureFlags::useOptimizedViewRegistryOnAndroid();
-}
-
 bool JReactNativeFeatureFlagsCxxInterop::useSharedAnimatedBackend(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useSharedAnimatedBackend();
@@ -1282,9 +1271,6 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useNestedScrollViewAndroid",
         JReactNativeFeatureFlagsCxxInterop::useNestedScrollViewAndroid),
-      makeNativeMethod(
-        "useOptimizedViewRegistryOnAndroid",
-        JReactNativeFeatureFlagsCxxInterop::useOptimizedViewRegistryOnAndroid),
       makeNativeMethod(
         "useSharedAnimatedBackend",
         JReactNativeFeatureFlagsCxxInterop::useSharedAnimatedBackend),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<746da63dcbec1bb165731e7380993659>>
+ * @generated SignedSource<<0e9eba59d082b9320280e849f2bc9977>>
  */
 
 /**
@@ -268,9 +268,6 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useNestedScrollViewAndroid(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
-
-  static bool useOptimizedViewRegistryOnAndroid(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useSharedAnimatedBackend(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<38e26847bb30888adaf6a965dae07cfb>>
+ * @generated SignedSource<<8011ab8c1a991cb4908d30b1f8a0281a>>
  */
 
 /**
@@ -344,10 +344,6 @@ bool ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode() {
 
 bool ReactNativeFeatureFlags::useNestedScrollViewAndroid() {
   return getAccessor().useNestedScrollViewAndroid();
-}
-
-bool ReactNativeFeatureFlags::useOptimizedViewRegistryOnAndroid() {
-  return getAccessor().useOptimizedViewRegistryOnAndroid();
 }
 
 bool ReactNativeFeatureFlags::useSharedAnimatedBackend() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6958847f0d788c06cf64478ee2c36386>>
+ * @generated SignedSource<<4e892daae3cfae8fc24369f10e2b7ecc>>
  */
 
 /**
@@ -438,11 +438,6 @@ class ReactNativeFeatureFlags {
    * When enabled, ReactScrollView will extend NestedScrollView instead of ScrollView on Android for improved nested scrolling support.
    */
   RN_EXPORT static bool useNestedScrollViewAndroid();
-
-  /**
-   * Use MutableIntObjectMap with ReadWriteLock instead of ConcurrentHashMap for the view registry in SurfaceMountingManager to reduce memory overhead and GC pressure.
-   */
-  RN_EXPORT static bool useOptimizedViewRegistryOnAndroid();
 
   /**
    * Use shared animation backend in C++ Animated

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<78640fe49801cfa03638739e712c5e92>>
+ * @generated SignedSource<<df8f11981c5f8481aff6ec757d882841>>
  */
 
 /**
@@ -1469,24 +1469,6 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
   return flagValue.value();
 }
 
-bool ReactNativeFeatureFlagsAccessor::useOptimizedViewRegistryOnAndroid() {
-  auto flagValue = useOptimizedViewRegistryOnAndroid_.load();
-
-  if (!flagValue.has_value()) {
-    // This block is not exclusive but it is not necessary.
-    // If multiple threads try to initialize the feature flag, we would only
-    // be accessing the provider multiple times but the end state of this
-    // instance and the returned flag value would be the same.
-
-    markFlagAsAccessed(80, "useOptimizedViewRegistryOnAndroid");
-
-    flagValue = currentProvider_->useOptimizedViewRegistryOnAndroid();
-    useOptimizedViewRegistryOnAndroid_ = flagValue;
-  }
-
-  return flagValue.value();
-}
-
 bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
   auto flagValue = useSharedAnimatedBackend_.load();
 
@@ -1496,7 +1478,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useSharedAnimatedBackend");
+    markFlagAsAccessed(80, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1514,7 +1496,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(81, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1532,7 +1514,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "useTurboModuleInterop");
+    markFlagAsAccessed(82, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1550,7 +1532,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "viewCullingOutsetRatio");
+    markFlagAsAccessed(83, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1568,7 +1550,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "viewTransitionEnabled");
+    markFlagAsAccessed(84, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1586,7 +1568,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionUseHardwareBitmapAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "viewTransitionUseHardwareBitmapAndroid");
+    markFlagAsAccessed(85, "viewTransitionUseHardwareBitmapAndroid");
 
     flagValue = currentProvider_->viewTransitionUseHardwareBitmapAndroid();
     viewTransitionUseHardwareBitmapAndroid_ = flagValue;
@@ -1604,7 +1586,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(87, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(86, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1974d5797f43e8f73b521ebfd46ce492>>
+ * @generated SignedSource<<854e22517268a4e170dfe3224f9b6782>>
  */
 
 /**
@@ -112,7 +112,6 @@ class ReactNativeFeatureFlagsAccessor {
   bool useFabricInterop();
   bool useNativeViewConfigsInBridgelessMode();
   bool useNestedScrollViewAndroid();
-  bool useOptimizedViewRegistryOnAndroid();
   bool useSharedAnimatedBackend();
   bool useTraitHiddenOnAndroid();
   bool useTurboModuleInterop();
@@ -131,7 +130,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 88> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 87> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -213,7 +212,6 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> useFabricInterop_;
   std::atomic<std::optional<bool>> useNativeViewConfigsInBridgelessMode_;
   std::atomic<std::optional<bool>> useNestedScrollViewAndroid_;
-  std::atomic<std::optional<bool>> useOptimizedViewRegistryOnAndroid_;
   std::atomic<std::optional<bool>> useSharedAnimatedBackend_;
   std::atomic<std::optional<bool>> useTraitHiddenOnAndroid_;
   std::atomic<std::optional<bool>> useTurboModuleInterop_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8dfc52502bd539e5e43d547f895a6d33>>
+ * @generated SignedSource<<cc6b71563473b74b1407c39ba0a99dae>>
  */
 
 /**
@@ -344,10 +344,6 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool useNestedScrollViewAndroid() override {
-    return false;
-  }
-
-  bool useOptimizedViewRegistryOnAndroid() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<15bb8c904ef3116d0f6042623a150d8c>>
+ * @generated SignedSource<<cdc6ee919341e329b94880bd51c0d516>>
  */
 
 /**
@@ -763,15 +763,6 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::useNestedScrollViewAndroid();
-  }
-
-  bool useOptimizedViewRegistryOnAndroid() override {
-    auto value = values_["useOptimizedViewRegistryOnAndroid"];
-    if (!value.isNull()) {
-      return value.getBool();
-    }
-
-    return ReactNativeFeatureFlagsDefaults::useOptimizedViewRegistryOnAndroid();
   }
 
   bool useSharedAnimatedBackend() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e066fb9f428dbc0d26fda892404316a8>>
+ * @generated SignedSource<<5ab7922a2c192a1fd66d748cac8a6c8c>>
  */
 
 /**
@@ -105,7 +105,6 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useFabricInterop() = 0;
   virtual bool useNativeViewConfigsInBridgelessMode() = 0;
   virtual bool useNestedScrollViewAndroid() = 0;
-  virtual bool useOptimizedViewRegistryOnAndroid() = 0;
   virtual bool useSharedAnimatedBackend() = 0;
   virtual bool useTraitHiddenOnAndroid() = 0;
   virtual bool useTurboModuleInterop() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<34ba54f5915738fc4792567680679880>>
+ * @generated SignedSource<<7671a159d1369a4c57fc00efb9d2fc5c>>
  */
 
 /**
@@ -442,11 +442,6 @@ bool NativeReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode(
 bool NativeReactNativeFeatureFlags::useNestedScrollViewAndroid(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useNestedScrollViewAndroid();
-}
-
-bool NativeReactNativeFeatureFlags::useOptimizedViewRegistryOnAndroid(
-    jsi::Runtime& /*runtime*/) {
-  return ReactNativeFeatureFlags::useOptimizedViewRegistryOnAndroid();
 }
 
 bool NativeReactNativeFeatureFlags::useSharedAnimatedBackend(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<32404575231774f230ece7a097ae08c5>>
+ * @generated SignedSource<<2d2e225b634a309e40bd2ece73cfa055>>
  */
 
 /**
@@ -195,8 +195,6 @@ class NativeReactNativeFeatureFlags
   bool useNativeViewConfigsInBridgelessMode(jsi::Runtime& runtime);
 
   bool useNestedScrollViewAndroid(jsi::Runtime& runtime);
-
-  bool useOptimizedViewRegistryOnAndroid(jsi::Runtime& runtime);
 
   bool useSharedAnimatedBackend(jsi::Runtime& runtime);
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -904,17 +904,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    useOptimizedViewRegistryOnAndroid: {
-      defaultValue: false,
-      metadata: {
-        dateAdded: '2026-04-28',
-        description:
-          'Use MutableIntObjectMap with ReadWriteLock instead of ConcurrentHashMap for the view registry in SurfaceMountingManager to reduce memory overhead and GC pressure.',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
     useSharedAnimatedBackend: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<609451fd0a38e0f8eaf685e7cf534e27>>
+ * @generated SignedSource<<0e23153a5eb02c1d42e7db7d8b27b439>>
  * @flow strict
  * @noformat
  */
@@ -129,7 +129,6 @@ export type ReactNativeFeatureFlags = Readonly<{
   useFabricInterop: Getter<boolean>,
   useNativeViewConfigsInBridgelessMode: Getter<boolean>,
   useNestedScrollViewAndroid: Getter<boolean>,
-  useOptimizedViewRegistryOnAndroid: Getter<boolean>,
   useSharedAnimatedBackend: Getter<boolean>,
   useTraitHiddenOnAndroid: Getter<boolean>,
   useTurboModuleInterop: Getter<boolean>,
@@ -533,10 +532,6 @@ export const useNativeViewConfigsInBridgelessMode: Getter<boolean> = createNativ
  * When enabled, ReactScrollView will extend NestedScrollView instead of ScrollView on Android for improved nested scrolling support.
  */
 export const useNestedScrollViewAndroid: Getter<boolean> = createNativeFlagGetter('useNestedScrollViewAndroid', false);
-/**
- * Use MutableIntObjectMap with ReadWriteLock instead of ConcurrentHashMap for the view registry in SurfaceMountingManager to reduce memory overhead and GC pressure.
- */
-export const useOptimizedViewRegistryOnAndroid: Getter<boolean> = createNativeFlagGetter('useOptimizedViewRegistryOnAndroid', false);
 /**
  * Use shared animation backend in C++ Animated
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7dce2cc7ad3dc4f61ba9ae24fcefe3c2>>
+ * @generated SignedSource<<ad52a9db8a34a03e4d85ff9cb535e100>>
  * @flow strict
  * @noformat
  */
@@ -105,7 +105,6 @@ export interface Spec extends TurboModule {
   readonly useFabricInterop?: () => boolean;
   readonly useNativeViewConfigsInBridgelessMode?: () => boolean;
   readonly useNestedScrollViewAndroid?: () => boolean;
-  readonly useOptimizedViewRegistryOnAndroid?: () => boolean;
   readonly useSharedAnimatedBackend?: () => boolean;
   readonly useTraitHiddenOnAndroid?: () => boolean;
   readonly useTurboModuleInterop?: () => boolean;


### PR DESCRIPTION
Summary:
The flag gated a more memory-efficient view registry implementation in `SurfaceMountingManager` (`MutableIntObjectMap` with a `ReadWriteLock` instead of `ConcurrentHashMap`). Removing the gate, keeping the optimized path, and inlining the helper methods that previously dispatched between the two implementations.

Changelog:
[Internal]

Reviewed By: mdvacca

Differential Revision: D108415790


