### PR TITLE
Fix color stop interpolation when positioned stop has no gap before it

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/ColorStop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/ColorStop.kt
@@ -124,6 +124,12 @@ internal object ColorStopUtils {
                 )
           }
           lastDefinedIndex = i
+        } else if (endPosition != null) {
+          // Current stop has a defined position but there are no unpositioned
+          // stops between lastDefinedIndex and i. Still need to advance
+          // lastDefinedIndex so that subsequent interpolation uses the
+          // correct start point instead of stale data.
+          lastDefinedIndex = i
         }
       }
     }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/style/ColorStopTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/style/ColorStopTest.kt
@@ -158,4 +158,29 @@ class ColorStopTest {
     assertThat(processed[20].color).isEqualTo(Color.BLUE)
     assertThat(processed[20].position).isEqualTo(1f)
   }
+
+  @Test
+  fun testColorStopsWithPositionedStopAdjacentToUnpositionedStop() {
+    val colorStops =
+        listOf(
+            ColorStop(Color.RED, LengthPercentage(0f, LengthPercentageType.PERCENT)),
+            ColorStop(Color.GREEN, LengthPercentage(20f, LengthPercentageType.PERCENT)),
+            ColorStop(Color.BLUE),
+            ColorStop(Color.YELLOW, LengthPercentage(80f, LengthPercentageType.PERCENT)),
+            ColorStop(Color.MAGENTA, LengthPercentage(100f, LengthPercentageType.PERCENT)),
+        )
+    val processed = ColorStopUtils.getFixedColorStops(colorStops, 100f)
+
+    assertThat(processed).hasSize(5)
+    assertThat(processed[0].color).isEqualTo(Color.RED)
+    assertThat(processed[0].position).isEqualTo(0f)
+    assertThat(processed[1].color).isEqualTo(Color.GREEN)
+    assertThat(processed[1].position).isEqualTo(0.2f)
+    assertThat(processed[2].color).isEqualTo(Color.BLUE)
+    assertThat(processed[2].position).isEqualTo(0.5f)
+    assertThat(processed[3].color).isEqualTo(Color.YELLOW)
+    assertThat(processed[3].position).isEqualTo(0.8f)
+    assertThat(processed[4].color).isEqualTo(Color.MAGENTA)
+    assertThat(processed[4].position).isEqualTo(1f)
+  }
 }


### PR DESCRIPTION
## Summary:

Fixes #57345

`ColorStopUtils.getFixedColorStops()` produced incorrect positions when a
color stop with an explicit position was immediately followed by a color
stop without a position (i.e. zero unpositioned stops between them).

The root cause is that `lastDefinedIndex` was only advanced when
interpolation actually occurred (`unpositionedStops > 0`). When a positioned
stop was encountered with no unpositioned stops before it, `lastDefinedIndex`
failed to advance, causing the *next* interpolation to use a stale start
point and silently overwrite the explicitly declared position of the
skipped stop.

The fix adds an `else if` branch that advances `lastDefinedIndex` whenever
the current stop has a defined position, even when no interpolation is
needed at that step.

## Changelog:

[ANDROID] [FIXED] - Fix incorrect color stop positions in gradients when a positioned stop is immediately followed by an unpositioned stop

## Test Plan:

Added `testColorStopsWithPositionedStopAdjacentToUnpositionedStop` to
`ColorStopTest.kt`, covering the exact case from the issue:

Input:    [red 0%, green 20%, blue (no position), yellow 80%, purple 100%]
Expected: [0.0, 0.2, 0.5, 0.8, 1.0]

Before the fix this produced [0.0, 0.267, 0.533, 0.8, 1.0].

Verified the new test passes via CI (no local Android environment available).