### PR TITLE
Use HTTPS repository URL for react-native-babel-preset

### DIFF
--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -4,7 +4,7 @@
   "description": "Babel preset for React Native applications",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/react/react-native.git",
+    "url": "git+https://github.com/react/react-native.git",
     "directory": "packages/react-native-babel-preset"
   },
   "keywords": [


### PR DESCRIPTION
## Summary:

Update `@react-native/babel-preset` package metadata to use a `git+https` repository URL instead of the SSH-style URL. This avoids requiring SSH credentials for tooling that reads npm repository metadata.

## Changelog:

[Internal] [Changed] - Use an HTTPS repository URL for `@react-native/babel-preset` package metadata.

## Test Plan:

Parsed `packages/react-native-babel-preset/package.json` as JSON after the metadata update.
