### PR TITLE
Apply prettier to .yml files + consistent quote style (#57286)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,10 +1,10 @@
 name: 🐛 React Native - Bug Report
 description: Report a reproducible bug or regression in React Native.
-labels: ["Needs: Triage :mag:"]
+labels: ['Needs: Triage :mag:']
 body:
   - type: markdown
     attributes:
-      value: "## Reporting a bug to React Native"
+      value: '## Reporting a bug to React Native'
   - type: markdown
     attributes:
       value: |
@@ -46,7 +46,7 @@ body:
     attributes:
       label: React Native Version
       description: The version of react-native that this issue reproduces on. Bear in mind that only issues on [supported versions](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) will be looked into.
-      placeholder: "0.73.0"
+      placeholder: '0.73.0'
     validations:
       required: true
   - type: dropdown
@@ -111,7 +111,7 @@ body:
     attributes:
       label: MANDATORY Reproducer
       description: A link to either a failing RNTesterPlayground.js file, an Expo Snack or a public repository from [this template](https://github.com/react-native-community/reproducer-react-native) that reproduces this bug. Reproducers are **mandatory**, issues without a reproducer will be closed.
-      placeholder: "https://github.com/<myuser>/<myreproducer>"
+      placeholder: 'https://github.com/<myuser>/<myreproducer>'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,26 +1,26 @@
 blank_issues_enabled: false
 contact_links:
-    - name: ⬆️ Upgrade - Build Regression
-      url: https://github.com/reactwg/react-native-releases/issues/new/choose
-      about: |
-        If you are upgrading to a new React Native version (stable or pre-release) and encounter a build regression.
-    - name: 🚀 Expo Issue
-      url: https://github.com/expo/expo/issues/new
-      about: |
-        If you're using Expo in your project, please report the issue first in the Expo issue tracker.
-    - name: 📃 Documentation Issue
-      url: https://github.com/facebook/react-native-website/issues
-      about: Please report documentation issues in the React Native website repository.
-    - name: 📦 Metro Issue
-      url: https://github.com/facebook/metro/issues/new
-      about: |
-        If you've encountered a module resolution problem, e.g. "Error: Unable to resolve module ...", or something else that might be related to Metro, please open an issue in the Metro repo instead.
-    - name: 🤔 Questions and Help
-      url: https://reactnative.dev/help
-      about: Looking for help with your app? Please refer to the React Native community's support resources.
-    - name: 💫 New Architecture - Questions & Technical Deep dive insights
-      url: https://github.com/reactwg/react-native-new-architecture
-      about: Questions and doubts related to technical questions for the New Architecture should be directed to the Working Group. Instructions on how to join are available in the README.
-    - name: 🚀 Discussions and Proposals
-      url: https://github.com/react-native-community/discussions-and-proposals
-      about: Discuss the future of React Native in the React Native community's discussions and proposals repository.
+  - name: ⬆️ Upgrade - Build Regression
+    url: https://github.com/reactwg/react-native-releases/issues/new/choose
+    about: |
+      If you are upgrading to a new React Native version (stable or pre-release) and encounter a build regression.
+  - name: 🚀 Expo Issue
+    url: https://github.com/expo/expo/issues/new
+    about: |
+      If you're using Expo in your project, please report the issue first in the Expo issue tracker.
+  - name: 📃 Documentation Issue
+    url: https://github.com/facebook/react-native-website/issues
+    about: Please report documentation issues in the React Native website repository.
+  - name: 📦 Metro Issue
+    url: https://github.com/facebook/metro/issues/new
+    about: |
+      If you've encountered a module resolution problem, e.g. "Error: Unable to resolve module ...", or something else that might be related to Metro, please open an issue in the Metro repo instead.
+  - name: 🤔 Questions and Help
+    url: https://reactnative.dev/help
+    about: Looking for help with your app? Please refer to the React Native community's support resources.
+  - name: 💫 New Architecture - Questions & Technical Deep dive insights
+    url: https://github.com/reactwg/react-native-new-architecture
+    about: Questions and doubts related to technical questions for the New Architecture should be directed to the Working Group. Instructions on how to join are available in the README.
+  - name: 🚀 Discussions and Proposals
+    url: https://github.com/react-native-community/discussions-and-proposals
+    about: Discuss the future of React Native in the React Native community's discussions and proposals repository.

--- a/.github/ISSUE_TEMPLATE/debugger_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/debugger_bug_report.yml
@@ -1,11 +1,11 @@
 name: 🔍 Debugger - Bug Report
 description: Report a bug with React Native DevTools and the New Debugger
-labels: ["Needs: Triage :mag:", "Debugging"]
+labels: ['Needs: Triage :mag:', 'Debugging']
 
 body:
   - type: markdown
     attributes:
-      value: "## Reporting a bug for React Native DevTools"
+      value: '## Reporting a bug for React Native DevTools'
   - type: markdown
     attributes:
       value: |
@@ -42,7 +42,7 @@ body:
     attributes:
       label: React Native Version
       description: The version of react-native that this issue reproduces on. Bear in mind that only issues on [supported versions](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) will be looked into.
-      placeholder: "0.76.0"
+      placeholder: '0.76.0'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
@@ -1,11 +1,11 @@
 name: 💫 New Architecture - Bug Report
 description: Report a reproducible bug or a build issue when using the New Architecture (Fabric & TurboModules) in React Native.
-labels: ["Needs: Triage :mag:", "Type: New Architecture"]
+labels: ['Needs: Triage :mag:', 'Type: New Architecture']
 
 body:
   - type: markdown
     attributes:
-      value: "## New Architecture Related Bugs"
+      value: '## New Architecture Related Bugs'
   - type: markdown
     attributes:
       value: |
@@ -43,7 +43,7 @@ body:
     attributes:
       label: React Native Version
       description: The version of react-native that this issue reproduces on. Bear in mind that only issues on [supported versions](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) will be looked into.
-      placeholder: "0.73.0"
+      placeholder: '0.73.0'
     validations:
       required: true
   - type: dropdown
@@ -123,7 +123,7 @@ body:
     attributes:
       label: MANDATORY Reproducer
       description: A link to either a failing RNTesterPlayground.js file, an Expo Snack or a public repository from [this template](https://github.com/react-native-community/reproducer-react-native) that reproduces this bug. Reproducers are **mandatory**, issues without a reproducer will be closed.
-      placeholder: "https://github.com/<myuser>/<myreproducer>"
+      placeholder: 'https://github.com/<myuser>/<myreproducer>'
     validations:
       required: true
   - type: textarea

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -5,7 +5,7 @@ inputs:
     required: true
     description: The type of release we are building. It could be nightly, release or dry-run
   gradle-cache-encryption-key:
-    description: "The encryption key needed to store the Gradle Configuration cache"
+    description: 'The encryption key needed to store the Gradle Configuration cache'
 runs:
   using: composite
   steps:
@@ -34,7 +34,7 @@ runs:
     - name: Setup gradle
       uses: ./.github/actions/setup-gradle
       with:
-        cache-read-only: "false"
+        cache-read-only: 'false'
         cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
     - name: Restore Android ccache
       uses: actions/cache/restore@v5

--- a/.github/actions/build-fantom-runner/action.yml
+++ b/.github/actions/build-fantom-runner/action.yml
@@ -4,7 +4,7 @@ inputs:
     required: true
     description: The type of release we are building. It could be nightly, release or dry-run
   gradle-cache-encryption-key:
-    description: "The encryption key needed to store the Gradle Configuration cache"
+    description: 'The encryption key needed to store the Gradle Configuration cache'
 
 runs:
   using: composite
@@ -24,22 +24,22 @@ runs:
     - name: Setup gradle
       uses: ./.github/actions/setup-gradle
       with:
-        cache-read-only: "false"
+        cache-read-only: 'false'
         cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
     - name: Restore Fantom ccache
       uses: actions/cache/restore@v5
       with:
         path: /github/home/.cache/ccache
         key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
-            'packages/react-native/ReactAndroid/**/*.cpp',
-            'packages/react-native/ReactAndroid/**/*.h',
-            'packages/react-native/ReactAndroid/**/CMakeLists.txt',
-            'packages/react-native/ReactCommon/**/*.cpp',
-            'packages/react-native/ReactCommon/**/*.h',
-            'packages/react-native/ReactCommon/**/CMakeLists.txt',
-            'private/react-native-fantom/tester/**/*.cpp',
-            'private/react-native-fantom/tester/**/*.h',
-            'private/react-native-fantom/tester/**/CMakeLists.txt'
+          'packages/react-native/ReactAndroid/**/*.cpp',
+          'packages/react-native/ReactAndroid/**/*.h',
+          'packages/react-native/ReactAndroid/**/CMakeLists.txt',
+          'packages/react-native/ReactCommon/**/*.cpp',
+          'packages/react-native/ReactCommon/**/*.h',
+          'packages/react-native/ReactCommon/**/CMakeLists.txt',
+          'private/react-native-fantom/tester/**/*.cpp',
+          'private/react-native-fantom/tester/**/*.h',
+          'private/react-native-fantom/tester/**/CMakeLists.txt'
           ) }}
         restore-keys: |
           v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-
