### PR TITLE
Enable animatedShouldDebounceQueueFlush by default

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -971,7 +971,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     animatedShouldDebounceQueueFlush: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2024-02-05',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<68e9dbd18bfcb5e7d5cad27d8663ce66>>
+ * @generated SignedSource<<c9804d0743d9a9d905193cb02816da46>>
  * @flow strict
  * @noformat
  */
@@ -154,7 +154,7 @@ export const animatedForceNativeDriver: Getter<boolean> = createJavaScriptFlagGe
 /**
  * Enables an experimental flush-queue debouncing in Animated.js.
  */
-export const animatedShouldDebounceQueueFlush: Getter<boolean> = createJavaScriptFlagGetter('animatedShouldDebounceQueueFlush', false);
+export const animatedShouldDebounceQueueFlush: Getter<boolean> = createJavaScriptFlagGetter('animatedShouldDebounceQueueFlush', true);
 
 /**
  * When a useNativeDriver animation completes, syncs the JS-side AnimatedValue with the post-animation value BEFORE invoking the user-supplied start({finished}) callback. Without the flag, the callback observes the pre-animation value, which can cause downstream re-renders to read stale interpolation outputs.


### PR DESCRIPTION
Summary:
Flip the default value of the `animatedShouldDebounceQueueFlush` JavaScript feature flag to `true`, enabling Animated flush-queue debouncing everywhere, and remove the per-app overrides that already forced it on.

This flag just put operations in a microtasks queue, it doesn't rely on any specific native animated implementation

Changelog:
[General][Changed] - Enable Animated flush-queue debouncing (`animatedShouldDebounceQueueFlush`) by default

Reviewed By: christophpurrer

Differential Revision: D109468771


