### PR TITLE
Include a leaf's padding and border in its §4.5 automatic minimum size (#57279)

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -729,7 +729,14 @@ static float computeMinContentMainSize(
               wantRow ? MeasureMode::AtMost : MeasureMode::Undefined,
               wantRow ? YGUndefined : 0.0f,
               wantRow ? MeasureMode::Undefined : MeasureMode::AtMost);
-    return wantRow ? size.width : size.height;
+    // Add the leaf's own padding and border, like the container branch below.
+    const Direction leafDirection = node->resolveDirection(ownerDirection);
+    const float paddingAndBorder =
+        node->style().computeFlexStartPaddingAndBorder(
+            requestedAxis, leafDirection, ownerWidth) +
+        node->style().computeFlexEndPaddingAndBorder(
+            requestedAxis, leafDirection, ownerWidth);
+    return (wantRow ? size.width : size.height) + paddingAndBorder;
   }
 
   if (node->getChildCount() == 0) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/react/yoga/pull/1979


X-link: https://github.com/react/yoga/pull/1978

When a flex item with a measure function (such as text) participates in CSS Flexbox §4.5 automatic minimum sizing, its min-content contribution must include the item's own padding and border — the same box model the container-recursion branch and the normal measure pass already apply. The measure-function leaf branch previously returned only the measured content size, so a padded item was floored below its true minimum. Downstream this let content be clipped or wrapped even when there was room for it — for example a single unbroken word breaking across two lines because the floor was one padding-width too small.

Both the canonical Yoga copy and the React Native vendored copy are updated, and `YGAutoMinSizeTest` gains coverage on the width (padding + border) and height (padding) axes.

Changelog:
[General][Fixed] - Include a node's padding and border in its automatic minimum size when it has a measure function

Reviewed By: astreet

Differential Revision: D108958715


