### PR TITLE
Stop publishing `@react-native/core-cli-utils`

### DIFF
--- a/private/core-cli-utils/package.json
+++ b/private/core-cli-utils/package.json
@@ -1,13 +1,9 @@
 {
   "name": "@react-native/core-cli-utils",
+  "private": true,
   "version": "0.0.0",
   "description": "Reference implementation of React Native CLI tooling",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/react/react-native.git",
-    "directory": "private/core-cli-utils"
-  },
   "main": "./src/index.js",
   "exports": {
     ".": "./src/index.js",


### PR DESCRIPTION
Summary:
https://github.com/facebook/react-native/pull/56922 intended to prevent this package publishing to npm but didn't - we've been continuing to publish it in nightlies.

`scripts/shared/monorepoUtils.js` filters with `packageJson.private !== true || includePrivate`, i.e. the `private` field is load-bearing, not the path. All other packages in `private/` have `package.json#private: true`.

Changelog: [Internal] - the breaking change is already noted in https://github.com/react/react-native/pull/56922 , no release / cut since.

Differential Revision: D109153641


