### PR TITLE
Skip dropped mapped node in PropsAnimatedNode.updateView instead of crashing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/PropsAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/PropsAnimatedNode.kt
@@ -75,7 +75,15 @@ internal class PropsAnimatedNode(
     }
     for ((key, value) in propNodeMapping) {
       val node = nativeAnimatedNodesManager.getNodeById(value)
-      requireNotNull(node) { "Mapped property node does not exist" }
+      // A mapped child node can be dropped (e.g. its component unmounted during
+      // navigation) between animation frames while this prop node is still
+      // queued for an update. Skip the stale node instead of throwing: the
+      // connected view is being torn down, so there is no meaningful value to
+      // write for this prop on this frame. Mirrors the connectedViewTag == -1
+      // early-return above. Fixes #37267.
+      if (node == null) {
+        continue
+      }
       if (node is StyleAnimatedNode) {
         node.collectViewUpdates(propMap)
       } else if (node is ValueAnimatedNode) {


### PR DESCRIPTION
## Summary

`PropsAnimatedNode.updateView()` iterates its mapped property nodes every frame and calls `requireNotNull(node) { "Mapped property node does not exist" }` for each one. When a connected component is unmounted (for example during a navigation transition), its child animated nodes can be dropped from `NativeAnimatedNodesManager` while a frame callback for the prop node is still in flight. On the next `updateView` the mapped node is gone, `requireNotNull` throws, and the app crashes:

```
java.lang.IllegalArgumentException: Mapped property node does not exist
  at com.facebook.react.animated.PropsAnimatedNode.updateView(PropsAnimatedNode.kt)
  at com.facebook.react.animated.NativeAnimatedNodesManager.updateNodes(NativeAnimatedNodesManager.java)
  at com.facebook.react.animated.NativeAnimatedNodesManager.runUpdates(NativeAnimatedNodesManager.java)
```

This is a teardown race: by the time the mapped node has been removed, the connected view is being torn down, so there is no meaningful value to write for that prop on this frame. This change skips a missing mapped node instead of throwing.

It mirrors the guard already at the top of the same method, which returns early when the view itself is gone (`connectedViewTag == -1`), and matches the lenient behavior on iOS, where `RCTPropsAnimatedNode` iterates its parent nodes with `isKindOfClass:` checks and a missing (`nil`) node is simply skipped.

Fixes #37267.

## Changelog:

[ANDROID] [FIXED] - Prevent "Mapped property node does not exist" crash in `PropsAnimatedNode.updateView` when a mapped node is removed during an in-flight native animation

## Test Plan

The crash is a timing-dependent race, so it reproduces probabilistically rather than deterministically. Using the repro from #37267 (a screen with many simultaneous native-driver animations, navigating in and out repeatedly) and increasing **Animator duration scale** in Developer Options widens the window and makes it reproduce reliably on lower-end devices.

- **Before:** rapidly navigating away from a screen with running native-driver animations crashes with `IllegalArgumentException: Mapped property node does not exist`.
- **After:** the stale node is skipped and no crash occurs.
- **Happy path unaffected:** when all mapped nodes are present, behavior is identical. The change only adds an early `continue` for the already-removed-node case, so no prop update is lost for live nodes.
