### PR TITLE
Add IntBuffer and DoubleBuffer entry types to MapBuffer (#57359)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1665,7 +1665,9 @@ public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer : 
 	public abstract fun getBoolean (I)Z
 	public abstract fun getCount ()I
 	public abstract fun getDouble (I)D
+	public abstract fun getDoubleBuffer (I)[D
 	public abstract fun getInt (I)I
+	public abstract fun getIntBuffer (I)[I
 	public abstract fun getKeyOffset (I)I
 	public abstract fun getLong (I)J
 	public abstract fun getMapBuffer (I)Lcom/facebook/react/common/mapbuffer/MapBuffer;
@@ -1680,7 +1682,9 @@ public final class com/facebook/react/common/mapbuffer/MapBuffer$Companion {
 public final class com/facebook/react/common/mapbuffer/MapBuffer$DataType : java/lang/Enum {
 	public static final field BOOL Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field DOUBLE Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
+	public static final field DOUBLE_BUFFER Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field INT Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
+	public static final field INT_BUFFER Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field LONG Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field MAP Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field STRING Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
@@ -1691,7 +1695,9 @@ public final class com/facebook/react/common/mapbuffer/MapBuffer$DataType : java
 
 public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer$Entry {
 	public abstract fun getBooleanValue ()Z
+	public abstract fun getDoubleBufferValue ()[D
 	public abstract fun getDoubleValue ()D
+	public abstract fun getIntBufferValue ()[I
 	public abstract fun getIntValue ()I
 	public abstract fun getKey ()I
 	public abstract fun getLongValue ()J
@@ -1708,7 +1714,9 @@ public final class com/facebook/react/common/mapbuffer/ReadableMapBuffer : com/f
 	public fun getBoolean (I)Z
 	public fun getCount ()I
 	public fun getDouble (I)D
+	public fun getDoubleBuffer (I)[D
 	public fun getInt (I)I
+	public fun getIntBuffer (I)[I
 	public fun getKeyOffset (I)I
 	public fun getLong (I)J
 	public synthetic fun getMapBuffer (I)Lcom/facebook/react/common/mapbuffer/MapBuffer;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
@@ -46,6 +46,8 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
     STRING,
     MAP,
     LONG,
+    INT_BUFFER,
+    DOUBLE_BUFFER,
   }
 
   /**
@@ -161,6 +163,30 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
    */
   public fun getMapBufferList(key: Int): List<MapBuffer>
 
+  /**
+   * Provides parsed [IntArray] value if the entry for given key exists with [DataType.INT_BUFFER]
+   * type. This is a compact representation of a homogeneous list of ints with no per-element
+   * key/type overhead.
+   *
+   * @param key key to lookup the [IntArray] value for
+   * @return value associated with the requested key
+   * @throws IllegalArgumentException if the key doesn't exist
+   * @throws IllegalStateException if the data type doesn't match
+   */
+  public fun getIntBuffer(key: Int): IntArray
+
+  /**
+   * Provides parsed [DoubleArray] value if the entry for given key exists with
+   * [DataType.DOUBLE_BUFFER] type. This is a compact representation of a homogeneous list of
+   * doubles with no per-element key/type overhead.
+   *
+   * @param key key to lookup the [DoubleArray] value for
+   * @return value associated with the requested key
+   * @throws IllegalArgumentException if the key doesn't exist
+   * @throws IllegalStateException if the data type doesn't match
+   */
+  public fun getDoubleBuffer(key: Int): DoubleArray
+
   /** Iterable entry representing parsed MapBuffer values */
   public interface Entry {
     /**
@@ -213,5 +239,19 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
      * @throws IllegalStateException if the data type doesn't match [DataType.MAP]
      */
     public val mapBufferValue: MapBuffer
+
+    /**
+     * Entry value represented as [IntArray]
+     *
+     * @throws IllegalStateException if the data type doesn't match [DataType.INT_BUFFER]
+     */
+    public val intBufferValue: IntArray
+
+    /**
+     * Entry value represented as [DoubleArray]
+     *
+     * @throws IllegalStateException if the data type doesn't match [DataType.DOUBLE_BUFFER]
+     */
+    public val doubleBufferValue: DoubleArray
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
@@ -152,6 +152,24 @@ private constructor(
     return readMapBufferList
   }
 
+  private fun readIntBufferValue(bufferPosition: Int): IntArray {
+    var offset = offsetForDynamicData + buffer.getInt(bufferPosition)
+    val count = buffer.getInt(offset)
+    offset += Int.SIZE_BYTES
+    val result = IntArray(count)
+    buffer.duplicate().order(buffer.order()).apply { position(offset) }.asIntBuffer().get(result)
+    return result
+  }
+
+  private fun readDoubleBufferValue(bufferPosition: Int): DoubleArray {
+    var offset = offsetForDynamicData + buffer.getInt(bufferPosition)
+    val count = buffer.getInt(offset)
+    offset += Int.SIZE_BYTES
+    val result = DoubleArray(count)
+    buffer.duplicate().order(buffer.order()).apply { position(offset) }.asDoubleBuffer().get(result)
+    return result
+  }
+
   private fun getKeyOffsetForBucketIndex(bucketIndex: Int): Int {
     return offsetToMapBuffer + HEADER_SIZE + BUCKET_SIZE * bucketIndex
   }
@@ -193,6 +211,12 @@ private constructor(
   override fun getMapBufferList(key: Int): List<ReadableMapBuffer> =
       readMapBufferListValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.MAP))
 
+  override fun getIntBuffer(key: Int): IntArray =
+      readIntBufferValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.INT_BUFFER))
+
+  override fun getDoubleBuffer(key: Int): DoubleArray =
+      readDoubleBufferValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.DOUBLE_BUFFER))
+
   override fun hashCode(): Int {
     buffer.rewind()
     return buffer.hashCode()
@@ -229,6 +253,8 @@ private constructor(
             append('"')
           }
           MapBuffer.DataType.MAP -> append(entry.mapBufferValue.toString())
+          MapBuffer.DataType.INT_BUFFER -> append(entry.intBufferValue.contentToString())
+          MapBuffer.DataType.DOUBLE_BUFFER -> append(entry.doubleBufferValue.contentToString())
         }
       }
     }
@@ -310,6 +336,18 @@ private constructor(
       get() {
         assertType(MapBuffer.DataType.MAP)
         return readMapBufferValue(bucketOffset + VALUE_OFFSET)
+      }
+
+    override val intBufferValue: IntArray
+      get() {
+        assertType(MapBuffer.DataType.INT_BUFFER)
+        return readIntBufferValue(bucketOffset + VALUE_OFFSET)
+      }
+
+    override val doubleBufferValue: DoubleArray
+      get() {
+        assertType(MapBuffer.DataType.DOUBLE_BUFFER)
+        return readDoubleBufferValue(bucketOffset + VALUE_OFFSET)
       }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
@@ -84,6 +84,24 @@ internal class WritableMapBuffer : MapBuffer {
    */
   fun put(key: Int, value: MapBuffer): WritableMapBuffer = putInternal(key, value)
 
+  /**
+   * Adds an [IntArray] value for given key to the current MapBuffer.
+   *
+   * @param key entry key
+   * @param value entry value
+   * @throws IllegalArgumentException if key is out of [UShort] range
+   */
+  fun put(key: Int, value: IntArray): WritableMapBuffer = putInternal(key, value)
+
+  /**
+   * Adds a [DoubleArray] value for given key to the current MapBuffer.
+   *
+   * @param key entry key
+   * @param value entry value
+   * @throws IllegalArgumentException if key is out of [UShort] range
+   */
+  fun put(key: Int, value: DoubleArray): WritableMapBuffer = putInternal(key, value)
+
   private fun putInternal(key: Int, value: Any): WritableMapBuffer {
     require(key in KEY_RANGE) {
       "Only integers in [${UShort.MIN_VALUE};${UShort.MAX_VALUE}] range are allowed for keys."
@@ -126,6 +144,10 @@ internal class WritableMapBuffer : MapBuffer {
 
   override fun getMapBufferList(key: Int): List<MapBuffer> = verifyValue(key, values.get(key))
 
+  override fun getIntBuffer(key: Int): IntArray = verifyValue(key, values.get(key))
+
+  override fun getDoubleBuffer(key: Int): DoubleArray = verifyValue(key, values.get(key))
+
   /** Generalizes verification of the value types based on the requested type. */
   private inline fun <reified T> verifyValue(key: Int, value: Any?): T {
     require(value != null) { "Key not found: $key" }
@@ -143,6 +165,8 @@ internal class WritableMapBuffer : MapBuffer {
       is Double -> DataType.DOUBLE
       is String -> DataType.STRING
       is MapBuffer -> DataType.MAP
+      is IntArray -> DataType.INT_BUFFER
+      is DoubleArray -> DataType.DOUBLE_BUFFER
       else -> throw IllegalStateException("Key $key has value of unknown type: ${value.javaClass}")
     }
   }
@@ -175,6 +199,12 @@ internal class WritableMapBuffer : MapBuffer {
       get() = verifyValue(key, values.valueAt(index))
 
     override val mapBufferValue: MapBuffer
+      get() = verifyValue(key, values.valueAt(index))
+
+    override val intBufferValue: IntArray
+      get() = verifyValue(key, values.valueAt(index))
+
+    override val doubleBufferValue: DoubleArray
       get() = verifyValue(key, values.valueAt(index))
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/react/common/mapbuffer/JWritableMapBuffer.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/react/common/mapbuffer/JWritableMapBuffer.cpp
@@ -35,6 +35,8 @@ MapBuffer JWritableMapBuffer::getMapBuffer() {
     static const auto stringClass = jni::JString::javaClassStatic();
     static const auto readableMapClass = JReadableMapBuffer::javaClassStatic();
     static const auto writableMapClass = JWritableMapBuffer::javaClassStatic();
+    static const auto intArrayClass = jni::JArrayInt::javaClassStatic();
+    static const auto doubleArrayClass = jni::JArrayDouble::javaClassStatic();
 
     if (value->isInstanceOf(booleanClass)) {
       auto element = jni::static_ref_cast<jni::JBoolean>(value);
@@ -56,6 +58,17 @@ MapBuffer JWritableMapBuffer::getMapBuffer() {
       auto element =
           jni::static_ref_cast<JWritableMapBuffer::javaobject>(value);
       builder.putMapBuffer(key, element->getMapBuffer());
+    } else if (value->isInstanceOf(intArrayClass)) {
+      auto array = jni::static_ref_cast<jni::JArrayInt>(value);
+      auto pinned = array->pin();
+      builder.putIntBuffer(
+          key,
+          std::vector<int32_t>(pinned.get(), pinned.get() + pinned.size()));
+    } else if (value->isInstanceOf(doubleArrayClass)) {
+      auto array = jni::static_ref_cast<jni::JArrayDouble>(value);
+      auto pinned = array->pin();
+      builder.putDoubleBuffer(
+          key, std::vector<double>(pinned.get(), pinned.get() + pinned.size()));
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
@@ -163,6 +163,46 @@ std::vector<MapBuffer> MapBuffer::getMapBufferList(MapBuffer::Key key) const {
   return mapBufferList;
 }
 
+std::vector<int32_t> MapBuffer::getIntBuffer(MapBuffer::Key key) const {
+  auto bucketIndex = getKeyBucket(key);
+  react_native_assert(bucketIndex != -1 && "Key not found in MapBuffer");
+  if (bucketIndex == -1) {
+    return {};
+  }
+
+  int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
+  int32_t count = *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
+
+  std::vector<int32_t> result(count);
+  if (count > 0) {
+    memcpy(
+        result.data(),
+        bytes_.data() + offset + sizeof(int32_t),
+        static_cast<size_t>(count) * sizeof(int32_t));
+  }
+  return result;
+}
+
+std::vector<double> MapBuffer::getDoubleBuffer(MapBuffer::Key key) const {
+  auto bucketIndex = getKeyBucket(key);
+  react_native_assert(bucketIndex != -1 && "Key not found in MapBuffer");
+  if (bucketIndex == -1) {
+    return {};
+  }
+
+  int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
+  int32_t count = *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
+
+  std::vector<double> result(count);
+  if (count > 0) {
+    memcpy(
+        result.data(),
+        bytes_.data() + offset + sizeof(int32_t),
+        static_cast<size_t>(count) * sizeof(double));
+  }
+  return result;
+}
+
 size_t MapBuffer::size() const {
   return bytes_.size();
 }

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -94,8 +94,9 @@ class MapBuffer {
 
   /**
    * Data types available for serialization in MapBuffer
-   * Keep in sync with `DataType` enum in `JReadableMapBuffer.java`, which
-   * expects the same values after reading them through JNI.
+   * Keep in sync with the `DataType` enum in `MapBuffer.kt`
+   * (packages/react-native/ReactAndroid/.../common/mapbuffer/MapBuffer.kt),
+   * which is ordinal-indexed on the JVM side, so the order must match exactly.
    */
   enum DataType : uint16_t {
     Boolean = 0,
@@ -104,6 +105,13 @@ class MapBuffer {
     String = 3,
     Map = 4,
     Long = 5,
+    // Homogeneous, length-prefixed arrays stored contiguously in the dynamic
+    // data section. Unlike Map, they carry no per-element key/type overhead, so
+    // a batch of N values costs ~N*elementSize bytes plus a single 4-byte count
+    // prefix instead of N*12-byte buckets. The bucket value is the offset of the
+    // array within the dynamic data section.
+    IntBuffer = 6,
+    DoubleBuffer = 7,
   };
 
   explicit MapBuffer(std::vector<uint8_t> data);
@@ -130,6 +138,10 @@ class MapBuffer {
   MapBuffer getMapBuffer(MapBuffer::Key key) const;
 
   std::vector<MapBuffer> getMapBufferList(MapBuffer::Key key) const;
+
+  std::vector<int32_t> getIntBuffer(MapBuffer::Key key) const;
+
+  std::vector<double> getDoubleBuffer(MapBuffer::Key key) const;
 
   size_t size() const;
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -161,6 +161,52 @@ void MapBufferBuilder::putMapBufferList(
       INT_SIZE);
 }
 
+void MapBufferBuilder::putIntBuffer(
+    MapBuffer::Key key,
+    const std::vector<int32_t>& value) {
+  // Wire format: [element count (int32)] + [count * int32]. The count is the
+  // number of elements, not bytes; see MapBuffer::getIntBuffer.
+  auto count = static_cast<int32_t>(value.size());
+  auto payloadSize = static_cast<int32_t>(value.size() * sizeof(int32_t));
+
+  auto offset = static_cast<int32_t>(dynamicData_.size());
+  dynamicData_.resize(offset + INT_SIZE + payloadSize, 0);
+  memcpy(dynamicData_.data() + offset, &count, INT_SIZE);
+  if (payloadSize > 0) {
+    memcpy(dynamicData_.data() + offset + INT_SIZE, value.data(), payloadSize);
+  }
+
+  storeKeyValue(
+      key,
+      MapBuffer::DataType::IntBuffer,
+      reinterpret_cast<const uint8_t*>(&offset),
+      INT_SIZE);
+}
+
+void MapBufferBuilder::putDoubleBuffer(
+    MapBuffer::Key key,
+    const std::vector<double>& value) {
+  // Wire format: [element count (int32)] + [count * double]. Doubles are copied
+  // byte-for-byte; the reader uses memcpy, so the payload needs no special
+  // alignment for correctness. A consumer that wants a zero-copy typed view on
+  // the JVM (ByteBuffer::asDoubleBuffer) must ensure 8-byte alignment itself.
+  auto count = static_cast<int32_t>(value.size());
+  auto payloadSize = static_cast<int32_t>(value.size() * sizeof(double));
+
+  auto offset = static_cast<int32_t>(dynamicData_.size());
+  dynamicData_.resize(offset + INT_SIZE + payloadSize, 0);
+  memcpy(dynamicData_.data() + offset, &count, INT_SIZE);
+  if (payloadSize > 0) {
+    memcpy(dynamicData_.data() + offset + INT_SIZE, value.data(), payloadSize);
+  }
+
+  storeKeyValue(
+      key,
+      MapBuffer::DataType::DoubleBuffer,
+      reinterpret_cast<const uint8_t*>(&offset),
+      INT_SIZE);
+}
+
 static inline bool compareBuckets(
     const MapBuffer::Bucket& a,
     const MapBuffer::Bucket& b) {

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
@@ -39,6 +39,10 @@ class MapBufferBuilder {
 
   void putMapBufferList(MapBuffer::Key key, const std::vector<MapBuffer> &mapBufferList);
 
+  void putIntBuffer(MapBuffer::Key key, const std::vector<int32_t> &value);
+
+  void putDoubleBuffer(MapBuffer::Key key, const std::vector<double> &value);
+
   MapBuffer build();
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
@@ -205,6 +205,101 @@ TEST(MapBufferTest, testMapListEntries) {
   EXPECT_EQ(mapBufferList2[1].getDouble(3), 908.1);
 }
 
+TEST(MapBufferTest, testEmptyMapBufferList) {
+  auto builder = MapBufferBuilder();
+
+  builder.putMapBufferList(0, {});
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getMapBufferList(0).size(), 0);
+}
+
+// Place the list behind another dynamic-data entry so its offset is non-zero,
+// exercising `getDynamicDataOffset() + getIntAtBucket(...)` against a non-zero
+// base rather than the zero-offset path testMapListEntries covers.
+TEST(MapBufferTest, testMapListEntriesAtNonZeroOffset) {
+  std::vector<MapBuffer> mapBufferList;
+  auto inner = MapBufferBuilder();
+  inner.putString(0, "inner");
+  inner.putInt(1, 42);
+  mapBufferList.push_back(inner.build());
+
+  auto builder = MapBufferBuilder();
+  builder.putString(0, "prefix");
+  builder.putMapBufferList(1, mapBufferList);
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getString(0), "prefix");
+  std::vector<MapBuffer> readList = map.getMapBufferList(1);
+  EXPECT_EQ(readList.size(), 1);
+  EXPECT_EQ(readList[0].getString(0), "inner");
+  EXPECT_EQ(readList[0].getInt(1), 42);
+}
+
+TEST(MapBufferTest, testIntBufferEntries) {
+  auto builder = MapBufferBuilder();
+
+  std::vector<int32_t> values{
+      1,
+      -2,
+      3,
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max()};
+  builder.putIntBuffer(0, values);
+  auto map = builder.build();
+
+  EXPECT_EQ(map.count(), 1);
+  EXPECT_EQ(map.getIntBuffer(0), values);
+}
+
+TEST(MapBufferTest, testEmptyIntBuffer) {
+  auto builder = MapBufferBuilder();
+
+  builder.putIntBuffer(0, {});
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getIntBuffer(0).size(), 0);
+}
+
+TEST(MapBufferTest, testDoubleBufferEntries) {
+  auto builder = MapBufferBuilder();
+
+  std::vector<double> values{0.0, -1.5, 3.14159, 1e300, -1e-300};
+  builder.putDoubleBuffer(0, values);
+  auto map = builder.build();
+
+  EXPECT_EQ(map.count(), 1);
+  EXPECT_EQ(map.getDoubleBuffer(0), values);
+}
+
+TEST(MapBufferTest, testEmptyDoubleBuffer) {
+  auto builder = MapBufferBuilder();
+
+  builder.putDoubleBuffer(0, {});
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getDoubleBuffer(0).size(), 0);
+}
+
+// Mirrors the batched-animated-props use case: a pair of typed streams plus
+// some scalar metadata, with keys inserted out of order to exercise both the
+// dynamic-data section and the bucket sort path.
+TEST(MapBufferTest, testIntAndDoubleBuffersAlongsideScalars) {
+  std::vector<int32_t> intStream{1, 100, 1, 2, 4, 15, 4};
+  std::vector<double> doubleStream{0.5, 12.0, 0.25};
+
+  auto builder = MapBufferBuilder();
+  builder.putDoubleBuffer(2, doubleStream);
+  builder.putInt(0, 7);
+  builder.putIntBuffer(1, intStream);
+  auto map = builder.build();
+
+  EXPECT_EQ(map.count(), 3);
+  EXPECT_EQ(map.getInt(0), 7);
+  EXPECT_EQ(map.getIntBuffer(1), intStream);
+  EXPECT_EQ(map.getDoubleBuffer(2), doubleStream);
+}
+
 TEST(MapBufferTest, testMapRandomAccess) {
   auto builder = MapBufferBuilder();
   builder.putInt(1234, 4321);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -3249,7 +3249,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -3257,7 +3259,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -3282,7 +3286,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -3158,7 +3158,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -3166,7 +3168,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -3191,7 +3195,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -3246,7 +3246,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -3254,7 +3256,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -3279,7 +3283,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -5484,7 +5484,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -5492,7 +5494,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -5517,7 +5521,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -5408,7 +5408,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -5416,7 +5418,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -5441,7 +5445,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -5481,7 +5481,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -5489,7 +5491,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -5514,7 +5518,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -2170,7 +2170,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -2178,7 +2180,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -2203,7 +2207,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -2106,7 +2106,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -2114,7 +2116,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -2139,7 +2143,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -2167,7 +2167,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -2175,7 +2177,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -2200,7 +2204,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);


### PR DESCRIPTION
Summary:

Adds two new MapBuffer entry types, `IntBuffer` and `DoubleBuffer`, for storing homogeneous arrays of ints and doubles compactly in the dynamic data section. Unlike `Map` / map lists, these carry no per-element key/type overhead: a batch of N values costs ~N*elementSize bytes plus a single 4-byte count prefix instead of N 12-byte buckets. The bucket value holds the offset of the array within the dynamic data section.

Covers the full surface: the C++ reader (`MapBuffer::getIntBuffer` / `getDoubleBuffer`), the C++ builder (`MapBufferBuilder::putIntBuffer` / `putDoubleBuffer`), and the Kotlin reader API (`MapBuffer.getIntBuffer` / `getDoubleBuffer`, `Entry.intBufferValue` / `doubleBufferValue`). The `DataType` enum gains `IntBuffer = 6` and `DoubleBuffer = 7`, kept in sync across C++ and Kotlin.

Changelog:
[General][Added] - Add `IntBuffer` and `DoubleBuffer` entry types to MapBuffer for compact homogeneous int/double arrays

Reviewed By: zeyap

Differential Revision: D109848476


