### PR TITLE
Remove unused Libraries/*.d.ts export subpath (2/2)

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -43,10 +43,6 @@
       "react-native-strict-api": null,
       "default": "./Libraries/*.js"
     },
-    "./Libraries/*.d.ts": {
-      "react-native-strict-api": null,
-      "default": "./Libraries/*.d.ts"
-    },
     "./scripts/*": "./scripts/*",
     "./src/*": {
       "types": null,


### PR DESCRIPTION
Summary:
Follows https://github.com/react/react-native/pull/57362 (accidentally missed).

Simplifying our `"exports"` map to its minimum form will help for the incoming review/understandability of the Strict TS API rollout by default.

Changelog: [Internal]

Differential Revision: D110055788


