### PR TITLE
chore(changelog) remove non-merged fix from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -669,7 +669,6 @@
 
 - **Appearance**: Fix color scheme in appearance state after setting it to unspecified ([08d1764530](https://github.com/facebook/react-native/commit/08d176453095db99300aa77632603ab42c57e152) by [@ismarbesic](https://github.com/ismarbesic))
 - **Assets**: Handle `unstable_path` query param in asset URLs ([42986f27a0](https://github.com/facebook/react-native/commit/42986f27a0285e501f71cf5cedacedefdc44c74e) by [@tido64](https://github.com/tido64))
-- **Networking**: Fix incorrect `fetch()` response URL after redirect (https://github.com/facebook/react-native/issues/55248) ([fbe6a686e6](https://github.com/facebook/react-native/commit/fbe6a686e65e70dd61700413084ddc54c0b86765) by [@MarkCSmith](https://github.com/MarkCSmith))
 
 #### Android specific
 


### PR DESCRIPTION
## Summary:

The changelog wrongly included a change (#1216) that wasn't picked due to conflicts. It seems that the Changelog generator included the change even though it was not merged to the release branch.

This commit fixes this by removing the fix from 0.83.2 - the fix is available in 0.84.

## Changelog:

[GENERAL] [FIXED] - Removed wrong changelog entry in 0.83.2
