### PR TITLE
Fix Dependabot security update for concurrent-ruby in react-native (#57355)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,17 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
+# concurrent-ruby >= 1.3.5 no longer requires 'logger', and activesupport 6.1.x
+# references Logger without requiring it, so `bundle exec pod` crashes with
+# "uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger". A bare
+# `gem 'logger'` is not enough because bundler does not auto-require Gemfile gems;
+# require it here so it is loaded before cocoapods loads active_support.
+require 'logger'
+
 gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '<= 1.3.4'
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.7)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -97,7 +97,7 @@ DEPENDENCIES
   benchmark
   bigdecimal
   cocoapods (~> 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (<= 1.3.4)
+  concurrent-ruby (>= 1.3.7)
   logger
   mutex_m
   xcodeproj (< 1.26.0)

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -3,13 +3,20 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
+# concurrent-ruby >= 1.3.5 no longer requires 'logger', and activesupport 6.1.x
+# references Logger without requiring it, so `bundle exec pod` crashes with
+# "uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger". A bare
+# `gem 'logger'` is not enough because bundler does not auto-require Gemfile gems;
+# require it here so it is loaded before cocoapods loads active_support.
+require 'logger'
+
 # Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
 # bound in the template on Cocoapods with next React Native release.
 gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'rexml'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '<= 1.3.4'
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/private/helloworld/Gemfile
+++ b/private/helloworld/Gemfile
@@ -2,10 +2,17 @@ source 'https://rubygems.org'
 
 ruby ">= 2.6.10"
 
+# concurrent-ruby >= 1.3.5 no longer requires 'logger', and activesupport 6.1.x
+# references Logger without requiring it, so `bundle exec pod` crashes with
+# "uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger". A bare
+# `gem 'logger'` is not enough because bundler does not auto-require Gemfile gems;
+# require it here so it is loaded before cocoapods loads active_support.
+require 'logger'
+
 gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '<= 1.3.4'
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/private/helloworld/Gemfile.lock
+++ b/private/helloworld/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.7)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -101,7 +101,7 @@ DEPENDENCIES
   benchmark
   bigdecimal
   cocoapods (~> 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (<= 1.3.4)
+  concurrent-ruby (>= 1.3.7)
   ffi (>= 1.17.2)
   logger
   mutex_m


### PR DESCRIPTION
Summary:

Changelog: [INTERNAL] Fix Dependabot security update for concurrent-ruby in react-native

The Dependabot GitHub Action on `react/react-native` `main` has been failing repeatedly because of `concurrent-ruby`. A security advisory marks `concurrent-ruby < 1.3.7` as affected (patched in `1.3.7`), but all three RN Gemfiles pin `gem 'concurrent-ruby', '<= 1.3.4'`. Dependabot cannot satisfy the advisory under that pin, so it opens a security PR to bump to `1.3.7` and then, on every subsequent run, reports `pull_request_exists_for_latest_version` as a hard error — failing the check and regenerating the internal CI task.

The `<= 1.3.4` upper bound was originally added because `concurrent-ruby 1.3.5` dropped its `logger` dependency, which broke older `activesupport`/CocoaPods setups. That cause is already mitigated: every Gemfile now explicitly lists `gem 'logger'`. The upper-bound pin is therefore obsolete.

This change relaxes the constraint from `<= 1.3.4` to `>= 1.3.7` in all three Gemfiles (root, `private/helloworld`, `packages/rn-tester`) and updates the two corresponding `Gemfile.lock` files to resolve `concurrent-ruby 1.3.7`. `1.3.7` introduces no new transitive dependencies over `1.3.4`, so no other lockfile entries change. With the advisory satisfied on `main`, Dependabot stops recreating the security PR and the recurring check failure stops.

Reviewed By: javache

Differential Revision: D109967250


