### PR TITLE
[0.85] Fix display: contents nodes having hasNewLayout set incorrectly

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -528,7 +528,6 @@ bool layoutAbsoluteDescendants(
       // we need to mutate these descendents. Make sure the path of
       // nodes to them is mutable before positioning.
       child->cloneChildrenIfNeeded();
-      cleanupContentsNodesRecursively(child);
       const Direction childDirection =
           child->resolveDirection(currentNodeDirection);
       // By now all descendants of the containing block that are not absolute
@@ -554,6 +553,8 @@ bool layoutAbsoluteDescendants(
                          containingNodeAvailableInnerHeight) ||
           hasNewLayout;
 
+      cleanupContentsNodesRecursively(
+          child, /* didPerformLayout */ hasNewLayout);
       if (hasNewLayout) {
         child->setHasNewLayout(hasNewLayout);
       }

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -528,6 +528,7 @@ bool layoutAbsoluteDescendants(
       // we need to mutate these descendents. Make sure the path of
       // nodes to them is mutable before positioning.
       child->cloneChildrenIfNeeded();
+      cleanupContentsNodesRecursively(child);
       const Direction childDirection =
           child->resolveDirection(currentNodeDirection);
       // By now all descendants of the containing block that are not absolute

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -480,7 +480,7 @@ static void zeroOutLayoutRecursively(yoga::Node* const node) {
   }
 }
 
-static void cleanupContentsNodesRecursively(yoga::Node* const node) {
+void cleanupContentsNodesRecursively(yoga::Node* const node) {
   if (node->hasContentsChildren()) [[unlikely]] {
     node->cloneContentsChildrenIfNeeded();
     for (auto child : node->getChildren()) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -480,7 +480,9 @@ static void zeroOutLayoutRecursively(yoga::Node* const node) {
   }
 }
 
-void cleanupContentsNodesRecursively(yoga::Node* const node) {
+void cleanupContentsNodesRecursively(
+    yoga::Node* const node,
+    bool didPerformLayout) {
   if (node->hasContentsChildren()) [[unlikely]] {
     node->cloneContentsChildrenIfNeeded();
     for (auto child : node->getChildren()) {
@@ -488,11 +490,13 @@ void cleanupContentsNodesRecursively(yoga::Node* const node) {
         child->getLayout() = {};
         child->setLayoutDimension(0, Dimension::Width);
         child->setLayoutDimension(0, Dimension::Height);
-        child->setHasNewLayout(true);
+        if (didPerformLayout) {
+          child->setHasNewLayout(true);
+        }
         child->setDirty(false);
         child->cloneChildrenIfNeeded();
 
-        cleanupContentsNodesRecursively(child);
+        cleanupContentsNodesRecursively(child, didPerformLayout);
       }
     }
   }
@@ -1317,7 +1321,7 @@ static void calculateLayoutImpl(
 
     // Clean and update all display: contents nodes with a direct path to the
     // current node as they will not be traversed
-    cleanupContentsNodesRecursively(node);
+    cleanupContentsNodesRecursively(node, performLayout);
     return;
   }
 
@@ -1335,7 +1339,7 @@ static void calculateLayoutImpl(
 
     // Clean and update all display: contents nodes with a direct path to the
     // current node as they will not be traversed
-    cleanupContentsNodesRecursively(node);
+    cleanupContentsNodesRecursively(node, performLayout);
     return;
   }
 
@@ -1353,7 +1357,7 @@ static void calculateLayoutImpl(
           ownerHeight)) {
     // Clean and update all display: contents nodes with a direct path to the
     // current node as they will not be traversed
-    cleanupContentsNodesRecursively(node);
+    cleanupContentsNodesRecursively(node, /* didPerformLayout */ false);
     return;
   }
 
@@ -1365,7 +1369,7 @@ static void calculateLayoutImpl(
 
   // Clean and update all display: contents nodes with a direct path to the
   // current node as they will not be traversed
-  cleanupContentsNodesRecursively(node);
+  cleanupContentsNodesRecursively(node, performLayout);
 
   // STEP 1: CALCULATE VALUES FOR REMAINDER OF ALGORITHM
   const FlexDirection mainAxis =

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.h
@@ -35,6 +35,6 @@ bool calculateLayoutInternal(
     uint32_t depth,
     uint32_t generationCount);
 
-void cleanupContentsNodesRecursively(yoga::Node* const node);
+void cleanupContentsNodesRecursively(yoga::Node* node, bool didPerformLayout);
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.h
@@ -35,4 +35,6 @@ bool calculateLayoutInternal(
     uint32_t depth,
     uint32_t generationCount);
 
+void cleanupContentsNodesRecursively(yoga::Node* const node);
+
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -392,7 +392,12 @@ void Node::cloneChildrenIfNeeded() {
       child = resolveRef(config_->cloneNode(child, this, i));
       child->setOwner(this);
 
-      if (child->hasContentsChildren()) [[unlikely]] {
+      if (child->style().display() == Display::Contents) [[unlikely]] {
+        // The contents node's children are treated as children of the
+        // contents node's parent for layout purposes, so they need
+        // to be cloned as well.
+        child->cloneChildrenIfNeeded();
+      } else if (child->hasContentsChildren()) [[unlikely]] {
         child->cloneContentsChildrenIfNeeded();
       }
     }


### PR DESCRIPTION
Changelog: [General][Fixed] Fixed display: contents nodes having hasNewLayout set incorrectly
Changelog: [GENERAL][FIXED] Fixed Yoga node ownership when display: contents is used in absolutely positioned subtrees

Cherry-pick of https://github.com/facebook/react-native/pull/56422

Fixes an edge case where nodes with display: contents weren't cloned properly inside absolutely positioned subtrees.

Cherry-pick of https://github.com/facebook/react-native/pull/57103

cleanupContentsNodesRecursively unconditionally sets hasNewLayout=true on display: contents children, including on code paths where their parent's layout was not actually performed in this pass. The stale flag can survive across layout passes and, in clone-on-write renderers (e.g. React Native Fabric), be observed by a subsequent pass whose parent was cloned but whose layout was served from cache, leaving the contents child's owner pointing at the previous parent revision.

There are two paths through which the cleanup could stamp a contents child whose parent's hasNewLayout would end up false:

Measure-phase visit. Inside calculateLayoutImpl, the cleanup ran with no knowledge of performLayout. When the parent's calculateLayoutImpl was invoked only with performLayout=false (cache miss on measure, cache hit on layout), the cleanup stamped contents children even though the parent itself never had its hasNewLayout set.

Absolute-layout walk. layoutAbsoluteDescendants walks every static layout descendant of the containing block - including ones whose own calculateLayoutImpl was skipped via the layout-phase cache. The cleanup invoked along that walk unconditionally stamped contents children, but the parent's hasNewLayout was only updated when the recursion actually found new layout downstream.

In both cases, the result is the same invariant violation: a contents node with hasNewLayout=true whose parent has hasNewLayout=false. A consumer iterating the tree via hasNewLayout skips the parent and never clears the stale flag.

## Test Plan

Both of the picked PRs added unit tests in Yoga