### PR TITLE
Route `enableCppPropsIteratorSetter` through a copy ctor + `RawProps::forEachItem` (#57328)

### DIFF
--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -6,6 +6,7 @@
  *
  * @flow strict-local
  * @fantom_flags enableNativeCSSParsing:*
+ * @fantom_flags enableCppPropsIteratorSetter:*
  * @format
  */
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -112,9 +112,30 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
       ShadowNodeT::filterRawProps(rawProps);
     }
 
-    rawProps.parse(rawPropsParser_);
+    // Two construction paths:
+    //  - Iterator-setter (only available when `ConcreteProps` satisfies
+    //    `HasIteratorSetterCtor` AND the runtime flag is on): copy-construct
+    //    from sourceProps, then walk rawProps in-place via `forEachItem` and
+    //    route each entry through `setProp`. Skips both
+    //    `RawProps::parse(parser)` and the `folly::dynamic` materialization
+    //    that the legacy path needed.
+    //  - Classic (the fallback for any `ConcreteProps` that doesn't opt in,
+    //    and the only path when the flag is off): parse + per-field
+    //    `convertRawProp` via the 3-arg ctor.
+    constexpr bool kSupportsIteratorSetter = HasIteratorSetterCtor<ConcreteProps>;
+    const bool useIteratorSetter = kSupportsIteratorSetter && ReactNativeFeatureFlags::enableCppPropsIteratorSetter();
 
-    auto shadowNodeProps = ShadowNodeT::Props(context, rawProps, props);
+    std::shared_ptr<ConcreteProps> shadowNodeProps;
+    if constexpr (kSupportsIteratorSetter) {
+      if (useIteratorSetter) {
+        shadowNodeProps = ShadowNodeT::Props(props);
+      }
+    }
+    if (!useIteratorSetter) {
+      rawProps.parse(rawPropsParser_);
+      shadowNodeProps = ShadowNodeT::Props(context, rawProps, props);
+    }
+
 #ifdef RN_SERIALIZABLE_STATE
     bool fallbackToDynamicRawPropsAccumulation = true;
     if (ReactNativeFeatureFlags::enableExclusivePropsUpdateAndroid() &&
@@ -134,19 +155,12 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
       ShadowNodeT::initializeDynamicProps(shadowNodeProps, rawProps, props);
     }
 #endif
