### PR TITLE
Bump compileSdk and buildTools to 37

### DIFF
--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 # Android versions
 minSdk = "24"
 targetSdk = "36"
-compileSdk = "36"
-buildTools = "36.0.0"
+compileSdk = "37"
+buildTools = "37.0.0"
 ndkVersion = "27.1.12297006"
 # Dependencies versions
 agp = "9.2.1"

--- a/private/helloworld/android/build.gradle
+++ b/private/helloworld/android/build.gradle
@@ -7,9 +7,9 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "36.0.0"
+        buildToolsVersion = "37.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 36
+        compileSdkVersion = 37
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.1.20"


### PR DESCRIPTION
## Summary:
Bump the `compileSdk` and `buildTools` to 37

## Changelog:
[Android][Added] - Update `compileSdk` and `buildTools` to 37

## Test Plan:
RN tester builds