@@ -60,15 +60,15 @@ runs:
       with:
         path: /github/home/.cache/ccache
         key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
-            'packages/react-native/ReactAndroid/**/*.cpp',
-            'packages/react-native/ReactAndroid/**/*.h',
-            'packages/react-native/ReactAndroid/**/CMakeLists.txt',
-            'packages/react-native/ReactCommon/**/*.cpp',
-            'packages/react-native/ReactCommon/**/*.h',
-            'packages/react-native/ReactCommon/**/CMakeLists.txt',
-            'private/react-native-fantom/tester/**/*.cpp',
-            'private/react-native-fantom/tester/**/*.h',
-            'private/react-native-fantom/tester/**/CMakeLists.txt'
+          'packages/react-native/ReactAndroid/**/*.cpp',
+          'packages/react-native/ReactAndroid/**/*.h',
+          'packages/react-native/ReactAndroid/**/CMakeLists.txt',
+          'packages/react-native/ReactCommon/**/*.cpp',
+          'packages/react-native/ReactCommon/**/*.h',
+          'packages/react-native/ReactCommon/**/CMakeLists.txt',
+          'private/react-native-fantom/tester/**/*.cpp',
+          'private/react-native-fantom/tester/**/*.h',
+          'private/react-native-fantom/tester/**/CMakeLists.txt'
           ) }}
     - name: Show ccache stats (after)
       shell: bash

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -2,15 +2,15 @@ name: create_release
 description: Creates a new React Native release
 inputs:
   version:
-    description: "The version of React Native we want to release. For example 0.75.0-rc.0"
+    description: 'The version of React Native we want to release. For example 0.75.0-rc.0'
     required: true
   is-latest-on-npm:
-    description: "Whether we want to tag this release as latest on NPM"
+    description: 'Whether we want to tag this release as latest on NPM'
     required: true
-    default: "false"
+    default: 'false'
   dry-run:
-    description: "Whether the job should be executed in dry-run mode or not"
-    default: "true"
+    description: 'Whether the job should be executed in dry-run mode or not'
+    default: 'true'
 runs:
   using: composite
   steps:

--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: release
   working-directory:
     required: false
-    default: "."
+    default: '.'
     description: The directory from which metro should be started
   emulator-arch:
     required: false

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: Release
   working-directory:
     required: false
-    default: "."
+    default: '.'
     description: The directory from which metro should be started
 
 runs:

--- a/.github/actions/prepare-ios-tests/action.yml
+++ b/.github/actions/prepare-ios-tests/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Boot iPhone Simulator
       shell: bash
       run: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
-    - name: "Brew: Tap wix/brew"
+    - name: 'Brew: Tap wix/brew'
       shell: bash
       run: brew tap wix/brew
     - name: brew install applesimutils watchman

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,13 +1,13 @@
 name: Setup gradle
-description: "Set up your GitHub Actions workflow with a specific version of gradle"
+description: 'Set up your GitHub Actions workflow with a specific version of gradle'
 inputs:
   cache-read-only:
     description: "Whether the Gradle Cache should be in read-only mode so this job won't be allowed to write to it"
-    default: "true"
+    default: 'true'
   cache-encryption-key:
-    description: "The encryption key needed to store the Gradle Configuration cache"
+    description: 'The encryption key needed to store the Gradle Configuration cache'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Setup gradle
       uses: gradle/actions/setup-gradle@v4

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: ''
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Setup node.js
       uses: actions/setup-node@v6

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: '16.4.0'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Setup xcode
       uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -92,7 +92,7 @@ runs:
 
           echo "App found at $APP_PATH"
           echo "app-path=$APP_PATH" >> $GITHUB_ENV
-    - name: "Run Tests: iOS Unit and Integration Tests"
+    - name: 'Run Tests: iOS Unit and Integration Tests'
       if: ${{ inputs.run-unit-tests == 'true' }}
       shell: bash
       run: yarn test-ios

--- a/.github/actions/test-js/action.yml
+++ b/.github/actions/test-js/action.yml
@@ -2,9 +2,9 @@ name: test-js
 description: Runs all the JS tests in the codebase
 inputs:
   node-version:
