### PR TITLE
Guard statusBarShow/statusBarHide against detached decorView (#57342)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -125,6 +125,7 @@ internal fun Window.setStatusBarStyle(style: String?) {
 
 @Suppress("DEPRECATION")
 private fun Window.statusBarHide() {
+  if (!decorView.isAttachedToWindow) return
   if (isEdgeToEdgeFeatureFlagOn) {
     WindowInsetsControllerCompat(this, decorView).run {
       systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
@@ -144,6 +145,7 @@ private fun Window.statusBarHide() {
 
 @Suppress("DEPRECATION")
 private fun Window.statusBarShow() {
+  if (!decorView.isAttachedToWindow) return
   if (isEdgeToEdgeFeatureFlagOn) {
     WindowInsetsControllerCompat(this, decorView).run {
       systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE


### PR DESCRIPTION
Summary:

`statusBarShow()` and `statusBarHide()` access the window's `decorView`, which throws `IllegalArgumentException` when the decorView is not attached to the window manager. This can happen for extra windows (dialogs/popups) whose decorView is detached independently of the host activity's lifecycle, or when status bar visibility is updated during teardown.

Guard both functions with `if (!decorView.isAttachedToWindow) return` so the fix protects every caller at the source. The guard is a no-op during normal operation (the decorView is always attached) and only short-circuits during the teardown race.

Changelog:
[Android][Fixed] - Prevent `IllegalArgumentException` crash in `statusBarShow`/`statusBarHide` when the window decorView is detached

Reviewed By: Abbondanzo

Differential Revision: D107934787
