### PR TITLE
Refactor imports from Metro to avoid deprecated styles and prefer main package (#57378)

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -35,8 +35,6 @@
     "debug": "^4.4.0",
     "invariant": "^2.2.4",
     "metro": "^0.85.0",
-    "metro-config": "^0.85.0",
-    "metro-core": "^0.85.0",
     "semver": "^7.1.3"
   },
   "devDependencies": {

--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -10,7 +10,6 @@
 
 import type {Config} from '@react-native-community/cli-types';
 import type {RunBuildOptions} from 'metro';
-import type {ConfigT} from 'metro-config';
 
 import loadMetroConfig from '../../utils/loadMetroConfig';
 import parseKeyValueParamArray from '../../utils/parseKeyValueParamArray';
@@ -19,6 +18,8 @@ import {promises as fs} from 'fs';
 import {runBuild} from 'metro';
 import path from 'path';
 import {styleText} from 'util';
+
+type HydratedMetroConfig = Awaited<ReturnType<typeof loadMetroConfig>>;
 
 export type BundleCommandArgs = {
   assetsDest?: string,
@@ -60,7 +61,7 @@ async function buildBundle(
 
 async function buildBundleWithConfig(
   args: BundleCommandArgs,
-  config: ConfigT,
+  config: HydratedMetroConfig,
   bundleImpl?: RunBuildOptions['output'],
 ): Promise<void> {
   const customResolverOptions = parseKeyValueParamArray(

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -18,8 +18,7 @@ import * as version from '../../utils/version';
 import attachKeyHandlers from './attachKeyHandlers';
 import {createDevServerMiddleware} from './middleware';
 import {createDevMiddleware} from '@react-native/dev-middleware';
-import Metro from 'metro';
-import {Terminal} from 'metro-core';
+import * as Metro from 'metro';
 import path from 'path';
 import url from 'url';
 import {styleText} from 'util';
@@ -104,7 +103,7 @@ async function runServer(
   }
 
   let reportEvent: (event: TerminalReportableEvent) => void;
-  const terminal = new Terminal(process.stdout);
+  const terminal = new Metro.Terminal(process.stdout);
   const ReporterImpl = getReporterImpl(args.customLogReporterPath);
   const terminalReporter = new ReporterImpl(terminal);
 

--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -9,14 +9,17 @@
  */
 
 import type {Config} from '@react-native-community/cli-types';
-import type {ConfigT, InputConfigT, YargArguments} from 'metro-config';
+import type {MetroConfig} from 'metro';
 
 import {CLIError} from './errors';
 import {reactNativePlatformResolver} from './metroPlatformResolver';
-import {loadConfig, resolveConfig} from 'metro-config';
+import {loadConfig, resolveConfig} from 'metro';
 import path from 'path';
 
 const debug = require('debug')('ReactNative:CommunityCliPlugin');
+
+type HydratedMetroConfig = Awaited<ReturnType<typeof loadConfig>>;
+type ArgvInput = Parameters<typeof loadConfig>[0];
 
 export type {Config};
 
@@ -32,12 +35,12 @@ export type ConfigLoadingContext = Readonly<{
  */
 function getCommunityCliDefaultConfig(
   ctx: ConfigLoadingContext,
-  config: ConfigT,
-): InputConfigT {
+  config: HydratedMetroConfig,
+): MetroConfig {
   const outOfTreePlatforms = Object.keys(ctx.platforms).filter(
     platform => ctx.platforms[platform].npmPackageName,
   );
-  const resolver: Partial<{...ConfigT['resolver']}> = {
+  const resolver: Partial<{...HydratedMetroConfig['resolver']}> = {
     platforms: [...Object.keys(ctx.platforms), 'native'],
   };
 
@@ -83,8 +86,8 @@ function getCommunityCliDefaultConfig(
  */
 export default async function loadMetroConfig(
   ctx: ConfigLoadingContext,
-  options: YargArguments = {},
-): Promise<ConfigT> {
+  options: NonNullable<ArgvInput> = {},
+): Promise<HydratedMetroConfig> {
   let RNMetroConfig = null;
   try {
     RNMetroConfig = require('@react-native/metro-config');

--- a/private/react-native-fantom/runner/global-setup/globalSetup.js
+++ b/private/react-native-fantom/runner/global-setup/globalSetup.js
@@ -16,7 +16,7 @@ import {getTestBuildOutputPath} from '../paths';
 import build from './build';
 import {createDevMiddleware} from '@react-native/dev-middleware';
 import connect from 'connect';
-import Metro from 'metro';
+import * as Metro from 'metro';
 import {Server} from 'net';
 import path from 'path';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6726,7 +6726,7 @@ metro-config@0.85.0, metro-config@^0.85.0:
     metro-runtime "0.85.0"
     yaml "^2.6.1"
 
-metro-core@0.85.0, metro-core@^0.85.0:
+metro-core@0.85.0:
   version "0.85.0"
   resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.85.0.tgz#5283b5f64078eea8bf7520c64fccad697390c096"
   integrity sha512-AHpD2RVtW44iTswxR79R3EIq/seKgdBBtOoQxlDnSf9z9YHBJZyqTNpT4PHHWSvmIeuo1xZ9B7OgdtV6dTOBXA==


### PR DESCRIPTION
Summary:

Refactor Metro imports to:
 - Remove use of deprecated default object export, prefer named/namespace exports.
 - Prefer imports from `metro`, remove public dependencies on `metro-core` and `metro-config` from `react-native/community-cli-plugin`.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D110177050


