### PR TITLE
Add `selection` to `TextInputChangeEventData` in TypeScript types

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -515,6 +515,10 @@ export type TextInputKeyPressEvent =
 export interface TextInputChangeEventData extends TargetedEvent {
   eventCount: number;
   text: string;
+  selection?: {
+    start: number;
+    end: number;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary:

The native `TextInput.onChange` event now emits `selection` data (cursor location) on both iOS and Android, added in [162627a](https://github.com/facebook/react-native/commit/162627af7c53e27433f39f82c4630baff0695bf1) (#55044).

- https://github.com/react/react-native/pull/55044

The JS companion PR [c1f5445](https://github.com/facebook/react-native/commit/c1f5445f4a59d0035389725e47da58eb3d2c267c) (#55043) added the corresponding types, but only to two of the three TypeScript/Flow type sources:

- https://github.com/react/react-native/pull/55043

| Type source | Has `selection`? |
|---|---|
| `TextInput.flow.js` (Flow) | ✅ |
| `ReactNativeApi.d.ts` (generated API surface) | ✅ |
| `TextInput.d.ts` (legacy public `.d.ts`) | ❌ |

The hand-written legacy `TextInput.d.ts` was missed, so consumers relying on it can't access `selection` from the `onChange` event even though native genuinely sends it. This PR adds the optional `selection` field there so all three type sources agree.

## Changelog:

[GENERAL] [ADDED] - Add `selection` to `TextInputChangeEventData` in TypeScript types

## Test Plan:

Type-only change. `selection` is now available and correctly typed on the `onChange` event:

```tsx
<TextInput
  onChange={e => {
    // e.nativeEvent.selection is now typed as { start: number; end: number } | undefined
    console.log(e.nativeEvent.selection?.start, e.nativeEvent.selection?.end);
  }}
/>
