### PR TITLE
Export RCTDidInitializeModuleNotificationModuleKey for the `module` userInfo key

### DIFF
--- a/packages/react-native/React/Base/RCTConstants.h
+++ b/packages/react-native/React/Base/RCTConstants.h
@@ -44,6 +44,7 @@ RCT_EXTERN NSString *const RCTJavaScriptDidFailToLoadNotification;
  * the `[bridge moduleForClass:]` method.
  */
 RCT_EXTERN NSString *const RCTDidInitializeModuleNotification;
+RCT_EXTERN NSString *const RCTDidInitializeModuleNotificationModuleKey;
 
 /*
  * W3C Pointer Events

--- a/packages/react-native/React/Base/RCTConstants.m
+++ b/packages/react-native/React/Base/RCTConstants.m
@@ -20,6 +20,7 @@ NSString *const RCTJavaScriptWillStartExecutingNotification = @"RCTJavaScriptWil
 NSString *const RCTJavaScriptWillStartLoadingNotification = @"RCTJavaScriptWillStartLoadingNotification";
 
 NSString *const RCTDidInitializeModuleNotification = @"RCTDidInitializeModuleNotification";
+NSString *const RCTDidInitializeModuleNotificationModuleKey = @"module";
 
 NSString *const RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED =
     @"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED";

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -726,9 +726,10 @@ Class getFallbackClassFromName(const char *name)
    * TODO(T41180176): Investigate whether we can delete this after TM
    * rollout.
    */
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTDidInitializeModuleNotification
-                                                      object:nil
-                                                    userInfo:@{@"module" : module, @"bridge" : [NSNull null]}];
+  [[NSNotificationCenter defaultCenter]
+      postNotificationName:RCTDidInitializeModuleNotification
+                    object:nil
+                  userInfo:@{RCTDidInitializeModuleNotificationModuleKey : module, @"bridge" : [NSNull null]}];
 
   TurboModulePerfLogger::moduleCreateSetUpEnd(moduleName, moduleId);
 


### PR DESCRIPTION
Summary:
Add `RCTDidInitializeModuleNotificationModuleKey` to `RCTConstants.h`/`.m` so observers of `RCTDidInitializeModuleNotification` can read the module out of `userInfo` via a named constant instead of the bare `@"module"` literal. Update the poster in `RCTTurboModuleManager.mm` to use the new symbol so producer and consumer share a single source of truth.

This follows the existing naming convention in `RCTConstants.h` (`RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey`).

Purely additive — no existing API affected.

Changelog:
[iOS][Added] - Export `RCTDidInitializeModuleNotificationModuleKey` constant for `RCTDidInitializeModuleNotification` userInfo

Differential Revision: D109716080


