### PR TITLE
fix(image): fix data race in imageURLLoaderForURL: and imageDataDecoderForData:

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -163,23 +163,17 @@ RCT_EXPORT_MODULE()
   _imageCache = cache;
 }
 
-- (id<RCTImageURLLoader>)imageURLLoaderForURL:(NSURL *)URL
+- (NSArray<id<RCTImageURLLoader>> *)loaders
 {
-  if (!_isLoaderSetup) {
-    [self setUp];
-  }
-
   if (!_loadersReady.load(std::memory_order_acquire)) {
     std::lock_guard<std::mutex> guard(_loadersMutex);
     if (!_loadersReady.load(std::memory_order_relaxed)) {
-      // Get loaders, sorted in reverse priority order (highest priority first)
       if (_loadersProvider) {
         _loaders = _loadersProvider(self.moduleRegistry);
       } else {
         RCTAssert(_bridge, @"Trying to find RCTImageURLLoaders and bridge not set.");
         _loaders = [_bridge modulesConformingToProtocol:@protocol(RCTImageURLLoader)];
       }
-
       _loaders =
           [_loaders sortedArrayUsingComparator:^NSComparisonResult(id<RCTImageURLLoader> a, id<RCTImageURLLoader> b) {
             float priorityA = [a respondsToSelector:@selector(loaderPriority)] ? [a loaderPriority] : 0;
@@ -195,7 +189,45 @@ RCT_EXPORT_MODULE()
       _loadersReady.store(YES, std::memory_order_release);
     }
   }
-  NSArray<id<RCTImageURLLoader>> *loaders = _loaders;
+  return _loaders;
+}
+
+- (NSArray<id<RCTImageDataDecoder>> *)decoders
+{
+  if (!_decodersReady.load(std::memory_order_acquire)) {
+    std::lock_guard<std::mutex> guard(_loadersMutex);
+    if (!_decodersReady.load(std::memory_order_relaxed)) {
+      if (_decodersProvider) {
+        _decoders = _decodersProvider(self.moduleRegistry);
+      } else {
+        RCTAssert(_bridge, @"Trying to find RCTImageDataDecoders and bridge not set.");
+        _decoders = [_bridge modulesConformingToProtocol:@protocol(RCTImageDataDecoder)];
+      }
+      _decoders = [_decoders
+          sortedArrayUsingComparator:^NSComparisonResult(id<RCTImageDataDecoder> a, id<RCTImageDataDecoder> b) {
+            float priorityA = [a respondsToSelector:@selector(decoderPriority)] ? [a decoderPriority] : 0;
+            float priorityB = [b respondsToSelector:@selector(decoderPriority)] ? [b decoderPriority] : 0;
+            if (priorityA > priorityB) {
+              return NSOrderedAscending;
+            } else if (priorityA < priorityB) {
+              return NSOrderedDescending;
+            } else {
+              return NSOrderedSame;
+            }
+          }];
+      _decodersReady.store(YES, std::memory_order_release);
+    }
+  }
+  return _decoders;
+}
+
+- (id<RCTImageURLLoader>)imageURLLoaderForURL:(NSURL *)URL
+{
+  if (!_isLoaderSetup) {
+    [self setUp];
+  }
+
+  NSArray<id<RCTImageURLLoader>> *loaders = [self loaders];
 
   if (RCT_DEBUG) {
     // Check for handler conflicts
@@ -244,34 +276,7 @@ RCT_EXPORT_MODULE()
     [self setUp];
   }
 
-  if (!_decodersReady.load(std::memory_order_acquire)) {
-    std::lock_guard<std::mutex> guard(_loadersMutex);
-    if (!_decodersReady.load(std::memory_order_relaxed)) {
-      // Get decoders, sorted in reverse priority order (highest priority first)
-
-      if (_decodersProvider) {
-        _decoders = _decodersProvider(self.moduleRegistry);
-      } else {
-        RCTAssert(_bridge, @"Trying to find RCTImageDataDecoders and bridge not set.");
-        _decoders = [_bridge modulesConformingToProtocol:@protocol(RCTImageDataDecoder)];
-      }
-
-      _decoders = [_decoders
-          sortedArrayUsingComparator:^NSComparisonResult(id<RCTImageDataDecoder> a, id<RCTImageDataDecoder> b) {
-            float priorityA = [a respondsToSelector:@selector(decoderPriority)] ? [a decoderPriority] : 0;
-            float priorityB = [b respondsToSelector:@selector(decoderPriority)] ? [b decoderPriority] : 0;
-            if (priorityA > priorityB) {
-              return NSOrderedAscending;
-            } else if (priorityA < priorityB) {
-              return NSOrderedDescending;
-            } else {
-              return NSOrderedSame;
-            }
-          }];
-      _decodersReady.store(YES, std::memory_order_release);
-    }
-  }
-  NSArray<id<RCTImageDataDecoder>> *decoders = _decoders;
+  NSArray<id<RCTImageDataDecoder>> *decoders = [self decoders];
 
   if (RCT_DEBUG) {
     // Check for handler conflicts
@@ -1182,7 +1187,10 @@ static RCTImageLoaderCancellationBlock RCTLoadImageURLFromLoader(
     return NO;
   }
 
-  for (id<RCTImageURLLoader> loader in _loaders) {
+  if (!_isLoaderSetup) {
+    [self setUp];
+  }
+  for (id<RCTImageURLLoader> loader in [self loaders]) {
     // Don't use RCTImageURLLoader protocol for modules that already conform to
     // RCTURLRequestHandler as it's inefficient to decode an image and then
     // convert it back into data

--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -73,7 +73,9 @@ static NSError *addResponseHeadersToError(NSError *originalError, NSHTTPURLRespo
   NSArray<id<RCTImageURLLoader>> * (^_loadersProvider)(RCTModuleRegistry *);
   NSArray<id<RCTImageDataDecoder>> * (^_decodersProvider)(RCTModuleRegistry *);
   NSArray<id<RCTImageURLLoader>> *_loaders;
+  std::atomic<BOOL> _loadersReady;
   NSArray<id<RCTImageDataDecoder>> *_decoders;
+  std::atomic<BOOL> _decodersReady;
   NSOperationQueue *_imageDecodeQueue;
   dispatch_queue_t _URLRequestQueue;
   id<RCTImageCache> _imageCache;
@@ -167,9 +169,9 @@ RCT_EXPORT_MODULE()
     [self setUp];
   }
 
-  if (!_loaders) {
-    std::unique_lock<std::mutex> guard(_loadersMutex);
-    if (!_loaders) {
+  if (!_loadersReady.load(std::memory_order_acquire)) {
+    std::lock_guard<std::mutex> guard(_loadersMutex);
+    if (!_loadersReady.load(std::memory_order_relaxed)) {
       // Get loaders, sorted in reverse priority order (highest priority first)
       if (_loadersProvider) {
         _loaders = _loadersProvider(self.moduleRegistry);
@@ -190,14 +192,16 @@ RCT_EXPORT_MODULE()
               return NSOrderedSame;
             }
           }];
+      _loadersReady.store(YES, std::memory_order_release);
     }
   }
+  NSArray<id<RCTImageURLLoader>> *loaders = _loaders;
 
   if (RCT_DEBUG) {
     // Check for handler conflicts
     float previousPriority = 0;
     id<RCTImageURLLoader> previousLoader = nil;
-    for (id<RCTImageURLLoader> loader in _loaders) {
+    for (id<RCTImageURLLoader> loader in loaders) {
       float priority = [loader respondsToSelector:@selector(loaderPriority)] ? [loader loaderPriority] : 0;
       if (previousLoader && priority < previousPriority) {
         return previousLoader;
@@ -224,7 +228,7 @@ RCT_EXPORT_MODULE()
   }
 
   // Normal code path
-  for (id<RCTImageURLLoader> loader in _loaders) {
+  for (id<RCTImageURLLoader> loader in loaders) {
     if ([loader canLoadImageURL:URL]) {
       return loader;
     }
@@ -240,35 +244,40 @@ RCT_EXPORT_MODULE()
     [self setUp];
   }
 
-  if (!_decoders) {
-    // Get decoders, sorted in reverse priority order (highest priority first)
+  if (!_decodersReady.load(std::memory_order_acquire)) {
+    std::lock_guard<std::mutex> guard(_loadersMutex);
+    if (!_decodersReady.load(std::memory_order_relaxed)) {
+      // Get decoders, sorted in reverse priority order (highest priority first)
 
-    if (_decodersProvider) {
-      _decoders = _decodersProvider(self.moduleRegistry);
-    } else {
-      RCTAssert(_bridge, @"Trying to find RCTImageDataDecoders and bridge not set.");
-      _decoders = [_bridge modulesConformingToProtocol:@protocol(RCTImageDataDecoder)];
+      if (_decodersProvider) {
+        _decoders = _decodersProvider(self.moduleRegistry);
+      } else {
+        RCTAssert(_bridge, @"Trying to find RCTImageDataDecoders and bridge not set.");
+        _decoders = [_bridge modulesConformingToProtocol:@protocol(RCTImageDataDecoder)];
+      }
+
+      _decoders = [_decoders
+          sortedArrayUsingComparator:^NSComparisonResult(id<RCTImageDataDecoder> a, id<RCTImageDataDecoder> b) {
+            float priorityA = [a respondsToSelector:@selector(decoderPriority)] ? [a decoderPriority] : 0;
+            float priorityB = [b respondsToSelector:@selector(decoderPriority)] ? [b decoderPriority] : 0;
+            if (priorityA > priorityB) {
+              return NSOrderedAscending;
+            } else if (priorityA < priorityB) {
+              return NSOrderedDescending;
+            } else {
+              return NSOrderedSame;
+            }
+          }];
+      _decodersReady.store(YES, std::memory_order_release);
     }
-
-    _decoders = [_decoders
-        sortedArrayUsingComparator:^NSComparisonResult(id<RCTImageDataDecoder> a, id<RCTImageDataDecoder> b) {
-          float priorityA = [a respondsToSelector:@selector(decoderPriority)] ? [a decoderPriority] : 0;
-          float priorityB = [b respondsToSelector:@selector(decoderPriority)] ? [b decoderPriority] : 0;
-          if (priorityA > priorityB) {
-            return NSOrderedAscending;
-          } else if (priorityA < priorityB) {
-            return NSOrderedDescending;
-          } else {
-            return NSOrderedSame;
-          }
-        }];
   }
+  NSArray<id<RCTImageDataDecoder>> *decoders = _decoders;
 
   if (RCT_DEBUG) {
     // Check for handler conflicts
     float previousPriority = 0;
     id<RCTImageDataDecoder> previousDecoder = nil;
-    for (id<RCTImageDataDecoder> decoder in _decoders) {
+    for (id<RCTImageDataDecoder> decoder in decoders) {
       float priority = [decoder respondsToSelector:@selector(decoderPriority)] ? [decoder decoderPriority] : 0;
       if (previousDecoder && priority < previousPriority) {
         return previousDecoder;
@@ -297,7 +306,7 @@ RCT_EXPORT_MODULE()
   }
 
   // Normal code path
-  for (id<RCTImageDataDecoder> decoder in _decoders) {
+  for (id<RCTImageDataDecoder> decoder in decoders) {
     if ([decoder canDecodeImageData:data]) {
       return decoder;
     }


### PR DESCRIPTION
## Summary

`imageURLLoaderForURL:` had a broken double-checked lock on `_loaders`: the outer `if (!_loaders)` guard and the `for` loop iteration both ran without `_loadersMutex`, while the assignment ran inside it. `imageDataDecoderForData:` had no lock at all on `_decoders`. Both methods write the ivar in two steps (raw list then sorted), so a concurrent reader could observe the intermediate value and iterate a concurrently-released array, crashing with `EXC_BAD_ACCESS` in `objc_release` on a GCD worker thread.

Verified with a reproducer — crashes 5/5 without the fix, 0/10 with it: https://github.com/mfazekas/rn-rctimageloader-dcl-repro

## Fix

The fix mirrors the `setUp()` pattern from #46153: add `std::atomic<BOOL>` flags (`_loadersReady` / `_decodersReady`) as acquire/release DCL guards, protect the slow path with `_loadersMutex`, and iterate a local strong ref captured under the lock so the shared ivar is never read outside it.

Two simpler alternatives were considered and rejected:

- **Always lock** (always acquire `_loadersMutex` on every call, even after init): correct but ~40× slower on the hot path — `imageURLLoaderForURL:` is called for every image load.
- **`dispatch_once`**: correct and lock-free after init, but involves a function call into libdispatch on every call.

The atomic DCL approach matches what `setUp()` already does and compiles to a single `ldar` (load-acquire) instruction on ARM64 on the hot path — effectively free after first use.

## Related

Fixes #57296
See also #46115, #46153