### PR TITLE
Move remaining `js1 build-*` commands under the `build` namespace

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
@@ -116,4 +116,26 @@ const RawValue* RawProps::at(const char* name) const noexcept {
   return parser_->at(*this, name);
 }
 
+const RawValue* RawProps::at(
+    const char* name,
+    const char* prefix,
+    const char* suffix) const noexcept {
+  if (prefix == nullptr && suffix == nullptr) {
+    return at(name);
+  }
+
+  std::string concatenated;
+  if (prefix != nullptr) {
+    concatenated += prefix;
+  }
+  concatenated += name;
+  if (suffix != nullptr) {
+    concatenated += suffix;
+  }
+  react_native_assert(
+      parser_ &&
+      "The object is not parsed. `parse` must be called before `at`.");
+  return parser_->at(*this, concatenated);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -9,6 +9,7 @@
 
 #include <limits>
 #include <optional>
+#include <string>
 
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
@@ -91,6 +92,10 @@ class RawProps final {
    * Returns `nullptr` if a prop with the given name does not exist.
    */
   const RawValue *at(const char *name) const noexcept;
+
+  // Deprecated: Use at(name) instead. This overload exists for backwards
+  // compatibility with callers that pass prefix/suffix separately.
+  const RawValue *at(const char *name, const char *prefix, const char *suffix) const noexcept;
 
  private:
   friend class RawPropsParser;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -4190,6 +4190,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -4034,6 +4034,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -4187,6 +4187,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -6407,6 +6407,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -6279,6 +6279,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -6404,6 +6404,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -2772,6 +2772,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -2656,6 +2656,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -2769,6 +2769,7 @@ class facebook::react::RawProps {
   public RawProps(folly::dynamic dynamic) noexcept;
   public bool isEmpty() const noexcept;
   public const facebook::react::RawValue* at(const char* name) const noexcept;
+  public const facebook::react::RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   public facebook::react::RawProps& operator=(const facebook::react::RawProps& other) noexcept = delete;
   public facebook::react::RawProps& operator=(facebook::react::RawProps&& other) noexcept = delete;
   public folly::dynamic toDynamic(const std::function<bool(const std::string&)>& filterObjectKeys = nullptr) const;

--- a/scripts/js-api/build-types/buildApiSnapshot.js
+++ b/scripts/js-api/build-types/buildApiSnapshot.js
@@ -148,7 +148,7 @@ async function validateSnapshots(
     // $FlowFixMe[prop-missing]
     // $FlowFixMe[incompatible-type]
     const diffResult = diff(prevSnapshot, newSnapshot, options);
-    const rerunCommand = isGitRepo() ? 'yarn build-types' : 'js1 build-js-api';
+    const rerunCommand = isGitRepo() ? 'yarn build-types' : 'js1 build js-api';
     console.error(
       `${styleText(['bold', 'inverse', 'red'], ' FAIL ')} ReactNativeApi.d.ts has changed. Please re-run '${rerunCommand}' and commit the updated snapshot.\n`,
     );


### PR DESCRIPTION
Summary:
Follow-up to the `js1 build-cxx-api` rename. Move `build-geo-screenshot-tests`, `build-js-api`, and `build-twui-screenshot-tests` under the `build` group so they sit next to their siblings (`js1 build assets`, `js1 build turbomodule`, etc.) instead of being top-level hyphenated outliers.

Each old top-level command stays as a hidden alias that prints a deprecation notice and delegates to the new module, so existing muscle memory and any out-of-tree scripts keep working.

Also updates the two places that emit the old command names into user-visible output: the TWUI template comment headers, and the JS API snapshot failure message.

Changelog:
[Internal]

Differential Revision: D109844649