-    description: "The node.js version to use"
+    description: 'The node.js version to use'
     required: false
-    default: "22"
+    default: '22'
 runs:
   using: composite
   steps:

--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run every 2hrs during weekdays
-    - cron: "0 0/2 * * 1-5"
+    - cron: '0 0/2 * * 1-5'
 
 jobs:
   cache-cleaner:

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -1,6 +1,5 @@
 name: Label closed PR as merged and leave a comment
-on:
-  push
+on: push
 
 permissions:
   contents: read

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,16 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "The version of React Native we want to release. For example 0.75.0-rc.0"
+        description: 'The version of React Native we want to release. For example 0.75.0-rc.0'
         required: true
         type: string
       is-latest-on-npm:
-        description: "Whether we want to tag this release as latest on NPM"
+        description: 'Whether we want to tag this release as latest on NPM'
         required: true
         type: boolean
         default: false
       dry-run:
-        description: "Whether the job should be executed in dry-run mode or not"
+        description: 'Whether the job should be executed in dry-run mode or not'
         type: boolean
         default: true
 

--- a/.github/workflows/e2e-android-rntester.yml
+++ b/.github/workflows/e2e-android-rntester.yml
@@ -11,7 +11,7 @@ on:
         default: false
     outputs:
       status:
-        description: "The result of the E2E tests (success or failure)"
+        description: 'The result of the E2E tests (success or failure)'
         value: ${{ jobs.report.outputs.status }}
 
 jobs:

--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -11,7 +11,7 @@ on:
         default: false
     outputs:
       status:
-        description: "The result of the E2E tests (success or failure)"
+        description: 'The result of the E2E tests (success or failure)'
         value: ${{ jobs.report.outputs.status }}
 
 jobs:

--- a/.github/workflows/e2e-ios-rntester.yml
+++ b/.github/workflows/e2e-ios-rntester.yml
@@ -11,7 +11,7 @@ on:
         default: false
     outputs:
       status:
-        description: "The result of the E2E tests (success or failure)"
+        description: 'The result of the E2E tests (success or failure)'
         value: ${{ jobs.report.outputs.status }}
 
 jobs:
@@ -42,7 +42,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/maestro-ios
         with:
-          app-path: "/tmp/RNTesterBuild/RNTester.app"
+          app-path: '/tmp/RNTesterBuild/RNTester.app'
           app-id: com.meta.RNTester.localDevelopment
           maestro-flow: ./packages/rn-tester/.maestro/
           flavor: ${{ matrix.flavor }}

--- a/.github/workflows/e2e-ios-templateapp.yml
+++ b/.github/workflows/e2e-ios-templateapp.yml
@@ -11,7 +11,7 @@ on:
         default: false
     outputs:
       status:
-        description: "The result of the E2E tests (success or failure)"
+        description: 'The result of the E2E tests (success or failure)'
         value: ${{ jobs.report.outputs.status }}
 
 jobs:
@@ -62,8 +62,8 @@ jobs:
       - name: Configure git
         shell: bash
         run: |
-            git config --global user.email "react-native-bot@meta.com"
-            git config --global user.name "React Native Bot"
+          git config --global user.email "react-native-bot@meta.com"
+          git config --global user.name "React Native Bot"
       - name: Prepare artifacts
         run: |
           REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
@@ -99,7 +99,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/maestro-ios
         with:
-          app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
+          app-path: '/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app'
           app-id: org.reactjs.native.example.RNTestProject
           maestro-flow: ./scripts/e2e/.maestro/
           flavor: ${{ matrix.flavor }}

--- a/.github/workflows/fantom-tests.yml
+++ b/.github/workflows/fantom-tests.yml
@@ -11,7 +11,7 @@ on:
         default: false
     outputs:
       status:
-        description: "The result of the Fantom tests (success or failure)"
+        description: 'The result of the Fantom tests (success or failure)'
         value: ${{ jobs.report.outputs.status }}
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
     container:
       image: reactnativecommunity/react-native-android:latest
       env:
-        TERM: "dumb"
+        TERM: 'dumb'
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/monitor-new-issues.yml
+++ b/.github/workflows/monitor-new-issues.yml
@@ -2,7 +2,7 @@ name: Monitor React Native New Issues
 
 on:
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: '0 0,6,12,18 * * *'
   workflow_dispatch:
 
 # Reminder for when we have to update the schedule (before Jan 2026):
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: ./.github/actions/setup-node
       - name: Install dependencies
-        uses:  ./.github/actions/yarn-install
+        uses: ./.github/actions/yarn-install
       - name: Extract next oncall
         run: |
           ONCALLS=$(node ./.github/workflow-scripts/extractIssueOncalls.js "${{ secrets.ONCALL_SCHEDULE }}")
@@ -30,12 +30,12 @@ jobs:
       - name: Monitor New Issues
         uses: react-native-community/repo-monitor@v1.0.1
         with:
-          task: "monitor-issues"
+          task: 'monitor-issues'
           git_secret: ${{ secrets.GITHUB_TOKEN }}
-          notifier: "discord"
+          notifier: 'discord'
           fetch_data_interval: 6
-          repo_owner: "react"
-          repo_name: "react-native"
-          discord_webhook_url: "${{ secrets.DISCORD_WEBHOOK_URL }}"
-          discord_id_type: "user"
-          discord_ids: "${{ env.oncall1 }},${{ env.oncall2 }}"
+          repo_owner: 'react'
+          repo_name: 'react-native'
+          discord_webhook_url: '${{ secrets.DISCORD_WEBHOOK_URL }}'
+          discord_id_type: 'user'
+          discord_ids: '${{ env.oncall1 }},${{ env.oncall2 }}'

--- a/.github/workflows/needs-attention.yml
+++ b/.github/workflows/needs-attention.yml
@@ -21,8 +21,8 @@ jobs:
         uses: react-native-community/needs-attention@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          response-required-label: "Needs: Author Feedback"
-          needs-attention-label: "Needs: Attention"
+          response-required-label: 'Needs: Author Feedback'
+          needs-attention-label: 'Needs: Attention'
         id: needs-attention
       - name: Result
         run: echo '${{ steps.needs-attention.outputs.result }}'

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -21,11 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         flavor: ['Debug', 'Release']
-        slice: [
-          'ios',
-          'ios-simulator',
-          'mac-catalyst',
-        ]
+        slice: ['ios', 'ios-simulator', 'mac-catalyst']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -103,8 +99,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: prebuild-ios-core-headers-${{ matrix.flavor }}-${{ matrix.slice }}
-          path:
-            packages/react-native/.build/headers
+          path: packages/react-native/.build/headers
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/prebuild-ios-dependencies.yml
+++ b/.github/workflows/prebuild-ios-dependencies.yml
@@ -3,7 +3,6 @@ name: Prebuild iOS Dependencies
 on:
   workflow_call: # this directive allow us to call this workflow from other workflows
 
