### PR TITLE
Remove unused types/*.d.ts export subpath

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -52,10 +52,6 @@
       "types": null,
       "default": "./src/*.js"
     },
-    "./types/*.d.ts": {
-      "react-native-strict-api": null,
-      "default": "./types/*.d.ts"
-    },
     "./jest-preset": "./jest-preset.js",
     "./rn-get-polyfills": "./rn-get-polyfills.js",
     "./src/fb_internal/*": "./src/fb_internal/*",


### PR DESCRIPTION
Summary:
The `"./types/*.d.ts"` entry was an overly defensive addition during our non-breaking `"exports"` field addition back in 0.80.

In reality, this subpath has no real consumers: the legacy types entry point (`.`) resolves its own declaration files through relative references, and the supported deep-import surface is `react-native/Libraries/*`, not `react-native/types/*`.

Type resolution of the main entry point and of `react-native/Libraries/*` deep imports is unaffected, and there is no runtime impact (these are declaration files).

Follows the exports-map cleanup in https://github.com/react/react-native/pull/57276.

Changelog: [Internal]

Differential Revision: D110044754


