### PR TITLE
fix: add null checks for getViewState in SurfaceMountingManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
@@ -756,9 +756,14 @@ internal constructor(
       return
     }
 
-    val view = getViewState(reactTag).view
+    val viewState = getNullableViewState(reactTag)
+    val view = viewState?.view
     if (view == null) {
-      throw RetryableMountingLayerException("Unable to find viewState view for tag $reactTag")
+      ReactSoftExceptionLogger.logSoftException(
+          ReactSoftExceptionLogger.Categories.SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE,
+          ReactNoCrashSoftException("Unable to find viewState for tag $reactTag for sendAccessibilityEvent"),
+      )
+      return
     }
 
     view.sendAccessibilityEvent(eventType)
@@ -1000,15 +1005,21 @@ internal constructor(
       return
     }
 
-    val viewState = getViewState(reactTag)
-    val view = viewState.view
+    val viewState = getNullableViewState(reactTag)
+
+    val view = viewState?.view
+    if (view == null) {
+      ReactSoftExceptionLogger.logSoftException(
+          ReactSoftExceptionLogger.Categories.SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE,
+          ReactNoCrashSoftException("Unable to find viewState for tag $reactTag for setJSResponder"),
+      )
+      return
+    }
+
     if (initialReactTag != reactTag && view is ViewParent) {
       // In this case, initialReactTag corresponds to a virtual/layout-only View, and we already
       // have a parent of that View in reactTag, so we can use it.
       jsResponderHandler.setJSResponder(initialReactTag, view as ViewParent)
-      return
-    } else if (view == null) {
-      SoftAssertions.assertUnreachable("Cannot find view for tag [$reactTag].")
       return
     }
 
@@ -1117,12 +1128,6 @@ internal constructor(
             "Unable to find view for tag $reactTag. Surface $surfaceId stopped: $isStopped, rootViewAttached: $isRootViewAttached"
         )
   }
-
-  private fun getViewState(reactTag: Int): ViewState =
-      getNullableViewState(reactTag)
-          ?: throw RetryableMountingLayerException(
-              "Unable to find viewState for tag $reactTag. Surface stopped: $isStopped"
-          )
 
   private fun getNullableViewState(reactTag: Int): ViewState? = registryLock.read {
     tagToViewState[reactTag]


### PR DESCRIPTION
## Summary:

Fix SurfaceMountingManager null handling for methods that can be invoked after a view has been deleted or is otherwise missing. sendAccessibilityEvent and setJSResponder now use getNullableViewState(...) and guard against missing ViewState before accessing .view, logging a soft exception and returning instead of crashing. Also removed the now-unused getViewState helper.

## Changelog:

[ANDROID][FIXED] Avoid crash in SurfaceMountingManager when sendAccessibilityEvent or setJSResponder is called for a missing or deleted view state.

## Test Plan:

This is a safe check added to avoid crashing the application with reference to similiar checks added in other related methods.