-
 jobs:
   prepare_workspace:
     name: Prepare workspace
@@ -52,14 +51,17 @@ jobs:
       fail-fast: false
       matrix:
         flavor: ['Debug', 'Release']
-        slice: ['ios',
-                'ios-simulator',
-                'macos',
-                'mac-catalyst',
-                'tvos',
-                'tvos-simulator',
-                'xros',
-                'xros-simulator']
+        slice:
+          [
+            'ios',
+            'ios-simulator',
+            'macos',
+            'mac-catalyst',
+            'tvos',
+            'tvos-simulator',
+            'xros',
+            'xros-simulator',
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -88,7 +90,7 @@ jobs:
         run: ls -lR packages/react-native/third-party
       - name: Build slice ${{ matrix.slice }} for ${{ matrix.flavor }}
         if: steps.restore-slice-folder.outputs.cache-hit != 'true'
-        run:  node scripts/releases/prepare-ios-prebuilds.js -b -p ${{ matrix.slice }} -r ${{ matrix.flavor }}
+        run: node scripts/releases/prepare-ios-prebuilds.js -b -p ${{ matrix.slice }} -r ${{ matrix.flavor }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -17,15 +17,15 @@ name: Publish to npm
 on:
   push:
     tags:
-      - "v0.*.*" # This should match v0.X.Y
-      - "v0.*.*-rc.*" # This should match v0.X.Y-RC.0
+      - 'v0.*.*' # This should match v0.X.Y
+      - 'v0.*.*-rc.*' # This should match v0.X.Y-RC.0
     branches:
-      - "main"
-      - "*-stable"
+      - 'main'
+      - '*-stable'
   workflow_dispatch:
   # nightly build @ 2:15 AM UTC
   schedule:
-    - cron: "15 2 * * *"
+    - cron: '15 2 * * *'
 
 permissions:
   contents: read
@@ -95,11 +95,11 @@ jobs:
     container:
       image: reactnativecommunity/react-native-android:latest
       env:
-        TERM: "dumb"
+        TERM: 'dumb'
         # Set the encoding to resolve a known character encoding issue with decompressing tar.gz files in containers
         # via Gradle: https://github.com/gradle/gradle/issues/23391#issuecomment-1878979127
         LC_ALL: C.UTF8
-        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
@@ -144,13 +144,13 @@ jobs:
     container:
       image: reactnativecommunity/react-native-android:latest
       env:
-        TERM: "dumb"
+        TERM: 'dumb'
         # Set the encoding to resolve a known character encoding issue with decompressing tar.gz files in containers
         # via Gradle: https://github.com/gradle/gradle/issues/23391#issuecomment-1878979127
         LC_ALL: C.UTF8
-        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
         # By default we only build ARM64 to save time/resources. For release/nightlies, we override this value to build all archs.
-        ORG_GRADLE_PROJECT_reactNativeArchitectures: "arm64-v8a"
+        ORG_GRADLE_PROJECT_reactNativeArchitectures: 'arm64-v8a'
         REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     env:
       ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
@@ -203,8 +203,8 @@ jobs:
       - name: Setup node.js
         uses: ./.github/actions/setup-node
         with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       # TEMPORARY DEBUG: print the OIDC token claims npm Trusted Publishing
       # matches against. A 404 from the OIDC exchange means these claims don't
       # match the Trusted Publisher entry configured on npmjs.com (org/repo/

--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -2,19 +2,19 @@ name: Retry workflow
 # Based on https://stackoverflow.com/a/78314483
 
 on:
-    workflow_dispatch:
-        inputs:
-            run_id:
-                required: true
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
 jobs:
-    rerun:
-        runs-on: ubuntu-latest
-        if: github.repository == 'react/react-native'
-        steps:
-            - name: rerun ${{ inputs.run_id }}
-              env:
-                  GH_REPO: ${{ github.repository }}
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
-                  gh run rerun ${{ inputs.run_id }} --failed
+  rerun:
+    runs-on: ubuntu-latest
+    if: github.repository == 'react/react-native'
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,7 +1,7 @@
 name: Stale bot
 on:
   schedule:
-    - cron: "*/10 5 * * *"
+    - cron: '*/10 5 * * *'
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -54,8 +54,8 @@ jobs:
           stale-pr-message: "This PR is waiting for author's feedback since 24 days. Please provide the requested feedback or this will be closed in 7 days"
           close-issue-message: "This issue was closed because the author hasn't provided the requested feedback after 7 days."
           close-pr-message: "This PR was closed because the author hasn't provided the requested feedback after 7 days."
-          exempt-issue-labels: "Help Wanted :octocat:, Good first issue, Never gets stale, Issue: Author Provided Repro"
-          exempt-pr-labels: "Help Wanted :octocat:, Never gets stale"
+          exempt-issue-labels: 'Help Wanted :octocat:, Good first issue, Never gets stale, Issue: Author Provided Repro'
+          exempt-pr-labels: 'Help Wanted :octocat:, Never gets stale'
   stale-needs-author-feedback-asc:
     runs-on: ubuntu-latest
     if: github.repository == 'react/react-native'
@@ -73,5 +73,5 @@ jobs:
           stale-pr-message: "This PR is waiting for author's feedback since 24 days. Please provide the requested feedback or this will be closed in 7 days"
           close-issue-message: "This issue was closed because the author hasn't provided the requested feedback after 7 days."
           close-pr-message: "This PR was closed because the author hasn't provided the requested feedback after 7 days."
-          exempt-issue-labels: "Help Wanted :octocat:, Good first issue, Never gets stale, Issue: Author Provided Repro"
-          exempt-pr-labels: "Help Wanted :octocat:, Never gets stale"
+          exempt-issue-labels: 'Help Wanted :octocat:, Good first issue, Never gets stale, Issue: Author Provided Repro'
+          exempt-pr-labels: 'Help Wanted :octocat:, Never gets stale'

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - "*-stable"
+      - '*-stable'
 
 permissions:
   contents: read
@@ -107,8 +107,7 @@ jobs:
 
   test_ios_rntester_ruby_3_2_0:
     runs-on: macos-15
-    needs:
-      [prebuild_apple_dependencies, prebuild_react_native_core]
+    needs: [prebuild_apple_dependencies, prebuild_react_native_core]
     if: ${{ needs.prebuild_react_native_core.result == 'success' }}
     steps:
       - name: Checkout
@@ -116,7 +115,7 @@ jobs:
       - name: Run it
         uses: ./.github/actions/test-ios-rntester
         with:
-          ruby-version: "3.2.0"
+          ruby-version: '3.2.0'
           flavor: Debug
 
   test_ios_rntester_dynamic_frameworks:
@@ -141,8 +140,7 @@ jobs:
 
   test_ios_rntester:
     runs-on: macos-15-large
-    needs:
-      [prebuild_apple_dependencies, prebuild_react_native_core]
+    needs: [prebuild_apple_dependencies, prebuild_react_native_core]
     if: ${{ needs.prebuild_react_native_core.result == 'success' }}
     continue-on-error: true
     strategy:
@@ -229,8 +227,8 @@ jobs:
         # Set the encoding to resolve a known character encoding issue with decompressing tar.gz files in containers
         # via Gradle: https://github.com/gradle/gradle/issues/23391#issuecomment-1878979127
         LC_ALL: C.UTF8
-        TERM: "dumb"
-        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        TERM: 'dumb'
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
@@ -274,8 +272,8 @@ jobs:
         # Set the encoding to resolve a known character encoding issue with decompressing tar.gz files in containers
         # via Gradle: https://github.com/gradle/gradle/issues/23391#issuecomment-1878979127
         LC_ALL: C.UTF8
-        TERM: "dumb"
-        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        TERM: 'dumb'
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
@@ -325,11 +323,11 @@ jobs:
     container:
       image: reactnativecommunity/react-native-android:latest
       env:
-        TERM: "dumb"
+        TERM: 'dumb'
         # Set the encoding to resolve a known character encoding issue with decompressing tar.gz files in containers
         # via Gradle: https://github.com/gradle/gradle/issues/23391#issuecomment-1878979127
         LC_ALL: C.UTF8
-        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
         REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     steps:
       - name: Checkout
@@ -352,9 +350,9 @@ jobs:
       # via Gradle: https://github.com/gradle/gradle/issues/23391#issuecomment-1878979127
       LC_ALL: C.UTF8
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
-      TERM: "dumb"
-      GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-      TARGET_ARCHITECTURE: "arm64-v8a"
+      TERM: 'dumb'
+      GRADLE_OPTS: '-Dorg.gradle.daemon=false'
+      TARGET_ARCHITECTURE: 'arm64-v8a'
       REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     continue-on-error: true
     strategy:
@@ -484,7 +482,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["24", "22.13.0"]
+        node-version: ['24', '22.13.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/validate-cxx-api-snapshots.yml
+++ b/.github/workflows/validate-cxx-api-snapshots.yml
@@ -4,26 +4,26 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - "packages/react-native/ReactCommon/**"
-      - "packages/react-native/ReactAndroid/**"
-      - "packages/react-native/React/**"
-      - "packages/react-native/ReactApple/**"
-      - "packages/react-native/Libraries/**"
-      - "scripts/cxx-api/**"
+      - 'packages/react-native/ReactCommon/**'
+      - 'packages/react-native/ReactAndroid/**'
+      - 'packages/react-native/React/**'
+      - 'packages/react-native/ReactApple/**'
+      - 'packages/react-native/Libraries/**'
+      - 'scripts/cxx-api/**'
   push:
     branches:
       - main
-      - "*-stable"
+      - '*-stable'
     paths:
-      - "packages/react-native/ReactCommon/**"
-      - "packages/react-native/ReactAndroid/**"
-      - "packages/react-native/React/**"
-      - "packages/react-native/ReactApple/**"
-      - "packages/react-native/Libraries/**"
-      - "scripts/cxx-api/**"
+      - 'packages/react-native/ReactCommon/**'
+      - 'packages/react-native/ReactAndroid/**'
+      - 'packages/react-native/React/**'
+      - 'packages/react-native/ReactApple/**'
+      - 'packages/react-native/Libraries/**'
+      - 'scripts/cxx-api/**'
 
 env:
-  DOXYGEN_VERSION: "1.16.1"
+  DOXYGEN_VERSION: '1.16.1'
 
 permissions:
   contents: read
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.12'
       - name: Install Python dependencies
         shell: bash
         run: pip install doxmlparser natsort pyyaml

--- a/.github/workflows/validate-dotslash-artifacts.yml
+++ b/.github/workflows/validate-dotslash-artifacts.yml
@@ -9,7 +9,7 @@ on:
       - main
     paths:
       - packages/debugger-shell/bin/react-native-devtools
-      - "scripts/releases/**"
+      - 'scripts/releases/**'
       - package.json
       - yarn.lock
   pull_request:
@@ -17,12 +17,12 @@ on:
       - main
     paths:
       - packages/debugger-shell/bin/react-native-devtools
-      - "scripts/releases/**"
+      - 'scripts/releases/**'
       - package.json
       - yarn.lock
   # Same time as the nightly build: 2:15 AM UTC
   schedule:
-    - cron: "15 2 * * *"
+    - cron: '15 2 * * *'
 
 jobs:
   validate-dotslash-artifacts:

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -42,5 +42,11 @@ module.exports = {
         requirePragma: false,
       },
     },
+    {
+      files: ['*.yml', '*.yaml'],
+      options: {
+        requirePragma: false,
+      },
+    },
   ],
 };

