### PR TITLE
fix: Make `EventTarget` methods enumerable

### DIFF
--- a/packages/react-native/src/private/webapis/dom/events/EventTarget.js
+++ b/packages/react-native/src/private/webapis/dom/events/EventTarget.js
@@ -258,6 +258,13 @@ export default class EventTarget {
   }
 }
 
+// $FlowExpectedError[cannot-write]
+Object.defineProperties(EventTarget.prototype, {
+  addEventListener: {enumerable: true},
+  removeEventListener: {enumerable: true},
+  dispatchEvent: {enumerable: true},
+});
+
 setPlatformObject(EventTarget);
 
 function validateCallback(callback: EventListener, methodName: string): void {

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
@@ -54,6 +54,19 @@ function createListener(
 }
 
 describe('EventTarget', () => {
+  it('should have 3 enumerable methods', () => {
+    const methods = new Set([
+      'addEventListener',
+      'removeEventListener',
+      'dispatchEvent',
+    ]);
+    for (const key in new EventTarget()) {
+      expect(methods.has(key)).toBe(true);
+      methods.delete(key);
+    }
+    expect(methods.size).toBe(0);
+  });
+
   describe('addEventListener', () => {
     it('should throw an error if event or callback are NOT passed', () => {
       const eventTarget = new EventTarget();


### PR DESCRIPTION

## Summary:

By spec `EventTarget` should have 3 enumerable methods (`addEventListener`, `removeEventListener` and `dispatchEvent`)



<img width="458" height="250" alt="Screenshot 2026-06-17 at 12 50 15" src="https://github.com/user-attachments/assets/c78b19ef-34d8-4df1-9b7a-22117362a043" />


## Changelog:

[GENERAL] [CHANGED] - Make `EventTarget` methods enumerable by spec

## Test Plan:

Create  aRN app and run code with/without commented code
 
```tsx
// Object.defineProperties(EventTarget.prototype, {
//   addEventListener: { enumerable: true },
//   removeEventListener: { enumerable: true },
//   dispatchEvent: { enumerable: true },
// });

console.log('Start');
for (const key in new EventTarget()) {
  console.log({ key });
}
console.log('End');
```

