### PR TITLE
Stabilize RNTester Maestro flows against app cold-start race (#57343)

### DIFF
--- a/packages/rn-tester/.maestro/button.yml
+++ b/packages/rn-tester/.maestro/button.yml
@@ -1,7 +1,11 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: 'Components'
+# Wait for the JS bundle to render the landing screen instead of asserting
+# immediately, which races app cold start on CI.
+- extendedWaitUntil:
+    visible: 'Components'
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: 'Button'

--- a/packages/rn-tester/.maestro/flatlist.yml
+++ b/packages/rn-tester/.maestro/flatlist.yml
@@ -1,7 +1,11 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: 'Components'
+# Wait for the JS bundle to render the landing screen instead of asserting
+# immediately, which races app cold start on CI.
+- extendedWaitUntil:
+    visible: 'Components'
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: 'Flatlist'

--- a/packages/rn-tester/.maestro/helpers/launch-app-and-search.yml
+++ b/packages/rn-tester/.maestro/helpers/launch-app-and-search.yml
@@ -1,5 +1,9 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: 'Components'
+# Wait for the JS bundle to render the landing screen instead of asserting
+# immediately, which races app cold start on CI.
+- extendedWaitUntil:
+    visible: 'Components'
+    timeout: 30000
 - runFlow: ./search.yml

--- a/packages/rn-tester/.maestro/legacy-native-module.yml
+++ b/packages/rn-tester/.maestro/legacy-native-module.yml
@@ -1,8 +1,12 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible:
-    text: 'APIs'
+# Wait for the JS bundle to render the landing screen instead of asserting
+# immediately, which races app cold start on CI.
+- extendedWaitUntil:
+    visible:
+      text: 'APIs'
+    timeout: 30000
 - tapOn:
     id: 'apis-tab'
 - runFlow: ./helpers/search.yml

--- a/packages/rn-tester/.maestro/modal.yml
+++ b/packages/rn-tester/.maestro/modal.yml
@@ -1,7 +1,11 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: 'Components'
+# Wait for the JS bundle to render the landing screen instead of asserting
+# immediately, which races app cold start on CI.
+- extendedWaitUntil:
+    visible: 'Components'
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: 'Modal'


### PR DESCRIPTION
Summary:

The iOS RNTester Maestro suite is flaky because several flows assert the landing screen immediately after `launchApp`, with no wait. On a CI simulator the JS bundle hasn't rendered yet when the assertion fires, so flows fail with `Assertion is false: "Components" is visible` (e.g. `text`, `modal`) or fail downstream after entering through the shared launch helper (e.g. `pressable`). It is a race, not a deterministic failure — `flatlist`/`button` use the same pattern and pass on faster runs.

Replace the bare landing-screen `assertVisible` with `extendedWaitUntil` (30s) so the bundle has time to render:
- `helpers/launch-app-and-search.yml` (`Components`) — the shared entry path for `text`, `pressable`, `image`, and the new image smoke-test flows.
- `modal.yml`, `flatlist.yml`, `button.yml` (`Components`).
- `legacy-native-module.yml` (`APIs`).

`extendedWaitUntil` returns as soon as the element appears, so this adds no time on the happy path — only headroom on cold start.

This is the actual fix for the red iOS E2E; the earlier `spawnSync ETIMEDOUT` was the suite failing + retrying + occasionally overrunning the 10-minute per-attempt cap, not a simulator/driver-startup problem. No harness/setup changes.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D109742688