--- a/packages/rn-tester/.maestro/button.yml
+++ b/packages/rn-tester/.maestro/button.yml
@@ -1,15 +1,15 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: "Components"
+- assertVisible: 'Components'
 - scrollUntilVisible:
     element:
-      id: "Button"
+      id: 'Button'
     direction: DOWN
     speed: 40
 - tapOn:
-    id: "Button"
+    id: 'Button'
 - tapOn:
-    id: "button_default_styling"
-- assertVisible: "Your application has been submitted!"
-- tapOn: "OK"
+    id: 'button_default_styling'
+- assertVisible: 'Your application has been submitted!'
+- tapOn: 'OK'

--- a/packages/rn-tester/.maestro/flatlist.yml
+++ b/packages/rn-tester/.maestro/flatlist.yml
@@ -1,18 +1,18 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: "Components"
+- assertVisible: 'Components'
 - scrollUntilVisible:
     element:
-      id: "Flatlist"
+      id: 'Flatlist'
     direction: DOWN
     speed: 40
 - tapOn:
-    id: "Flatlist"
+    id: 'Flatlist'
 - tapOn:
-    id: "Basic"
+    id: 'Basic'
 - assertVisible:
-    id: "item_550"
+    id: 'item_550'
 # - repeat:
 #     while:
 #       notVisible:
@@ -26,8 +26,8 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 # - assertVisible:
 #     id: "item_600"
 - assertVisible:
-    text: "Empty:"
+    text: 'Empty:'
 - tapOn:
