### PR TITLE
Prevent iOS Alert and Modal from rendering in the top-left corner

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -7,6 +7,7 @@
 
 #import "RCTUtils.h"
 
+#import <atomic>
 #import <dlfcn.h>
 #import <mach/mach_time.h>
 #import <objc/message.h>
@@ -383,24 +384,26 @@ UIDeviceOrientation RCTDeviceOrientation(void)
 
 CGSize RCTScreenSize(void)
 {
-  static CGSize portraitSize;
+  static std::atomic<CGSize> cachedSize;
+  __block CGSize size = cachedSize.load(std::memory_order_relaxed);
 
-  if (CGSizeEqualToSize(portraitSize, CGSizeZero)) {
+  if (CGSizeEqualToSize(size, CGSizeZero)) {
     RCTUnsafeExecuteOnMainQueueSync(^{
       CGSize screenSize = [UIScreen mainScreen].bounds.size;
-      portraitSize = CGSizeMake(MIN(screenSize.width, screenSize.height), MAX(screenSize.width, screenSize.height));
+      size = CGSizeMake(MIN(screenSize.width, screenSize.height), MAX(screenSize.width, screenSize.height));
+      cachedSize.store(size, std::memory_order_relaxed);
     });
   }
 
 #if !TARGET_OS_TV
   if (UIDeviceOrientationIsLandscape(RCTDeviceOrientation())) {
-    return CGSizeMake(portraitSize.height, portraitSize.width);
+    return CGSizeMake(size.height, size.width);
   } else {
-    return CGSizeMake(portraitSize.width, portraitSize.height);
+    return CGSizeMake(size.width, size.height);
   }
 #else
   // tvOS doesn't have device orientation, always return landscape size
-  return CGSizeMake(portraitSize.height, portraitSize.width);
+  return CGSizeMake(size.height, size.width);
 #endif
 }
 

--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -384,13 +384,13 @@ UIDeviceOrientation RCTDeviceOrientation(void)
 CGSize RCTScreenSize(void)
 {
   static CGSize portraitSize;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+
+  if (CGSizeEqualToSize(portraitSize, CGSizeZero)) {
     RCTUnsafeExecuteOnMainQueueSync(^{
       CGSize screenSize = [UIScreen mainScreen].bounds.size;
       portraitSize = CGSizeMake(MIN(screenSize.width, screenSize.height), MAX(screenSize.width, screenSize.height));
     });
-  });
+  }
 
 #if !TARGET_OS_TV
   if (UIDeviceOrientationIsLandscape(RCTDeviceOrientation())) {

--- a/packages/react-native/React/CoreModules/RCTAlertController.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertController.mm
@@ -23,6 +23,7 @@
     UIWindowScene *scene = RCTKeyWindow().windowScene;
     if (scene != nil) {
       _alertWindow = [[UIWindow alloc] initWithWindowScene:scene];
+      _alertWindow.frame = scene.coordinateSpace.bounds;
     } else {
       _alertWindow = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
     }

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewUtils.mm
@@ -13,8 +13,16 @@ namespace facebook::react {
 
 Size ModalHostViewScreenSize(void)
 {
-  CGSize screenSize = RCTScreenSize();
-  return {.width = screenSize.width, .height = screenSize.height};
+  __block CGSize viewportSize;
+
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    viewportSize = RCTViewportSize();
+  });
+
+  return {
+    .width = viewportSize.width,
+    .height = viewportSize.height,
+  };
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewUtils.mm
@@ -13,16 +13,8 @@ namespace facebook::react {
 
 Size ModalHostViewScreenSize(void)
 {
-  __block CGSize viewportSize;
-
-  RCTUnsafeExecuteOnMainQueueSync(^{
-    viewportSize = RCTViewportSize();
-  });
-
-  return {
-    .width = viewportSize.width,
-    .height = viewportSize.height,
-  };
+  CGSize screenSize = RCTScreenSize();
+  return {.width = screenSize.width, .height = screenSize.height};
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

On iOS, both `Alert` and `Modal` could render in the top-left corner of the screen instead of filling it.

- `RCTAlertController`: when the alert window is created from a `UIWindowScene`, it was initialized without a frame and defaulted to a zero-sized frame. We now set its frame to the scene's coordinate space bounds.
- `ModalHostViewUtils`: `ModalHostViewScreenSize` used `RCTScreenSize()`, whose value is cached once via `dispatch_once`. If that first read happens before the screen is ready, it caches `0` and stays `0`, so the modal renders zero-sized in the top-left corner. We now read `RCTViewportSize()` on the main queue, which reads the key window's bounds live.

Fixes https://github.com/react/react-native/issues/45453

## Changelog:

[IOS] [FIXED] - Prevent Alert and Modal from rendering in the top-left corner

## Test Plan:

- Open an `Alert` on iOS and confirm it is centered and correctly sized.
- Open a `Modal` on iOS and confirm it fills the screen instead of appearing in the top-left corner.

## Screenshots:

<img width="284" height="542" alt="Alert" src="https://github.com/user-attachments/assets/e98ae159-9752-4b6e-8a97-0276984af3ba" />

<img width="284" height="542" alt="Modal" src="https://github.com/user-attachments/assets/1fff4217-5f28-4017-8699-01b757e7fb8a" />