### PR TITLE
Report deep type imports without a public API mapping in no-deep-imports rule

### DIFF
--- a/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
@@ -125,5 +125,31 @@ eslintTester.run('../no-deep-imports', rule, {
       ],
       output: null,
     },
+    {
+      // Deep type import with no public API mapping: still reported, no fix.
+      code: "import type {Foo} from 'react-native/Libraries/Components/Foo';",
+      errors: [
+        {
+          messageId: 'deepImport',
+          data: {importPath: 'react-native/Libraries/Components/Foo'},
+        },
+      ],
+      output: null,
+    },
+    {
+      // Deep type import from a module whose mapping has `types: null`
+      // (e.g. AccessibilityInfo): still reported, no fix.
+      code: "import type {AccessibilityChangeEventName} from 'react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo';",
+      errors: [
+        {
+          messageId: 'deepImport',
+          data: {
+            importPath:
+              'react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo',
+          },
+        },
+      ],
+      output: null,
+    },
   ],
 });

--- a/packages/eslint-plugin-react-native/no-deep-imports.js
+++ b/packages/eslint-plugin-react-native/no-deep-imports.js
@@ -79,6 +79,11 @@ module.exports = {
                 );
               },
             });
+          } else {
+            // Deep type imports without a known public API type mapping are
+            // still deep imports and must be reported (just without an
+            // auto-fix), matching the behavior for default and named imports.
+            context.report(getStandardReport(node.source));
           }
         } else {
           context.report(getStandardReport(node.source));


### PR DESCRIPTION
## Summary

The `no-deep-imports` ESLint rule (`packages/eslint-plugin-react-native`) is meant to flag every deep import from `react-native/...`. Deep **default** and **named** imports are reported even when there is no public API mapping for the path (just without an auto-fix). Deep **type** imports, however, were only reported when the imported module had a truthy `types` mapping:

```js
} else if (isTypeImport(node)) {
  const publicAPIDefaultComponent = publicAPIMapping[reactNativeSource];
  if (publicAPIDefaultComponent && publicAPIDefaultComponent.types) {
    /* ...report (with fix)... */
  }
  // no else -> nothing reported
}
```

So a deep type import from a path with **no mapping**, or one whose mapping has `types: null` (e.g. `AccessibilityInfo`), slipped through unreported — inconsistent with the default/named import behavior.

## Fix

Add the missing `else` branch so these deep type imports are reported (without an auto-fix), matching how default and named deep imports are handled.

## Test plan

Added two regression cases to `__tests__/no-deep-imports-test.js`:
- a deep type import with no public API mapping
- a deep type import from a module whose mapping has `types: null`

Both assert a `deepImport` error with `output: null`. Verified with ESLint's `RuleTester` (hermes-eslint parser): the new cases fail before the change ("Should have 1 error but had 0") and pass after, with all pre-existing valid/invalid cases still passing.

## Changelog:

[INTERNAL] [FIXED] - Report deep type imports without a public API mapping in the `no-deep-imports` ESLint rule
