### PR TITLE
Fix Fantom dev-mode tests when the tester is built in optimized mode

### DIFF
--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -123,22 +123,25 @@ export function getBuckModesForPlatform({
     );
   }
 
-  // When coverage instrumentation is enabled, the active build platform
-  // may not carry a `hermes_build_mode` constraint, causing
-  // `rn_build_mode()` in `tools/build_defs/oss/rn_defs.bzl` to fall back
-  // to the non-debug path. That leaves `REACT_NATIVE_DEBUG` undefined,
-  // which breaks dev-mode tests that use debug-only native APIs (e.g.
-  // timer mocking via `installHighResTimeStampMock`).
+  // The coverage platform (e.g. `@//arvr/mode/linux/code-coverage`) pins the
+  // `core_build_mode` constraint to `opt`. `get_react_native_preprocessor_flags()`
+  // in `tools/build_defs/oss/rn_defs.bzl` selects on that constraint
+  // (`ovr_config//build_mode/constraints:{dev,opt}`) to decide between
+  // `-DREACT_NATIVE_DEBUG` and `-DREACT_NATIVE_PRODUCTION`. Under coverage it
+  // therefore compiles the native tester with `REACT_NATIVE_PRODUCTION`, which
+  // breaks dev-mode tests that use debug-only native APIs (e.g. timer mocking
+  // via `installHighResTimeStampMock`).
   //
-  // Explicitly stack the `hermes_build_mode` constraint so the build
-  // reflects the test's intended dev/opt mode regardless of how the
-  // coverage build is configured.
+  // Explicitly stack the `core_build_mode` constraint so the build reflects the
+  // test's intended dev/opt mode. This only overrides `core_build_mode`; the
+  // coverage instrumentation constraint and `-c code_coverage.*` flags above are
+  // left intact, so coverage is still collected.
   if (enableCoverage) {
     result.push(
       '--modifier',
       enableOptimized
-        ? 'fbsource//xplat/hermes/constraints:opt'
-        : 'fbsource//xplat/hermes/constraints:dev',
+        ? 'ovr_config//build_mode/constraints:opt'
+        : 'ovr_config//build_mode/constraints:dev',
     );
   }
 


### PR DESCRIPTION
Summary:
Fantom integration tests declared with `fantom_mode dev` rely on debug-only native APIs (e.g. timer mocking via `installHighResTimeStampMock`) that are only compiled when the native tester is built in debug mode.

Under some build configurations the active platform pins the core build mode to optimized, so the preprocessor flag that gates those debug-only APIs is not defined and the tester is compiled in optimized mode. As a result, dev-mode tests that depend on those APIs throw at runtime (e.g. "Mocking timers is not supported in optimized builds").

A previous attempt stacked a build-mode constraint on the Hermes build mode setting, which the native preprocessor flags never read, so it had no effect. Stack the constraint on the core build mode setting that actually gates the flag instead, so the tester is compiled in the test's intended dev/opt mode.

Changelog: [Internal]

Differential Revision: D109014401


