### PR TITLE
Set FileReader to LOADING state while a read is in progress

### DIFF
--- a/packages/react-native/Libraries/Blob/FileReader.js
+++ b/packages/react-native/Libraries/Blob/FileReader.js
@@ -80,6 +80,8 @@ class FileReader extends EventTarget {
       );
     }
 
+    this._setReadyState(LOADING);
+
     NativeFileReaderModule.readAsDataURL(blob.data).then(
       (text: string) => {
         if (this._aborted) {
@@ -111,6 +113,8 @@ class FileReader extends EventTarget {
       );
     }
 
+    this._setReadyState(LOADING);
+
     NativeFileReaderModule.readAsDataURL(blob.data).then(
       (text: string) => {
         if (this._aborted) {
@@ -137,6 +141,8 @@ class FileReader extends EventTarget {
         "Failed to execute 'readAsText' on 'FileReader': parameter 1 is not of type 'Blob'",
       );
     }
+
+    this._setReadyState(LOADING);
 
     NativeFileReaderModule.readAsText(blob.data, encoding).then(
       (text: string) => {

--- a/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
@@ -46,6 +46,31 @@ describe('FileReader', function () {
     expect(e.target?.result).toBe('data:text/plain;base64,NDI=');
   });
 
+  it('should be in the LOADING state while a read is in progress', () => {
+    const reader = new FileReader();
+    expect(reader.readyState).toBe(FileReader.EMPTY);
+    reader.readAsText(new Blob());
+    // The native read resolves on a later microtask, so the reader should
+    // report LOADING synchronously after the read starts.
+    expect(reader.readyState).toBe(FileReader.LOADING);
+  });
+
+  it('should dispatch abort and loadend when aborted during a read', () => {
+    const reader = new FileReader();
+    let aborted = false;
+    let loadended = false;
+    reader.onabort = () => {
+      aborted = true;
+    };
+    reader.onloadend = () => {
+      loadended = true;
+    };
+    reader.readAsText(new Blob());
+    reader.abort();
+    expect(aborted).toBe(true);
+    expect(loadended).toBe(true);
+  });
+
   it('should read blob as ArrayBuffer', async () => {
     const e = await new Promise<Event>((resolve, reject) => {
       const reader = new FileReader();


### PR DESCRIPTION
## Summary

`FileReader`'s `readAsText` / `readAsDataURL` / `readAsArrayBuffer` go straight from `EMPTY` to `DONE` — they never set `readyState` to `LOADING`. Two consequences:

1. `readyState` is never observably `LOADING` during a read (it should be, per the [W3C FileReader spec](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState)).
2. `abort()` is dead during a read. Its body only emits events when the reader is mid-read:

   ```js
   abort() {
     this._aborted = true;
     // only call onreadystatechange if there is something to abort, as per spec
     if (this._readyState !== EMPTY && this._readyState !== DONE) {
       this._reset();
       this._setReadyState(DONE);
     }
     this._reset();
   }
   ```

   Because a read never sets `LOADING`, `readyState` is still `EMPTY` when `abort()` runs, so the guard is false and **no `abort`/`loadend` events are dispatched** — even though the method is written specifically to handle that case.

## Fix

Set the `LOADING` state when each read starts (via the existing `_setReadyState` helper, which also fires `readystatechange`). This makes `readyState` correct during a read and makes `abort()` during a read dispatch `abort`/`loadend` as its own code already anticipates.

## Test plan

Added tests to `Libraries/Blob/__tests__/FileReader-test.js`:
- `readyState` is `LOADING` synchronously after a read starts.
- `abort()` during a read dispatches `abort` and `loadend`.

Both fail before this change and pass after; the existing read tests and the full Blob test suite still pass (20/20). ESLint clean on the changed files.

## Changelog:

[General] [Fixed] - Set `FileReader` `readyState` to `LOADING` during a read so `abort()` correctly emits `abort`/`loadend`