### PR TITLE
Run `npm publish` with Node 24 / npm 11.5 for trusted publish support

### DIFF
--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -42,6 +42,7 @@ runs:
     - name: Setup node.js
       uses: ./.github/actions/setup-node
       with:
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
     - name: Install dependencies
       uses: ./.github/actions/yarn-install

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -203,6 +203,7 @@ jobs:
       - name: Setup node.js
         uses: ./.github/actions/setup-node
         with:
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       # TEMPORARY DEBUG: print the OIDC token claims npm Trusted Publishing
       # matches against. A 404 from the OIDC exchange means these claims don't


### PR DESCRIPTION
Summary:
Trusted publish support requires `npm` CLI version >=11.5.1 ([docs](https://docs.npmjs.com/trusted-publishers)), which is bundled with Node 24.

This bumps the Node version for just those jobs that call `npm publish`.

Changelog: [Internal]

Differential Revision: D109009971


