### PR TITLE
Explicitly wake the main loop when scheduling a React revision merge (#57245)

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -349,8 +349,16 @@ class ReactRevisionMergeRunLoopObserverDelegate final : public RunLoopObserver::
     return;
   }
 
-  std::lock_guard<std::mutex> lock(_pendingReactRevisionMergesMutex);
-  _pendingReactRevisionMerges.insert(surfaceId);
+  bool needsWake = false;
+  {
+    std::lock_guard<std::mutex> lock(_pendingReactRevisionMergesMutex);
+    needsWake = _pendingReactRevisionMerges.empty();
+    _pendingReactRevisionMerges.insert(surfaceId);
+  }
+
+  if (needsWake) {
+    CFRunLoopWakeUp(CFRunLoopGetMain());
+  }
 }
 
 - (void)_mergeReactRevisionForSurfaceId:(SurfaceId)surfaceId


### PR DESCRIPTION
Summary:

Changelog: [IOS][FIXED] Add an explicit wake up call to the main loop hen scheduling a React revision merge

I could be possible that on idle screens the run loop is asleep, so without an explicit wake up call, the scheduled merges aren't processed.

This diff adds an explicit wake call when a merge is scheduled.

Differential Revision: D108610347


