### PR TITLE
Fix React-RCTAnimatedModuleProvider build failures

### DIFF
--- a/packages/react-native/ReactApple/RCTAnimatedModuleProvider/React-RCTAnimatedModuleProvider.podspec
+++ b/packages/react-native/ReactApple/RCTAnimatedModuleProvider/React-RCTAnimatedModuleProvider.podspec
@@ -23,6 +23,7 @@ other_cflags = "$(inherited) " + new_arch_enabled_flag + " " + js_engine_flags()
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/../../ReactCommon",
   "$(PODS_ROOT)/Headers/Private/React-Core",
+  "$(PODS_ROOT)/Headers/Private/Yoga",
   "$(PODS_ROOT)/Headers/Public/ReactCommon",
 ]
 
@@ -52,6 +53,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency "React-featureflags"
   s.dependency "React-Fabric/animated"
+  s.dependency "Yoga"
 
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
 

--- a/packages/react-native/ReactApple/RCTAnimatedModuleProvider/React-RCTAnimatedModuleProvider.podspec
+++ b/packages/react-native/ReactApple/RCTAnimatedModuleProvider/React-RCTAnimatedModuleProvider.podspec
@@ -18,7 +18,7 @@ end
 
 is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] != "0"
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED=1" : "")
-other_cflags = "$(inherited) " + new_arch_enabled_flag + js_engine_flags()
+other_cflags = "$(inherited) " + new_arch_enabled_flag + " " + js_engine_flags()
 
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/../../ReactCommon",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

`React-RCTAnimatedModuleProvider` could fail to build because of two issues in its podspec:

- **Missing space between compiler flags**: `new_arch_enabled_flag` and `js_engine_flags()` were concatenated without a separator, producing a single malformed flag (e.g. `-DRCT_NEW_ARCH_ENABLED=1-DUSE_HERMES=1`) instead of two distinct flags.
- **Missing Yoga dependency**: the pod uses Yoga headers (through `React-Fabric/animated`) but did not declare the `Yoga` dependency nor its private header search path, leading to a `'yoga/...' file not found` build error.

This adds the missing space, declares the `Yoga` dependency, and adds `$(PODS_ROOT)/Headers/Private/Yoga` to the header search paths.

## Changelog:

[IOS] [FIXED] - Fix React-RCTAnimatedModuleProvider build by adding the missing Yoga dependency and a missing space between compiler flags

## Test Plan:

Without these changes, building the pod fails with errors such as:

```
fatal error: 'yoga/Yoga.h' file not found
```

and the macro flags being mangled into a single unrecognized define.

- Run `pod install` and build the app on iOS.
- Confirm `React-RCTAnimatedModuleProvider` compiles and the build succeeds.
