### PR TITLE
Annotate throwable methods in ColorPropConverter, log bad Android resource lookup (#57239)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.kt
@@ -30,6 +30,7 @@ public object ColorPropConverter {
   private const val ATTR = "attr"
   private const val ATTR_SEGMENT = "attr/"
 
+  @Throws(JSApplicationCausedNativeException::class)
   private fun getColorInteger(value: Any?, context: Context): Int? {
     if (value == null) {
       return null
@@ -64,6 +65,12 @@ public object ColorPropConverter {
         }
       }
 
+      val attemptedPaths = (0 until resourcePaths.size()).map { resourcePaths.getString(it) }
+      FLog.w(
+          ReactConstants.TAG,
+          "ColorValue: Failed to resolve resource paths: ${attemptedPaths.joinToString(", ")}",
+      )
+
       throw JSApplicationCausedNativeException(
           "ColorValue: None of the paths in the `$JSON_KEY` array resolved to a color resource."
       )
@@ -73,6 +80,7 @@ public object ColorPropConverter {
   }
 
   @JvmStatic
+  @Throws(JSApplicationCausedNativeException::class)
   public fun getColorInstance(value: Any?, context: Context): Color? {
     if (value == null) {
       return null
@@ -113,6 +121,12 @@ public object ColorPropConverter {
         }
       }
 
+      val attemptedPaths = (0 until resourcePaths.size()).map { resourcePaths.getString(it) }
+      FLog.w(
+          ReactConstants.TAG,
+          "ColorValue: Failed to resolve resource paths: ${attemptedPaths.joinToString(", ")}",
+      )
+
       throw JSApplicationCausedNativeException(
           "ColorValue: None of the paths in the `$JSON_KEY` array resolved to a color resource."
       )
@@ -122,6 +136,7 @@ public object ColorPropConverter {
   }
 
   @JvmStatic
+  @Throws(JSApplicationCausedNativeException::class)
   public fun getColor(value: Any?, context: Context): Int? {
     try {
       if (supportWideGamut()) {
@@ -188,6 +203,7 @@ public object ColorPropConverter {
     return ResourcesCompat.getColor(context.resources, resourceId, context.theme)
   }
 
+  @Throws(Resources.NotFoundException::class)
   private fun resolveThemeAttribute(context: Context, resourcePath: String): Int {
     val path = resourcePath.replace(ATTR_SEGMENT, "")
     val pathTokens = path.split(PACKAGE_DELIMITER)


### PR DESCRIPTION
Summary:

Adds logcat logging when resource lookups fail if `resource_paths` is defined for a color prop, and annotates the `ColorProp` calls with the throwable class that they can raise

Changelog: [Internal]

Reviewed By: zeyap

Differential Revision: D108777172