-    // Use the new-style iterator
-    // Note that we just check if `Props` has this flag set, no matter
-    // the type of ShadowNode; it acts as the single global flag.
-    if (ReactNativeFeatureFlags::enableCppPropsIteratorSetter()) {
-#ifdef RN_SERIALIZABLE_STATE
-      const auto &dynamic =
-          fallbackToDynamicRawPropsAccumulation ? shadowNodeProps->rawProps : static_cast<folly::dynamic>(rawProps);
-#else
-      const auto &dynamic = static_cast<folly::dynamic>(rawProps);
-#endif
-      for (const auto &pair : dynamic.items()) {
-        const auto &name = pair.first.getString();
-        shadowNodeProps->setProp(context, RAW_PROPS_KEY_HASH(name), name.c_str(), RawValue(pair.second));
+
+    if constexpr (kSupportsIteratorSetter) {
+      if (useIteratorSetter) {
+        rawProps.forEachItem([&](std::string_view name, const RawValue &value) {
+          shadowNodeProps->setProp(context, RAW_PROPS_KEY_HASH(name), name.data(), value);
+        });
       }
     }
     return shadowNodeProps;

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -71,11 +71,30 @@ class ConcreteShadowNode : public BaseShadowNodeT {
     return BaseShadowNodeT::BaseTraits();
   }
 
+  /*
+   * Classic / parse path: construct `PropsT` by parsing `rawProps` field-by-
+   * field via the 3-arg `(context, sourceProps, rawProps)` constructor.
+   * `ConcreteComponentDescriptor::cloneProps` calls this when the
+   * iterator-setter path is disabled (per-class via the
+   * `HasIteratorSetterCtor` concept, or globally via the runtime flag).
+   */
   static UnsharedConcreteProps
   Props(const PropsParserContext &context, const RawProps &rawProps, const Props::Shared &baseProps = nullptr)
   {
     return std::make_shared<PropsT>(
         context, baseProps ? static_cast<const PropsT &>(*baseProps) : *defaultSharedProps(), rawProps);
+  }
+
+  /*
+   * Iterator-setter path: copy-construct `PropsT` from `baseProps` only.
+   * `ConcreteComponentDescriptor::cloneProps` then walks `rawProps` via
+   * `RawProps::forEachItem` and overwrites individual fields through
+   * `PropsT::setProp`. Available when `PropsT` satisfies
+   * `HasIteratorSetterCtor`.
+   */
+  static UnsharedConcreteProps Props(const Props::Shared &baseProps)
+  {
+    return std::make_shared<PropsT>(baseProps ? static_cast<const PropsT &>(*baseProps) : *defaultSharedProps());
   }
 
 #ifdef RN_SERIALIZABLE_STATE

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
@@ -29,13 +29,7 @@ Props::Props(
                     rawProps,
                     "nativeID",
                     sourceProps.nativeId,
-                    {})) {
-#ifdef RN_SERIALIZABLE_STATE
-  if (!ReactNativeFeatureFlags::enableExclusivePropsUpdateAndroid()) {
-    initializeDynamicProps(sourceProps, rawProps, filterObjectKeys);
-  }
-#endif
-}
+                    {})) {}
 
 void Props::setProp(
     const PropsParserContext& context,

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -41,7 +41,7 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
   virtual ~Props() = default;
 #endif
 
-  Props(const Props &other) = delete;
+  Props(const Props &other) = default;
   Props &operator=(const Props &other) = delete;
 
   /**
@@ -83,5 +83,67 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
 
 #endif
 };
+
+namespace detail {
+
+/*
+ * Extracts the class type from a pointer-to-member-function expression.
+ * Used in unevaluated context only.
+ */
+template <typename T, typename C>
+auto memberFunctionClass(T C::*) -> C;
+
+} // namespace detail
+
+/*
+ * Internal: `T` declares its OWN `setProp` (not just inherits one from a
+ * base class). `&T::setProp` resolves to a pointer-to-member-function whose
+ * class part is the level where `setProp` was actually declared — if `T`
+ * inherits without overriding, that class is some base, not `T`.
+ *
+ * Distinguishing own-declaration from inherited-declaration matters because
+ * `setProp` is non-virtual. A subclass that adds fields but forgets to
+ * override `setProp` would silently inherit its parent's switch — and the new
+ * fields would never be reached by the iterator-setter dispatch.
+ */
+template <typename T>
+concept DeclaresOwnSetProp = std::is_same_v<decltype(detail::memberFunctionClass(&T::setProp)), T>;
+
+/*
+ * Internal: `T` exposes a `setProp(ctx, hash, name, value) -> void` callable
+ * with the canonical Props signature, declared on `T` itself.
+ */
+template <typename T>
+concept HasSetProp = DeclaresOwnSetProp<T> &&
+    requires(T &t, const PropsParserContext &ctx, RawPropsPropNameHash hash, const char *name, const RawValue &value) {
+      { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+    };
+
+/*
+ * Marks a Props type as supporting the iterator-setter construction path used
+ * by `ConcreteComponentDescriptor::cloneProps` when
+ * `enableCppPropsIteratorSetter` is on. The contract is:
+ *
+ *   1. The type is copy-constructible from a source Props (so `cloneProps`
+ *      can build the new Props by copy and then overwrite individual fields).
+ *   2. The type descends from `Props`, anchoring the `setProp` chain in the
+ *      `Props::setProp` base case.
+ *   3. The type declares its OWN `setProp` with the canonical signature —
+ *      not inherited — so the iterator dispatch reaches every field that the
+ *      type adds beyond its base.
+ *
+ * `setProp` is non-virtual; subclasses chain explicitly via
+ * `Parent::setProp(...)`. The chain integrity beyond `T` is enforced by the
+ * compiler at each level's `setProp` body — if a subclass calls
+ * `Parent::setProp(...)` and `Parent` does not define one, the build fails
+ * at that call site. This concept guards the entry point (`T` itself) and
+ * relies on those per-level calls to keep the chain whole.
+ *
+ * When the concept is NOT satisfied for some `ConcreteProps`,
+ * `cloneProps` falls through to the classic per-field `convertRawProp` path
+ * for that component regardless of the runtime flag.
+ */
+template <typename T>
+concept HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, Props> && HasSetProp<T>;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -97,6 +97,45 @@ class RawProps final {
   // compatibility with callers that pass prefix/suffix separately.
   const RawValue *at(const char *name, const char *prefix, const char *suffix) const noexcept;
 
+  /*
+   * Iterates the underlying source object and invokes `fn(name, value)` for
+   * each entry, in source order. Skips parsing — does NOT require a prior
+   * `parse(parser)` call. For `Mode::JSI` this walks the JSI object in-place
+   * (no `folly::dynamic` materialization). For `Mode::Dynamic` it walks
+   * `dynamic_.items()`. For `Mode::Empty` it is a no-op.
+   *
+   * The callback signature is `void(std::string_view name, const RawValue &value)`.
+   * The view points into storage owned by `forEachItem` for the duration of
+   * the call and is null-terminated (i.e. `name.data()` is a valid C string).
+   */
+  template <typename Fn>
+  void forEachItem(Fn fn) const
+  {
+    switch (mode_) {
+      case Mode::Empty:
+        return;
+      case Mode::JSI: {
+        auto object = value_.asObject(*runtime_);
+        auto names = object.getPropertyNames(*runtime_);
+        auto count = names.size(*runtime_);
+        for (size_t i = 0; i < count; ++i) {
+          auto name = names.getValueAtIndex(*runtime_, i).getString(*runtime_);
+          auto propValue = object.getProperty(*runtime_, name);
+          auto nameUtf8 = name.utf8(*runtime_);
+          fn(std::string_view{nameUtf8}, RawValue{*runtime_, std::move(propValue)});
+        }
+        return;
+      }
+      case Mode::Dynamic:
+        for (const auto &pair : dynamic_.items()) {
+          fn(std::string_view{pair.first.getString()}, RawValue{pair.second});
+        }
+        return;
+      default:
+        return;
+    }
+  }
+
  private:
   friend class RawPropsParser;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
@@ -7,11 +7,19 @@
 
 #include <gtest/gtest.h>
 
+#include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 #include "TestComponent.h"
 
 using namespace facebook::react;
+
+static_assert(
+    HasIteratorSetterCtor<Props>,
+    "base `Props` must itself satisfy `HasIteratorSetterCtor` — it is copy-constructible, "
+    "derived from itself, and declares its own `setProp`. If this fails, "
+    "`ConcreteComponentDescriptor::cloneProps` will silently fall back to the classic "
+    "path for any concrete props whose nearest setProp-declaring ancestor is `Props` itself.");
 
 TEST(ComponentDescriptorTest, createShadowNode) {
   auto eventDispatcher = std::shared_ptr<const EventDispatcher>();

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/PropsConceptsTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/PropsConceptsTest.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/RawProps.h>
+#include <react/renderer/core/propsConversions.h>
+
+using namespace facebook::react;
+
+namespace {
+
+// Mimics the shape the React Native codegen emits for
+// `codegenNativeComponent<NativeProps>(...)` (see
+// `react-native-codegen/src/generators/components/GeneratePropsH.js`
+// `ClassTemplate`): default ctor, the 3-arg classic ctor with
+// `convertRawProp` in its initializer list, public prop fields, and
+// NO `setProp` override.
+class CodegenStyleProps : public Props {
+ public:
+  CodegenStyleProps() = default;
+  CodegenStyleProps(
+      const PropsParserContext& context,
+      const CodegenStyleProps& sourceProps,
+      const RawProps& rawProps)
+      : Props(context, sourceProps, rawProps),
+        customField(convertRawProp(
+            context,
+            rawProps,
+            "customField",
+            sourceProps.customField,
+            0)) {}
+
+  int customField{0};
+};
+
+// Mimics a hand-written Props subclass that opts in to the
+// iterator-setter path by declaring its own `setProp`.
+class HandWrittenSetPropProps : public Props {
+ public:
+  HandWrittenSetPropProps() = default;
+  HandWrittenSetPropProps(
+      const PropsParserContext& context,
+      const HandWrittenSetPropProps& sourceProps,
+      const RawProps& rawProps)
+      : Props(context, sourceProps, rawProps),
+        customField(sourceProps.customField) {}
+
+  void setProp(
+      const PropsParserContext& context,
+      RawPropsPropNameHash hash,
+      const char* propName,
+      const RawValue& value) {
+    Props::setProp(context, hash, propName, value);
+    switch (hash) {
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("customField"):
+        fromRawValue(context, value, customField, 0);
+        return;
+    }
+  }
+
+  int customField{0};
+};
+
+// A subclass of a hand-written setProp class that does NOT redeclare
+// `setProp`. Acts like a downstream specialization (e.g. how
+// `ViewShadowNodeProps` extends `ViewProps`). The concept must reject
+// this — otherwise the iterator-setter dispatch would silently miss
+// `extraField`.
+class InheritedSetPropProps : public HandWrittenSetPropProps {
+ public:
+  InheritedSetPropProps() = default;
+  InheritedSetPropProps(
+      const PropsParserContext& context,
+      const InheritedSetPropProps& sourceProps,
+      const RawProps& rawProps)
+      : HandWrittenSetPropProps(context, sourceProps, rawProps),
+        extraField(sourceProps.extraField) {}
+
+  int extraField{0};
+};
+
+// `using Base::setProp;` is sugar — it doesn't constitute "own"
+// declaration. Concept must still reject.
+class UsingDeclSetPropProps : public HandWrittenSetPropProps {
+ public:
+  using HandWrittenSetPropProps::setProp;
+};
+
+// Concept axioms — fail the build if the iterator-setter dispatch ever
+// regresses to silently accepting classes that inherit `setProp`.
+static_assert(
+    !DeclaresOwnSetProp<CodegenStyleProps>,
+    "Codegen'd Props classes don't declare setProp — concept must reject them.");
+static_assert(
+    !HasSetProp<CodegenStyleProps>,
+    "HasSetProp requires DeclaresOwnSetProp.");
+static_assert(
+    !HasIteratorSetterCtor<CodegenStyleProps>,
+    "Codegen'd Props must fall through to the classic cloneProps path. "
+    "If this fires, the iterator-setter would skip every field the codegen'd "
+    "ctor populates via convertRawProp, leaving the component unrendered.");
+
+static_assert(DeclaresOwnSetProp<HandWrittenSetPropProps>);
+static_assert(HasSetProp<HandWrittenSetPropProps>);
+static_assert(HasIteratorSetterCtor<HandWrittenSetPropProps>);
+
+static_assert(
+    !DeclaresOwnSetProp<InheritedSetPropProps>,
+    "A subclass that inherits setProp without redeclaring it must not "
+    "satisfy the concept — its new fields would be skipped.");
+static_assert(!HasIteratorSetterCtor<InheritedSetPropProps>);
+
+static_assert(
+    !DeclaresOwnSetProp<UsingDeclSetPropProps>,
+    "`using Base::setProp;` is not an own declaration.");
+static_assert(!HasIteratorSetterCtor<UsingDeclSetPropProps>);
+
+// Baselines: `Props` itself owns `setProp`, so it satisfies the concept.
+static_assert(DeclaresOwnSetProp<Props>);
+static_assert(HasIteratorSetterCtor<Props>);
+
+} // namespace
+
+// gtest entry so the file participates in the test binary (the
+// static_asserts above are the real check — this just keeps gtest's
+// test discovery happy).
+TEST(PropsConceptsTest, ConceptAxiomsCompile) {
+  SUCCEED();
+}

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -76,20 +76,23 @@ std::shared_ptr<ShadowNode> UIManager::createNode(
       {.tag = tag,
        .surfaceId = surfaceId,
        .instanceHandle = std::move(instanceHandle)});
-  const auto props = componentDescriptor.cloneProps(
+  auto props = componentDescriptor.cloneProps(
       propsParserContext, nullptr, std::move(rawProps));
-  const auto state = componentDescriptor.createInitialState(props, family);
+  auto state = componentDescriptor.createInitialState(props, family);
+
+  // Add a "name" prop if this is the fallback component
+  if (fallbackDescriptor != nullptr &&
+      fallbackDescriptor->getComponentHandle() ==
+          componentDescriptor.getComponentHandle()) {
+    props = componentDescriptor.cloneProps(
+        propsParserContext,
+        props,
+        RawProps(folly::dynamic::object("name", name)));
+  }
 
   auto shadowNode = componentDescriptor.createShadowNode(
       ShadowNodeFragment{
-          .props = fallbackDescriptor != nullptr &&
-                  fallbackDescriptor->getComponentHandle() ==
-                      componentDescriptor.getComponentHandle()
-              ? componentDescriptor.cloneProps(
-                    propsParserContext,
-                    props,
-                    RawProps(folly::dynamic::object("name", name)))
-              : props,
+          .props = props,
           .children = ShadowNodeFragment::childrenPlaceholder(),
           .state = state,
       },

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -796,6 +796,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -4125,7 +4134,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public folly::dynamic rawProps;
@@ -4196,6 +4205,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -8263,6 +8274,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public static void initializeDynamicProps(facebook::react::ConcreteShadowNode::UnsharedConcreteProps props, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
@@ -9947,6 +9959,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -795,6 +795,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -3979,7 +3988,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public folly::dynamic rawProps;
@@ -4040,6 +4049,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -8024,6 +8035,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public static void initializeDynamicProps(facebook::react::ConcreteShadowNode::UnsharedConcreteProps props, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
@@ -9570,6 +9582,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -796,6 +796,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -4122,7 +4131,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public folly::dynamic rawProps;
@@ -4193,6 +4202,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -8254,6 +8265,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public static void initializeDynamicProps(facebook::react::ConcreteShadowNode::UnsharedConcreteProps props, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
@@ -9800,6 +9812,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -3651,6 +3651,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -6317,7 +6326,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public std::string nativeId;
@@ -6418,6 +6427,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -10249,6 +10260,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public using ConcreteEventEmitter = EventEmitterT;
@@ -11850,6 +11862,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -3638,6 +3638,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -6199,7 +6208,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public std::string nativeId;
@@ -6290,6 +6299,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -10062,6 +10073,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public using ConcreteEventEmitter = EventEmitterT;
@@ -11535,6 +11547,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -3651,6 +3651,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -6314,7 +6323,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public std::string nativeId;
@@ -6415,6 +6424,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -10240,6 +10251,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public using ConcreteEventEmitter = EventEmitterT;
@@ -11713,6 +11725,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -405,6 +405,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -2737,7 +2746,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public std::string nativeId;
@@ -2785,6 +2794,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -6360,6 +6371,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public using ConcreteEventEmitter = EventEmitterT;
@@ -7014,6 +7026,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -404,6 +404,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -2631,7 +2640,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public std::string nativeId;
@@ -2669,6 +2678,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -6185,6 +6196,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public using ConcreteEventEmitter = EventEmitterT;
@@ -6839,6 +6851,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -405,6 +405,15 @@ concept facebook::react::CSSSyntaxVisitorReturn = std::is_default_constructible_
 template <typename T>
 concept facebook::react::CSSValidCompoundDataType = facebook::react::detail::is_variant_of_data_types<T>::value;
 template <typename T>
+concept facebook::react::DeclaresOwnSetProp = std::is_same_v<decltype(facebook::react::detail::memberFunctionClass(&T::setProp)), T>;
+template <typename T>
+concept facebook::react::HasIteratorSetterCtor = std::copy_constructible<T> && std::derived_from<T, facebook::react::Props> && HasSetProp<T>;
+template <typename T>
+concept facebook::react::HasSetProp = DeclaresOwnSetProp<T> &&
+requires(T& t, const facebook::react::PropsParserContext& ctx, facebook::react::RawPropsPropNameHash hash, const char* name, const facebook::react::RawValue& value) {
+  { t.setProp(ctx, hash, name, value) } -> std::same_as<void>;
+};
+template <typename T>
 concept facebook::react::Hashable = !std::is_same_v<T, const char*>&& (requires(T a) {
   { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 });
@@ -2734,7 +2743,7 @@ class facebook::react::PreparedTextCacheKey {
 
 class facebook::react::Props : public virtual facebook::react::Sealable, public virtual facebook::react::DebugStringConvertible {
   public Props() = default;
-  public Props(const facebook::react::Props& other) = delete;
+  public Props(const facebook::react::Props& other) = default;
   public Props(const facebook::react::PropsParserContext& context, const facebook::react::Props& sourceProps, const facebook::react::RawProps& rawProps, const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
   public facebook::react::Props& operator=(const facebook::react::Props& other) = delete;
   public std::string nativeId;
@@ -2782,6 +2791,8 @@ class facebook::react::RawProps {
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;
   public operator folly::dynamic() const;
   public void parse(const facebook::react::RawPropsParser& parser) noexcept;
+  template <typename Fn>
+  public void forEachItem(Fn fn) const;
 }
 
 enum facebook::react::RawProps::Mode {
@@ -6351,6 +6362,7 @@ class facebook::react::ConcreteShadowNode : public BaseShadowNodeT {
   public static facebook::react::ComponentHandle Handle();
   public static facebook::react::ComponentName Name();
   public static facebook::react::ConcreteShadowNode::ConcreteStateData initialStateData(const facebook::react::Props::Shared&, const facebook::react::ShadowNodeFamily::Shared&, const facebook::react::ComponentDescriptor&);
+  public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::Props::Shared& baseProps);
   public static facebook::react::ConcreteShadowNode::UnsharedConcreteProps Props(const facebook::react::PropsParserContext& context, const facebook::react::RawProps& rawProps, const facebook::react::Props::Shared& baseProps = nullptr);
   public static facebook::react::ShadowNodeTraits BaseTraits();
   public using ConcreteEventEmitter = EventEmitterT;
@@ -7005,6 +7017,8 @@ template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseLegacyHslFunction(facebook::react::CSSValueParser& parser);
 template <typename CSSColor>
 std::optional<facebook::react::CSSColor> facebook::react::detail::parseModernHslFunction(facebook::react::CSSValueParser& parser);
+template <typename T, typename C>
+C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
 


### PR DESCRIPTION
Summary:

Today the iterator-setter path in `ConcreteComponentDescriptor::cloneProps` runs three sequential walks over the input — `RawProps::parse(parser)` (builds `keyIndexToValueIndex_` for `convertRawProp`), `static_cast<folly::dynamic>(rawProps)` (materializes a `folly::dynamic` via `jsi::dynamicFromValue` in JSI mode), and then `dynamic.items()` to dispatch `setProp`. Only the third is actually used: `convertRawProp` is never called on the iterator-setter branch, and the `folly::dynamic` materialization exists only as iteration scaffolding.

Restructure so the runtime flag picks one of two construction paths up front:

- **Iterator-setter** — copy-construct from `sourceProps` via the (re-enabled) `Props` copy ctor, then walk `rawProps` in-place via the new `RawProps::forEachItem` helper and route each entry through `setProp`. `parse()` is skipped entirely; the `folly::dynamic` materialization is skipped in `Mode::JSI`.
- **Classic** — unchanged: `parse()` + 3-arg `convertRawProp`-driven ctor.

`forEachItem` switches on `RawProps::Mode`:
- `Mode::JSI` — walks `value_.asObject(*runtime_).getPropertyNames(...)` and constructs `RawValue` from each `jsi::Value` directly, no `folly::dynamic` in between.
- `Mode::Dynamic` — iterates `dynamic_.items()` (same as today).
- `Mode::Empty` — no-op.

A new `HasIteratorSetterCtor<T>` concept (`std::copy_constructible<T>`) documents the contract and feeds a `static_assert` in `cloneProps`, so a future Props type that deletes its copy ctor fails at compile time rather than silently diverging at runtime between the two flag states.

The `RN_SERIALIZABLE_STATE` Props 2.0 accumulation branch keeps its existing dynamic-iteration shape — when `fallbackToDynamicRawPropsAccumulation` is true, `initializeDynamicProps` has already merged the source's rawProps with the input onto `shadowNodeProps->rawProps`, so we iterate that merged dynamic rather than the raw input.

The per-field `flag ? sourceProps.X : convertRawProp(...)` ternaries across every Props .cpp file become dead in the flag-on path (the copy ctor handles those fields) but are still functional in the flag-off path. They get removed in a follow-up cleanup; this diff is structurally non-breaking on either flag state.

Changelog:
[Internal]

Reviewed By: zeyap

Differential Revision: D109568749