-    id: "switch_empty_option"
+    id: 'switch_empty_option'
 - assertVisible:
-    text: "The list is empty :o"
+    text: 'The list is empty :o'

--- a/packages/rn-tester/.maestro/helpers/launch-app-and-search.yml
+++ b/packages/rn-tester/.maestro/helpers/launch-app-and-search.yml
@@ -1,5 +1,5 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: "Components"
+- assertVisible: 'Components'
 - runFlow: ./search.yml

--- a/packages/rn-tester/.maestro/helpers/search.yml
+++ b/packages/rn-tester/.maestro/helpers/search.yml
@@ -1,6 +1,6 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - assertVisible:
-    id: "explorer_search"
+    id: 'explorer_search'
 - tapOn:
-    id: "explorer_search"
+    id: 'explorer_search'

--- a/packages/rn-tester/.maestro/image-getsize-local-drawables.yml
+++ b/packages/rn-tester/.maestro/image-getsize-local-drawables.yml
@@ -13,45 +13,45 @@ tags:
       # Navigate to Image examples
       - runFlow: ./helpers/launch-app-and-search.yml
       - inputText:
-          text: "Image"
+          text: 'Image'
       - assertVisible:
-          id: "Image"
+          id: 'Image'
       - tapOn:
-          id: "Image"
+          id: 'Image'
 
       # Search for the local drawables example
       - assertVisible:
-          id: "example_search"
+          id: 'example_search'
       - tapOn:
-          id: "example_search"
+          id: 'example_search'
       - inputText:
-          text: "local drawables"
+          text: 'local drawables'
       - hideKeyboard
 
       # Navigate to the example
       # RNTester appends " (android only)" to platform-scoped example titles, so
       # match with an inline regex rather than the bare title.
       - scrollUntilVisible:
-          element: "Image.getSize with local drawables.*"
+          element: 'Image.getSize with local drawables.*'
           direction: DOWN
           speed: 40
           timeout: 10000
-      - tapOn: "Image.getSize with local drawables.*"
+      - tapOn: 'Image.getSize with local drawables.*'
 
       # Tap the run button
-      - tapOn: "Run Image.getSize on local drawable resources"
+      - tapOn: 'Run Image.getSize on local drawable resources'
 
       # Assert success results contain dp dimensions
       - extendedWaitUntil:
-          visible: "24x24 dp"
+          visible: '24x24 dp'
           timeout: 10000
-      - assertVisible: "108x108 dp"
+      - assertVisible: '108x108 dp'
 
       # Assert error case shows error message. The six getSize results render
       # asynchronously in callback-completion order, so the non-existent resource
       # row may land below the fold; scroll until the error text is visible.
       - scrollUntilVisible:
-          element: "error:.*"
+          element: 'error:.*'
           direction: DOWN
           speed: 40
           timeout: 10000

--- a/packages/rn-tester/.maestro/image.yml
+++ b/packages/rn-tester/.maestro/image.yml
@@ -2,26 +2,26 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - runFlow: ./helpers/launch-app-and-search.yml
 - inputText:
-    text: "Image"
+    text: 'Image'
 - assertVisible:
-    id: "Image"
+    id: 'Image'
 - tapOn:
-    id: "Image"
-- assertVisible: "Plain Network Image with `source` prop."
+    id: 'Image'
+- assertVisible: 'Plain Network Image with `source` prop.'
 - assertVisible:
-    id: "example_search"
+    id: 'example_search'
 - tapOn:
-    id: "example_search"
+    id: 'example_search'
 - inputText:
-    text: "Image.getSize"
+    text: 'Image.getSize'
 - hideKeyboard
 - tapOn:
-    id: "platform-test-results"
-- assertVisible: "Results"
+    id: 'platform-test-results'
+- assertVisible: 'Results'
 - extendedWaitUntil:
-    visible: "Image.getSize resolves source dimensions"
+    visible: 'Image.getSize resolves source dimensions'
     timeout: 30000
 - assertVisible:
-    id: "platform-test-pass-count-1"
+    id: 'platform-test-pass-count-1'
 - assertVisible:
-    id: "platform-test-fail-count-0"
+    id: 'platform-test-fail-count-0'

--- a/packages/rn-tester/.maestro/legacy-native-module.yml
+++ b/packages/rn-tester/.maestro/legacy-native-module.yml
@@ -2,45 +2,45 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible:
-    text: "APIs"
+    text: 'APIs'
 - tapOn:
-    id: "apis-tab"
+    id: 'apis-tab'
 - runFlow: ./helpers/search.yml
 - inputText:
-    text: "Legacy Native"
+    text: 'Legacy Native'
 - assertVisible:
-    id: "Legacy Native Module"
+    id: 'Legacy Native Module'
 - tapOn:
-    id: "Legacy Native Module"
-- tapOn: 
-    text: "voidFunc"
-- assertVisible:
-    id: "voidFunc-result"
+    id: 'Legacy Native Module'
 - tapOn:
-    text: "getBool"
+    text: 'voidFunc'
 - assertVisible:
-    id: "getBool-result"
+    id: 'voidFunc-result'
 - tapOn:
-    text: "getEnum"
+    text: 'getBool'
 - assertVisible:
-    id: "getEnum-result"
+    id: 'getBool-result'
 - tapOn:
-    text: "getInt"
+    text: 'getEnum'
 - assertVisible:
-    id: "getInt-result"
+    id: 'getEnum-result'
 - tapOn:
-    text: "getString"
+    text: 'getInt'
 - assertVisible:
-    id: "getString-result"
+    id: 'getInt-result'
 - tapOn:
-    text: "getObject"
+    text: 'getString'
 - assertVisible:
-    id: "getObject-result"
+    id: 'getString-result'
 - tapOn:
-    text: "getUnsafeObject"
+    text: 'getObject'
 - assertVisible:
-    id: "getUnsafeObject-result"
+    id: 'getObject-result'
 - tapOn:
-    text: "getValue"
+    text: 'getUnsafeObject'
 - assertVisible:
-    id: "getValue-result"
+    id: 'getUnsafeObject-result'
+- tapOn:
+    text: 'getValue'
+- assertVisible:
+    id: 'getValue-result'

--- a/packages/rn-tester/.maestro/modal.yml
+++ b/packages/rn-tester/.maestro/modal.yml
@@ -1,21 +1,21 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: "Components"
+- assertVisible: 'Components'
 - scrollUntilVisible:
     element:
-      id: "Modal"
+      id: 'Modal'
     direction: DOWN
     speed: 60
 - tapOn:
-    id: "Modal"
+    id: 'Modal'
 - assertVisible:
-    text: "Show Modal"
+    text: 'Show Modal'
 - tapOn:
