### PR TITLE
Remove unused ViewShadowNodeProps subclass (#57377)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -14,12 +14,6 @@ namespace facebook::react {
 // NOLINTNEXTLINE(facebook-hte-CArray,modernize-avoid-c-arrays)
 const char ViewComponentName[] = "View";
 
-ViewShadowNodeProps::ViewShadowNodeProps(
-    const PropsParserContext& context,
-    const ViewShadowNodeProps& sourceProps,
-    const RawProps& rawProps)
-    : ViewProps(context, sourceProps, rawProps) {};
-
 ViewShadowNode::ViewShadowNode(
     const ShadowNodeFragment& fragment,
     const ShadowNodeFamily::Shared& family,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
@@ -15,22 +15,12 @@ namespace facebook::react {
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
 extern const char ViewComponentName[];
 
-/**
- * Implementation of the ViewProps that propagates feature flag.
- */
-class ViewShadowNodeProps final : public ViewProps {
- public:
-  ViewShadowNodeProps() = default;
-  ViewShadowNodeProps(
-      const PropsParserContext &context,
-      const ViewShadowNodeProps &sourceProps,
-      const RawProps &rawProps);
-};
+using ViewShadowNodeProps = ViewProps;
 
 /*
  * `ShadowNode` for <View> component.
  */
-class ViewShadowNode final : public ConcreteViewShadowNode<ViewComponentName, ViewShadowNodeProps, ViewEventEmitter> {
+class ViewShadowNode final : public ConcreteViewShadowNode<ViewComponentName, ViewProps, ViewEventEmitter> {
  public:
   ViewShadowNode(const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family, ShadowNodeTraits traits);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -1017,8 +1017,7 @@ void YogaLayoutableShadowNode::swapLeftAndRightInYogaStyleProps() {
 void YogaLayoutableShadowNode::swapLeftAndRightInViewProps() {
   if (auto viewShadowNode = dynamic_cast<ViewShadowNode*>(this)) {
     // TODO: Do not mutate props directly.
-    auto& props =
-        const_cast<ViewShadowNodeProps&>(viewShadowNode->getConcreteProps());
+    auto& props = const_cast<ViewProps&>(viewShadowNode->getConcreteProps());
 
     // Swap border node values, borderRadii, borderColors and borderStyles.
     if (props.borderRadii.topLeft.has_value()) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
@@ -86,7 +86,7 @@ class LayoutTest : public ::testing::Test {
               .reference(viewShadowNodeA_)
               .tag(2)
               .props([] {
-                auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                auto sharedProps = std::make_shared<ViewProps>();
                 auto &props = *sharedProps;
                 auto &yogaStyle = props.yogaStyle;
                 yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -99,7 +99,7 @@ class LayoutTest : public ::testing::Test {
                   .reference(viewShadowNodeAB_)
                   .tag(3)
                   .props([=] {
-                    auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                    auto sharedProps = std::make_shared<ViewProps>();
                     auto &props = *sharedProps;
                     auto &yogaStyle = props.yogaStyle;
                     yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -127,7 +127,7 @@ class LayoutTest : public ::testing::Test {
                       .reference(viewShadowNodeABC_)
                       .tag(4)
                       .props([=] {
-                        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                        auto sharedProps = std::make_shared<ViewProps>();
                         auto &props = *sharedProps;
                         auto &yogaStyle = props.yogaStyle;
 
@@ -147,7 +147,7 @@ class LayoutTest : public ::testing::Test {
                           .reference(viewShadowNodeABCD_)
                           .tag(5)
                           .props([] {
-                            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                            auto sharedProps = std::make_shared<ViewProps>();
                             auto &props = *sharedProps;
                             auto &yogaStyle = props.yogaStyle;
                             yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -162,7 +162,7 @@ class LayoutTest : public ::testing::Test {
                       .reference(viewShadowNodeABE_)
                       .tag(6)
                       .props([] {
-                        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                        auto sharedProps = std::make_shared<ViewProps>();
                         auto &props = *sharedProps;
                         auto &yogaStyle = props.yogaStyle;
                         yogaStyle.setPositionType(yoga::PositionType::Absolute);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/ViewTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/ViewTest.cpp
@@ -51,7 +51,7 @@ class YogaDirtyFlagTest : public ::testing::Test {
                     /*
                      * Some non-default props.
                      */
-                    auto mutableViewProps = std::make_shared<ViewShadowNodeProps>();
+                    auto mutableViewProps = std::make_shared<ViewProps>();
                     auto &props = *mutableViewProps;
                     props.nativeId = "native Id";
                     props.opacity = 0.5;
@@ -113,7 +113,7 @@ TEST_F(YogaDirtyFlagTest, changingNonLayoutSubPropsMustNotDirtyYogaNode) {
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
       innerShadowNode_->getFamily(), [](const ShadowNode& oldShadowNode) {
-        auto viewProps = std::make_shared<ViewShadowNodeProps>();
+        auto viewProps = std::make_shared<ViewProps>();
         auto& props = *viewProps;
 
         props.nativeId = "some new native Id";
@@ -136,7 +136,7 @@ TEST_F(YogaDirtyFlagTest, changingLayoutSubPropsMustDirtyYogaNode) {
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
       innerShadowNode_->getFamily(), [](const ShadowNode& oldShadowNode) {
-        auto viewProps = std::make_shared<ViewShadowNodeProps>();
+        auto viewProps = std::make_shared<ViewProps>();
         auto& props = *viewProps;
 
         props.yogaStyle.setAlignContent(yoga::Align::Baseline);
@@ -243,7 +243,7 @@ TEST_F(YogaDirtyFlagTest, clonedPropsPreserveAspectRatio) {
   auto newRootShadowNode = rootShadowNode_->cloneTree(
       innerShadowNode_->getFamily(), [&](const ShadowNode& oldShadowNode) {
         // First clone: set aspectRatio to 1.5
-        auto viewProps = std::make_shared<ViewShadowNodeProps>();
+        auto viewProps = std::make_shared<ViewProps>();
         viewProps->yogaStyle.setAspectRatio(yoga::FloatOptional(1.5f));
         auto nodeWithAspectRatio =
             oldShadowNode.clone(ShadowNodeFragment{.props = viewProps});
@@ -255,8 +255,7 @@ TEST_F(YogaDirtyFlagTest, clonedPropsPreserveAspectRatio) {
         auto clonedProps = componentDescriptor.cloneProps(
             parserContext, nodeWithAspectRatio->getProps(), RawProps());
 
-        auto& clonedViewProps =
-            static_cast<const ViewShadowNodeProps&>(*clonedProps);
+        auto& clonedViewProps = static_cast<const ViewProps&>(*clonedProps);
         EXPECT_TRUE(clonedViewProps.yogaStyle.aspectRatio().isDefined());
         EXPECT_EQ(clonedViewProps.yogaStyle.aspectRatio().unwrap(), 1.5f);
 
@@ -303,7 +302,7 @@ class YogaCloneTest : public ::testing::Test {
               .reference(parentShadowNode_)
               .tag(2)
               .props([] {
-                auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                auto sharedProps = std::make_shared<ViewProps>();
                 auto &props = *sharedProps;
                 auto &yogaStyle = props.yogaStyle;
                 yogaStyle.setFlexDirection(yoga::FlexDirection::Row);
@@ -320,7 +319,7 @@ class YogaCloneTest : public ::testing::Test {
                   .reference(childAShadowNode_)
                   .tag(3)
                   .props([] {
-                    auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                    auto sharedProps = std::make_shared<ViewProps>();
                     sharedProps->yogaStyle.setDimension(
                         yoga::Dimension::Width,
                         yoga::StyleSizeLength::points(100));
@@ -333,7 +332,7 @@ class YogaCloneTest : public ::testing::Test {
                   .reference(childBShadowNode_)
                   .tag(4)
                   .props([] {
-                    auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                    auto sharedProps = std::make_shared<ViewProps>();
                     sharedProps->yogaStyle.setDimension(
                         yoga::Dimension::Width,
                         yoga::StyleSizeLength::points(100));
@@ -346,7 +345,7 @@ class YogaCloneTest : public ::testing::Test {
                   .reference(childCShadowNode_)
                   .tag(5)
                   .props([] {
-                    auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                    auto sharedProps = std::make_shared<ViewProps>();
                     sharedProps->yogaStyle.setDimension(
                         yoga::Dimension::Width,
                         yoga::StyleSizeLength::points(100));

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/FindNodeAtPointTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/FindNodeAtPointTest.cpp
@@ -126,7 +126,7 @@ TEST(FindNodeAtPointTest, viewIsScaled) {
           Element<ViewShadowNode>()
           .tag(3)
           .props([] {
-            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+            auto sharedProps = std::make_shared<ViewProps>();
             sharedProps->transform = Transform::Scale(0.5, 0.5, 0);
             return sharedProps;
           })
@@ -199,7 +199,7 @@ TEST(FindNodeAtPointTest, overlappingViewsWithZIndex) {
         Element<ViewShadowNode>()
         .tag(2)
         .props([] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           sharedProps->zIndex = 1;
           auto &yogaStyle = sharedProps->yogaStyle;
           yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -235,7 +235,7 @@ TEST(FindNodeAtPointTest, overlappingViewsWithParentPointerEventsBoxOnly) {
     Element<ViewShadowNode>()
       .tag(1)
       .props([] {
-        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+        auto sharedProps = std::make_shared<ViewProps>();
         sharedProps->pointerEvents = PointerEventsMode::BoxOnly;
         return sharedProps;
       })
@@ -277,7 +277,7 @@ TEST(FindNodeAtPointTest, overlappingViewsWithParentPointerEventsBoxNone) {
     Element<ViewShadowNode>()
       .tag(1)
       .props([] {
-        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+        auto sharedProps = std::make_shared<ViewProps>();
         sharedProps->pointerEvents = PointerEventsMode::BoxNone;
         return sharedProps;
       })
@@ -290,7 +290,7 @@ TEST(FindNodeAtPointTest, overlappingViewsWithParentPointerEventsBoxNone) {
         Element<ViewShadowNode>()
         .tag(2)
         .props([] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           sharedProps->zIndex = 1;
           auto &yogaStyle = sharedProps->yogaStyle;
           yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -326,7 +326,7 @@ TEST(FindNodeAtPointTest, overlappingViewsWithParentPointerEventsNone) {
     Element<ViewShadowNode>()
       .tag(1)
       .props([] {
-        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+        auto sharedProps = std::make_shared<ViewProps>();
         sharedProps->pointerEvents = PointerEventsMode::None;
         return sharedProps;
       })
@@ -339,7 +339,7 @@ TEST(FindNodeAtPointTest, overlappingViewsWithParentPointerEventsNone) {
         Element<ViewShadowNode>()
         .tag(2)
         .props([] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           sharedProps->zIndex = 1;
           auto &yogaStyle = sharedProps->yogaStyle;
           yogaStyle.setPositionType(yoga::PositionType::Absolute);

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
@@ -291,7 +291,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedNode) {
           shadowNode.setLayoutMetrics(layoutMetrics);
         })
         .props([] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           sharedProps->transform = Transform::Scale(0.5, 0.5, 1);
           return sharedProps;
         })
@@ -340,7 +340,7 @@ TEST(LayoutableShadowNodeTest, noOverflow) {
       }).children({
         Element<ViewShadowNode>()
         .props([=] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           auto &props = *sharedProps;
           auto &yogaStyle = props.yogaStyle;
           yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(100));
@@ -351,7 +351,7 @@ TEST(LayoutableShadowNodeTest, noOverflow) {
         .children({
           Element<ViewShadowNode>()
           .props([] {
-            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+            auto sharedProps = std::make_shared<ViewProps>();
             auto &props = *sharedProps;
             auto &yogaStyle = props.yogaStyle;
             yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -405,7 +405,7 @@ TEST(LayoutableShadowNodeTest, overflowInsetFrameToRightAndDown) {
       }).children({
         Element<ViewShadowNode>()
         .props([=] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           auto &props = *sharedProps;
           auto &yogaStyle = props.yogaStyle;
           yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(100));
@@ -416,7 +416,7 @@ TEST(LayoutableShadowNodeTest, overflowInsetFrameToRightAndDown) {
         .children({
           Element<ViewShadowNode>()
           .props([] {
-            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+            auto sharedProps = std::make_shared<ViewProps>();
             auto &props = *sharedProps;
             auto &yogaStyle = props.yogaStyle;
             yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -471,7 +471,7 @@ TEST(LayoutableShadowNodeTest, overflowInsetFrameToLeftAndTop) {
       }).children({
         Element<ViewShadowNode>()
         .props([=] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           auto &props = *sharedProps;
           auto &yogaStyle = props.yogaStyle;
           yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(100));
@@ -482,7 +482,7 @@ TEST(LayoutableShadowNodeTest, overflowInsetFrameToLeftAndTop) {
         .children({
           Element<ViewShadowNode>()
           .props([] {
-            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+            auto sharedProps = std::make_shared<ViewProps>();
             auto &props = *sharedProps;
             auto &yogaStyle = props.yogaStyle;
             yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -541,7 +541,7 @@ TEST(LayoutableShadowNodeTest, overflowInsetFrameToAllSides) {
       }).children({
         Element<ViewShadowNode>()
         .props([=] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           auto &props = *sharedProps;
           auto &yogaStyle = props.yogaStyle;
           yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(100));
@@ -552,7 +552,7 @@ TEST(LayoutableShadowNodeTest, overflowInsetFrameToAllSides) {
         .children({
           Element<ViewShadowNode>()
           .props([] {
-            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+            auto sharedProps = std::make_shared<ViewProps>();
             auto &props = *sharedProps;
             auto &yogaStyle = props.yogaStyle;
             yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -564,7 +564,7 @@ TEST(LayoutableShadowNodeTest, overflowInsetFrameToAllSides) {
           }),
           Element<ViewShadowNode>()
           .props([] {
-            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+            auto sharedProps = std::make_shared<ViewProps>();
             auto &props = *sharedProps;
             auto &yogaStyle = props.yogaStyle;
             yogaStyle.setPositionType(yoga::PositionType::Absolute);
@@ -620,7 +620,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedParent) {
       .children({
         Element<ViewShadowNode>()
         .props([] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           sharedProps->transform = Transform::Scale(0.5, 0.5, 1);
           return sharedProps;
         })
@@ -755,7 +755,7 @@ TEST(
       .children({
         Element<ViewShadowNode>()
         .props([] {
-          auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+          auto sharedProps = std::make_shared<ViewProps>();
           sharedProps->transform = Transform::Scale(0.5, 0.5, 1);
           return sharedProps;
         })
@@ -840,7 +840,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameTransformedNode) {
   auto element =
     Element<ViewShadowNode>()
       .props([] {
-        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+        auto sharedProps = std::make_shared<ViewProps>();
         sharedProps->transform = Transform::Scale(2, 2, 1);
         return sharedProps;
       })
@@ -1017,7 +1017,7 @@ TEST(LayoutableShadowNodeTest, invertedVerticalView) {
   auto element =
         Element<ViewShadowNode>()
           .props([] {
-            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+            auto sharedProps = std::make_shared<ViewProps>();
             sharedProps->transform = Transform::VerticalInversion(); // Inverted <ScrollView>
             return sharedProps;
           })
@@ -1093,7 +1093,7 @@ TEST(LayoutableShadowNodeTest, nestedInvertedVerticalView) {
   auto element =
     Element<ViewShadowNode>()
       .props([] {
-        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+        auto sharedProps = std::make_shared<ViewProps>();
         sharedProps->transform = Transform::VerticalInversion(); // Inverted <ScrollView>
         return sharedProps;
       })
@@ -1179,7 +1179,7 @@ TEST(LayoutableShadowNodeTest, nestedDoubleInvertedVerticalView) {
   auto element =
     Element<ViewShadowNode>()
       .props([] {
-        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+        auto sharedProps = std::make_shared<ViewProps>();
         sharedProps->transform = Transform::VerticalInversion(); // Inverted
         return sharedProps;
       })
@@ -1195,7 +1195,7 @@ TEST(LayoutableShadowNodeTest, nestedDoubleInvertedVerticalView) {
                 layoutMetrics.frame.size = {.width=100, .height=200};
                 shadowNode.setLayoutMetrics(layoutMetrics);
               }).props([] {
-                  auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                  auto sharedProps = std::make_shared<ViewProps>();
                   sharedProps->transform = Transform::VerticalInversion(); // Inverted
                   return sharedProps;
                 }).children({
@@ -1259,7 +1259,7 @@ TEST(LayoutableShadowNodeTest, invertedHorizontalView) {
   auto element =
         Element<ViewShadowNode>()
           .props([] {
-            auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+            auto sharedProps = std::make_shared<ViewProps>();
             sharedProps->transform = Transform::HorizontalInversion(); // Inverted <ScrollView>
             return sharedProps;
           })
@@ -1331,7 +1331,7 @@ TEST(LayoutableShadowNodeTest, nestedInvertedHorizontalView) {
   auto element =
     Element<ViewShadowNode>()
       .props([] {
-        auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+        auto sharedProps = std::make_shared<ViewProps>();
         sharedProps->transform = Transform::HorizontalInversion(); // Inverted <ScrollView>
         return sharedProps;
       })

--- a/packages/react-native/ReactCommon/react/renderer/element/tests/ElementTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/element/tests/ElementTest.cpp
@@ -26,7 +26,7 @@ TEST(ElementTest, testNormalCases) {
   auto shadowNodeAB = std::shared_ptr<ViewShadowNode>{};
   auto shadowNodeABA = std::shared_ptr<ViewShadowNode>{};
 
-  auto propsAA = std::make_shared<ViewShadowNodeProps>();
+  auto propsAA = std::make_shared<ViewProps>();
   propsAA->nativeId = "node AA";
 
   // clang-format off
@@ -51,7 +51,7 @@ TEST(ElementTest, testNormalCases) {
             .reference(shadowNodeAB)
             .tag(3)
             .props([]() {
-               auto props = std::make_shared<ViewShadowNodeProps>();
+               auto props = std::make_shared<ViewProps>();
                props->nativeId = "node AB";
                return props;
             })
@@ -60,7 +60,7 @@ TEST(ElementTest, testNormalCases) {
                 .reference(shadowNodeABA)
                 .tag(4)
                 .props([]() {
-                  auto props = std::make_shared<ViewShadowNodeProps>();
+                  auto props = std::make_shared<ViewProps>();
                   props->nativeId = "node ABA";
                   return props;
                 })

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/DifferentiatorUnflattenTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/DifferentiatorUnflattenTest.cpp
@@ -112,7 +112,7 @@ class DifferentiatorUnflattenTest : public ::testing::Test {
     rootShadowNode_ =
         std::static_pointer_cast<RootShadowNode>(rootShadowNode_->cloneTree(
             node->getFamily(), [&](const ShadowNode& oldShadowNode) {
-              auto viewProps = std::make_shared<ViewShadowNodeProps>();
+              auto viewProps = std::make_shared<ViewProps>();
               callback(*viewProps);
               return oldShadowNode.clone(
                   ShadowNodeFragment{.props = viewProps});

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/OrderIndexTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/OrderIndexTest.cpp
@@ -82,7 +82,7 @@ class OrderIndexTest : public ::testing::Test {
     rootShadowNode_ =
         std::static_pointer_cast<RootShadowNode>(rootShadowNode_->cloneTree(
             node->getFamily(), [&](const ShadowNode& oldShadowNode) {
-              auto viewProps = std::make_shared<ViewShadowNodeProps>();
+              auto viewProps = std::make_shared<ViewProps>();
               callback(*viewProps);
               return oldShadowNode.clone(
                   ShadowNodeFragment{.props = viewProps});

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
@@ -445,7 +445,7 @@ TEST_F(ShadowTreeLifecycleTest, moveFirstChildToLast) {
   auto builder = simpleComponentBuilder();
 
   auto makeProps = [](const std::string& id) {
-    auto props = std::make_shared<ViewShadowNodeProps>();
+    auto props = std::make_shared<ViewProps>();
     props->nativeId = id;
     return props;
   };

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -162,7 +162,7 @@ class StackingContextTest : public ::testing::Test {
     rootShadowNode_ =
         std::static_pointer_cast<RootShadowNode>(rootShadowNode_->cloneTree(
             node->getFamily(), [&](const ShadowNode& oldShadowNode) {
-              auto viewProps = std::make_shared<ViewShadowNodeProps>();
+              auto viewProps = std::make_shared<ViewProps>();
               callback(*viewProps);
               return oldShadowNode.clone(
                   ShadowNodeFragment{.props = viewProps});

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/tests/FindShadowNodeByTagTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/tests/FindShadowNodeByTagTest.cpp
@@ -85,7 +85,7 @@ class FindShadowNodeByTagTest : public ::testing::Test {
               .tag(viewTag_)
               .surfaceId(surfaceId_)
               .props([] {
-                auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                auto sharedProps = std::make_shared<ViewProps>();
                 auto& yogaStyle = sharedProps->yogaStyle;
                 yogaStyle.setDimension(
                     yoga::Dimension::Width,

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/tests/PointerEventsProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/tests/PointerEventsProcessorTest.cpp
@@ -101,7 +101,7 @@ class PointerEventsProcessorTest : public ::testing::Test {
               .surfaceId(surfaceId_)
               .reference(nodeA_)
               .props([] {
-                auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                auto sharedProps = std::make_shared<ViewProps>();
                 auto &props = *sharedProps;
                 listenToAllPointerEvents(props);
                 auto &yogaStyle = props.yogaStyle;
@@ -119,7 +119,7 @@ class PointerEventsProcessorTest : public ::testing::Test {
                   .surfaceId(surfaceId_)
                   .reference(nodeAA_)
                   .props([] {
-                    auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                    auto sharedProps = std::make_shared<ViewProps>();
                     auto &props = *sharedProps;
                     listenToAllPointerEvents(props);
                     auto &yogaStyle = props.yogaStyle;
@@ -133,7 +133,7 @@ class PointerEventsProcessorTest : public ::testing::Test {
               .surfaceId(surfaceId_)
               .reference(nodeB_)
               .props([] {
-                auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                auto sharedProps = std::make_shared<ViewProps>();
                 auto &props = *sharedProps;
                 listenToAllPointerEvents(props);
                 auto &yogaStyle = props.yogaStyle;
@@ -151,7 +151,7 @@ class PointerEventsProcessorTest : public ::testing::Test {
                   .surfaceId(surfaceId_)
                   .reference(nodeBB_)
                   .props([] {
-                    auto sharedProps = std::make_shared<ViewShadowNodeProps>();
+                    auto sharedProps = std::make_shared<ViewProps>();
                     auto &props = *sharedProps;
                     listenToAllPointerEvents(props);
                     auto &yogaStyle = props.yogaStyle;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -732,6 +732,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -5413,14 +5414,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -731,6 +731,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -5227,14 +5228,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -732,6 +732,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -5404,14 +5405,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -3596,6 +3596,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -7589,14 +7590,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -3583,6 +3583,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -7431,14 +7432,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -3596,6 +3596,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -7580,14 +7581,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -349,6 +349,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -3853,14 +3854,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -348,6 +348,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -3707,14 +3708,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -349,6 +349,7 @@ using facebook::react::ValueFactory = std::function<facebook::jsi::Value(faceboo
 using facebook::react::ViewEventEmitter = facebook::react::HostPlatformViewEventEmitter;
 using facebook::react::ViewNodePairScope = std::deque<facebook::react::ShadowViewNodePair>;
 using facebook::react::ViewProps = facebook::react::HostPlatformViewProps;
+using facebook::react::ViewShadowNodeProps = facebook::react::ViewProps;
 using facebook::react::VirtualViewComponentDescriptor = facebook::react::ConcreteComponentDescriptor<facebook::react::VirtualViewShadowNode>;
 using facebook::react::parsePlatformColorFn = facebook::react::SharedColor(*)(const facebook::react::ContextContainer&, int32_t, const facebook::react::RawValue&);
 template <typename GeneratorT, typename ValueT>
@@ -3844,14 +3845,9 @@ class facebook::react::ViewComponentDescriptor : public facebook::react::Concret
   public ViewComponentDescriptor(const facebook::react::ComponentDescriptorParameters& parameters);
 }
 
-class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewShadowNodeProps, facebook::react::ViewEventEmitter> {
+class facebook::react::ViewShadowNode : public facebook::react::ConcreteViewShadowNode<facebook::react::ViewComponentName, facebook::react::ViewProps, facebook::react::ViewEventEmitter> {
   public ViewShadowNode(const facebook::react::ShadowNode& sourceShadowNode, const facebook::react::ShadowNodeFragment& fragment);
   public ViewShadowNode(const facebook::react::ShadowNodeFragment& fragment, const facebook::react::ShadowNodeFamily::Shared& family, facebook::react::ShadowNodeTraits traits);
-}
-
-class facebook::react::ViewShadowNodeProps : public facebook::react::HostPlatformViewProps {
-  public ViewShadowNodeProps() = default;
-  public ViewShadowNodeProps(const facebook::react::PropsParserContext& context, const facebook::react::ViewShadowNodeProps& sourceProps, const facebook::react::RawProps& rawProps);
 }
 
 class facebook::react::ViewTransitionModule : public facebook::react::UIManagerViewTransitionDelegate, public facebook::react::UIManagerCommitHook, public facebook::react::MountingOverrideDelegate {


### PR DESCRIPTION
Summary:

ViewShadowNodeProps was a thin subclass of ViewProps that only forwarded its constructor. After the feature flag propagation logic was removed, the subclass serves no purpose.

Changelog:
[Internal]

Differential Revision: D110095190


