### PR TITLE
Fix Android display metrics refresh on density changes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -72,6 +72,7 @@ import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback;
 import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
+import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.interfaces.TaskInterface;
 import com.facebook.react.internal.AndroidChoreographerProvider;
 import com.facebook.react.internal.ChoreographerProvider;
@@ -79,6 +80,7 @@ import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ReactChoreographer;
+import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.ReactRoot;
@@ -859,6 +861,27 @@ public class ReactInstanceManager {
 
     ReactContext currentReactContext = getCurrentReactContext();
     if (currentReactContext != null) {
+      boolean didDisplayMetricsChange =
+          DisplayMetricsHolder.updateDisplayMetricsIfChanged(updatedContext);
+      if (didDisplayMetricsChange) {
+        @Nullable UIManager uiManager = UIManagerHelper.getUIManager(currentReactContext, FABRIC);
+        if (uiManager instanceof FabricUIManager) {
+          ((FabricUIManager) uiManager).updateDisplayMetricDensity();
+        }
+
+        synchronized (mAttachedReactRoots) {
+          for (ReactRoot reactRoot : mAttachedReactRoots) {
+            reactRoot.getRootViewGroup().requestLayout();
+          }
+        }
+
+        DeviceInfoModule deviceInfoModule =
+            currentReactContext.getNativeModule(DeviceInfoModule.class);
+        if (deviceInfoModule != null) {
+          deviceInfoModule.emitUpdateDimensionsEvent();
+        }
+      }
+
       AppearanceModule appearanceModule =
           currentReactContext.getNativeModule(AppearanceModule.class);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -76,6 +76,7 @@ import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.interfaces.TaskInterface;
 import com.facebook.react.internal.AndroidChoreographerProvider;
 import com.facebook.react.internal.ChoreographerProvider;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -861,24 +862,26 @@ public class ReactInstanceManager {
 
     ReactContext currentReactContext = getCurrentReactContext();
     if (currentReactContext != null) {
-      boolean didDisplayMetricsChange =
-          DisplayMetricsHolder.updateDisplayMetricsIfChanged(updatedContext);
-      if (didDisplayMetricsChange) {
-        @Nullable UIManager uiManager = UIManagerHelper.getUIManager(currentReactContext, FABRIC);
-        if (uiManager instanceof FabricUIManager) {
-          ((FabricUIManager) uiManager).updateDisplayMetricDensity();
-        }
-
-        synchronized (mAttachedReactRoots) {
-          for (ReactRoot reactRoot : mAttachedReactRoots) {
-            reactRoot.getRootViewGroup().requestLayout();
+      if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
+        boolean didDisplayMetricsChange =
+            DisplayMetricsHolder.updateDisplayMetricsIfChanged(updatedContext);
+        if (didDisplayMetricsChange) {
+          @Nullable UIManager uiManager = UIManagerHelper.getUIManager(currentReactContext, FABRIC);
+          if (uiManager instanceof FabricUIManager) {
+            ((FabricUIManager) uiManager).updateDisplayMetricDensity();
           }
-        }
 
-        DeviceInfoModule deviceInfoModule =
-            currentReactContext.getNativeModule(DeviceInfoModule.class);
-        if (deviceInfoModule != null) {
-          deviceInfoModule.emitUpdateDimensionsEvent();
+          synchronized (mAttachedReactRoots) {
+            for (ReactRoot reactRoot : mAttachedReactRoots) {
+              reactRoot.getRootViewGroup().requestLayout();
+            }
+          }
+
+          DeviceInfoModule deviceInfoModule =
+              currentReactContext.getNativeModule(DeviceInfoModule.class);
+          if (deviceInfoModule != null) {
+            deviceInfoModule.emitUpdateDimensionsEvent();
+          }
         }
       }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -137,7 +137,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     setClipChildren(false);
 
     if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
-      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext());
     }
   }
 
@@ -916,7 +916,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private int mDeviceRotation = 0;
 
     /* package */ CustomGlobalLayoutListener() {
-      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext());
       mVisibleViewArea = new Rect();
     }
 
@@ -991,7 +991,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         return;
       }
       mDeviceRotation = rotation;
-      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext());
       emitOrientationChanged(rotation);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -361,6 +361,7 @@ public class FabricUIManager
         UiThreadUtil.isOnUiThread() ? RootViewUtil.getViewportOffset(rootView) : new Point(0, 0);
 
     Assertions.assertNotNull(mBinding, "Binding in FabricUIManager is null");