-    text: "Show Modal"
+    text: 'Show Modal'
 - assertVisible:
-    text: "Close"
+    text: 'Close'
 - tapOn:
-    text: "Close"
+    text: 'Close'
 - assertVisible:
-    text: "Show Modal"
+    text: 'Show Modal'

--- a/packages/rn-tester/.maestro/new-arch-examples.yml
+++ b/packages/rn-tester/.maestro/new-arch-examples.yml
@@ -2,32 +2,32 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - runFlow: ./helpers/launch-app-and-search.yml
 - inputText:
-    text: "New Architecture"
+    text: 'New Architecture'
 - assertVisible:
-    id: "New Architecture Examples"
+    id: 'New Architecture Examples'
 - tapOn:
-    id: "New Architecture Examples"
-- assertVisible: "HSBA: h: 0, s: 0, b: 0, a: 0"
-- assertVisible: "Constants From Interop Layer: 3.14"
-- tapOn: "Change Background"
+    id: 'New Architecture Examples'
+- assertVisible: 'HSBA: h: 0, s: 0, b: 0, a: 0'
+- assertVisible: 'Constants From Interop Layer: 3.14'
+- tapOn: 'Change Background'
 - assertVisible:
-    text: "HSBA: h: 0, s: 1, b: 1, a: 255"
+    text: 'HSBA: h: 0, s: 1, b: 1, a: 255'
 - assertVisible:
-    text: "> Interop Layer Measurements <"
+    text: '> Interop Layer Measurements <'
 - assertVisible:
-    text: "measure x: 0, y: 0, width: 0, height: 0"
-- tapOn: "Console.log Measure"
+    text: 'measure x: 0, y: 0, width: 0, height: 0'
+- tapOn: 'Console.log Measure'
 - assertNotVisible:
-    text: "measure x: 0, y: 0, width: 0, height: 0"
+    text: 'measure x: 0, y: 0, width: 0, height: 0'
 - assertNotVisible:
-    text: "InWindow x: 0, y: 0, width: 0, height: 0"
+    text: 'InWindow x: 0, y: 0, width: 0, height: 0'
 - assertNotVisible:
-    text: "InLayout x: 0, y: 0, width: 0, height: 0"
-- assertVisible: "Legacy Style Event Fired 0 times"
+    text: 'InLayout x: 0, y: 0, width: 0, height: 0'
+- assertVisible: 'Legacy Style Event Fired 0 times'
 - tapOn:
-    text: "Fire Legacy Style Event"
+    text: 'Fire Legacy Style Event'
     repeat: 10
-- assertVisible: "Legacy Style Event Fired 10 times"
-- assertVisible: "Opacity: 1.0"
-- tapOn: "Set Opacity"
-- assertVisible: "Opacity: 0.8"
+- assertVisible: 'Legacy Style Event Fired 10 times'
+- assertVisible: 'Opacity: 1.0'
+- tapOn: 'Set Opacity'
+- assertVisible: 'Opacity: 0.8'

--- a/packages/rn-tester/.maestro/pressable.yml
+++ b/packages/rn-tester/.maestro/pressable.yml
@@ -2,45 +2,45 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - runFlow: ./helpers/launch-app-and-search.yml
 - inputText:
-    text: "Pressable"
+    text: 'Pressable'
 - assertVisible:
-    id: "Pressable"
+    id: 'Pressable'
 - tapOn:
-    id: "Pressable"
+    id: 'Pressable'
 - assertVisible:
-    text: "Change content based on Press"
+    text: 'Change content based on Press'
 - assertVisible:
-    text: "Change style based on Press"
+    text: 'Change style based on Press'
 - tapOn:
-    id: "one_press_me_button"
+    id: 'one_press_me_button'
 - assertVisible:
-    text: "onPress"
+    text: 'onPress'
 - tapOn:
-    id: "one_press_me_button"
+    id: 'one_press_me_button'
 - assertVisible:
-    text: "2x onPress"
+    text: '2x onPress'
 - scrollUntilVisible:
     element:
-      id: "pressable_feedback_events"
+      id: 'pressable_feedback_events'
     direction: DOWN
     speed: 10
     visibilityPercentage: 100
 - tapOn:
-    id: "pressable_feedback_events_button"
+    id: 'pressable_feedback_events_button'
 - scrollUntilVisible:
     element:
-      text: "pressIn"
+      text: 'pressIn'
     direction: DOWN
     speed: 10
 - assertVisible:
-    text: "press"
+    text: 'press'
 - assertVisible:
-    text: "pressOut"
+    text: 'pressOut'
 - longPressOn:
-    id: "pressable_feedback_events_button"
+    id: 'pressable_feedback_events_button'
 - assertVisible:
-    text: "pressIn"
+    text: 'pressIn'
 - assertVisible:
-    text: "longPress"
+    text: 'longPress'
 - assertVisible:
-    text: "pressOut"
+    text: 'pressOut'

--- a/packages/rn-tester/.maestro/text.yml
+++ b/packages/rn-tester/.maestro/text.yml
@@ -2,20 +2,20 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - runFlow: ./helpers/launch-app-and-search.yml
 - inputText:
-    text: "Text"
+    text: 'Text'
 - assertVisible:
-    id: "Text"
+    id: 'Text'
 - tapOn:
-    id: "Text"
+    id: 'Text'
 - assertVisible:
-    id: "example_search"
+    id: 'example_search'
 - tapOn:
-    id: "example_search"
+    id: 'example_search'
 - inputText:
-    text: "Background Color"
+    text: 'Background Color'
 - hideKeyboard
-- assertVisible: "Text with background color only"
-- assertVisible: "Text with background color and uniform borderRadii"
-- assertVisible: "Text with background color and non-uniform borders"
-- assertVisible: "Text with borderWidth"
-- assertVisible: "Text with background AND borderWidth"
+- assertVisible: 'Text with background color only'
+- assertVisible: 'Text with background color and uniform borderRadii'
+- assertVisible: 'Text with background color and non-uniform borders'
+- assertVisible: 'Text with borderWidth'
+- assertVisible: 'Text with background AND borderWidth'

--- a/scripts/cxx-api/config.yml
+++ b/scripts/cxx-api/config.yml
@@ -1,23 +1,23 @@
 exclude_patterns:
-  - "*/ReactCommon/react/nativemodule/fantomtestspecificmethods/*"
-  - "*/ReactCommon/react/nativemodule/featureflags/*"
-  - "*/ReactCommon/react/featureflags/*"
-  - "*/test_utils/*"
-  - "*/test/*"
-  - "*/test_helper/*"
-  - "*/stubs/*"
-  - "*/metainternal/*"
+  - '*/ReactCommon/react/nativemodule/fantomtestspecificmethods/*'
+  - '*/ReactCommon/react/nativemodule/featureflags/*'
+  - '*/ReactCommon/react/featureflags/*'
+  - '*/test_utils/*'
+  - '*/test/*'
+  - '*/test_helper/*'
+  - '*/stubs/*'
+  - '*/metainternal/*'
 
 exclude_symbols:
