### PR TITLE
Optimize MapBuffer representation (#57361)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1687,6 +1687,7 @@ public final class com/facebook/react/common/mapbuffer/MapBuffer$DataType : java
 	public static final field INT_BUFFER Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field LONG Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field MAP Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
+	public static final field MAP_BUFFER_LIST Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field STRING Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
@@ -1701,6 +1702,7 @@ public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer$En
 	public abstract fun getIntValue ()I
 	public abstract fun getKey ()I
 	public abstract fun getLongValue ()J
+	public abstract fun getMapBufferListValue ()Ljava/util/List;
 	public abstract fun getMapBufferValue ()Lcom/facebook/react/common/mapbuffer/MapBuffer;
 	public abstract fun getStringValue ()Ljava/lang/String;
 	public abstract fun getType ()Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1665,7 +1665,9 @@ public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer : 
 	public abstract fun getBoolean (I)Z
 	public abstract fun getCount ()I
 	public abstract fun getDouble (I)D
+	public abstract fun getDoubleBuffer (I)[D
 	public abstract fun getInt (I)I
+	public abstract fun getIntBuffer (I)[I
 	public abstract fun getKeyOffset (I)I
 	public abstract fun getLong (I)J
 	public abstract fun getMapBuffer (I)Lcom/facebook/react/common/mapbuffer/MapBuffer;
@@ -1680,7 +1682,9 @@ public final class com/facebook/react/common/mapbuffer/MapBuffer$Companion {
 public final class com/facebook/react/common/mapbuffer/MapBuffer$DataType : java/lang/Enum {
 	public static final field BOOL Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field DOUBLE Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
+	public static final field DOUBLE_BUFFER Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field INT Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
+	public static final field INT_BUFFER Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field LONG Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field MAP Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
 	public static final field STRING Lcom/facebook/react/common/mapbuffer/MapBuffer$DataType;
@@ -1691,7 +1695,9 @@ public final class com/facebook/react/common/mapbuffer/MapBuffer$DataType : java
 
 public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer$Entry {
 	public abstract fun getBooleanValue ()Z
+	public abstract fun getDoubleBufferValue ()[D
 	public abstract fun getDoubleValue ()D
+	public abstract fun getIntBufferValue ()[I
 	public abstract fun getIntValue ()I
 	public abstract fun getKey ()I
 	public abstract fun getLongValue ()J
@@ -1708,7 +1714,9 @@ public final class com/facebook/react/common/mapbuffer/ReadableMapBuffer : com/f
 	public fun getBoolean (I)Z
 	public fun getCount ()I
 	public fun getDouble (I)D
+	public fun getDoubleBuffer (I)[D
 	public fun getInt (I)I
+	public fun getIntBuffer (I)[I
 	public fun getKeyOffset (I)I
 	public fun getLong (I)J
 	public synthetic fun getMapBuffer (I)Lcom/facebook/react/common/mapbuffer/MapBuffer;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
@@ -46,6 +46,8 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
     STRING,
     MAP,
     LONG,
+    INT_BUFFER,
+    DOUBLE_BUFFER,
   }
 
   /**
@@ -161,6 +163,30 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
    */
   public fun getMapBufferList(key: Int): List<MapBuffer>
 
+  /**
+   * Provides parsed [IntArray] value if the entry for given key exists with [DataType.INT_BUFFER]
+   * type. This is a compact representation of a homogeneous list of ints with no per-element
+   * key/type overhead.
+   *
+   * @param key key to lookup the [IntArray] value for
+   * @return value associated with the requested key
+   * @throws IllegalArgumentException if the key doesn't exist
+   * @throws IllegalStateException if the data type doesn't match
+   */
+  public fun getIntBuffer(key: Int): IntArray
+
+  /**
+   * Provides parsed [DoubleArray] value if the entry for given key exists with
+   * [DataType.DOUBLE_BUFFER] type. This is a compact representation of a homogeneous list of
+   * doubles with no per-element key/type overhead.
+   *
+   * @param key key to lookup the [DoubleArray] value for
+   * @return value associated with the requested key
+   * @throws IllegalArgumentException if the key doesn't exist
+   * @throws IllegalStateException if the data type doesn't match
+   */
+  public fun getDoubleBuffer(key: Int): DoubleArray
+
   /** Iterable entry representing parsed MapBuffer values */
   public interface Entry {
     /**
@@ -213,5 +239,19 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
      * @throws IllegalStateException if the data type doesn't match [DataType.MAP]
      */
     public val mapBufferValue: MapBuffer
+
+    /**
+     * Entry value represented as [IntArray]
+     *
+     * @throws IllegalStateException if the data type doesn't match [DataType.INT_BUFFER]
+     */
+    public val intBufferValue: IntArray
+
+    /**
+     * Entry value represented as [DoubleArray]
+     *
+     * @throws IllegalStateException if the data type doesn't match [DataType.DOUBLE_BUFFER]
+     */
+    public val doubleBufferValue: DoubleArray
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
@@ -48,6 +48,7 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
     LONG,
     INT_BUFFER,
     DOUBLE_BUFFER,
+    MAP_BUFFER_LIST,
   }
 
   /**
@@ -153,8 +154,8 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
   public fun getMapBuffer(key: Int): MapBuffer
 
   /**
-   * Provides parsed [List<MapBuffer>] value if the entry for given key exists with [DataType.MAP]
-   * type
+   * Provides parsed [List<MapBuffer>] value if the entry for given key exists with
+   * [DataType.MAP_BUFFER_LIST] type
    *
    * @param key key to lookup [List<MapBuffer>] value for
    * @return value associated with the requested key
@@ -253,5 +254,12 @@ public interface MapBuffer : Iterable<MapBuffer.Entry> {
      * @throws IllegalStateException if the data type doesn't match [DataType.DOUBLE_BUFFER]
      */
     public val doubleBufferValue: DoubleArray
+
+    /**
+     * Entry value represented as [List<MapBuffer>]
+     *
+     * @throws IllegalStateException if the data type doesn't match [DataType.MAP_BUFFER_LIST]
+     */
+    public val mapBufferListValue: List<MapBuffer>
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
@@ -209,7 +209,7 @@ private constructor(
       readMapBufferValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.MAP))
 
   override fun getMapBufferList(key: Int): List<ReadableMapBuffer> =
-      readMapBufferListValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.MAP))
+      readMapBufferListValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.MAP_BUFFER_LIST))
 
   override fun getIntBuffer(key: Int): IntArray =
       readIntBufferValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.INT_BUFFER))
@@ -255,6 +255,7 @@ private constructor(
           MapBuffer.DataType.MAP -> append(entry.mapBufferValue.toString())
           MapBuffer.DataType.INT_BUFFER -> append(entry.intBufferValue.contentToString())
           MapBuffer.DataType.DOUBLE_BUFFER -> append(entry.doubleBufferValue.contentToString())
+          MapBuffer.DataType.MAP_BUFFER_LIST -> append(entry.mapBufferListValue.toString())
         }
       }
     }
