### PR TITLE
fix(android): restore namespace fallback for libraries not applying the React plugin

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -113,6 +113,20 @@ class ReactPlugin : Plugin<Project> {
       configureCodegen(project, extension, rootExtension, isLibrary = false)
       configureResources(project, extension)
       configureBuildTypesForApp(project)
+
+      // Apply the namespace fallback to every Android library in the build, including third-party
+      // libraries that don't apply the `com.facebook.react` plugin and still rely on the manifest
+      // `package` attribute (which AGP 9 no longer accepts as a namespace). The per-library hook
+      // below only covers libraries that apply our plugin, so we additionally sweep all library
+      // subprojects from the app. We do this once, from the application project, because re-running
+      // a rootProject-wide traversal from every library breaks on AGP 9, which errors when
+      // `finalizeDsl` is registered after a project's DSL has been finalized.
+      // See https://github.com/facebook/react-native/pull/57038.
+      project.rootProject.allprojects { subproject ->
+        subproject.pluginManager.withPlugin("com.android.library") {
+          configureNamespaceForLibraries(subproject)
+        }
+      }
     }
 
     // Library Only Configuration

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -122,9 +122,19 @@ class ReactPlugin : Plugin<Project> {
       // a rootProject-wide traversal from every library breaks on AGP 9, which errors when
       // `finalizeDsl` is registered after a project's DSL has been finalized.
       // See https://github.com/facebook/react-native/pull/57038.
+      //
+      // We skip projects that have already been evaluated: AGP finalizes a project's DSL during/
+      // after its evaluation, so registering a `finalizeDsl` callback on an already-evaluated
+      // project is "too late" and fails on AGP 9. In a regular app build the app is evaluated
+      // before its libraries (see ReactRootProjectPlugin's `evaluationDependsOn(":app")`), so every
+      // library is still pending here. In composite/monorepo builds (e.g. rn-tester, where
+      // ReactAndroid is a sibling) some library projects are already evaluated by this point; those
+      // already define their own namespace, so skipping them is safe.
       project.rootProject.allprojects { subproject ->
         subproject.pluginManager.withPlugin("com.android.library") {
-          configureNamespaceForLibraries(subproject)
+          if (!subproject.state.executed) {
+            configureNamespaceForLibraries(subproject)
+          }
         }
       }
     }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -106,6 +106,15 @@ internal object AgpConfiguratorUtils {
   }
 
   fun configureNamespaceForLibraries(project: Project) {
+    // This helper can be reached both from a library's own application of the React plugin and
+    // from the app-level sweep in ReactPlugin (which also covers libraries that don't apply
+    // `com.facebook.react`). A project's `finalizeDsl` callback must be registered before AGP
+    // finalizes its DSL — registering it twice (or after finalization) is a hard error on AGP 9+ —
+    // so we guard to register the namespace fallback at most once per project.
+    if (project.extensions.extraProperties.has(NAMESPACE_CONFIGURED_PROPERTY)) {
+      return
+    }
+    project.extensions.extraProperties.set(NAMESPACE_CONFIGURED_PROPERTY, true)
     project.extensions.getByType(LibraryAndroidComponentsExtension::class.java).finalizeDsl { ext ->
       if (ext.namespace == null) {
         val manifestFile =
@@ -121,6 +130,8 @@ internal object AgpConfiguratorUtils {
     }
   }
 }
+
+private const val NAMESPACE_CONFIGURED_PROPERTY = "com.facebook.react.internal.namespaceConfigured"
 
 const val DEFAULT_DEV_SERVER_PORT = "8081"
 


### PR DESCRIPTION
## Summary:

#57038 narrowed configureNamespaceForLibraries from a rootProject-wide sweep to only the project applying `com.facebook.react`. That was necessary because the old code re-ran the sweep from every library, and AGP 9 errors when `finalizeDsl` is registered after a project's DSL has been finalized.

The narrowing has a side effect: third-party Android libraries that do NOT apply `com.facebook.react` and still rely on the manifest `package` attribute (e.g. older react-native-linear-gradient) no longer receive a namespace, so they fail under AGP 9 with "Namespace not specified".

Restore the broad coverage by sweeping all `com.android.library` subprojects once, from the application project (which applies the plugin a single time, avoiding the repeated-traversal finalizeDsl error from #57038). Guard configureNamespaceForLibraries so it registers its finalizeDsl callback at most once per project, since libraries that DO apply the React plugin are now reachable from both the per-library hook and the app-level sweep.

## Changelog:

[INTERNAL] - restore namespace fallback for libraries not applying the React plugin

## Test Plan:

CI