### PR TITLE
fix(android): pin react-android aarMetadata.minCompileSdk to 34

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -553,6 +553,15 @@ android {
   defaultConfig {
     minSdk = libs.versions.minSdk.get().toInt()
 
+    aarMetadata {
+      // RN's public ABI exposes no android API newer than 34, and the source is written to
+      // compile against SDK 34 (see util/AndroidVersion.kt). compileSdk is 36 only to build
+      // against the latest platform — it is not an API requirement. Without this, AGP 9
+      // defaults minCompileSdk to compileSdk (36), needlessly forcing every consuming
+      // library/app to compileSdk 36.
+      minCompileSdk = 34
+    }
+
     consumerProguardFiles("proguard-rules.pro")
 
     buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")


### PR DESCRIPTION
## Summary:

AGP 9 changed the default so a library propagates a minCompileSdk equal to its own compileSdk. Since react-android compiles against compileSdk 36, this now forces every consuming library/app to compileSdk >= 36 (e.g. it breaks libraries still on compileSdk 35 at checkAarMetadata).

RN does not actually require API 36: its public ABI exposes no android type newer than ~API 23, the highest framework constant referenced in code is UPSIDE_DOWN_CAKE (34), and the source is deliberately written to compile against SDK 34 (see util/AndroidVersion.kt, which abstracts the 35/36 version codes and the API-35 windowOptOutEdgeToEdgeEnforcement attribute). compileSdk is 36 only to build against the latest platform.

Set minCompileSdk = 34 explicitly to restore the pre-AGP-9 behavior and avoid needlessly forcing the library ecosystem onto compileSdk 36. The binary-compatibility-validator dump (ReactAndroid.api) guards against future regressions: adding an API 35/36 type to the public ABI would change that file and signal that this floor must rise.
## Changelog:

[ANDROID] [CHANGED] - Set minCompileSdk to 34, libraries will have to specify a compileSdk of >= 34 in order to work with React Native

## Test Plan:

CI