### PR TITLE
Fix Blob.slice() for negative start and inverted ranges

### DIFF
--- a/packages/react-native/Libraries/Blob/Blob.js
+++ b/packages/react-native/Libraries/Blob/Blob.js
@@ -86,6 +86,11 @@ class Blob {
     let {offset, size} = this.data;
 
     if (typeof start === 'number') {
+      if (start < 0) {
+        // A negative start is relative to the end of the blob.
+        // $FlowFixMe[reassign-const]
+        start = Math.max(this.size + start, 0);
+      }
       if (start > size) {
         // $FlowFixMe[reassign-const]
         start = size;
@@ -102,7 +107,8 @@ class Blob {
           // $FlowFixMe[reassign-const]
           end = this.size;
         }
-        size = end - start;
+        // Clamp to 0 so an end that precedes start yields an empty blob.
+        size = Math.max(end - start, 0);
       }
     }
     return BlobManager.createFromOptions({

--- a/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
@@ -81,6 +81,38 @@ describe('Blob', function () {
     expect(sliceC.size).toBe(Math.min(blob.data.size, 34569) - 34543);
   });
 
+  it('should slice a blob with a negative start', () => {
+    const blob = new Blob();
+    blob.data.size = 34546;
+
+    // A negative start is relative to the end of the blob.
+    const slice = blob.slice(-100);
+
+    expect(slice.data.offset).toBe(34446);
+    expect(slice.size).toBe(100);
+  });
+
+  it('should slice a blob with a negative end', () => {
+    const blob = new Blob();
+    blob.data.size = 34546;
+
+    // A negative end is relative to the end of the blob.
+    const slice = blob.slice(0, -100);
+
+    expect(slice.data.offset).toBe(0);
+    expect(slice.size).toBe(34446);
+  });
+
+  it('should return an empty slice when end precedes start', () => {
+    const blob = new Blob();
+    blob.data.size = 34546;
+
+    const slice = blob.slice(200, 100);
+
+    expect(slice.data.offset).toBe(200);
+    expect(slice.size).toBe(0);
+  });
+
   it('should slice a blob and sets a contentType', () => {
     const blob = new Blob();
 


### PR DESCRIPTION
## Summary

`Blob.slice(start, end)` is modeled on the [W3C Blob API](https://developer.mozilla.org/en-US/docs/Web/API/Blob/slice), where both `start` and `end` may be negative (relative to the end of the blob) and an `end` that precedes `start` yields an empty blob.

The current implementation handles a negative `end` but not a negative `start`:

```js
if (typeof start === 'number') {
  if (start > size) { start = size; }   // only the upper bound is checked
  offset += start;
  size -= start;
  if (typeof end === 'number') {
    if (end < 0) { end = this.size + end; }  // negative end IS handled
    if (end > this.size) { end = this.size; }
    size = end - start;                       // not clamped to >= 0
  }
}
```

So:
- `blob.slice(-100)` sets `offset` to a **negative** value and makes `size` *larger* than the blob, instead of slicing the last 100 bytes.
- `blob.slice(200, 100)` (end before start) produces a **negative** size.

## Fix

- Normalize a negative `start` relative to the blob size (`Math.max(this.size + start, 0)`), mirroring the existing `end` handling.
- Clamp the resulting size with `Math.max(end - start, 0)` so an inverted range yields an empty blob.

## Test plan

Added tests to `Libraries/Blob/__tests__/Blob-test.js` for negative start, negative end, and end-precedes-start. The negative-start and inverted-range cases fail before this change (negative offset / negative size) and pass after; existing slice tests and the rest of the suite still pass (8/8). ESLint clean on the changed files.

## Changelog:

[General] [Fixed] - Fix `Blob.slice()` for negative start offsets and inverted ranges