### PR TITLE
Update package.json references to GitHub org "facebook"  -> "react"

### DIFF
--- a/packages/assets-registry/package.json
+++ b/packages/assets-registry/package.json
@@ -5,17 +5,17 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/assets-registry"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/assets-registry#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/assets-registry#readme",
   "keywords": [
     "assets",
     "registry",
     "react-native",
     "support"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/babel-plugin-codegen"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/babel-plugin-codegen#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/babel-plugin-codegen#readme",
   "keywords": [
     "babel",
     "plugin",
@@ -17,7 +17,7 @@
     "native-modules",
     "view-manager"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -6,11 +6,11 @@
     "react-native",
     "tools"
   ],
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/community-cli-plugin#readme",
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/community-cli-plugin#readme",
+  "bugs": "https://github.com/react/react-native/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/community-cli-plugin"
   },
   "license": "MIT",

--- a/packages/debugger-frontend/package.json
+++ b/packages/debugger-frontend/package.json
@@ -6,11 +6,11 @@
     "react-native",
     "tools"
   ],
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/debugger-frontend#readme",
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/debugger-frontend#readme",
+  "bugs": "https://github.com/react/react-native/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/debugger-frontend"
   },
   "license": "BSD-3-Clause",

--- a/packages/debugger-shell/package.json
+++ b/packages/debugger-shell/package.json
@@ -7,8 +7,8 @@
     "react-native",
     "tools"
   ],
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/debugger-shell#readme",
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/debugger-shell#readme",
+  "bugs": "https://github.com/react/react-native/issues",
   "main": "./src/index.js",
   "exports": {
     ".": {
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/debugger-shell"
   },
   "license": "MIT",

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -6,11 +6,11 @@
     "react-native",
     "tools"
   ],
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/dev-middleware#readme",
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/dev-middleware#readme",
+  "bugs": "https://github.com/react/react-native/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/dev-middleware"
   },
   "license": "MIT",

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -5,16 +5,16 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/eslint-config-react-native"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/eslint-config-react-native#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/eslint-config-react-native#readme",
   "keywords": [
     "eslint",
     "config",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/eslint-plugin-react-native/package.json
+++ b/packages/eslint-plugin-react-native/package.json
@@ -5,17 +5,17 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/eslint-plugin-react-native"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/eslint-plugin-react-native#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/eslint-plugin-react-native#readme",
   "keywords": [
     "eslint",
     "rules",
     "eslint-config",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "main": "index.js",
   "devDependencies": {
     "babel-plugin-syntax-hermes-parser": "0.36.1",

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/eslint-plugin-specs"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/eslint-plugin-specs#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/eslint-plugin-specs#readme",
   "keywords": [
     "eslint",
     "rules",
@@ -17,7 +17,7 @@
     "components",
     "specs"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "main": "index.js",
   "scripts": {
     "prepack": "node prepack.js",

--- a/packages/gradle-plugin/package.json
+++ b/packages/gradle-plugin/package.json
@@ -5,16 +5,16 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/gradle-plugin"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/gradle-plugin#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/gradle-plugin#readme",
   "keywords": [
     "gradle",
     "plugin",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/jest-preset"
   },
   "license": "MIT",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -5,16 +5,16 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/metro-config"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/metro-config#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/metro-config#readme",
   "keywords": [
     "metro",
     "config",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/new-app-screen/package.json
+++ b/packages/new-app-screen/package.json
@@ -5,11 +5,11 @@
   "keywords": [
     "react-native"
   ],
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/new-app-screen#readme",
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/new-app-screen#readme",
+  "bugs": "https://github.com/react/react-native/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/new-app-screen"
   },
   "license": "MIT",

--- a/packages/normalize-color/package.json
+++ b/packages/normalize-color/package.json
@@ -5,17 +5,17 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/normalize-color"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/normalize-color#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/normalize-color#readme",
   "keywords": [
     "color",
     "normalization",
     "normalize-colors",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "files": [
     "index.js",
     "README.md",

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/polyfills"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/polyfills#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/polyfills#readme",
   "keywords": [
     "polyfill",
     "polyfills",
@@ -16,7 +16,7 @@
     "js-polyfills",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -4,7 +4,8 @@
   "description": "Babel preset for React Native applications",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/facebook/react-native.git"
+    "url": "git+ssh://git@github.com/react/react-native.git",
+    "directory": "packages/react-native-babel-preset"
   },
   "keywords": [
     "babel",

--- a/packages/react-native-babel-transformer/package.json
+++ b/packages/react-native-babel-transformer/package.json
@@ -4,7 +4,7 @@
   "description": "Babel transformer for React Native applications.",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/facebook/react-native.git",
+    "url": "git+ssh://git@github.com/react/react-native.git",
     "directory": "packages/react-native-babel-transformer"
   },
   "keywords": [

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/react-native-codegen"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-codegen#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/react-native-codegen#readme",
   "keywords": [
     "code",
     "generation",
@@ -16,7 +16,7 @@
     "tools",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/react-native-compatibility-check/package.json
+++ b/packages/react-native-compatibility-check/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/react-native-compatibility-check"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-compatibility-check#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/react-native-compatibility-check#readme",
   "keywords": [
     "boundary",
     "crashes",
@@ -17,7 +17,7 @@
     "tools",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/react-native-popup-menu-android/package.json
+++ b/packages/react-native-popup-menu-android/package.json
@@ -2,6 +2,11 @@
   "name": "@react-native/popup-menu-android",
   "version": "0.87.0-main",
   "description": "PopupMenu for the Android platform",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/react/react-native.git",
+    "directory": "packages/react-native-popup-menu-android"
+  },
   "main": "index.js",
   "files": [
     "js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/react-native"
   },
   "homepage": "https://reactnative.dev/",
@@ -19,7 +19,7 @@
     "app-framework",
     "mobile-development"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/rn-tester"
   },
   "engines": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -5,16 +5,16 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/typescript-config"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/typescript-config#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/typescript-config#readme",
   "keywords": [
     "typescript",
     "tsconfig",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "exports": {
     ".": "./tsconfig.json",
     "./strict": "./tsconfig.strict.json"

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -5,17 +5,17 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/virtualized-lists"
   },
-  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/virtualized-lists#readme",
+  "homepage": "https://github.com/react/react-native/tree/HEAD/packages/virtualized-lists#readme",
   "keywords": [
     "lists",
     "virtualized-lists",
     "section-lists",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
+  "bugs": "https://github.com/react/react-native/issues",
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
   },


### PR DESCRIPTION
Summary:
Reflecting the move to https://github.com/react/react-native , update references in first-party `package.json`s

The `repository.url` field in particular is load-bearing for Trusted Publish.

Changelog: [Internal]

___

Differential Revision: D108986410


