### PR TITLE
Revert "Unbreak android CI by moving to ubuntu-latest (#57216)"

### DIFF
--- a/.github/workflows/e2e-android-rntester.yml
+++ b/.github/workflows/e2e-android-rntester.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     strategy:

--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     strategy:

--- a/.github/workflows/fantom-tests.yml
+++ b/.github/workflows/fantom-tests.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 8-core-ubuntu
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     container:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -218,7 +218,7 @@ jobs:
     secrets: inherit
 
   build_fantom_runner:
-    runs-on: ubuntu-latest
+    runs-on: 8-core-ubuntu
     needs: [set_release_type, check_code_changes, lint]
     if: needs.check_code_changes.outputs.any_code_change == 'true'
     container:
@@ -261,7 +261,7 @@ jobs:
     secrets: inherit
 
   build_android:
-    runs-on: ubuntu-latest
+    runs-on: 8-core-ubuntu
     needs: [set_release_type, check_code_changes]
     if: |
       needs.check_code_changes.outputs.any_code_change == 'true' &&
@@ -307,7 +307,7 @@ jobs:
     secrets: inherit
 
   build_npm_package:
-    runs-on: ubuntu-latest
+    runs-on: 8-core-ubuntu
     needs:
       [
         set_release_type,
@@ -340,7 +340,7 @@ jobs:
           skip-apple-prebuilts: ${{ needs.check_code_changes.outputs.should_test_ios == 'false' }}
 
   test_android_helloworld:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     needs: [build_npm_package, build_android]
     if: ${{ always() && needs.build_android.result == 'success' && needs.build_npm_package.result == 'success' }}
     container:


### PR DESCRIPTION
## Summary

This reverts the runner changes from #57216, which moved the Android CI jobs from the dedicated `4-core-ubuntu` / `8-core-ubuntu` runners onto the standard `ubuntu-latest` runners.

I'm opening this (as a draft) to **see if we can speed up the RN runners** — i.e. to measure whether going back to the larger dedicated runners gives us faster CI than `ubuntu-latest`. This is an experiment to compare timings.

### What's reverted
- `e2e-android-rntester.yml`: `ubuntu-latest` → `4-core-ubuntu`
- `e2e-android-templateapp.yml`: `ubuntu-latest` → `4-core-ubuntu`
- `fantom-tests.yml`: `ubuntu-latest` → `8-core-ubuntu`
- `test-all.yml`: `build_fantom_runner`, `build_android`, `build_npm_package` → `8-core-ubuntu`; `test_android_helloworld` → `4-core-ubuntu`

### Not reverted (drift since #57216)
- `nightly.yml` was deleted on main (consolidated into `publish-npm.yml`).
- `publish-npm.yml` was fully restructured on main (the old `publish-react-native` reusable job no longer exists).

These two are release/nightly jobs rather than the per-PR CI that determines runner speed, so they're intentionally left untouched.

Changelog:

[INTERNAL] - 

## Changelog

[INTERNAL] - 

## Test Plan

CI — compare job durations against `ubuntu-latest`.