-  - "Fantom"
-  - "NativeReactNativeFeatureFlags"
-  - "(?i)experimental"
-  - "unstable_"
-  - "UnstableLegacy"
-  - "packAnimatedProps"
-  - "DO_NOT_USE"
-  - "_DEPRECATED|DEPRECATED_"
-  - "internal_"
+  - 'Fantom'
+  - 'NativeReactNativeFeatureFlags'
+  - '(?i)experimental'
+  - 'unstable_'
+  - 'UnstableLegacy'
+  - 'packAnimatedProps'
+  - 'DO_NOT_USE'
+  - '_DEPRECATED|DEPRECATED_'
+  - 'internal_'
 
 platforms:
   ReactCommon:
@@ -25,12 +25,12 @@ platforms:
     inputs:
       - packages/react-native/ReactCommon
     exclude_patterns:
-      - "*/jni/*"
-      - "*/platform/cxx/*" # Should this be included in ReactCommon?
-      - "*/platform/windows/*"
-      - "*/platform/macos/*"
-      - "*/platform/ios/*"
-      - "*/platform/android/*"
+      - '*/jni/*'
+      - '*/platform/cxx/*' # Should this be included in ReactCommon?
+      - '*/platform/windows/*'
+      - '*/platform/macos/*'
+      - '*/platform/ios/*'
+      - '*/platform/android/*'
     input_filter: false
     definitions:
     variants:
@@ -52,16 +52,16 @@ platforms:
       - packages/react-native/ReactCommon
       - packages/react-native/ReactAndroid
     exclude_patterns:
-      - "*/ReactAndroid/src/main/jni/react/featureflags/*"
-      - "*/components/switch/iosswitch/*"
-      - "*/components/inputaccessory/*"
-      - "*/platform/cxx/*"
-      - "*/platform/windows/*"
-      - "*/platform/macos/*"
-      - "*/platform/ios/*"
+      - '*/ReactAndroid/src/main/jni/react/featureflags/*'
+      - '*/components/switch/iosswitch/*'
+      - '*/components/inputaccessory/*'
+      - '*/platform/cxx/*'
+      - '*/platform/windows/*'
+      - '*/platform/macos/*'
+      - '*/platform/ios/*'
     exclude_symbols:
-      - "InputAccessory"
-      - "IOS"
+      - 'InputAccessory'
+      - 'IOS'
     input_filter: false
     definitions:
       RN_SERIALIZABLE_STATE: 1
@@ -88,19 +88,19 @@ platforms:
       - packages/react-native/ReactApple
       - packages/react-native/Libraries
     exclude_patterns:
-      - "*/jni/*"
-      - "*/platform/cxx/*"
-      - "*/platform/windows/*"
-      - "*/platform/macos/*"
-      - "*/platform/android/*"
-      - "*+Private.h"
-      - "*+Internal.h"
-      - "*/scripts/*"
-      - "*/templates/*"
-      - "*/components/progressbar/android/*"
-      - "*/components/switch/androidswitch/*"
+      - '*/jni/*'
+      - '*/platform/cxx/*'
+      - '*/platform/windows/*'
+      - '*/platform/macos/*'
+      - '*/platform/android/*'
+      - '*+Private.h'
+      - '*+Internal.h'
+      - '*/scripts/*'
+      - '*/templates/*'
+      - '*/components/progressbar/android/*'
+      - '*/components/switch/androidswitch/*'
     exclude_symbols:
-      - "Android"
+      - 'Android'
       - "\\(Deprecated\\)"
       - "\\(Internal\\)"
     input_filter: true

--- a/scripts/e2e/.maestro/start.yml
+++ b/scripts/e2e/.maestro/start.yml
@@ -1,4 +1,4 @@
 appId: ${APP_ID} # iOS: org.reactjs.native.example.RNTestProject  | Android: com.rntestproject
 ---
 - launchApp
-- assertVisible: "Welcome to React Native"
+- assertVisible: 'Welcome to React Native'

--- a/scripts/e2e/verdaccio.yml
+++ b/scripts/e2e/verdaccio.yml
@@ -1,6 +1,6 @@
 storage: /tmp/verdaccio
 listen:
-- 0.0.0.0:4873 # See https://github.com/actions/runner-images/issues/10061
+  - 0.0.0.0:4873 # See https://github.com/actions/runner-images/issues/10061
 auth:
   htpasswd:
     file: ./htpasswd


### PR DESCRIPTION
Summary:

We currently have a mix of quote styles in `.yml` files (AI summary below). This applies prettier and reformats everything to single quotes to align with defaults.

Also fixes a couple of cases of over-indentation.

```
Single-quotes only (0 double-quoted scalars):

analyze-pr.yml
 — 12 single, 0 double
api-changes.yml
 — 3 single, 0 double
check-for-reproducer.yml
 — 4 single, 0 double
retry-workflow.yml
 — 1 single, 0 double
Single-quote predominant > double:

autorebase.yml 2 vs 1
create-draft-release.yml 8 vs 2
generate-changelog.yml 3 vs 2
on-issue-labeled.yml 7 vs 2
prebuild-ios-core.yml 59 vs 17
prebuild-ios-dependencies.yml 39 vs 1
stale-bot.yml 18 vs 15
test-all.yml 70 vs 27
Double-quote predominant > single:

bump-podfile-lock.yml 1 vs 10
create-release.yml 3 vs 12
e2e-android-rntester.yml 2 vs 6
e2e-android-templateapp.yml 6 vs 13
e2e-ios-rntester.yml 2 vs 7
e2e-ios-templateapp.yml 2 vs 18
fantom-tests.yml 2 vs 7
monitor-new-issues.yml 3 vs 12
publish-npm.yml 42 vs 50
validate-cxx-api-snapshots.yml 2 vs 23
validate-dotslash-artifacts.yml 2 vs 5
Tie / 1-1:

cache-reaper.yml 1 vs 1
close-pr.yml 1 vs 1
needs-attention.yml 2 vs 2
All files contain single quotes somewhere, but only those 4 are single-quote-exclusive. Most CI-heavy workflows — bump, create-release, e2e-, fantom, monitor, publish-npm, validate- — lean double-quoted, while the pr/issue automation, prebuild ios, test-all, and stale-bot lean single-quoted.
```

Changelog: [Internal]

___

Differential Revision: D109151683