+    mBinding.setPixelDensity(context.getResources().getDisplayMetrics().density);
     mBinding.startSurfaceWithConstraints(
         rootTag,
         moduleName,
@@ -1031,6 +1032,12 @@ public class FabricUIManager
 
   void setBinding(FabricUIManagerBinding binding) {
     mBinding = binding;
+  }
+
+  public void updateDisplayMetricDensity() {
+    if (mBinding != null) {
+      mBinding.setPixelDensity(PixelUtil.getDisplayMetricDensity());
+    }
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -62,12 +62,12 @@ import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatur
 import com.facebook.react.modules.appearance.AppearanceModule
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.facebook.react.modules.deviceinfo.DeviceInfoModule
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.runtime.internal.bolts.Task
 import com.facebook.react.runtime.internal.bolts.TaskCompletionSource
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import com.facebook.react.uimanager.DisplayMetricsHolder
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.events.BlackHoleEventDispatcher
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
@@ -736,16 +736,14 @@ public class ReactHostImpl(
   override fun onConfigurationChanged(context: Context) {
     val currentReactContext = this.currentReactContext
     if (currentReactContext != null) {
-      if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
-        val previousFontScale = PixelUtil.toPixelFromSP(1.0)
-        DisplayMetricsHolder.initDisplayMetrics(currentReactContext)
-        val newFontScale = PixelUtil.toPixelFromSP(1.0)
-
-        if (previousFontScale != newFontScale) {
-          synchronized(attachedSurfaces) {
-            attachedSurfaces.forEach { surface -> surface.view?.requestLayout() }
-          }
+      val didDisplayMetricsChange = DisplayMetricsHolder.updateDisplayMetricsIfChanged(context)
+      if (didDisplayMetricsChange) {
+        synchronized(attachedSurfaces) {
+          attachedSurfaces.forEach { surface -> surface.view?.requestLayout() }
         }
+
+        val deviceInfoModule = currentReactContext.getNativeModule(DeviceInfoModule::class.java)
+        deviceInfoModule?.emitUpdateDimensionsEvent()
       }
 
       val appearanceModule = currentReactContext.getNativeModule(AppearanceModule::class.java)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -736,14 +736,16 @@ public class ReactHostImpl(
   override fun onConfigurationChanged(context: Context) {
     val currentReactContext = this.currentReactContext
     if (currentReactContext != null) {
-      val didDisplayMetricsChange = DisplayMetricsHolder.updateDisplayMetricsIfChanged(context)
-      if (didDisplayMetricsChange) {
-        synchronized(attachedSurfaces) {
-          attachedSurfaces.forEach { surface -> surface.view?.requestLayout() }
-        }
+      if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
+        val didDisplayMetricsChange = DisplayMetricsHolder.updateDisplayMetricsIfChanged(context)
+        if (didDisplayMetricsChange) {
+          synchronized(attachedSurfaces) {
+            attachedSurfaces.forEach { surface -> surface.view?.requestLayout() }
+          }
 
-        val deviceInfoModule = currentReactContext.getNativeModule(DeviceInfoModule::class.java)
-        deviceInfoModule?.emitUpdateDimensionsEvent()
+          val deviceInfoModule = currentReactContext.getNativeModule(DeviceInfoModule::class.java)
+          deviceInfoModule?.emitUpdateDimensionsEvent()
+        }
       }
 
       val appearanceModule = currentReactContext.getNativeModule(AppearanceModule::class.java)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -50,6 +50,29 @@ public object DisplayMetricsHolder {
   @SuppressLint("DeprecatedMethod") // for Android Lint
   @Suppress("DEPRECATION") // for Kotlin compiler
   public fun initDisplayMetrics(context: Context) {
+    screenDisplayMetrics = getDisplayMetrics(context)
+  }
+
+  @JvmStatic
+  @SuppressLint("DeprecatedMethod") // for Android Lint
+  @Suppress("DEPRECATION") // for Kotlin compiler
+  public fun updateDisplayMetricsIfChanged(context: Context): Boolean {
+    val oldMetrics = screenDisplayMetrics
+    val newMetrics = getDisplayMetrics(context)
+    val didChange =
+        oldMetrics == null ||
+            oldMetrics.widthPixels != newMetrics.widthPixels ||
+            oldMetrics.heightPixels != newMetrics.heightPixels ||
+            oldMetrics.density != newMetrics.density ||
+            oldMetrics.scaledDensity != newMetrics.scaledDensity ||
+            oldMetrics.densityDpi != newMetrics.densityDpi
+    screenDisplayMetrics = newMetrics
+    return didChange
+  }
+
+  @SuppressLint("DeprecatedMethod") // for Android Lint
+  @Suppress("DEPRECATION") // for Kotlin compiler
+  private fun getDisplayMetrics(context: Context): DisplayMetrics {
     val displayMetrics = context.resources.displayMetrics
     val screenDisplayMetrics = DisplayMetrics()
     screenDisplayMetrics.setTo(displayMetrics)
@@ -65,7 +88,7 @@ public object DisplayMetricsHolder {
     // physical display metrics without the system font scale setting.
     // This is needed for proper text scaling when fontScale < 1.0
     screenDisplayMetrics.scaledDensity = displayMetrics.scaledDensity
-    DisplayMetricsHolder.screenDisplayMetrics = screenDisplayMetrics
+    return screenDisplayMetrics
   }
 
   internal fun getStatusBarHeightPx(activity: Activity?): Int {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/DisplayMetricsHolderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/DisplayMetricsHolderTest.kt
@@ -81,6 +81,61 @@ class DisplayMetricsHolderTest {
   }
 
   @Test
+  fun updateDisplayMetricsIfChanged_returnsTrueAndUpdatesMetricsWhenMetricsChange() {
+    val originalMetrics = DisplayMetrics().apply {
+      density = 2.0f
+      scaledDensity = 2.0f
+      widthPixels = 1000
+      heightPixels = 2000
+      densityDpi = DisplayMetrics.DENSITY_XHIGH
+    }
+    val updatedMetrics = DisplayMetrics().apply {
+      density = 1.5f
+      scaledDensity = 1.5f
+      widthPixels = 1200
+      heightPixels = 1800
+      densityDpi = DisplayMetrics.DENSITY_HIGH
+    }
+    val mockContext: Context = mock()
+    val mockResources: android.content.res.Resources = mock()
+
+    DisplayMetricsHolder.setScreenDisplayMetrics(originalMetrics)
+    whenever(mockContext.resources).thenReturn(mockResources)
+    whenever(mockResources.displayMetrics).thenReturn(updatedMetrics)
+    whenever(mockContext.getSystemService(Context.WINDOW_SERVICE))
+        .thenThrow(IllegalStateException("non-visual context"))
+
+    val didChange = DisplayMetricsHolder.updateDisplayMetricsIfChanged(mockContext)
+
+    assertThat(didChange).isTrue()
+    assertThat(DisplayMetricsHolder.getScreenDisplayMetrics().density).isEqualTo(1.5f)
+    assertThat(DisplayMetricsHolder.getScreenDisplayMetrics().scaledDensity).isEqualTo(1.5f)
+  }
+
+  @Test
+  fun updateDisplayMetricsIfChanged_returnsFalseWhenMetricsMatch() {
+    val metrics = DisplayMetrics().apply {
+      density = 2.0f
+      scaledDensity = 2.0f
+      widthPixels = 1000
+      heightPixels = 2000
+      densityDpi = DisplayMetrics.DENSITY_XHIGH
+    }
+    val mockContext: Context = mock()
+    val mockResources: android.content.res.Resources = mock()
+
+    DisplayMetricsHolder.setScreenDisplayMetrics(DisplayMetrics().apply { setTo(metrics) })
+    whenever(mockContext.resources).thenReturn(mockResources)
+    whenever(mockResources.displayMetrics).thenReturn(metrics)
+    whenever(mockContext.getSystemService(Context.WINDOW_SERVICE))
+        .thenThrow(IllegalStateException("non-visual context"))
+
+    val didChange = DisplayMetricsHolder.updateDisplayMetricsIfChanged(mockContext)
+
+    assertThat(didChange).isFalse()
+  }
+
+  @Test
   fun initDisplayMetricsIfNotInitialized_onlyInitializesOnce() {
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(context)
     val firstScreen = DisplayMetricsHolder.getScreenDisplayMetrics()


### PR DESCRIPTION
## Summary

Fixes Android display metrics getting stale when a React Native surface moves to a display/window with a different density, such as Samsung DeX, freeform windows, external monitors, or ChromeOS.

`DisplayMetricsHolder` was initialized once and could keep using the main display density, while Fabric/root layout could use the current display density. This caused text `sp -> px` conversion to use the wrong scale, making text render too large and clip.

## Changes

- Refresh `DisplayMetricsHolder` when Android configuration/display metrics change.
- Request relayout and emit Dimensions updates when display metrics change.
- Keep Fabric pixel density in sync with refreshed display metrics.
- Initialize root-view display metrics from the visual/root context instead of application context.
- Add tests for display metrics change detection.

## Changelog:

[ANDROID] [FIXED] - Keep display metrics in sync when Android display density changes

## Test Plan

- Ran `ktfmtFormat`.
- Ran `git diff --check`.
- Attempted targeted Android unit test, but local Windows codegen setup failed before tests ran due to `buildCodegenCLI` / `tar` path handling.