### PR TITLE
fix: correct Android logical border radius mapping

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderRadiusStyle.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderRadiusStyle.kt
@@ -161,11 +161,11 @@ internal data class BorderRadiusStyle(
                     CornerRadii(it, width, height)
                   } ?: zeroRadii,
               topRight =
-                  (endStart ?: topEnd ?: topRight ?: uniform)?.let {
+                  (startEnd ?: topEnd ?: topRight ?: uniform)?.let {
                     CornerRadii(it, width, height)
                   } ?: zeroRadii,
               bottomLeft =
-                  (startEnd ?: bottomStart ?: bottomLeft ?: uniform)?.let {
+                  (endStart ?: bottomStart ?: bottomLeft ?: uniform)?.let {
                     CornerRadii(it, width, height)
                   } ?: zeroRadii,
               bottomRight =
@@ -179,7 +179,7 @@ internal data class BorderRadiusStyle(
           if (I18nUtil.instance.doLeftAndRightSwapInRTL(context)) {
             ensureNoOverlap(
                 topLeft =
-                    (endStart ?: topEnd ?: topRight ?: uniform)?.let {
+                    (startEnd ?: topEnd ?: topRight ?: uniform)?.let {
                       CornerRadii(it, width, height)
                     } ?: zeroRadii,
                 topRight =
@@ -191,7 +191,7 @@ internal data class BorderRadiusStyle(
                       CornerRadii(it, width, height)
                     } ?: zeroRadii,
                 bottomRight =
-                    (startEnd ?: bottomStart ?: bottomLeft ?: uniform)?.let {
+                    (endStart ?: bottomStart ?: bottomLeft ?: uniform)?.let {
                       CornerRadii(it, width, height)
                     } ?: zeroRadii,
                 width = width,
@@ -200,7 +200,7 @@ internal data class BorderRadiusStyle(
           } else {
             ensureNoOverlap(
                 topLeft =
-                    (endStart ?: topEnd ?: topLeft ?: uniform)?.let {
+                    (startEnd ?: topEnd ?: topLeft ?: uniform)?.let {
                       CornerRadii(it, width, height)
                     } ?: zeroRadii,
                 topRight =
@@ -212,7 +212,7 @@ internal data class BorderRadiusStyle(
                       CornerRadii(it, width, height)
                     } ?: zeroRadii,
                 bottomRight =
-                    (startEnd ?: bottomEnd ?: bottomRight ?: uniform)?.let {
+                    (endStart ?: bottomEnd ?: bottomRight ?: uniform)?.let {
                       CornerRadii(it, width, height)
                     } ?: zeroRadii,
                 width = width,


### PR DESCRIPTION
## Summary:

Fixes incorrect Android mapping for `borderEndStartRadius` and `borderStartEndRadius`.

Fixes #57202

## Changelog:

[Android] [Fixed] - Correct logical border radius mapping for `borderEndStartRadius` and `borderStartEndRadius`.

## Test Plan:

- Reviewed the logical corner mapping implementation in `BorderRadiusStyle.kt`.
- Verified that `borderEndStartRadius` and `borderStartEndRadius` were mapped to opposite corners.
- Swapped the mappings so Android behavior matches iOS and CSS logical corner expectations.