### PR TITLE
Download React Native artifacts from the proxy cache server first (#57325)

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -15,6 +15,8 @@ import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY_DEFAULT
 import com.facebook.react.utils.PropertyUtils.INTERNAL_HERMES_PUBLISHING_GROUP
 import com.facebook.react.utils.PropertyUtils.INTERNAL_HERMES_VERSION_NAME
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO
+import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_MIRROR_ENABLED
+import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_MIRROR_ENABLED_DEFAULT
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_PUBLISHING_GROUP
 import com.facebook.react.utils.PropertyUtils.INTERNAL_USE_HERMES_NIGHTLY
 import com.facebook.react.utils.PropertyUtils.INTERNAL_VERSION_NAME
@@ -27,6 +29,8 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 
 internal object DependencyUtils {
+  private const val REACT_NATIVE_MAVEN_MIRROR_URL = "https://repo.reactnative.dev/maven2"
+  private const val REACT_NATIVE_MAVEN_MIRROR_ENABLED_ENV = "RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED"
 
   internal data class Coordinates(
       val versionString: String,
@@ -73,6 +77,19 @@ internal object DependencyUtils {
           // We add the snapshot for users on nightlies.
           mavenRepoFromUrl("https://central.sonatype.com/repository/maven-snapshots/") { repo ->
             repo.content { it.excludeGroup("org.webkit") }
+          }
+        }
+        // The React Native Maven mirror must be added before Maven Central so it can serve cached
+        // artifacts first, while Maven Central remains the fallback.
+        if (
+            !hasProperty(INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO) &&
+                isReactNativeMavenMirrorEnabled()
+        ) {
+          mavenRepoFromUrl(REACT_NATIVE_MAVEN_MIRROR_URL) { repo ->
+            repo.content { content ->
+              content.includeGroupByRegex("com\\.facebook\\.react.*")
+              content.includeGroupByRegex("com\\.facebook\\.hermes.*")
+            }
           }
         }
         repositories.mavenCentral { repo ->
@@ -269,6 +286,19 @@ internal object DependencyUtils {
         hasProperty(INCLUDE_JITPACK_REPOSITORY) ->
             property(INCLUDE_JITPACK_REPOSITORY).toString().toBoolean()
         else -> INCLUDE_JITPACK_REPOSITORY_DEFAULT
+      }
+
+  internal fun Project.isReactNativeMavenMirrorEnabled(
+      environmentValue: String? = System.getenv(REACT_NATIVE_MAVEN_MIRROR_ENABLED_ENV)
+  ): Boolean =
+      when {
+        hasProperty(INTERNAL_REACT_NATIVE_MAVEN_MIRROR_ENABLED) -> {
+          val value = property(INTERNAL_REACT_NATIVE_MAVEN_MIRROR_ENABLED).toString()
+          !value.equals("false", ignoreCase = true) && value != "0"
+        }
+        !environmentValue.isNullOrEmpty() ->
+            !environmentValue.equals("false", ignoreCase = true) && environmentValue != "0"
+        else -> INTERNAL_REACT_NATIVE_MAVEN_MIRROR_ENABLED_DEFAULT
       }
 
   internal fun String.isNightly(): Boolean = this.startsWith("0.0.0") || "-nightly-" in this

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -62,6 +62,11 @@ object PropertyUtils {
    */
   const val INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO = "react.internal.mavenLocalRepo"
 
+  /** Internal property that controls the React Native Maven mirror, which is enabled by default. */
+  const val INTERNAL_REACT_NATIVE_MAVEN_MIRROR_ENABLED =
+      "react.internal.reactNativeMavenMirrorEnabled"
+  const val INTERNAL_REACT_NATIVE_MAVEN_MIRROR_ENABLED_DEFAULT = true
+
   /**
    * Internal property used to specify where the Windows Bash executable is located. This is useful
    * for contributors who are running Windows on their machine.

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -13,6 +13,7 @@ import com.facebook.react.utils.DependencyUtils.configureRepositories
 import com.facebook.react.utils.DependencyUtils.exclusiveEnterpriseRepository
 import com.facebook.react.utils.DependencyUtils.getDependencySubstitutions
 import com.facebook.react.utils.DependencyUtils.isNightly
+import com.facebook.react.utils.DependencyUtils.isReactNativeMavenMirrorEnabled
 import com.facebook.react.utils.DependencyUtils.mavenRepoFromURI
 import com.facebook.react.utils.DependencyUtils.mavenRepoFromUrl
 import com.facebook.react.utils.DependencyUtils.readVersionAndGroupStrings
@@ -50,6 +51,22 @@ class DependencyUtilsTest {
   fun configureRepositories_containsMavenCentral() {
     val repositoryURI = URI.create("https://repo.maven.apache.org/maven2/")
     val project = createProject()
+
+    configureRepositories(project, false)
+
+    assertThat(
+            project.repositories.firstOrNull {
+              it is MavenArtifactRepository && it.url == repositoryURI
+            }
+        )
+        .isNotNull()
+  }
+
+  @Test
+  fun configureRepositories_withReactNativeMavenMirrorEnabled_containsMavenMirror() {
+    val repositoryURI = URI.create("https://repo.reactnative.dev/maven2")
+    val project = createProject()
+    project.extensions.extraProperties.set("react.internal.reactNativeMavenMirrorEnabled", "true")
 
     configureRepositories(project, false)
 
@@ -219,6 +236,107 @@ class DependencyUtilsTest {
           it is MavenArtifactRepository && it.url == mavenCentralURI
         }
     assertThat(indexOfLocalRepo < indexOfMavenCentral).isTrue()
+  }
+
+  @Test
+  fun configureRepositories_mavenMirrorHasHigherPriorityThanMavenCentral() {
+    val mavenMirrorURI = URI.create("https://repo.reactnative.dev/maven2")
+    val mavenCentralURI = URI.create("https://repo.maven.apache.org/maven2/")
+    val project = createProject()
+    project.extensions.extraProperties.set("react.internal.reactNativeMavenMirrorEnabled", "true")
+
+    configureRepositories(project, false)
+
+    val indexOfMavenMirror =
+        project.repositories.indexOfFirst {
+          it is MavenArtifactRepository && it.url == mavenMirrorURI
+        }
+    val indexOfMavenCentral =
+        project.repositories.indexOfFirst {
+          it is MavenArtifactRepository && it.url == mavenCentralURI
+        }
+    assertThat(indexOfMavenMirror < indexOfMavenCentral).isTrue()
+  }
+
+  @Test
+  fun configureRepositories_withProjectPropertySet_doesNotContainMavenMirror() {
+    val localMaven = tempFolder.newFolder("m2")
+    val mavenMirrorURI = URI.create("https://repo.reactnative.dev/maven2")
+    val project = createProject()
+    project.extensions.extraProperties.set("react.internal.mavenLocalRepo", localMaven.absolutePath)
+
+    configureRepositories(project, false)
+
+    assertThat(
+            project.repositories.firstOrNull {
+              it is MavenArtifactRepository && it.url == mavenMirrorURI
+            }
+        )
+        .isNull()
+  }
+
+  @Test
+  fun configureRepositories_byDefault_containsMavenMirror() {
+    val mavenMirrorURI = URI.create("https://repo.reactnative.dev/maven2")
+    val project = createProject()
+
+    configureRepositories(project, false)
+
+    assertThat(
+            project.repositories.firstOrNull {
+              it is MavenArtifactRepository && it.url == mavenMirrorURI
+            }
+        )
+        .isNotNull()
+  }
+
+  @Test
+  fun configureRepositories_withReactNativeMavenMirrorDisabled_doesNotContainMavenMirror() {
+    val mavenMirrorURI = URI.create("https://repo.reactnative.dev/maven2")
+    val project = createProject()
+    project.extensions.extraProperties.set("react.internal.reactNativeMavenMirrorEnabled", "false")
+
+    configureRepositories(project, false)
+
+    assertThat(
+            project.repositories.firstOrNull {
+              it is MavenArtifactRepository && it.url == mavenMirrorURI
+            }
+        )
+        .isNull()
+  }
+
+  @Test
+  fun isReactNativeMavenMirrorEnabled_withEnvironmentVariableEnabled_returnsTrue() {
+    val project = createProject()
+
+    assertThat(project.isReactNativeMavenMirrorEnabled("true")).isTrue()
+    assertThat(project.isReactNativeMavenMirrorEnabled("1")).isTrue()
+  }
+
+  @Test
+  fun isReactNativeMavenMirrorEnabled_withEnvironmentVariableDisabled_returnsFalse() {
+    val project = createProject()
+
+    assertThat(project.isReactNativeMavenMirrorEnabled("false")).isFalse()
+    assertThat(project.isReactNativeMavenMirrorEnabled("FALSE")).isFalse()
+    assertThat(project.isReactNativeMavenMirrorEnabled("0")).isFalse()
+  }
+
+  @Test
+  fun isReactNativeMavenMirrorEnabled_byDefault_returnsTrue() {
+    val project = createProject()
+
+    assertThat(project.isReactNativeMavenMirrorEnabled(null)).isTrue()
+    assertThat(project.isReactNativeMavenMirrorEnabled("")).isTrue()
+  }
+
+  @Test
+  fun isReactNativeMavenMirrorEnabled_withProjectProperty_ignoresEnvironmentVariable() {
+    val project = createProject()
+    project.extensions.extraProperties.set("react.internal.reactNativeMavenMirrorEnabled", "false")
+
+    assertThat(project.isReactNativeMavenMirrorEnabled("true")).isFalse()
   }
 
   @Test

--- a/packages/react-native/scripts/cocoapods/__tests__/maven_mirror_flag-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/maven_mirror_flag-test.rb
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "test/unit"
+require_relative "../utils.rb"
+require_relative "../../../sdks/hermes-engine/hermes-utils.rb"
+
+class MavenMirrorFlagTests < Test::Unit::TestCase
+    def setup
+        @original_value = ENV['RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED']
+        ENV.delete('RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED')
+    end
+
+    def teardown
+        if @original_value == nil
+            ENV.delete('RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED')
+        else
+            ENV['RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED'] = @original_value
+        end
+    end
+
+    def test_mavenMirror_isEnabledByDefault
+        assert_true(ReactNativePodsUtils.react_native_maven_mirror_enabled?)
+        assert_true(react_native_maven_mirror_enabled?)
+    end
+
+    def test_mavenMirror_isEnabledWhenExplicitlySetToTrue
+        ENV['RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED'] = 'true'
+
+        assert_true(ReactNativePodsUtils.react_native_maven_mirror_enabled?)
+        assert_true(react_native_maven_mirror_enabled?)
+    end
+
+    def test_mavenMirror_isDisabledWhenExplicitlySetToFalse
+        ENV['RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED'] = 'false'
+
+        assert_false(ReactNativePodsUtils.react_native_maven_mirror_enabled?)
+        assert_false(react_native_maven_mirror_enabled?)
+    end
+end

--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -350,16 +350,20 @@ class ReactNativeCoreUtils
     end
 
     def self.stable_tarball_url(version, build_type, dsyms = false)
-        ## You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
-        ## The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
-        maven_repo_url =
-            ENV['ENTERPRISE_REPOSITORY'] != nil && ENV['ENTERPRISE_REPOSITORY'] != "" ?
-            ENV['ENTERPRISE_REPOSITORY'] :
-            "https://repo1.maven.org/maven2"
+        candidates = stable_tarball_urls(version, build_type, dsyms)
+        return candidates.find { |url| artifact_exists(url) } || candidates.first
+    end
+
+    def self.stable_tarball_urls(version, build_type, dsyms = false)
         group = "com/facebook/react"
-        # Sample url from Maven:
-        # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.0/react-native-artifacts-0.81.0-reactnative-core-debug.tar.gz
-        return "#{maven_repo_url}/#{group}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-reactnative-core-#{dsyms ? "dSYM-" : ""}#{build_type.to_s}.tar.gz"
+        return ReactNativePodsUtils.maven_repository_urls().map { |maven_repo_url|
+            # Sample url from Maven:
+            # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.0/react-native-artifacts-0.81.0-reactnative-core-debug.tar.gz
+
+            # Sample url from mirror server:
+            # https://repo.reactnative.dev/maven2/com/facebook/react/react-native-artifacts/0.81.0/react-native-artifacts-0.81.0-reactnative-core-debug.tar.gz
+            "#{maven_repo_url}/#{group}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-reactnative-core-#{dsyms ? "dSYM-" : ""}#{build_type.to_s}.tar.gz"
+        }
     end
 
     def self.nightly_tarball_url(version, configuration, dsyms = false)
@@ -461,7 +465,7 @@ class ReactNativeCoreUtils
     end
 
     def self.release_artifact_exists(version)
-        return artifact_exists(stable_tarball_url(version, :debug))
+        return stable_tarball_urls(version, :debug).any? { |url| artifact_exists(url) }
     end
 
     def self.nightly_artifact_exists(version)

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -226,16 +226,21 @@ class ReactNativeDependenciesUtils
     end
 
     def self.release_tarball_url(version, build_type)
-        ## You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
-        ## The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
-        maven_repo_url =
-            ENV['ENTERPRISE_REPOSITORY'] != nil && ENV['ENTERPRISE_REPOSITORY'] != "" ?
-            ENV['ENTERPRISE_REPOSITORY'] :
-            "https://repo1.maven.org/maven2"
+        candidates = release_tarball_urls(version, build_type)
+        return candidates.find { |url| artifact_exists(url) } || candidates.first
+    end
+
+    def self.release_tarball_urls(version, build_type)
         group = "com/facebook/react"
+
         # Sample url from Maven:
         # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.79.0-rc.0/react-native-artifacts-0.79.0-rc.0-reactnative-dependencies-debug.tar.gz
-        return "#{maven_repo_url}/#{group}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-reactnative-dependencies-#{build_type.to_s}.tar.gz"
+
+        # Sample url from mirror server:
+        # https://repo.reactnative.dev/maven2/com/facebook/react/react-native-artifacts/0.79.0-rc.0/react-native-artifacts-0.79.0-rc.0-reactnative-dependencies-debug.tar.gz
+        return ReactNativePodsUtils.maven_repository_urls().map { |maven_repo_url|
+            "#{maven_repo_url}/#{group}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-reactnative-dependencies-#{build_type.to_s}.tar.gz"
+        }
     end
 
     def self.nightly_tarball_url(version, build_type)
@@ -362,7 +367,7 @@ class ReactNativeDependenciesUtils
     end
 
     def self.release_artifact_exists(version)
-        return artifact_exists(release_tarball_url(version, :debug))
+        return release_tarball_urls(version, :debug).any? { |url| artifact_exists(url) }
     end
 
     def self.nightly_artifact_exists(version)

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -12,9 +12,33 @@ require_relative "./jsengine.rb"
 
 # Utilities class for React Native Cocoapods
 class ReactNativePodsUtils
+    MAVEN_CENTRAL_REPOSITORY = "https://repo1.maven.org/maven2"
+    REACT_NATIVE_MAVEN_MIRROR_REPOSITORY = "https://repo.reactnative.dev/maven2"
+
     # URI::File.build validates path components as ASCII, so escape the filesystem path first.
     def self.local_file_uri(path)
         URI::File.build(path: URI::DEFAULT_PARSER.escape(path)).to_s
+    end
+
+    def self.maven_repository_urls()
+        ## You can use the `ENTERPRISE_REPOSITORY` variable to customise the base url from which artifacts will be downloaded.
+        ## The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
+        if ENV['ENTERPRISE_REPOSITORY'] != nil && ENV['ENTERPRISE_REPOSITORY'] != ""
+            return [ENV['ENTERPRISE_REPOSITORY'].sub(/\/+$/, "")]
+        end
+
+        # Keep the React Native Maven mirror before Maven Central so cached artifacts are tried first
+        # and Maven Central remains the fallback.
+        return react_native_maven_mirror_enabled? ?
+            [REACT_NATIVE_MAVEN_MIRROR_REPOSITORY, MAVEN_CENTRAL_REPOSITORY] :
+            [MAVEN_CENTRAL_REPOSITORY]
+    end
+
+    def self.react_native_maven_mirror_enabled?()
+        value = ENV['RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED']
+        return true if value == nil || value == ""
+
+        value.downcase != "false" && value != "0"
     end
 
     def self.warn_if_not_on_arm64

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-const {createLogger} = require('./utils');
+const {createLogger, getMavenRepositoryUrls} = require('./utils');
 const {execSync} = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -17,6 +17,7 @@ const {promisify} = require('node:util');
 
 const pipeline = promisify(stream.pipeline);
 const hermesLog = createLogger('Hermes');
+const artifactExistenceCache /*: Map<string, boolean> */ = new Map();
 
 /*::
 import type {BuildFlavor, Destination, Platform} from './types';
@@ -187,16 +188,40 @@ function hermesEngineTarballEnvvarDefined() /*: boolean */ {
   return !!process.env.HERMES_ENGINE_TARBALL_PATH;
 }
 
-function getTarballUrl(
+async function getTarballUrl(
   version /*: string */,
   buildType /*: BuildFlavor */,
-) /*: string */ {
-  // You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
-  // The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
-  const mavenRepoUrl =
-    process.env.ENTERPRISE_REPOSITORY ?? 'https://repo1.maven.org/maven2';
+) /*: Promise<string> */ {
+  const existingUrl = await findExistingTarballUrl(version, buildType);
+  if (existingUrl != null) {
+    return existingUrl;
+  }
+
+  return getTarballUrls(version, buildType)[0];
+}
+
+async function findExistingTarballUrl(
+  version /*: string */,
+  buildType /*: BuildFlavor */,
+) /*: Promise<?string> */ {
+  const candidates = getTarballUrls(version, buildType);
+  for (const url of candidates) {
+    if (await hermesArtifactExists(url)) {
+      return url;
+    }
+  }
+  return null;
+}
+
+function getTarballUrls(
+  version /*: string */,
+  buildType /*: BuildFlavor */,
+) /*: Array<string> */ {
   const namespace = 'com/facebook/hermes';
-  return `${mavenRepoUrl}/${namespace}/hermes-ios/${version}/hermes-ios-${version}-hermes-ios-${buildType.toLowerCase()}.tar.gz`;
+  return getMavenRepositoryUrls().map(
+    mavenRepoUrl =>
+      `${mavenRepoUrl}/${namespace}/hermes-ios/${version}/hermes-ios-${version}-hermes-ios-${buildType.toLowerCase()}.tar.gz`,
+  );
 }
 
 /**
@@ -205,13 +230,21 @@ function getTarballUrl(
 async function hermesArtifactExists(
   tarballUrl /*: string */,
 ) /*: Promise<boolean> */ {
+  const cached = artifactExistenceCache.get(tarballUrl);
+  if (cached != null) {
+    return cached;
+  }
+
   try {
     const response /*: Response */ = await fetch(tarballUrl, {
       method: 'HEAD',
     });
 
-    return response.status === 200;
+    const exists = response.status === 200;
+    artifactExistenceCache.set(tarballUrl, exists);
+    return exists;
   } catch (e) {
+    artifactExistenceCache.set(tarballUrl, false);
     return false;
   }
 }
@@ -228,8 +261,7 @@ async function hermesSourceType(
     return HermesEngineSourceTypes.LOCAL_PREBUILT_TARBALL;
   }
 
-  const tarballUrl = getTarballUrl(version, buildType);
-  if (await hermesArtifactExists(tarballUrl)) {
+  if ((await findExistingTarballUrl(version, buildType)) != null) {
     hermesLog(`Using download prebuild ${buildType} tarball`);
     return HermesEngineSourceTypes.DOWNLOAD_PREBUILD_TARBALL;
   }
@@ -278,7 +310,7 @@ async function downloadPrebuildTarball(
   buildType /*: BuildFlavor */,
   artifactsPath /*: string*/,
 ) /*: Promise<string> */ {
-  const url = getTarballUrl(version, buildType);
+  const url = await getTarballUrl(version, buildType);
   hermesLog(`Using release tarball from URL: ${url}`);
   return downloadStableHermes(version, buildType, artifactsPath);
 }
@@ -288,7 +320,7 @@ async function downloadStableHermes(
   buildType /*: BuildFlavor */,
   artifactsPath /*: string */,
 ) /*: Promise<string> */ {
-  const tarballUrl = getTarballUrl(version, buildType);
+  const tarballUrl = await getTarballUrl(version, buildType);
   return downloadHermesTarball(tarballUrl, version, buildType, artifactsPath);
 }
 

--- a/packages/react-native/scripts/ios-prebuild/reactNativeDependencies.js
+++ b/packages/react-native/scripts/ios-prebuild/reactNativeDependencies.js
@@ -10,7 +10,11 @@
 
 /*:: import type {BuildFlavor} from './types'; */
 
-const {computeNightlyTarballURL, createLogger} = require('./utils');
+const {
+  computeNightlyTarballURL,
+  createLogger,
+  getMavenRepositoryUrls,
+} = require('./utils');
 const {execSync} = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -20,6 +24,7 @@ const {promisify} = require('node:util');
 const pipeline = promisify(stream.pipeline);
 
 const dependencyLog = createLogger('ReactNativeDependencies');
+const artifactExistenceCache /*: Map<string, boolean> */ = new Map();
 
 /**
  * Downloads ReactNativeDependencies artifacts from the specified version and build type. If you want to specify a specific
@@ -215,16 +220,40 @@ function checkExistingVersion(
   return false;
 }
 
-function getTarballUrl(
+async function getTarballUrl(
   version /*: string */,
   buildType /*: BuildFlavor */,
-) /*: string */ {
-  // You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
-  // The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
-  const mavenRepoUrl =
-    process.env.ENTERPRISE_REPOSITORY ?? 'https://repo1.maven.org/maven2';
+) /*: Promise<string> */ {
+  const existingUrl = await findExistingTarballUrl(version, buildType);
+  if (existingUrl != null) {
+    return existingUrl;
+  }
+
+  return getTarballUrls(version, buildType)[0];
+}
+
+async function findExistingTarballUrl(
+  version /*: string */,
+  buildType /*: BuildFlavor */,
+) /*: Promise<?string> */ {
+  const candidates = getTarballUrls(version, buildType);
+  for (const url of candidates) {
+    if (await reactNativeDependenciesArtifactExists(url)) {
+      return url;
+    }
+  }
+  return null;
+}
+
+function getTarballUrls(
+  version /*: string */,
+  buildType /*: BuildFlavor */,
+) /*: Array<string> */ {
   const namespace = 'com/facebook/react';
-  return `${mavenRepoUrl}/${namespace}/react-native-artifacts/${version}/react-native-artifacts-${version}-reactnative-dependencies-${buildType.toLowerCase()}.tar.gz`;
+  return getMavenRepositoryUrls().map(
+    mavenRepoUrl =>
+      `${mavenRepoUrl}/${namespace}/react-native-artifacts/${version}/react-native-artifacts-${version}-reactnative-dependencies-${buildType.toLowerCase()}.tar.gz`,
+  );
 }
 
 async function getNightlyTarballUrl(
@@ -249,13 +278,21 @@ async function getNightlyTarballUrl(
 async function reactNativeDependenciesArtifactExists(
   tarballUrl /*: string */,
 ) /*: Promise<boolean> */ {
+  const cached = artifactExistenceCache.get(tarballUrl);
+  if (cached != null) {
+    return cached;
+  }
+
   try {
     const response /*: Response */ = await fetch(tarballUrl, {
       method: 'HEAD',
     });
 
-    return response.status === 200;
+    const exists = response.status === 200;
+    artifactExistenceCache.set(tarballUrl, exists);
+    return exists;
   } catch (e) {
+    artifactExistenceCache.set(tarballUrl, false);
     return false;
   }
 }
@@ -267,8 +304,7 @@ async function reactNativeDependenciesSourceType(
   version /*: string */,
   buildType /*: BuildFlavor */,
 ) /*: Promise<ReactNativeDependenciesEngineSourceType> */ {
-  const tarballUrl = getTarballUrl(version, buildType);
-  if (await reactNativeDependenciesArtifactExists(tarballUrl)) {
+  if ((await findExistingTarballUrl(version, buildType)) != null) {
     dependencyLog(`Using download prebuild ${buildType} tarball`);
     return ReactNativeDependenciesEngineSourceTypes.DOWNLOAD_PREBUILD_TARBALL;
   }
@@ -310,7 +346,7 @@ async function downloadPrebuildTarball(
   buildType /*: BuildFlavor */,
   artifactsPath /*: string*/,
 ) /*: Promise<string> */ {
-  const url = getTarballUrl(version, buildType);
+  const url = await getTarballUrl(version, buildType);
   dependencyLog(`Using release tarball from URL: ${url}`);
   return downloadStableReactNativeDependencies(
     version,
@@ -339,7 +375,7 @@ async function downloadStableReactNativeDependencies(
   buildType /*: BuildFlavor */,
   artifactsPath /*: string */,
 ) /*: Promise<string> */ {
-  const tarballUrl = getTarballUrl(version, buildType);
+  const tarballUrl = await getTarballUrl(version, buildType);
   return downloadReactNativeDependenciesTarball(
     tarballUrl,
     version,

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -14,6 +14,10 @@ const {execSync} = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
+const MAVEN_CENTRAL_REPOSITORY = 'https://repo1.maven.org/maven2';
+const REACT_NATIVE_MAVEN_MIRROR_REPOSITORY =
+  'https://repo.reactnative.dev/maven2';
+
 /**
  * Creates a folder if it does not exist
  * @param {string} folderPath - The path to the folder
@@ -128,10 +132,35 @@ async function computeNightlyTarballURL(
   return finalUrl;
 }
 
+function getMavenRepositoryUrls() /*: Array<string> */ {
+  // You can use the `ENTERPRISE_REPOSITORY` variable to customise the base url from which artifacts will be downloaded.
+  // The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
+  const enterpriseRepository = process.env.ENTERPRISE_REPOSITORY;
+  if (enterpriseRepository != null && enterpriseRepository !== '') {
+    return [enterpriseRepository.replace(/\/+$/, '')];
+  }
+
+  // Keep the React Native Maven mirror before Maven Central so cached artifacts are tried first
+  // and Maven Central remains the fallback.
+  return isReactNativeMavenMirrorEnabled()
+    ? [REACT_NATIVE_MAVEN_MIRROR_REPOSITORY, MAVEN_CENTRAL_REPOSITORY]
+    : [MAVEN_CENTRAL_REPOSITORY];
+}
+
+function isReactNativeMavenMirrorEnabled() /*: boolean */ {
+  const value = process.env.RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED;
+  if (value == null || value === '') {
+    return true;
+  }
+
+  return value.toLowerCase() !== 'false' && value !== '0';
+}
+
 module.exports = {
   createFolderIfNotExists,
   findFirst,
   throwIfOnEden,
   createLogger,
   computeNightlyTarballURL,
+  getMavenRepositoryUrls,
 };

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -7,6 +7,8 @@ require 'digest'
 
 HERMES_GITHUB_URL = "https://github.com/facebook/hermes.git"
 ENV_BUILD_FROM_SOURCE = "RCT_BUILD_HERMES_FROM_SOURCE"
+MAVEN_CENTRAL_REPOSITORY = "https://repo1.maven.org/maven2"
+REACT_NATIVE_MAVEN_MIRROR_REPOSITORY = "https://repo.reactnative.dev/maven2"
 
 module HermesEngineSourceType
     LOCAL_PREBUILT_TARBALL = :local_prebuilt_tarball
@@ -89,7 +91,7 @@ def force_build_from_stable_branch(react_native_path)
 end
 
 def release_artifact_exists(version)
-    return hermes_artifact_exists(release_tarball_url(version, :debug))
+    return release_tarball_urls(version, :debug).any? { |url| hermes_artifact_exists(url) }
 end
 
 def podspec_source(source_type, version, react_native_path)
@@ -190,17 +192,41 @@ def hermestag_file(react_native_path)
 end
 
 def release_tarball_url(version, build_type)
+    candidates = release_tarball_urls(version, build_type)
+    return candidates.find { |url| hermes_artifact_exists(url) } || candidates.first
+end
+
+def release_tarball_urls(version, build_type)
+    namespace = "com/facebook/hermes"
+    return maven_repository_urls().map { |maven_repo_url|
+        # Sample url from Maven:
+        # https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-hermes-ios-debug.tar.gz
+
+        # Sample url from mirror server:
+        # https://repo.reactnative.dev/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-hermes-ios-debug.tar.gz
+        "#{maven_repo_url}/#{namespace}/hermes-ios/#{version}/hermes-ios-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
+    }
+end
+
+def maven_repository_urls()
     ## You can use the `ENTERPRISE_REPOSITORY` variable to customise the base url from which artifacts will be downloaded.
     ## The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
-    maven_repo_url =
-        ENV['ENTERPRISE_REPOSITORY'] != nil && ENV['ENTERPRISE_REPOSITORY'] != "" ?
-        ENV['ENTERPRISE_REPOSITORY'] :
-        "https://repo1.maven.org/maven2"
+    if ENV['ENTERPRISE_REPOSITORY'] != nil && ENV['ENTERPRISE_REPOSITORY'] != ""
+        return [ENV['ENTERPRISE_REPOSITORY'].sub(/\/+$/, "")]
+    end
 
-    namespace = "com/facebook/hermes"
-    # Sample url from Maven:
-    # https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-hermes-ios-debug.tar.gz
-    return "#{maven_repo_url}/#{namespace}/hermes-ios/#{version}/hermes-ios-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
+    # Keep the React Native Maven mirror before Maven Central so cached artifacts are tried first
+    # and Maven Central remains the fallback.
+    return react_native_maven_mirror_enabled? ?
+        [REACT_NATIVE_MAVEN_MIRROR_REPOSITORY, MAVEN_CENTRAL_REPOSITORY] :
+        [MAVEN_CENTRAL_REPOSITORY]
+end
+
+def react_native_maven_mirror_enabled?()
+    value = ENV['RCT_REACT_NATIVE_MAVEN_MIRROR_ENABLED']
+    return true if value == nil || value == ""
+
+    value.downcase != "false" && value != "0"
 end
 
 def download_stable_hermes(react_native_path, version, configuration)


### PR DESCRIPTION
Summary:
This PR adds pull-through cache support for React Native Maven artifacts by trying `https://repo.reactnative.dev/maven2` before Maven Central for release artifacts.
- Updates the Android Gradle resolution by adding cache repository before `mavenCentral()` scoped to React Native groups via `includeGroupByRegex`.
- Updates iOS CocoaPods prebuilt artifact resolution to try the cache first, then fall back to `https://repo1.maven.org/maven2`.
- Updates SwiftPM/iOS prebuild JS tooling with the same cache-first fallback behavior.
- Preserves `ENTERPRISE_REPOSITORY` behavior as an explicit single custom repository override.
- Avoids duplicate artifact existence probes in Ruby and JS by checking candidate URLs directly and caching JS HEAD results within the process.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL][CHANGED] - Add React Native Maven pull-through cache fallback for prebuilt artifacts.


Test Plan:
Run:

```sh
react-native % RN_DEP_VERSION=0.81.0 \
HERMES_VERSION=250829098.0.13 \
node scripts/ios-prebuild -s -f Debug
```
The logs confirm that React Native artifacts are cached and pulled from the proxy:

```sh
[ReactNativeDependencies] Using download prebuild Debug tarball
[ReactNativeDependencies] Using release tarball from URL: https://rnmaven.swmtest.xyz/com/facebook/react/react-native-artifacts/0.81.0/react-native-artifacts-0.81.0-reactnative-dependencies-debug.tar.gz
[ReactNativeDependencies] Downloading ReactNativeDependencies tarball from https://rnmaven.swmtest.xyz/com/facebook/react/react-native-artifacts/0.81.0/react-native-artifacts-0.81.0-reactnative-dependencies-debug.tar.gz
```

Added gradle plugin tests which can be run with:
```sh
./gradlew :react-native-gradle-plugin:test --tests com.facebook.react.utils.DependencyUtilsTest
```

Reviewed By: cortinico

Differential Revision: D113902346

Pulled By: coado