@@ -348,6 +349,12 @@ private constructor(
       get() {
         assertType(MapBuffer.DataType.DOUBLE_BUFFER)
         return readDoubleBufferValue(bucketOffset + VALUE_OFFSET)
+      }
+
+    override val mapBufferListValue: List<MapBuffer>
+      get() {
+        assertType(MapBuffer.DataType.MAP_BUFFER_LIST)
+        return readMapBufferListValue(bucketOffset + VALUE_OFFSET)
       }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
@@ -51,13 +51,11 @@ private constructor(
       ReadableMapBuffer(buffer.duplicate().apply { position(offset) }, offset)
 
   private fun readHeader() {
-    // byte order
-    val storedAlignment = buffer.short
-    if (storedAlignment.toInt() != ALIGNMENT) {
-      buffer.order(ByteOrder.LITTLE_ENDIAN)
-    }
-    // count
-    count = readUnsignedShort(buffer.position()).toInt()
+    // The C++ writer always serializes in little-endian byte order. ByteBuffer
+    // defaults to big-endian and duplicate() resets the order, so set it
+    // explicitly on every instance, including nested clones.
+    buffer.order(ByteOrder.LITTLE_ENDIAN)
+    count = readUnsignedShort(offsetToMapBuffer).toInt()
   }
 
   /**
@@ -122,26 +120,27 @@ private constructor(
     return readIntValue(bufferPosition) == 1
   }
 
+  // Dynamic-data entries store [offset][byteLength] in the bucket's 8-byte
+  // value: getInt(bufferPosition) is the offset, getInt(bufferPosition + 4) is
+  // the byte length. The dynamic data section itself carries no length prefix.
   private fun readStringValue(bufferPosition: Int): String {
     val offset = offsetForDynamicData + buffer.getInt(bufferPosition)
-    val sizeOfString = buffer.getInt(offset)
+    val sizeOfString = buffer.getInt(bufferPosition + Int.SIZE_BYTES)
     val result = ByteArray(sizeOfString)
-    val stringOffset = offset + Int.SIZE_BYTES
-    buffer.position(stringOffset)
-    buffer[result, 0, sizeOfString]
+    buffer.position(offset)
+    buffer.get(result, 0, sizeOfString)
     return String(result)
   }
 
   private fun readMapBufferValue(position: Int): ReadableMapBuffer {
     val offset = offsetForDynamicData + buffer.getInt(position)
-    return cloneWithOffset(offset + Int.SIZE_BYTES)
+    return cloneWithOffset(offset)
   }
 
   private fun readMapBufferListValue(position: Int): List<ReadableMapBuffer> {
     val readMapBufferList = arrayListOf<ReadableMapBuffer>()
-    var offset = offsetForDynamicData + buffer.getInt(position)
-    val sizeMapBufferList = buffer.getInt(offset)
-    offset += Int.SIZE_BYTES
+    val offset = offsetForDynamicData + buffer.getInt(position)
+    val sizeMapBufferList = buffer.getInt(position + Int.SIZE_BYTES)
     var curLen = 0
     while (curLen < sizeMapBufferList) {
       val sizeMapBuffer = buffer.getInt(offset + curLen)
@@ -153,18 +152,18 @@ private constructor(
   }
 
   private fun readIntBufferValue(bufferPosition: Int): IntArray {
-    var offset = offsetForDynamicData + buffer.getInt(bufferPosition)
-    val count = buffer.getInt(offset)
-    offset += Int.SIZE_BYTES
+    val offset = offsetForDynamicData + buffer.getInt(bufferPosition)
+    val byteLength = buffer.getInt(bufferPosition + Int.SIZE_BYTES)
+    val count = byteLength / Int.SIZE_BYTES
     val result = IntArray(count)
     buffer.duplicate().order(buffer.order()).apply { position(offset) }.asIntBuffer().get(result)
     return result
   }
 
   private fun readDoubleBufferValue(bufferPosition: Int): DoubleArray {
-    var offset = offsetForDynamicData + buffer.getInt(bufferPosition)
-    val count = buffer.getInt(offset)
-    offset += Int.SIZE_BYTES
+    val offset = offsetForDynamicData + buffer.getInt(bufferPosition)
+    val byteLength = buffer.getInt(bufferPosition + Int.SIZE_BYTES)
+    val count = byteLength / Double.SIZE_BYTES
     val result = DoubleArray(count)
     buffer.duplicate().order(buffer.order()).apply { position(offset) }.asDoubleBuffer().get(result)
     return result
@@ -359,13 +358,10 @@ private constructor(
   }
 
   public companion object {
-    // Value used to verify if the data is serialized with LittleEndian order.
-    private const val ALIGNMENT = 0xFE
+    // 2 bytes = 2 (count)
+    private const val HEADER_SIZE = 2
 
-    // 8 bytes = 2 (alignment) + 2 (count) + 4 (size)
-    private const val HEADER_SIZE = 8
-
-    // 10 bytes = 2 (key) + 2 (type) + 8 (value)
+    // 12 bytes = 2 (key) + 2 (type) + 8 (value)
     private const val BUCKET_SIZE = 12
 
     // 2 bytes = 2 (key)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
@@ -152,6 +152,24 @@ private constructor(
     return readMapBufferList
   }
 
+  private fun readIntBufferValue(bufferPosition: Int): IntArray {
+    var offset = offsetForDynamicData + buffer.getInt(bufferPosition)
+    val count = buffer.getInt(offset)
+    offset += Int.SIZE_BYTES
+    val result = IntArray(count)
+    buffer.duplicate().order(buffer.order()).apply { position(offset) }.asIntBuffer().get(result)
+    return result
+  }
+
+  private fun readDoubleBufferValue(bufferPosition: Int): DoubleArray {
+    var offset = offsetForDynamicData + buffer.getInt(bufferPosition)
+    val count = buffer.getInt(offset)
+    offset += Int.SIZE_BYTES
+    val result = DoubleArray(count)
+    buffer.duplicate().order(buffer.order()).apply { position(offset) }.asDoubleBuffer().get(result)
+    return result
+  }
+
   private fun getKeyOffsetForBucketIndex(bucketIndex: Int): Int {
     return offsetToMapBuffer + HEADER_SIZE + BUCKET_SIZE * bucketIndex
   }
@@ -193,6 +211,12 @@ private constructor(
   override fun getMapBufferList(key: Int): List<ReadableMapBuffer> =
       readMapBufferListValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.MAP))
 
+  override fun getIntBuffer(key: Int): IntArray =
+      readIntBufferValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.INT_BUFFER))
+
+  override fun getDoubleBuffer(key: Int): DoubleArray =
+      readDoubleBufferValue(getTypedValueOffsetForKey(key, MapBuffer.DataType.DOUBLE_BUFFER))
+
   override fun hashCode(): Int {
     buffer.rewind()
     return buffer.hashCode()
@@ -229,6 +253,8 @@ private constructor(
             append('"')
           }
           MapBuffer.DataType.MAP -> append(entry.mapBufferValue.toString())
+          MapBuffer.DataType.INT_BUFFER -> append(entry.intBufferValue.contentToString())
+          MapBuffer.DataType.DOUBLE_BUFFER -> append(entry.doubleBufferValue.contentToString())
         }
       }
     }
@@ -310,6 +336,18 @@ private constructor(
       get() {
         assertType(MapBuffer.DataType.MAP)
         return readMapBufferValue(bucketOffset + VALUE_OFFSET)
+      }
+
+    override val intBufferValue: IntArray
+      get() {
+        assertType(MapBuffer.DataType.INT_BUFFER)
+        return readIntBufferValue(bucketOffset + VALUE_OFFSET)
+      }
+
+    override val doubleBufferValue: DoubleArray
+      get() {
+        assertType(MapBuffer.DataType.DOUBLE_BUFFER)
+        return readDoubleBufferValue(bucketOffset + VALUE_OFFSET)
       }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
@@ -84,6 +84,24 @@ internal class WritableMapBuffer : MapBuffer {
    */
   fun put(key: Int, value: MapBuffer): WritableMapBuffer = putInternal(key, value)
 
+  /**
+   * Adds an [IntArray] value for given key to the current MapBuffer.
+   *
+   * @param key entry key
+   * @param value entry value
+   * @throws IllegalArgumentException if key is out of [UShort] range
+   */
+  fun put(key: Int, value: IntArray): WritableMapBuffer = putInternal(key, value)
+
+  /**
+   * Adds a [DoubleArray] value for given key to the current MapBuffer.
+   *
+   * @param key entry key
+   * @param value entry value
+   * @throws IllegalArgumentException if key is out of [UShort] range
+   */
+  fun put(key: Int, value: DoubleArray): WritableMapBuffer = putInternal(key, value)
+
   private fun putInternal(key: Int, value: Any): WritableMapBuffer {
     require(key in KEY_RANGE) {
       "Only integers in [${UShort.MIN_VALUE};${UShort.MAX_VALUE}] range are allowed for keys."
@@ -126,6 +144,10 @@ internal class WritableMapBuffer : MapBuffer {
 
   override fun getMapBufferList(key: Int): List<MapBuffer> = verifyValue(key, values.get(key))
 
+  override fun getIntBuffer(key: Int): IntArray = verifyValue(key, values.get(key))
+
+  override fun getDoubleBuffer(key: Int): DoubleArray = verifyValue(key, values.get(key))
+
   /** Generalizes verification of the value types based on the requested type. */
   private inline fun <reified T> verifyValue(key: Int, value: Any?): T {
     require(value != null) { "Key not found: $key" }
@@ -143,6 +165,8 @@ internal class WritableMapBuffer : MapBuffer {
       is Double -> DataType.DOUBLE
       is String -> DataType.STRING
       is MapBuffer -> DataType.MAP
+      is IntArray -> DataType.INT_BUFFER
+      is DoubleArray -> DataType.DOUBLE_BUFFER
       else -> throw IllegalStateException("Key $key has value of unknown type: ${value.javaClass}")
     }
   }
@@ -175,6 +199,12 @@ internal class WritableMapBuffer : MapBuffer {
       get() = verifyValue(key, values.valueAt(index))
 
     override val mapBufferValue: MapBuffer
+      get() = verifyValue(key, values.valueAt(index))
+
+    override val intBufferValue: IntArray
+      get() = verifyValue(key, values.valueAt(index))
+
+    override val doubleBufferValue: DoubleArray
       get() = verifyValue(key, values.valueAt(index))
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
@@ -206,6 +206,9 @@ internal class WritableMapBuffer : MapBuffer {
 
     override val doubleBufferValue: DoubleArray
       get() = verifyValue(key, values.valueAt(index))
+
+    override val mapBufferListValue: List<MapBuffer>
+      get() = verifyValue(key, values.valueAt(index))
   }
 
   /*

--- a/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/react/common/mapbuffer/JWritableMapBuffer.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/react/common/mapbuffer/JWritableMapBuffer.cpp
@@ -35,6 +35,8 @@ MapBuffer JWritableMapBuffer::getMapBuffer() {
     static const auto stringClass = jni::JString::javaClassStatic();
     static const auto readableMapClass = JReadableMapBuffer::javaClassStatic();
     static const auto writableMapClass = JWritableMapBuffer::javaClassStatic();
+    static const auto intArrayClass = jni::JArrayInt::javaClassStatic();
+    static const auto doubleArrayClass = jni::JArrayDouble::javaClassStatic();
 
     if (value->isInstanceOf(booleanClass)) {
       auto element = jni::static_ref_cast<jni::JBoolean>(value);
@@ -56,6 +58,17 @@ MapBuffer JWritableMapBuffer::getMapBuffer() {
       auto element =
           jni::static_ref_cast<JWritableMapBuffer::javaobject>(value);
       builder.putMapBuffer(key, element->getMapBuffer());
+    } else if (value->isInstanceOf(intArrayClass)) {
+      auto array = jni::static_ref_cast<jni::JArrayInt>(value);
+      auto pinned = array->pin();
+      builder.putIntBuffer(
+          key,
+          std::vector<int32_t>(pinned.get(), pinned.get() + pinned.size()));
+    } else if (value->isInstanceOf(doubleArrayClass)) {
+      auto array = jni::static_ref_cast<jni::JArrayDouble>(value);
+      auto pinned = array->pin();
+      builder.putDoubleBuffer(
+          key, std::vector<double>(pinned.get(), pinned.get() + pinned.size()));
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
@@ -163,6 +163,46 @@ std::vector<MapBuffer> MapBuffer::getMapBufferList(MapBuffer::Key key) const {
   return mapBufferList;
 }
 
+std::vector<int32_t> MapBuffer::getIntBuffer(MapBuffer::Key key) const {
+  auto bucketIndex = getKeyBucket(key);
+  react_native_assert(bucketIndex != -1 && "Key not found in MapBuffer");
+  if (bucketIndex == -1) {
+    return {};
+  }
+
+  int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
+  int32_t count = *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
+
+  std::vector<int32_t> result(count);
+  if (count > 0) {
+    memcpy(
+        result.data(),
+        bytes_.data() + offset + sizeof(int32_t),
+        static_cast<size_t>(count) * sizeof(int32_t));
+  }
+  return result;
+}
+
+std::vector<double> MapBuffer::getDoubleBuffer(MapBuffer::Key key) const {
+  auto bucketIndex = getKeyBucket(key);
+  react_native_assert(bucketIndex != -1 && "Key not found in MapBuffer");
+  if (bucketIndex == -1) {
+    return {};
+  }
+
+  int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
+  int32_t count = *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
+
+  std::vector<double> result(count);
+  if (count > 0) {
+    memcpy(
+        result.data(),
+        bytes_.data() + offset + sizeof(int32_t),
+        static_cast<size_t>(count) * sizeof(double));
+  }
+  return result;
+}
+
 size_t MapBuffer::size() const {
   return bytes_.size();
 }

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
@@ -8,7 +8,42 @@
 #include "MapBuffer.h"
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 
+#include <algorithm>
+#include <cstring>
+
 namespace facebook::react {
+
+namespace {
+// Reads a value of type T from a (possibly unaligned) offset in the buffer.
+// MapBuffer's packed layout places multi-byte values at offsets that are not
+// naturally aligned for their type (e.g. an 8-byte value at a 2-byte boundary),
+// so dereferencing a reinterpret_cast pointer there is undefined behavior and
+// can fault on 32-bit ARM. memcpy compiles to a single unaligned load on
+// arm64/x86 and to alignment-safe loads on armv7.
+template <typename T>
+inline T readUnaligned(const uint8_t* data, int32_t offset) {
+  T value;
+  std::memcpy(&value, data + offset, sizeof(T));
+  return value;
+}
+
+// Debug-asserts on OOB (catches corrupt buffers early in dev) AND clamps in
+// release so a corrupt bucket length can never drive an OOB memcpy read.
+// react_native_assert is compiled out in release, so the runtime cost outside
+// dev is the single min() call.
+inline int32_t
+clampToBufferBounds(int32_t offset, int32_t byteLength, size_t bufferSize) {
+  react_native_assert(offset >= 0 && byteLength >= 0);
+  react_native_assert(
+      static_cast<size_t>(offset) + static_cast<size_t>(byteLength) <=
+      bufferSize);
+  size_t maxLength = bufferSize > static_cast<size_t>(offset)
+      ? bufferSize - static_cast<size_t>(offset)
+      : 0;
+  return static_cast<int32_t>(
+      std::min(static_cast<size_t>(std::max(byteLength, 0)), maxLength));
+}
+} // namespace
 
 static inline int32_t bucketOffset(int32_t index) {
   return sizeof(MapBuffer::Header) + sizeof(MapBuffer::Bucket) * index;
@@ -18,16 +53,20 @@ static inline int32_t valueOffset(int32_t bucketIndex) {
   return bucketOffset(bucketIndex) + offsetof(MapBuffer::Bucket, data);
 }
 
+// Dynamic-data entries pack [offset (low 32 bits)][byteLength (high 32 bits)]
+// into the bucket's 8-byte value, so the payload in the dynamic data section
+// carries no in-band length prefix. This returns the position of the high
+// 32 bits (the length).
+static inline int32_t lengthOffset(int32_t bucketIndex) {
+  return valueOffset(bucketIndex) + static_cast<int32_t>(sizeof(int32_t));
+}
+
 // TODO T83483191: Extend MapBuffer C++ implementation to support basic random
 // access
 MapBuffer::MapBuffer(std::vector<uint8_t> data) : bytes_(std::move(data)) {
-  auto header = reinterpret_cast<const Header*>(bytes_.data());
-  count_ = header->count;
-
-  if (header->bufferSize != bytes_.size()) {
-    LOG(ERROR) << "Error: Data size does not match, expected "
-               << header->bufferSize << " found: " << bytes_.size();
-    abort();
+  if (bytes_.size() >= sizeof(Header)) {
+    auto header = reinterpret_cast<const Header*>(bytes_.data());
+    count_ = header->count;
   }
 }
 
@@ -37,8 +76,7 @@ int32_t MapBuffer::getKeyBucket(Key key) const {
   while (lo <= hi) {
     int32_t mid = (lo + hi) >> 1;
 
-    Key midVal =
-        *reinterpret_cast<const Key*>(bytes_.data() + bucketOffset(mid));
+    Key midVal = readUnaligned<Key>(bytes_.data(), bucketOffset(mid));
 
     if (midVal < key) {
       lo = mid + 1;
@@ -53,8 +91,7 @@ int32_t MapBuffer::getKeyBucket(Key key) const {
 }
 
 inline int32_t MapBuffer::getIntAtBucket(int32_t bucketIndex) const {
-  return *reinterpret_cast<const int32_t*>(
-      bytes_.data() + valueOffset(bucketIndex));
+  return readUnaligned<int32_t>(bytes_.data(), valueOffset(bucketIndex));
 }
 
 int32_t MapBuffer::getInt(Key key) const {
@@ -74,8 +111,7 @@ int64_t MapBuffer::getLong(Key key) const {
     return 0;
   }
 
-  return *reinterpret_cast<const int64_t*>(
-      bytes_.data() + valueOffset(bucketIndex));
+  return readUnaligned<int64_t>(bytes_.data(), valueOffset(bucketIndex));
 }
 
 bool MapBuffer::getBool(Key key) const {
@@ -89,8 +125,7 @@ double MapBuffer::getDouble(Key key) const {
     return 0;
   }
 
-  return *reinterpret_cast<const double*>(
-      bytes_.data() + valueOffset(bucketIndex));
+  return readUnaligned<double>(bytes_.data(), valueOffset(bucketIndex));
 }
 
 int32_t MapBuffer::getDynamicDataOffset() const {
@@ -107,9 +142,10 @@ std::string MapBuffer::getString(Key key) const {
   }
 
   int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
-  int32_t stringLength =
-      *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
-  const uint8_t* stringPtr = bytes_.data() + offset + sizeof(int);
+  auto stringLength =
+      readUnaligned<int32_t>(bytes_.data(), lengthOffset(bucketIndex));
+  stringLength = clampToBufferBounds(offset, stringLength, bytes_.size());
+  const uint8_t* stringPtr = bytes_.data() + offset;
 
   return {stringPtr, stringPtr + stringLength};
 }
@@ -122,17 +158,13 @@ MapBuffer MapBuffer::getMapBuffer(Key key) const {
   }
 
   int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
-  int32_t mapBufferLength =
-      *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
-  size_t maxLength = bytes_.size() - offset - sizeof(int32_t);
-  if (mapBufferLength > maxLength) {
-    mapBufferLength = maxLength;
-  }
+  auto mapBufferLength =
+      readUnaligned<int32_t>(bytes_.data(), lengthOffset(bucketIndex));
+  mapBufferLength = clampToBufferBounds(offset, mapBufferLength, bytes_.size());
 
   std::vector<uint8_t> value(mapBufferLength);
 
-  memcpy(
-      value.data(), bytes_.data() + offset + sizeof(int32_t), mapBufferLength);
+  memcpy(value.data(), bytes_.data() + offset, mapBufferLength);
 
   return MapBuffer(std::move(value));
 }
@@ -146,19 +178,27 @@ std::vector<MapBuffer> MapBuffer::getMapBufferList(MapBuffer::Key key) const {
 
   std::vector<MapBuffer> mapBufferList;
   int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
-  int32_t mapBufferListLength =
-      *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
-  offset = offset + sizeof(uint32_t);
+  auto mapBufferListLength =
+      readUnaligned<int32_t>(bytes_.data(), lengthOffset(bucketIndex));
+  mapBufferListLength =
+      clampToBufferBounds(offset, mapBufferListLength, bytes_.size());
 
   int32_t curLen = 0;
   while (curLen < mapBufferListLength) {
-    int32_t mapBufferLength =
-        *reinterpret_cast<const int32_t*>(bytes_.data() + offset + curLen);
-    curLen = curLen + sizeof(uint32_t);
+    if (curLen + sizeof(int32_t) > mapBufferListLength) {
+      break;
+    }
+
+    auto mapBufferLength =
+        readUnaligned<int32_t>(bytes_.data(), offset + curLen);
+    curLen += sizeof(int32_t);
+
+    mapBufferLength =
+        clampToBufferBounds(offset + curLen, mapBufferLength, bytes_.size());
     std::vector<uint8_t> value(mapBufferLength);
     memcpy(value.data(), bytes_.data() + offset + curLen, mapBufferLength);
     mapBufferList.emplace_back(std::move(value));
-    curLen = curLen + mapBufferLength;
+    curLen += mapBufferLength;
   }
   return mapBufferList;
 }
@@ -171,13 +211,18 @@ std::vector<int32_t> MapBuffer::getIntBuffer(MapBuffer::Key key) const {
   }
 
   int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
-  int32_t count = *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
+  auto byteLength =
+      readUnaligned<int32_t>(bytes_.data(), lengthOffset(bucketIndex));
+  byteLength = clampToBufferBounds(offset, byteLength, bytes_.size());
+  int32_t count = byteLength / static_cast<int32_t>(sizeof(int32_t));
 
   std::vector<int32_t> result(count);
   if (count > 0) {
+    // Copy only whole elements: a clamped byteLength may not be a multiple of
+    // sizeof(int32_t), and result holds exactly count elements.
     memcpy(
         result.data(),
-        bytes_.data() + offset + sizeof(int32_t),
+        bytes_.data() + offset,
         static_cast<size_t>(count) * sizeof(int32_t));
   }
   return result;
@@ -191,13 +236,18 @@ std::vector<double> MapBuffer::getDoubleBuffer(MapBuffer::Key key) const {
   }
 
   int32_t offset = getDynamicDataOffset() + getIntAtBucket(bucketIndex);
-  int32_t count = *reinterpret_cast<const int32_t*>(bytes_.data() + offset);
+  auto byteLength =
+      readUnaligned<int32_t>(bytes_.data(), lengthOffset(bucketIndex));
+  byteLength = clampToBufferBounds(offset, byteLength, bytes_.size());
+  int32_t count = byteLength / static_cast<int32_t>(sizeof(double));
 
   std::vector<double> result(count);
   if (count > 0) {
+    // Copy only whole elements: a clamped byteLength may not be a multiple of
+    // sizeof(double), and result holds exactly count elements.
     memcpy(
         result.data(),
-        bytes_.data() + offset + sizeof(int32_t),
+        bytes_.data() + offset,
         static_cast<size_t>(count) * sizeof(double));
   }
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -94,8 +94,9 @@ class MapBuffer {
 
   /**
    * Data types available for serialization in MapBuffer
-   * Keep in sync with `DataType` enum in `JReadableMapBuffer.java`, which
-   * expects the same values after reading them through JNI.
+   * Keep in sync with the `DataType` enum in `MapBuffer.kt`
+   * (packages/react-native/ReactAndroid/.../common/mapbuffer/MapBuffer.kt),
+   * which is ordinal-indexed on the JVM side, so the order must match exactly.
    */
   enum DataType : uint16_t {
     Boolean = 0,
@@ -104,6 +105,13 @@ class MapBuffer {
     String = 3,
     Map = 4,
     Long = 5,
+    // Homogeneous, length-prefixed arrays stored contiguously in the dynamic
+    // data section. Unlike Map, they carry no per-element key/type overhead, so
+    // a batch of N values costs ~N*elementSize bytes plus a single 4-byte count
+    // prefix instead of N*12-byte buckets. The bucket value is the offset of the
+    // array within the dynamic data section.
+    IntBuffer = 6,
+    DoubleBuffer = 7,
   };
 
   explicit MapBuffer(std::vector<uint8_t> data);
@@ -130,6 +138,10 @@ class MapBuffer {
   MapBuffer getMapBuffer(MapBuffer::Key key) const;
 
   std::vector<MapBuffer> getMapBufferList(MapBuffer::Key key) const;
+
+  std::vector<int32_t> getIntBuffer(MapBuffer::Key key) const;
+
+  std::vector<double> getDoubleBuffer(MapBuffer::Key key) const;
 
   size_t size() const;
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -112,6 +112,10 @@ class MapBuffer {
     // array within the dynamic data section.
     IntBuffer = 6,
     DoubleBuffer = 7,
+    // A homogeneous, ordered array of nested MapBuffers. Distinct from `Map` so
+    // that a list of MapBuffers is self-describing (a single Map and a list are
+    // byte-distinct in payload but previously shared the `Map` type tag).
+    MapBufferList = 8,
   };
 
   explicit MapBuffer(std::vector<uint8_t> data);

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -40,11 +40,11 @@ class JReadableMapBuffer;
  *
  * MapBuffer data is stored in a continuous chunk of memory (bytes_ field below) with the following layout:
  *
- * ┌─────────────────────Header──────────────────────┐
- * │                    10 bytes                     │
- * ├─Alignment─┬─Item count─┬──────Buffer size───────┤
- * │  2 bytes  │  2 bytes   │        4 bytes         │
- * └───────────┴────────────┴────────────────────────┘
+ * ┌──────Header──────┐
+ * │      2 bytes     │
+ * ├────Item count────┤
+ * │      2 bytes     │
+ * └──────────────────┘
  * ┌────────────────────────────────────────────────────────────────────────────────────────┐
  * │                           Buckets (one per item in the map)                            │
  * │                                                                                        │
@@ -69,14 +69,8 @@ class MapBuffer {
  public:
   using Key = uint16_t;
 
-  // The first value in the buffer, used to check correct encoding/endianness on
-  // JVM side.
-  constexpr static uint16_t HEADER_ALIGNMENT = 0xFE;
-
   struct Header {
-    uint16_t alignment = HEADER_ALIGNMENT; // alignment of serialization
     uint16_t count; // amount of items in the map
-    uint32_t bufferSize; // Amount of bytes used to store the map in memory
   };
 
 #pragma pack(push, 1)
@@ -89,7 +83,7 @@ class MapBuffer {
   };
 #pragma pack(pop)
 
-  static_assert(sizeof(Header) == 8, "MapBuffer header size is incorrect.");
+  static_assert(sizeof(Header) == 2, "MapBuffer header size is incorrect.");
   static_assert(sizeof(Bucket) == 12, "MapBuffer bucket size is incorrect.");
 
   /**
@@ -105,15 +99,17 @@ class MapBuffer {
     String = 3,
     Map = 4,
     Long = 5,
-    // Homogeneous, length-prefixed arrays stored contiguously in the dynamic
+    // Homogeneous arrays of raw elements stored contiguously in the dynamic
     // data section. Unlike Map, they carry no per-element key/type overhead, so
-    // a batch of N values costs ~N*elementSize bytes plus a single 4-byte count
-    // prefix instead of N*12-byte buckets. The bucket value is the offset of the
-    // array within the dynamic data section.
+    // a batch of N values costs ~N*elementSize bytes instead of N*12-byte
+    // buckets. The bucket value packs [offset][byteLength]; the element count is
+    // recovered as byteLength / elementSize.
     IntBuffer = 6,
     DoubleBuffer = 7,
-    // A homogeneous, ordered array of nested MapBuffers. Distinct from `Map` so
-    // that a list of MapBuffers is self-describing (a single Map and a list are
+    // A homogeneous, ordered array of nested MapBuffers. The bucket value packs
+    // [offset][byteLength] for the whole list region; within it each child stays
+    // framed as [int32 childSize][child bytes]. Distinct from `Map` so that a
+    // list of MapBuffers is self-describing (a single Map and a list are
     // byte-distinct in payload but previously shared the `Map` type tag).
     MapBufferList = 8,
   };

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -15,6 +15,14 @@ constexpr uint32_t LONG_SIZE = sizeof(uint64_t);
 constexpr uint32_t DOUBLE_SIZE = sizeof(double);
 constexpr uint32_t MAX_BUCKET_VALUE_SIZE = sizeof(uint64_t);
 
+// Dynamic-data entries store their location in the bucket's 8-byte value as
+// [offset (low 32 bits)][byteLength (high 32 bits)], so the payload in the
+// dynamic data section needs no in-band length prefix.
+static inline uint64_t packOffsetAndLength(int32_t offset, int32_t length) {
+  return static_cast<uint64_t>(static_cast<uint32_t>(offset)) |
+      (static_cast<uint64_t>(static_cast<uint32_t>(length)) << 32);
+}
+
 MapBuffer MapBufferBuilder::EMPTY() {
   return MapBufferBuilder(0).build();
 }
@@ -22,7 +30,6 @@ MapBuffer MapBufferBuilder::EMPTY() {
 MapBufferBuilder::MapBufferBuilder(uint32_t initialSize) {
   buckets_.reserve(initialSize);
   header_.count = 0;
-  header_.bufferSize = 0;
 }
 
 void MapBufferBuilder::storeKeyValue(
@@ -84,128 +91,111 @@ void MapBufferBuilder::putLong(MapBuffer::Key key, int64_t value) {
 }
 
 void MapBufferBuilder::putString(MapBuffer::Key key, const std::string& value) {
-  // The wire format encodes lengths and offsets as int32_t (see
-  // MapBuffer::getString). Without an explicit narrowing cast, `auto` deduces
-  // size_t (8 bytes on 64-bit) and `memcpy(&x, ..., INT_SIZE)` then copies only
-  // the first 4 bytes of an 8-byte value: silent truncation on little-endian,
-  // wrong (high) bytes on big-endian.
   auto strSize = static_cast<int32_t>(value.size());
-  const char* strData = value.data();
-
-  // format [length of string (int)] + [Array of Characters in the string]
   auto offset = static_cast<int32_t>(dynamicData_.size());
-  dynamicData_.resize(offset + INT_SIZE + strSize, 0);
-  memcpy(dynamicData_.data() + offset, &strSize, INT_SIZE);
-  memcpy(dynamicData_.data() + offset + INT_SIZE, strData, strSize);
 
-  // Store Key and pointer to the string
+  // The bucket stores [offset][byteLength]; the dynamic section holds only the
+  // raw string bytes.
+  dynamicData_.resize(offset + strSize, 0);
+  if (strSize > 0) {
+    memcpy(dynamicData_.data() + offset, value.data(), strSize);
+  }
+
+  uint64_t data = packOffsetAndLength(offset, strSize);
   storeKeyValue(
       key,
       MapBuffer::DataType::String,
-      reinterpret_cast<const uint8_t*>(&offset),
-      INT_SIZE);
+      reinterpret_cast<const uint8_t*>(&data),
+      sizeof(data));
 }
 
 void MapBufferBuilder::putMapBuffer(MapBuffer::Key key, const MapBuffer& map) {
-  // Wire format encodes lengths and offsets as int32_t (see
-  // MapBuffer::getMapBuffer). Cast explicitly so memcpy(&x, ..., INT_SIZE)
-  // copies the full value, not the first 4 bytes of an 8-byte size_t.
   auto mapBufferSize = static_cast<int32_t>(map.size());
-
   auto offset = static_cast<int32_t>(dynamicData_.size());
 
-  // format [length of buffer (int)] + [bytes of MapBuffer]
-  dynamicData_.resize(offset + INT_SIZE + mapBufferSize, 0);
-  memcpy(dynamicData_.data() + offset, &mapBufferSize, INT_SIZE);
-  // Copy the content of the map into dynamicData_
-  memcpy(dynamicData_.data() + offset + INT_SIZE, map.data(), mapBufferSize);
+  // The bucket stores [offset][byteLength]; the dynamic section holds only the
+  // serialized child MapBuffer bytes.
+  dynamicData_.resize(offset + mapBufferSize, 0);
+  memcpy(dynamicData_.data() + offset, map.data(), mapBufferSize);
 
-  // Store Key and pointer to the string
+  uint64_t data = packOffsetAndLength(offset, mapBufferSize);
   storeKeyValue(
       key,
       MapBuffer::DataType::Map,
-      reinterpret_cast<const uint8_t*>(&offset),
-      INT_SIZE);
+      reinterpret_cast<const uint8_t*>(&data),
+      sizeof(data));
 }
 
 void MapBufferBuilder::putMapBufferList(
     MapBuffer::Key key,
     const std::vector<MapBuffer>& mapBufferList) {
   auto offset = static_cast<int32_t>(dynamicData_.size());
-  int32_t dataSize = 0;
-  for (const MapBuffer& mapBuffer : mapBufferList) {
-    dataSize = dataSize + INT_SIZE + static_cast<int32_t>(mapBuffer.size());
-  }
 
-  dynamicData_.resize(offset + INT_SIZE, 0);
-  memcpy(dynamicData_.data() + offset, &dataSize, INT_SIZE);
-
+  // The bucket stores [offset][byteLength] for the whole list region; within it
+  // each child stays framed as [int32 childSize][child bytes] so the children
+  // remain individually delimited.
   for (const MapBuffer& mapBuffer : mapBufferList) {
     auto mapBufferSize = static_cast<int32_t>(mapBuffer.size());
-    auto dynamicDataSize = static_cast<int32_t>(dynamicData_.size());
-    dynamicData_.resize(dynamicDataSize + INT_SIZE + mapBufferSize, 0);
-    // format [length of buffer (int)] + [bytes of MapBuffer]
-    memcpy(dynamicData_.data() + dynamicDataSize, &mapBufferSize, INT_SIZE);
-    // Copy the content of the map into dynamicData_
+    auto pos = static_cast<int32_t>(dynamicData_.size());
+    dynamicData_.resize(pos + INT_SIZE + mapBufferSize, 0);
+    memcpy(dynamicData_.data() + pos, &mapBufferSize, INT_SIZE);
     memcpy(
-        dynamicData_.data() + dynamicDataSize + INT_SIZE,
-        mapBuffer.data(),
-        mapBufferSize);
+        dynamicData_.data() + pos + INT_SIZE, mapBuffer.data(), mapBufferSize);
   }
 
-  // Store Key and pointer to the list. Uses the dedicated MapBufferList type so
-  // the entry is self-describing and distinguishable from a single Map.
+  auto totalSize = static_cast<int32_t>(dynamicData_.size()) - offset;
+  uint64_t data = packOffsetAndLength(offset, totalSize);
+  // Uses the dedicated MapBufferList type so the entry is self-describing and
+  // distinguishable from a single Map.
   storeKeyValue(
       key,
       MapBuffer::DataType::MapBufferList,
-      reinterpret_cast<const uint8_t*>(&offset),
-      INT_SIZE);
+      reinterpret_cast<const uint8_t*>(&data),
+      sizeof(data));
 }
 
 void MapBufferBuilder::putIntBuffer(
     MapBuffer::Key key,
     const std::vector<int32_t>& value) {
-  // Wire format: [element count (int32)] + [count * int32]. The count is the
-  // number of elements, not bytes; see MapBuffer::getIntBuffer.
-  auto count = static_cast<int32_t>(value.size());
+  // The bucket stores [offset][byteLength]; the dynamic section holds the raw
+  // int32 elements. Element count is recovered as byteLength / sizeof(int32_t).
   auto payloadSize = static_cast<int32_t>(value.size() * sizeof(int32_t));
-
   auto offset = static_cast<int32_t>(dynamicData_.size());
-  dynamicData_.resize(offset + INT_SIZE + payloadSize, 0);
-  memcpy(dynamicData_.data() + offset, &count, INT_SIZE);
+  dynamicData_.resize(offset + payloadSize, 0);
   if (payloadSize > 0) {
-    memcpy(dynamicData_.data() + offset + INT_SIZE, value.data(), payloadSize);
+    memcpy(dynamicData_.data() + offset, value.data(), payloadSize);
   }
 
+  uint64_t data = packOffsetAndLength(offset, payloadSize);
   storeKeyValue(
       key,
       MapBuffer::DataType::IntBuffer,
-      reinterpret_cast<const uint8_t*>(&offset),
-      INT_SIZE);
+      reinterpret_cast<const uint8_t*>(&data),
+      sizeof(data));
 }
 
 void MapBufferBuilder::putDoubleBuffer(
     MapBuffer::Key key,
     const std::vector<double>& value) {
-  // Wire format: [element count (int32)] + [count * double]. Doubles are copied
-  // byte-for-byte; the reader uses memcpy, so the payload needs no special
-  // alignment for correctness. A consumer that wants a zero-copy typed view on
-  // the JVM (ByteBuffer::asDoubleBuffer) must ensure 8-byte alignment itself.
-  auto count = static_cast<int32_t>(value.size());
+  // The bucket stores [offset][byteLength]; the dynamic section holds the raw
+  // double elements. Element count is recovered as byteLength / sizeof(double).
+  // Doubles are copied byte-for-byte; the reader uses memcpy, so the payload
+  // needs no special alignment for correctness. A consumer that wants a
+  // zero-copy typed view on the JVM (ByteBuffer::asDoubleBuffer) must ensure
+  // 8-byte alignment itself.
   auto payloadSize = static_cast<int32_t>(value.size() * sizeof(double));
-
   auto offset = static_cast<int32_t>(dynamicData_.size());
-  dynamicData_.resize(offset + INT_SIZE + payloadSize, 0);
-  memcpy(dynamicData_.data() + offset, &count, INT_SIZE);
+  dynamicData_.resize(offset + payloadSize, 0);
   if (payloadSize > 0) {
-    memcpy(dynamicData_.data() + offset + INT_SIZE, value.data(), payloadSize);
+    memcpy(dynamicData_.data() + offset, value.data(), payloadSize);
   }
 
+  uint64_t data = packOffsetAndLength(offset, payloadSize);
   storeKeyValue(
       key,
       MapBuffer::DataType::DoubleBuffer,
-      reinterpret_cast<const uint8_t*>(&offset),
-      INT_SIZE);
+      reinterpret_cast<const uint8_t*>(&data),
+      sizeof(data));
 }
 
 static inline bool compareBuckets(
@@ -219,8 +209,6 @@ MapBuffer MapBufferBuilder::build() {
   auto bucketSize = buckets_.size() * sizeof(MapBuffer::Bucket);
   auto headerSize = sizeof(MapBuffer::Header);
   auto bufferSize = headerSize + bucketSize + dynamicData_.size();
-
-  header_.bufferSize = static_cast<uint32_t>(bufferSize);
 
   if (needsSort_) {
     std::sort(buckets_.begin(), buckets_.end(), compareBuckets);

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -161,6 +161,52 @@ void MapBufferBuilder::putMapBufferList(
       INT_SIZE);
 }
 
+void MapBufferBuilder::putIntBuffer(
+    MapBuffer::Key key,
+    const std::vector<int32_t>& value) {
+  // Wire format: [element count (int32)] + [count * int32]. The count is the
+  // number of elements, not bytes; see MapBuffer::getIntBuffer.
+  auto count = static_cast<int32_t>(value.size());
+  auto payloadSize = static_cast<int32_t>(value.size() * sizeof(int32_t));
+
+  auto offset = static_cast<int32_t>(dynamicData_.size());
+  dynamicData_.resize(offset + INT_SIZE + payloadSize, 0);
+  memcpy(dynamicData_.data() + offset, &count, INT_SIZE);
+  if (payloadSize > 0) {
+    memcpy(dynamicData_.data() + offset + INT_SIZE, value.data(), payloadSize);
+  }
+
+  storeKeyValue(
+      key,
+      MapBuffer::DataType::IntBuffer,
+      reinterpret_cast<const uint8_t*>(&offset),
+      INT_SIZE);
+}
+
+void MapBufferBuilder::putDoubleBuffer(
+    MapBuffer::Key key,
+    const std::vector<double>& value) {
+  // Wire format: [element count (int32)] + [count * double]. Doubles are copied
+  // byte-for-byte; the reader uses memcpy, so the payload needs no special
+  // alignment for correctness. A consumer that wants a zero-copy typed view on
+  // the JVM (ByteBuffer::asDoubleBuffer) must ensure 8-byte alignment itself.
+  auto count = static_cast<int32_t>(value.size());
+  auto payloadSize = static_cast<int32_t>(value.size() * sizeof(double));
+
+  auto offset = static_cast<int32_t>(dynamicData_.size());
+  dynamicData_.resize(offset + INT_SIZE + payloadSize, 0);
+  memcpy(dynamicData_.data() + offset, &count, INT_SIZE);
+  if (payloadSize > 0) {
+    memcpy(dynamicData_.data() + offset + INT_SIZE, value.data(), payloadSize);
+  }
+
+  storeKeyValue(
+      key,
+      MapBuffer::DataType::DoubleBuffer,
+      reinterpret_cast<const uint8_t*>(&offset),
+      INT_SIZE);
+}
+
 static inline bool compareBuckets(
     const MapBuffer::Bucket& a,
     const MapBuffer::Bucket& b) {

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -153,10 +153,11 @@ void MapBufferBuilder::putMapBufferList(
         mapBufferSize);
   }
 
-  // Store Key and pointer to the string
+  // Store Key and pointer to the list. Uses the dedicated MapBufferList type so
+  // the entry is self-describing and distinguishable from a single Map.
   storeKeyValue(
       key,
-      MapBuffer::DataType::Map,
+      MapBuffer::DataType::MapBufferList,
       reinterpret_cast<const uint8_t*>(&offset),
       INT_SIZE);
 }

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
@@ -39,6 +39,10 @@ class MapBufferBuilder {
 
   void putMapBufferList(MapBuffer::Key key, const std::vector<MapBuffer> &mapBufferList);
 
+  void putIntBuffer(MapBuffer::Key key, const std::vector<int32_t> &value);
+
+  void putDoubleBuffer(MapBuffer::Key key, const std::vector<double> &value);
+
   MapBuffer build();
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
@@ -49,7 +49,7 @@ TEST(MapBufferTest, testSimpleLongMap) {
 }
 
 TEST(MapBufferTest, testMapBufferExtension) {
-  // 26 = 2 buckets: 2*10 + 6 sizeof(header)
+  // initialSize is a reserve hint for the number of buckets
   int initialSize = 26;
   auto buffer = MapBufferBuilder(initialSize);
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
@@ -205,6 +205,101 @@ TEST(MapBufferTest, testMapListEntries) {
   EXPECT_EQ(mapBufferList2[1].getDouble(3), 908.1);
 }
 
+TEST(MapBufferTest, testEmptyMapBufferList) {
+  auto builder = MapBufferBuilder();
+
+  builder.putMapBufferList(0, {});
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getMapBufferList(0).size(), 0);
+}
+
+// Place the list behind another dynamic-data entry so its offset is non-zero,
+// exercising `getDynamicDataOffset() + getIntAtBucket(...)` against a non-zero
+// base rather than the zero-offset path testMapListEntries covers.
+TEST(MapBufferTest, testMapListEntriesAtNonZeroOffset) {
+  std::vector<MapBuffer> mapBufferList;
+  auto inner = MapBufferBuilder();
+  inner.putString(0, "inner");
+  inner.putInt(1, 42);
+  mapBufferList.push_back(inner.build());
+
+  auto builder = MapBufferBuilder();
+  builder.putString(0, "prefix");
+  builder.putMapBufferList(1, mapBufferList);
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getString(0), "prefix");
+  std::vector<MapBuffer> readList = map.getMapBufferList(1);
+  EXPECT_EQ(readList.size(), 1);
+  EXPECT_EQ(readList[0].getString(0), "inner");
+  EXPECT_EQ(readList[0].getInt(1), 42);
+}
+
+TEST(MapBufferTest, testIntBufferEntries) {
+  auto builder = MapBufferBuilder();
+
+  std::vector<int32_t> values{
+      1,
+      -2,
+      3,
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max()};
+  builder.putIntBuffer(0, values);
+  auto map = builder.build();
+
+  EXPECT_EQ(map.count(), 1);
+  EXPECT_EQ(map.getIntBuffer(0), values);
+}
+
+TEST(MapBufferTest, testEmptyIntBuffer) {
+  auto builder = MapBufferBuilder();
+
+  builder.putIntBuffer(0, {});
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getIntBuffer(0).size(), 0);
+}
+
+TEST(MapBufferTest, testDoubleBufferEntries) {
+  auto builder = MapBufferBuilder();
+
+  std::vector<double> values{0.0, -1.5, 3.14159, 1e300, -1e-300};
+  builder.putDoubleBuffer(0, values);
+  auto map = builder.build();
+
+  EXPECT_EQ(map.count(), 1);
+  EXPECT_EQ(map.getDoubleBuffer(0), values);
+}
+
+TEST(MapBufferTest, testEmptyDoubleBuffer) {
+  auto builder = MapBufferBuilder();
+
+  builder.putDoubleBuffer(0, {});
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getDoubleBuffer(0).size(), 0);
+}
+
+// Mirrors the batched-animated-props use case: a pair of typed streams plus
+// some scalar metadata, with keys inserted out of order to exercise both the
+// dynamic-data section and the bucket sort path.
+TEST(MapBufferTest, testIntAndDoubleBuffersAlongsideScalars) {
+  std::vector<int32_t> intStream{1, 100, 1, 2, 4, 15, 4};
+  std::vector<double> doubleStream{0.5, 12.0, 0.25};
+
+  auto builder = MapBufferBuilder();
+  builder.putDoubleBuffer(2, doubleStream);
+  builder.putInt(0, 7);
+  builder.putIntBuffer(1, intStream);
+  auto map = builder.build();
+
+  EXPECT_EQ(map.count(), 3);
+  EXPECT_EQ(map.getInt(0), 7);
+  EXPECT_EQ(map.getIntBuffer(1), intStream);
+  EXPECT_EQ(map.getDoubleBuffer(2), doubleStream);
+}
+
 TEST(MapBufferTest, testMapRandomAccess) {
   auto builder = MapBufferBuilder();
   builder.putInt(1234, 4321);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -3247,7 +3247,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -3276,9 +3275,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -3249,7 +3249,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -3257,7 +3259,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -3282,7 +3286,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -3264,6 +3264,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -3173,6 +3173,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -3156,7 +3156,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -3185,9 +3184,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -3158,7 +3158,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -3166,7 +3168,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -3191,7 +3195,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -3244,7 +3244,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -3273,9 +3272,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -3246,7 +3246,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -3254,7 +3256,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -3279,7 +3283,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -3261,6 +3261,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -5499,6 +5499,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -5482,7 +5482,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -5511,9 +5510,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -5484,7 +5484,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -5492,7 +5494,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -5517,7 +5521,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -5408,7 +5408,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -5416,7 +5418,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -5441,7 +5445,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -5423,6 +5423,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -5406,7 +5406,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -5435,9 +5434,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -5496,6 +5496,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -5479,7 +5479,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -5508,9 +5507,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -5481,7 +5481,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -5489,7 +5491,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -5514,7 +5518,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -2170,7 +2170,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -2178,7 +2180,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -2203,7 +2207,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -2168,7 +2168,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -2197,9 +2196,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -2185,6 +2185,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -2104,7 +2104,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -2133,9 +2132,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -2121,6 +2121,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -2106,7 +2106,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -2114,7 +2116,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -2139,7 +2143,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -2167,7 +2167,9 @@ class facebook::react::MapBuffer {
   public size_t size() const;
   public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
+  public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
+  public std::vector<int32_t> getIntBuffer(facebook::react::MapBuffer::Key key) const;
   public uint16_t count() const;
   public using Key = uint16_t;
 }
@@ -2175,7 +2177,9 @@ class facebook::react::MapBuffer {
 enum facebook::react::MapBuffer::DataType : uint16_t {
   Boolean,
   Double,
+  DoubleBuffer,
   Int,
+  IntBuffer,
   Long,
   Map,
   String,
@@ -2200,7 +2204,9 @@ class facebook::react::MapBufferBuilder {
   public static facebook::react::MapBuffer EMPTY();
   public void putBool(facebook::react::MapBuffer::Key key, bool value);
   public void putDouble(facebook::react::MapBuffer::Key key, double value);
+  public void putDoubleBuffer(facebook::react::MapBuffer::Key key, const std::vector<double>& value);
   public void putInt(facebook::react::MapBuffer::Key key, int32_t value);
+  public void putIntBuffer(facebook::react::MapBuffer::Key key, const std::vector<int32_t>& value);
   public void putLong(facebook::react::MapBuffer::Key key, int64_t value);
   public void putMapBuffer(facebook::react::MapBuffer::Key key, const facebook::react::MapBuffer& map);
   public void putMapBufferList(facebook::react::MapBuffer::Key key, const std::vector<facebook::react::MapBuffer>& mapBufferList);

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -2182,6 +2182,7 @@ enum facebook::react::MapBuffer::DataType : uint16_t {
   IntBuffer,
   Long,
   Map,
+  MapBufferList,
   String,
 }
 

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -2165,7 +2165,6 @@ class facebook::react::MapBuffer {
   public int32_t getInt(facebook::react::MapBuffer::Key key) const;
   public int64_t getLong(facebook::react::MapBuffer::Key key) const;
   public size_t size() const;
-  public static constexpr uint16_t HEADER_ALIGNMENT;
   public std::string getString(facebook::react::MapBuffer::Key key) const;
   public std::vector<double> getDoubleBuffer(facebook::react::MapBuffer::Key key) const;
   public std::vector<facebook::react::MapBuffer> getMapBufferList(facebook::react::MapBuffer::Key key) const;
@@ -2194,9 +2193,7 @@ struct facebook::react::MapBuffer::Bucket {
 }
 
 struct facebook::react::MapBuffer::Header {
-  public uint16_t alignment;
   public uint16_t count;
-  public uint32_t bufferSize;
 }
 
 class facebook::react::MapBufferBuilder {


### PR DESCRIPTION
Summary:

Broadens the former header-shrink change into a single representation-optimization commit for MapBuffer. It bundles three layout optimizations that were previously split: (1) the header is reduced to a single 2-byte `count` field; (2) multi-byte values are read via `memcpy` so unaligned access is well-defined on all platforms; (3) every dynamic-data entry (`String`, `Map`, `MapBufferList`, `IntBuffer`, `DoubleBuffer`) packs its `[offset][byteLength]` into the bucket's 8-byte value instead of writing an in-band length prefix into the dynamic data section.

Net effect: 4 fewer bytes per dynamic entry, one fewer indirection on read (the length is already in the bucket), and every dynamic entry becomes self-delimiting from its bucket alone. No public API change — only the internal serialized representation.

Changelog: [Internal]

Reviewed By: lenaic, zeyap

Differential Revision: D109848478
