### PR TITLE
Improve generated API doc comments (match baseline) (#57380)

### DIFF
--- a/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -38,6 +38,10 @@ export type ShareActionSheetIOSOptions = Readonly<{
   tintColor?: ?number,
   cancelButtonTintColor?: ?number,
   disabledButtonTintColor?: ?number,
+  /**
+   * The activities to exclude from the ActionSheet.
+   * For example: ['com.apple.UIKit.activity.PostToTwitter']
+   */
   excludedActivityTypes?: ?Array<string>,
   userInterfaceStyle?: ?string,
 }>;

--- a/packages/react-native/Libraries/Alert/Alert.js
+++ b/packages/react-native/Libraries/Alert/Alert.js
@@ -57,6 +57,33 @@ export type AlertOptions = {
  * alerts. On iOS, you can show an alert that prompts the user to enter
  * some information.
  *
+ * ## iOS
+ *
+ * On iOS you can specify any number of buttons. Each button can optionally
+ * specify a style, which is one of 'default', 'cancel' or 'destructive'.
+ *
+ * ## Android
+ *
+ * On Android at most three buttons can be specified. Android has a concept
+ * of a neutral, negative and a positive button:
+ *
+ *   - If you specify one button, it will be the 'positive' one (such as 'OK')
+ *   - Two buttons mean 'negative', 'positive' (such as 'Cancel', 'OK')
+ *   - Three buttons mean 'neutral', 'negative', 'positive' (such as 'Later', 'Cancel', 'OK')
+ *
+ * ```
+ * // Works on both iOS and Android
+ * Alert.alert(
+ *   'Alert Title',
+ *   'My Alert Msg',
+ *   [
+ *     {text: 'Ask me later', onPress: () => console.log('Ask me later pressed')},
+ *     {text: 'Cancel', onPress: () => console.log('Cancel Pressed'), style: 'cancel'},
+ *     {text: 'OK', onPress: () => console.log('OK Pressed')},
+ *   ]
+ * )
+ * ```
+ *
  * See https://reactnative.dev/docs/alert
  */
 class Alert {

--- a/packages/react-native/Libraries/Animated/AnimatedExports.js
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js
@@ -24,21 +24,43 @@ const Animated: typeof AnimatedImplementation = Platform.isDisableAnimations
   : AnimatedImplementation;
 
 export default {
+  /**
+   * FlatList and SectionList infer generic Type defined under their `data` and `section` props.
+   */
   get FlatList(): AnimatedFlatList<any> {
     return require('./components/AnimatedFlatList').default;
   },
+  /**
+   * Animated variants of the basic native views. Accepts Animated.Value for
+   * props and style.
+   */
   get Image(): AnimatedImage {
     return require('./components/AnimatedImage').default;
   },
+  /**
+   * Animated variants of the basic native views. Accepts Animated.Value for
+   * props and style.
+   */
   get ScrollView(): AnimatedScrollView {
     return require('./components/AnimatedScrollView').default;
   },
+  /**
+   * FlatList and SectionList infer generic Type defined under their `data` and `section` props.
+   */
   get SectionList(): AnimatedSectionList<any, any> {
     return require('./components/AnimatedSectionList').default;
   },
+  /**
+   * Animated variants of the basic native views. Accepts Animated.Value for
+   * props and style.
+   */
   get Text(): AnimatedText {
     return require('./components/AnimatedText').default;
   },
+  /**
+   * Animated variants of the basic native views. Accepts Animated.Value for
+   * props and style.
+   */
   get View(): AnimatedView {
     return require('./components/AnimatedView').default;
   },

--- a/packages/react-native/Libraries/Animated/AnimatedImplementation.js
+++ b/packages/react-native/Libraries/Animated/AnimatedImplementation.js
@@ -40,8 +40,29 @@ import AnimatedValue from './nodes/AnimatedValue';
 import AnimatedValueXY from './nodes/AnimatedValueXY';
 
 export type CompositeAnimation = {
+  /**
+   * Animations are started by calling start() on your animation.
+   * start() takes a completion callback that will be called when the
+   * animation is done or when the animation is done because stop() was
+   * called on it before it could finish.
+   *
+   * @param callback - Optional function that will be called
+   *      after the animation finished running normally or when the animation
+   *      is done because stop() was called on it before it could finish
+   *
+   * @example
+   *   Animated.timing({}).start(({ finished }) => {
+   *    // completion callback
+   *   });
+   */
   start: (callback?: ?EndCallback, isLooping?: boolean) => void,
+  /**
+   * Stops any running animation.
+   */
   stop: () => void,
+  /**
+   * Stops any running animation and resets the value to its original.
+   */
   reset: () => void,
   _startNativeLoop: (iterations?: number) => void,
   _isUsingNativeDriver: () => boolean,
@@ -621,21 +642,104 @@ export default {
    * See https://reactnative.dev/docs/animated#node
    */
   Node: AnimatedNode,
+  /**
+   * Animates a value from an initial velocity to zero based on a decay
+   * coefficient.
+   */
   decay: decayImpl,
+  /**
+   * Animates a value along a timed easing curve.  The `Easing` module has tons
+   * of pre-defined curves, or you can use your own function.
+   */
   timing: timingImpl,
+  /**
+   * Spring animation based on Rebound and Origami.  Tracks velocity state to
+   * create fluid motions as the `toValue` updates, and can be chained together.
+   */
   spring: springImpl,
+  /**
+   * Creates a new Animated value composed from two Animated values added
+   * together.
+   */
   add: addImpl,
+  /**
+   * Creates a new Animated value composed by subtracting the second Animated
+   * value from the first Animated value.
+   */
   subtract: subtractImpl,
+  /**
+   * Creates a new Animated value composed by dividing the first Animated
+   * value by the second Animated value.
+   */
   divide: divideImpl,
+  /**
+   * Creates a new Animated value composed from two Animated values multiplied
+   * together.
+   */
   multiply: multiplyImpl,
+  /**
+   * Creates a new Animated value that is the (non-negative) modulo of the
+   * provided Animated value
+   */
   modulo: moduloImpl,
+  /**
+   * Create a new Animated value that is limited between 2 values. It uses the
+   * difference between the last value so even if the value is far from the bounds
+   * it will start changing when the value starts getting closer again.
+   * (`value = clamp(value + diff, min, max)`).
+   *
+   * This is useful with scroll events, for example, to show the navbar when
+   * scrolling up and to hide it when scrolling down.
+   */
   diffClamp: diffClampImpl,
+  /**
+   * Starts an animation after the given delay.
+   */
   delay: delayImpl,
+  /**
+   * Starts an array of animations in order, waiting for each to complete
+   * before starting the next.  If the current running animation is stopped, no
+   * following animations will be started.
+   */
   sequence: sequenceImpl,
+  /**
+   * Starts an array of animations all at the same time.  By default, if one
+   * of the animations is stopped, they will all be stopped.  You can override
+   * this with the `stopTogether` flag.
+   */
   parallel: parallelImpl,
+  /**
+   * Array of animations may run in parallel (overlap), but are started in
+   * sequence with successive delays.  Nice for doing trailing effects.
+   */
   stagger: staggerImpl,
+  /**
+   * Loops a given animation continuously, so that each time it reaches the end,
+   * it resets and begins again from the start. Can specify number of times to
+   * loop using the key 'iterations' in the config. Will loop without blocking
+   * the UI thread if the child animation is set to 'useNativeDriver'.
+   */
   loop: loopImpl,
+  /**
+   *  Takes an array of mappings and extracts values from each arg accordingly,
+   *  then calls `setValue` on the mapped outputs.  e.g.
+   *
+   *```javascript
+   *  onScroll={Animated.event(
+   *    [{nativeEvent: {contentOffset: {x: this._scrollX}}}]
+   *    {listener},          // Optional async listener
+   *  )
+   *  ...
+   *  onPanResponderMove: Animated.event([
+   *    null,                // raw event arg ignored
+   *    {dx: this._panX},    // gestureState arg
+   *  ]),
+   *```
+   */
   event: eventImpl,
+  /**
+   * Make any React component Animatable.  Used to create `Animated.View`, etc.
+   */
   createAnimatedComponent,
   attachNativeEvent: attachNativeEventImpl,
   forkEvent: forkEventImpl,

--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -180,6 +180,13 @@ function updateErrorWithErrorData(
   return Object.assign(error, errorData || {});
 }
 
+/**
+ * Native Modules written in ObjectiveC/Swift/Java exposed via the RCTBridge
+ * Define lazy getters for each module. These will return the module if already loaded, or load it if not.
+ * See https://reactnative.dev/docs/native-modules-ios
+ * @example
+ * const MyModule = NativeModules.ModuleName
+ */
 /* $FlowFixMe[unclear-type] unclear type of NativeModules */
 let NativeModules: {[moduleName: string]: any, ...} = {};
 if (global.nativeModuleProxy) {

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+
 import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {ViewProps} from '../View/ViewPropTypes';
 
@@ -30,39 +31,75 @@ type IndicatorSize = number | 'small' | 'large';
 
 type ActivityIndicatorIOSProps = Readonly<{
   /**
-    Whether the indicator should hide when not animating.
-
-    @platform ios
-  */
+   * Whether the indicator should hide when not animating.
+   *
+   * @platform ios
+   */
   hidesWhenStopped?: ?boolean,
 }>;
+
 /** @build-types emit-as-interface Uniwind compatibility */
 export type ActivityIndicatorProps = Readonly<{
   ...ViewProps,
   ...ActivityIndicatorIOSProps,
 
   /**
-   	Whether to show the indicator (`true`) or hide it (`false`).
+   * Whether to show the indicator (`true`) or hide it (`false`).
    */
   animating?: ?boolean,
 
   /**
-    The foreground color of the spinner.
-
-    @default {@platform android} `null` (system accent default color)
-    @default {@platform ios} '#999999'
-  */
+   * The foreground color of the spinner.
+   *
+   * @default {@platform android} `null` (system accent default color)
+   * @default {@platform ios} '#999999'
+   */
   color?: ?ColorValue,
 
   /**
-    Size of the indicator.
-
-    @type enum(`'small'`, `'large'`)
-    @type {@platform android} number
-  */
+   * Size of the indicator.
+   *
+   * Small has a height of 20, large has a height of 36.
+   *
+   * @type enum(`'small'`, `'large'`)
+   * @type {@platform android} number
+   */
   size?: ?IndicatorSize,
 }>;
 
+/**
+ * Displays a circular loading indicator.
+ *
+ * Example:
+ *
+ * ```js
+ * import React from 'react';
+ * import {ActivityIndicator, StyleSheet, View} from 'react-native';
+ *
+ * const App = () => (
+ *   <View style={[styles.container, styles.horizontal]}>
+ *     <ActivityIndicator />
+ *     <ActivityIndicator size="large" />
+ *     <ActivityIndicator size="small" color="#0000ff" />
+ *     <ActivityIndicator size="large" color="#00ff00" />
+ *   </View>
+ * );
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     justifyContent: 'center',
+ *   },
+ *   horizontal: {
+ *     flexDirection: 'row',
+ *     justifyContent: 'space-around',
+ *     padding: 10,
+ *   },
+ * });
+ *
+ * export default App;
+ * ```
+ */
 const ActivityIndicator: component(
   ref?: React.RefSetter<ActivityIndicatorInstance>,
   ...props: ActivityIndicatorProps
@@ -128,38 +165,6 @@ const ActivityIndicator: component(
     </View>
   );
 };
-
-/**
-  Displays a circular loading indicator.
-
-  ```SnackPlayer name=ActivityIndicator%20Example
-  import React from 'react';
-  import {ActivityIndicator, StyleSheet, View} from 'react-native';
-
-  const App = () => (
-    <View style={[styles.container, styles.horizontal]}>
-      <ActivityIndicator />
-      <ActivityIndicator size="large" />
-      <ActivityIndicator size="small" color="#0000ff" />
-      <ActivityIndicator size="large" color="#00ff00" />
-    </View>
-  );
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      justifyContent: 'center',
-    },
-    horizontal: {
-      flexDirection: 'row',
-      justifyContent: 'space-around',
-      padding: 10,
-    },
-  });
-
-  export default App;
-```
-*/
 
 ActivityIndicator.displayName = 'ActivityIndicator';
 

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -30,101 +30,101 @@ import * as React from 'react';
 /** @build-types emit-as-interface Uniwind compatibility */
 export type ButtonProps = Readonly<{
   /**
-    Text to display inside the button. On Android the given title will be
-    converted to the uppercased form.
+   * Text to display inside the button. On Android the given title will be
+   * converted to the uppercased form.
    */
   title: string,
 
   /**
-    Handler to be called when the user taps the button. The first function
-    argument is an event in form of [GestureResponderEvent](pressevent).
+   * Handler to be called when the user taps the button. The first function
+   * argument is an event in form of [GestureResponderEvent](pressevent).
    */
   onPress?: (event?: GestureResponderEvent) => unknown,
 
   /**
-    If `true`, doesn't play system sound on touch.
-
-    @platform android
-
-    @default false
+   * If `true`, doesn't play system sound on touch.
+   *
+   * @platform android
+   *
+   * @default false
    */
   touchSoundDisabled?: ?boolean,
 
   /**
-    Color of the text (iOS), or background color of the button (Android).
-
-    @default {@platform android} '#2196F3'
-    @default {@platform ios} '#007AFF'
+   * Color of the text (iOS), or background color of the button (Android).
+   *
+   * @default {@platform android} '#2196F3'
+   * @default {@platform ios} '#007AFF'
    */
   color?: ?ColorValue,
 
   /**
-    TV preferred focus.
-
-    @platform tv
-
-    @default false
-    @deprecated Use `focusable` instead
+   * TV preferred focus.
+   *
+   * @platform tv
+   *
+   * @default false
+   * @deprecated Use `focusable` instead
    */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-    Designates the next view to receive focus when the user navigates down. See
-    the [Android documentation][android:nextFocusDown].
-
-    [android:nextFocusDown]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates down. See
+   * the [Android documentation][android:nextFocusDown].
+   *
+   * [android:nextFocusDown]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
+   *
+   * @platform android, tv
    */
   nextFocusDown?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates forward.
-    See the [Android documentation][android:nextFocusForward].
-
-    [android:nextFocusForward]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates forward.
+   * See the [Android documentation][android:nextFocusForward].
+   *
+   * [android:nextFocusForward]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
+   *
+   * @platform android, tv
    */
   nextFocusForward?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates left. See
-    the [Android documentation][android:nextFocusLeft].
-
-    [android:nextFocusLeft]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates left. See
+   * the [Android documentation][android:nextFocusLeft].
+   *
+   * [android:nextFocusLeft]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
+   *
+   * @platform android, tv
    */
   nextFocusLeft?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates right. See
-    the [Android documentation][android:nextFocusRight].
-
-    [android:nextFocusRight]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates right. See
+   * the [Android documentation][android:nextFocusRight].
+   *
+   * [android:nextFocusRight]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
+   *
+   * @platform android, tv
    */
   nextFocusRight?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates up. See
-    the [Android documentation][android:nextFocusUp].
-
-    [android:nextFocusUp]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates up. See
+   * the [Android documentation][android:nextFocusUp].
+   *
+   * [android:nextFocusUp]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
+   *
+   * @platform android, tv
    */
   nextFocusUp?: ?number,
 
   /**
-    Text to display for blindness accessibility features.
+   * Text to display for blindness accessibility features.
    */
   accessibilityLabel?: ?string,
   /**
@@ -133,14 +133,14 @@ export type ButtonProps = Readonly<{
    */
   'aria-label'?: ?string,
   /**
-    If `true`, disable all interactions for this component.
-
-    @default false
+   * If `true`, disable all interactions for this component.
+   *
+   * @default false
    */
   disabled?: ?boolean,
 
   /**
-    Used to locate this view in end-to-end tests.
+   * Used to locate this view in end-to-end tests.
    */
   testID?: ?string,
 
@@ -171,114 +171,6 @@ export type ButtonProps = Readonly<{
   accessibilityLanguage?: ?Stringish,
 }>;
 
-/**
-  A basic button component that should render nicely on any platform. Supports a
-  minimal level of customization.
-
-  If this button doesn't look right for your app, you can build your own button
-  using [TouchableOpacity](touchableopacity) or
-  [TouchableWithoutFeedback](touchablewithoutfeedback). For inspiration, look at
-  the [source code for this button component][button:source]. Or, take a look at
-  the [wide variety of button components built by the community]
-  [button:examples].
-
-  [button:source]:
-  https://github.com/facebook/react-native/blob/HEAD/Libraries/Components/Button.js
-
-  ```jsx
-  <Button
-    onPress={onPressLearnMore}
-    title="Learn More"
-    color="#841584"
-    accessibilityLabel="Learn more about this purple button"
-  />
-  ```
-
-  ```SnackPlayer name=Button%20Example
-  import React from 'react';
-  import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
-
-  const Separator = () => (
-    <View style={styles.separator} />
-  );
-
-  const App = () => (
-    <SafeAreaView style={styles.container}>
-      <View>
-        <Text style={styles.title}>
-          The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
-        </Text>
-        <Button
-          title="Press me"
-          onPress={() => Alert.alert('Simple Button pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
-        </Text>
-        <Button
-          title="Press me"
-          color="#f194ff"
-          onPress={() => Alert.alert('Button with adjusted color pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          All interaction for the component are disabled.
-        </Text>
-        <Button
-          title="Press me"
-          disabled
-          onPress={() => Alert.alert('Cannot press this one')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          This layout strategy lets the title define the width of the button.
-        </Text>
-        <View style={styles.fixToText}>
-          <Button
-            title="Left button"
-            onPress={() => Alert.alert('Left button pressed')}
-          />
-          <Button
-            title="Right button"
-            onPress={() => Alert.alert('Right button pressed')}
-          />
-        </View>
-      </View>
-    </SafeAreaView>
-  );
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      justifyContent: 'center',
-      marginHorizontal: 16,
-    },
-    title: {
-      textAlign: 'center',
-      marginVertical: 8,
-    },
-    fixToText: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-    },
-    separator: {
-      marginVertical: 8,
-      borderBottomColor: '#737373',
-      borderBottomWidth: StyleSheet.hairlineWidth,
-    },
-  });
-
-  export default App;
-  ```
- */
-
 const NativeTouchable:
   | typeof TouchableNativeFeedback
   | typeof TouchableOpacity =
@@ -286,6 +178,113 @@ const NativeTouchable:
 
 export type ButtonInstance = React.ElementRef<typeof NativeTouchable>;
 
+/**
+ * A basic button component that should render nicely on any platform. Supports a
+ * minimal level of customization.
+ *
+ * If this button doesn't look right for your app, you can build your own button
+ * using [TouchableOpacity](touchableopacity) or
+ * [TouchableWithoutFeedback](touchablewithoutfeedback). For inspiration, look at
+ * the [source code for this button component][button:source]. Or, take a look at
+ * the [wide variety of button components built by the community]
+ * [button:examples].
+ *
+ * [button:source]:
+ * https://github.com/facebook/react-native/blob/HEAD/Libraries/Components/Button.js
+ *
+ * ```jsx
+ * <Button
+ *   onPress={onPressLearnMore}
+ *   title="Learn More"
+ *   color="#841584"
+ *   accessibilityLabel="Learn more about this purple button"
+ * />
+ * ```
+ *
+ * ```
+ * import React from 'react';
+ * import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
+ *
+ * const Separator = () => (
+ *   <View style={styles.separator} />
+ * );
+ *
+ * const App = () => (
+ *   <SafeAreaView style={styles.container}>
+ *     <View>
+ *       <Text style={styles.title}>
+ *         The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
+ *       </Text>
+ *       <Button
+ *         title="Press me"
+ *         onPress={() => Alert.alert('Simple Button pressed')}
+ *       />
+ *     </View>
+ *     <Separator />
+ *     <View>
+ *       <Text style={styles.title}>
+ *         Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
+ *       </Text>
+ *       <Button
+ *         title="Press me"
+ *         color="#f194ff"
+ *         onPress={() => Alert.alert('Button with adjusted color pressed')}
+ *       />
+ *     </View>
+ *     <Separator />
+ *     <View>
+ *       <Text style={styles.title}>
+ *         All interaction for the component are disabled.
+ *       </Text>
+ *       <Button
+ *         title="Press me"
+ *         disabled
+ *         onPress={() => Alert.alert('Cannot press this one')}
+ *       />
+ *     </View>
+ *     <Separator />
+ *     <View>
+ *       <Text style={styles.title}>
+ *         This layout strategy lets the title define the width of the button.
+ *       </Text>
+ *       <View style={styles.fixToText}>
+ *         <Button
+ *           title="Left button"
+ *           onPress={() => Alert.alert('Left button pressed')}
+ *         />
+ *         <Button
+ *           title="Right button"
+ *           onPress={() => Alert.alert('Right button pressed')}
+ *         />
+ *       </View>
+ *     </View>
+ *   </SafeAreaView>
+ * );
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     justifyContent: 'center',
+ *     marginHorizontal: 16,
+ *   },
+ *   title: {
+ *     textAlign: 'center',
+ *     marginVertical: 8,
+ *   },
+ *   fixToText: {
+ *     flexDirection: 'row',
+ *     justifyContent: 'space-between',
+ *   },
+ *   separator: {
+ *     marginVertical: 8,
+ *     borderBottomColor: '#737373',
+ *     borderBottomWidth: StyleSheet.hairlineWidth,
+ *   },
+ * });
+ *
+ * export default App;
+ * ```
+ */
 const Button: component(
   ref?: React.RefSetter<ButtonInstance>,
   ...props: ButtonProps

--- a/packages/react-native/Libraries/Components/Clipboard/Clipboard.js
+++ b/packages/react-native/Libraries/Components/Clipboard/Clipboard.js
@@ -12,6 +12,11 @@ import NativeClipboard from './NativeClipboard';
 
 /**
  * `Clipboard` gives you an interface for setting and getting content from Clipboard on both iOS and Android
+ *
+ * Clipboard has been extracted from react-native core and will be removed in a future release.
+ * It can now be installed and imported from `@react-native-clipboard/clipboard` instead of 'react-native'.
+ * @see https://github.com/react-native-clipboard/clipboard
+ * @deprecated
  */
 export default {
   /**

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -42,7 +42,13 @@ type BaseKeyboardEvent = {
 
 export type AndroidKeyboardEvent = Readonly<{
   ...BaseKeyboardEvent,
+  /**
+   * Always set to 0 on Android.
+   */
   duration: 0,
+  /**
+   * Always set to "keyboard" on Android.
+   */
   easing: 'keyboard',
 }>;
 
@@ -60,48 +66,6 @@ type KeyboardEventDefinitions = {
   keyboardWillChangeFrame: [KeyboardEvent],
   keyboardDidChangeFrame: [KeyboardEvent],
 };
-
-/**
- * `Keyboard` module to control keyboard events.
- *
- * ### Usage
- *
- * The Keyboard module allows you to listen for native events and react to them, as
- * well as make changes to the keyboard, like dismissing it.
- *
- *```
- * import React, { Component } from 'react';
- * import { Keyboard, TextInput } from 'react-native';
- *
- * class Example extends Component {
- *   componentWillMount () {
- *     this.keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', this._keyboardDidShow);
- *     this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', this._keyboardDidHide);
- *   }
- *
- *   componentWillUnmount () {
- *     this.keyboardDidShowListener.remove();
- *     this.keyboardDidHideListener.remove();
- *   }
- *
- *   _keyboardDidShow () {
- *     alert('Keyboard Shown');
- *   }
- *
- *   _keyboardDidHide () {
- *     alert('Keyboard Hidden');
- *   }
- *
- *   render() {
- *     return (
- *       <TextInput
- *         onSubmitEditing={Keyboard.dismiss}
- *       />
- *     );
- *   }
- * }
- *```
- */
 
 class KeyboardImpl {
   _currentlyShowing: ?KeyboardEvent;
@@ -204,6 +168,47 @@ class KeyboardImpl {
   }
 }
 
+/**
+ * `Keyboard` module to control keyboard events.
+ *
+ * ### Usage
+ *
+ * The Keyboard module allows you to listen for native events and react to them, as
+ * well as make changes to the keyboard, like dismissing it.
+ *
+ *```
+ * import React, { Component } from 'react';
+ * import { Keyboard, TextInput } from 'react-native';
+ *
+ * class Example extends Component {
+ *   componentWillMount () {
+ *     this.keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', this._keyboardDidShow);
+ *     this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', this._keyboardDidHide);
+ *   }
+ *
+ *   componentWillUnmount () {
+ *     this.keyboardDidShowListener.remove();
+ *     this.keyboardDidHideListener.remove();
+ *   }
+ *
+ *   _keyboardDidShow () {
+ *     alert('Keyboard Shown');
+ *   }
+ *
+ *   _keyboardDidHide () {
+ *     alert('Keyboard Hidden');
+ *   }
+ *
+ *   render() {
+ *     return (
+ *       <TextInput
+ *         onSubmitEditing={Keyboard.dismiss}
+ *       />
+ *     );
+ *   }
+ * }
+ *```
+ */
 const Keyboard: KeyboardImpl = new KeyboardImpl();
 
 export default Keyboard;

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -51,11 +51,13 @@ type PressableBaseProps = Readonly<{
 
   /**
    * Duration to wait after hover in before calling `onHoverIn`.
+   * @platform macos windows
    */
   delayHoverIn?: ?number,
 
   /**
    * Duration to wait after hover out before calling `onHoverOut`.
+   * @platform macos windows
    */
   delayHoverOut?: ?number,
 

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js
@@ -20,10 +20,23 @@ import type {ViewProps} from '../View/ViewPropTypes';
 type DeterminateProgressBarAndroidStyleAttrProp = {
   styleAttr: 'Horizontal',
   indeterminate: false,
+  /**
+   * The progress value (between 0 and 1).
+   */
   progress: number,
 };
 
 type IndeterminateProgressBarAndroidStyleAttrProp = {
+  /**
+   * Style of the ProgressBar. One of:
+   *     Horizontal
+   *     Normal (default)
+   *     Small
+   *     Large
+   *     Inverse
+   *     SmallInverse
+   *     LargeInverse
+   */
   styleAttr:
     | 'Horizontal'
     | 'Normal'
@@ -32,6 +45,10 @@ type IndeterminateProgressBarAndroidStyleAttrProp = {
     | 'Inverse'
     | 'SmallInverse'
     | 'LargeInverse',
+  /**
+   * If the progress bar will show indeterminate progress.
+   * Note that this can only be false if styleAttr is Horizontal.
+   */
   indeterminate: true,
 };
 

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -135,17 +135,48 @@ export interface ScrollViewScrollToOptions {
 
 // Public methods for ScrollView
 export interface ScrollViewImperativeMethods {
+  /**
+   * Returns a reference to the underlying scroll responder, which supports
+   * operations like `scrollTo`. All ScrollView-like components should
+   * implement this method so that they can be composed while providing access
+   * to the underlying scroll responder's methods.
+   */
   readonly getScrollResponder: () => ScrollResponderType;
   readonly getScrollableNode: () => ?number;
   readonly getInnerViewNode: () => ?number;
   readonly getInnerViewRef: () => InnerViewInstance | null;
+  /**
+   * Returns a reference to the underlying native scroll view, or null if the
+   * native instance is not mounted.
+   */
   readonly getNativeScrollRef: () => ScrollViewInstance | null;
+  /**
+   * Scrolls to a given x, y offset, either immediately or with a smooth animation.
+   * Syntax:
+   *
+   * scrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})
+   *
+   * Note: The weird argument signature is due to the fact that, for historical reasons,
+   * the function also accepts separate arguments as an alternative to the options object.
+   * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
+   */
   readonly scrollTo: (
     options?: ScrollViewScrollToOptions | number,
     deprecatedX?: number,
     deprecatedAnimated?: boolean,
   ) => void;
+  /**
+   * A helper function that scrolls to the end of the scrollview;
+   * If this is a vertical ScrollView, it scrolls to the bottom.
+   * If this is a horizontal ScrollView scrolls to the right.
+   *
+   * The options object has an animated prop, that enables the scrolling animation or not.
+   * The animated prop defaults to true
+   */
   readonly scrollToEnd: (options?: ?ScrollViewScrollToOptions) => void;
+  /**
+   * Displays the scroll indicators momentarily.
+   */
   readonly flashScrollIndicators: () => void;
   readonly scrollResponderZoomTo: (
     rect: {

--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
@@ -18,6 +18,18 @@ import useWindowDimensions from '../../Utilities/useWindowDimensions';
 import RCTInputAccessoryViewNativeComponent from './RCTInputAccessoryViewNativeComponent';
 import * as React from 'react';
 
+/** @build-types emit-as-interface Expo compatibility */
+export type InputAccessoryViewProps = Readonly<{
+  readonly children: React.Node,
+  /**
+   * An ID which is used to associate this `InputAccessoryView` to
+   * specified TextInput(s).
+   */
+  nativeID?: ?string,
+  style?: ?ViewStyleProp,
+  backgroundColor?: ?ColorValue,
+}>;
+
 /**
  * Note: iOS only
  *
@@ -75,19 +87,6 @@ import * as React from 'react';
  * TextInput with the InputAccessoryView component, and don't set a nativeID.
  * For an example, look at InputAccessoryViewExample.js in RNTester.
  */
-
-/** @build-types emit-as-interface Expo compatibility */
-export type InputAccessoryViewProps = Readonly<{
-  readonly children: React.Node,
-  /**
-   * An ID which is used to associate this `InputAccessoryView` to
-   * specified TextInput(s).
-   */
-  nativeID?: ?string,
-  style?: ?ViewStyleProp,
-  backgroundColor?: ?ColorValue,
-}>;
-
 const InputAccessoryView: React.ComponentType<InputAccessoryViewProps> = (
   props: InputAccessoryViewProps,
 ) => {

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -1069,9 +1069,18 @@ export type TextInputProps = Readonly<{
  * It isn't technically a class but this is the most elegant way to type it.
  */
 declare class _TextInputInstance extends ReactNativeElement {
+  /**
+   * Removes all text from the input.
+   */
   clear(): void;
+  /**
+   * Returns if the input is currently focused.
+   */
   isFocused(): boolean;
   getNativeRef(): ?ReactNativeElement;
+  /**
+   * Sets the start and end positions of text selection.
+   */
   setSelection(start: number, end: number): void;
 }
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -244,117 +244,6 @@ function useTextInputStateSynchronization({
   return {setLastNativeSelection, setLastNativeText};
 }
 
-/**
- * A foundational component for inputting text into the app via a
- * keyboard. Props provide configurability for several features, such as
- * auto-correction, auto-capitalization, placeholder text, and different keyboard
- * types, such as a numeric keypad.
- *
- * The simplest use case is to plop down a `TextInput` and subscribe to the
- * `onChangeText` events to read the user input. There are also other events,
- * such as `onSubmitEditing` and `onFocus` that can be subscribed to. A simple
- * example:
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react';
- * import { AppRegistry, TextInput } from 'react-native';
- *
- * export default class UselessTextInput extends Component {
- *   constructor(props) {
- *     super(props);
- *     this.state = { text: 'Useless Placeholder' };
- *   }
- *
- *   render() {
- *     return (
- *       <TextInput
- *         style={{height: 40, borderColor: 'gray', borderWidth: 1}}
- *         onChangeText={(text) => this.setState({text})}
- *         value={this.state.text}
- *       />
- *     );
- *   }
- * }
- *
- * // skip this line if using Create React Native App
- * AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
- * ```
- *
- * Two methods exposed via the native element are .focus() and .blur() that
- * will focus or blur the TextInput programmatically.
- *
- * Note that some props are only available with `multiline={true/false}`.
- * Additionally, border styles that apply to only one side of the element
- * (e.g., `borderBottomColor`, `borderLeftWidth`, etc.) will not be applied if
- * `multiline=false`. To achieve the same effect, you can wrap your `TextInput`
- * in a `View`:
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react';
- * import { AppRegistry, View, TextInput } from 'react-native';
- *
- * class UselessTextInput extends Component {
- *   render() {
- *     return (
- *       <TextInput
- *         {...this.props} // Inherit any props passed to it; e.g., multiline, numberOfLines below
- *         editable={true}
- *         maxLength={40}
- *       />
- *     );
- *   }
- * }
- *
- * export default class UselessTextInputMultiline extends Component {
- *   constructor(props) {
- *     super(props);
- *     this.state = {
- *       text: 'Useless Multiline Placeholder',
- *     };
- *   }
- *
- *   // If you type something in the text box that is a color, the background will change to that
- *   // color.
- *   render() {
- *     return (
- *      <View style={{
- *        backgroundColor: this.state.text,
- *        borderBottomColor: '#000000',
- *        borderBottomWidth: 1 }}
- *      >
- *        <UselessTextInput
- *          multiline={true}
- *          numberOfLines={4}
- *          onChangeText={(text) => this.setState({text})}
- *          value={this.state.text}
- *        />
- *      </View>
- *     );
- *   }
- * }
- *
- * // skip these lines if using Create React Native App
- * AppRegistry.registerComponent(
- *  'AwesomeProject',
- *  () => UselessTextInputMultiline
- * );
- * ```
- *
- * `TextInput` has by default a border at the bottom of its view. This border
- * has its padding set by the background image provided by the system, and it
- * cannot be changed. Solutions to avoid this is to either not set height
- * explicitly, case in which the system will take care of displaying the border
- * in the correct position, or to not display the border by setting
- * `underlineColorAndroid` to transparent.
- *
- * Note that on Android performing text selection in input can change
- * app's activity `windowSoftInputMode` param to `adjustResize`.
- * This may cause issues with components that have position: 'absolute'
- * while keyboard is active. To avoid this behavior either specify `windowSoftInputMode`
- * in AndroidManifest.xml ( https://developer.android.com/guide/topics/manifest/activity-element.html )
- * or control this param programmatically with native code.
- *
- */
 function InternalTextInput(props: TextInputProps): React.Node {
   const {
     'aria-busy': ariaBusy,
@@ -899,6 +788,117 @@ const autoCompleteWebToTextContentTypeMap = {
   username: 'username',
 } as const;
 
+/**
+ * A foundational component for inputting text into the app via a
+ * keyboard. Props provide configurability for several features, such as
+ * auto-correction, auto-capitalization, placeholder text, and different keyboard
+ * types, such as a numeric keypad.
+ *
+ * The simplest use case is to plop down a `TextInput` and subscribe to the
+ * `onChangeText` events to read the user input. There are also other events,
+ * such as `onSubmitEditing` and `onFocus` that can be subscribed to. A simple
+ * example:
+ *
+ * ```ReactNativeWebPlayer
+ * import React, { Component } from 'react';
+ * import { AppRegistry, TextInput } from 'react-native';
+ *
+ * export default class UselessTextInput extends Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = { text: 'Useless Placeholder' };
+ *   }
+ *
+ *   render() {
+ *     return (
+ *       <TextInput
+ *         style={{height: 40, borderColor: 'gray', borderWidth: 1}}
+ *         onChangeText={(text) => this.setState({text})}
+ *         value={this.state.text}
+ *       />
+ *     );
+ *   }
+ * }
+ *
+ * // skip this line if using Create React Native App
+ * AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
+ * ```
+ *
+ * Two methods exposed via the native element are .focus() and .blur() that
+ * will focus or blur the TextInput programmatically.
+ *
+ * Note that some props are only available with `multiline={true/false}`.
+ * Additionally, border styles that apply to only one side of the element
+ * (e.g., `borderBottomColor`, `borderLeftWidth`, etc.) will not be applied if
+ * `multiline=false`. To achieve the same effect, you can wrap your `TextInput`
+ * in a `View`:
+ *
+ * ```ReactNativeWebPlayer
+ * import React, { Component } from 'react';
+ * import { AppRegistry, View, TextInput } from 'react-native';
+ *
+ * class UselessTextInput extends Component {
+ *   render() {
+ *     return (
+ *       <TextInput
+ *         {...this.props} // Inherit any props passed to it; e.g., multiline, numberOfLines below
+ *         editable={true}
+ *         maxLength={40}
+ *       />
+ *     );
+ *   }
+ * }
+ *
+ * export default class UselessTextInputMultiline extends Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = {
+ *       text: 'Useless Multiline Placeholder',
+ *     };
+ *   }
+ *
+ *   // If you type something in the text box that is a color, the background will change to that
+ *   // color.
+ *   render() {
+ *     return (
+ *      <View style={{
+ *        backgroundColor: this.state.text,
+ *        borderBottomColor: '#000000',
+ *        borderBottomWidth: 1 }}
+ *      >
+ *        <UselessTextInput
+ *          multiline={true}
+ *          numberOfLines={4}
+ *          onChangeText={(text) => this.setState({text})}
+ *          value={this.state.text}
+ *        />
+ *      </View>
+ *     );
+ *   }
+ * }
+ *
+ * // skip these lines if using Create React Native App
+ * AppRegistry.registerComponent(
+ *  'AwesomeProject',
+ *  () => UselessTextInputMultiline
+ * );
+ * ```
+ *
+ * `TextInput` has by default a border at the bottom of its view. This border
+ * has its padding set by the background image provided by the system, and it
+ * cannot be changed. Solutions to avoid this is to either not set height
+ * explicitly, case in which the system will take care of displaying the border
+ * in the correct position, or to not display the border by setting
+ * `underlineColorAndroid` to transparent.
+ *
+ * Note that on Android performing text selection in input can change
+ * app's activity `windowSoftInputMode` param to `adjustResize`.
+ * This may cause issues with components that have position: 'absolute'
+ * while keyboard is active. To avoid this behavior either specify `windowSoftInputMode`
+ * in AndroidManifest.xml ( https://developer.android.com/guide/topics/manifest/activity-element.html )
+ * or control this param programmatically with native code.
+ *
+ */
 const TextInput: component(
   ref?: React.RefSetter<TextInputInstance>,
   ...props: React.ElementConfig<typeof InternalTextInput>

--- a/packages/react-native/Libraries/Components/Touchable/Touchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/Touchable.js
@@ -49,91 +49,6 @@ const extractSingleTouch = (nativeEvent: {
 };
 
 /**
- * `Touchable`: Taps done right.
- *
- * You hook your `ResponderEventPlugin` events into `Touchable`. `Touchable`
- * will measure time/geometry and tells you when to give feedback to the user.
- *
- * ====================== Touchable Tutorial ===============================
- * The `Touchable` mixin helps you handle the "press" interaction. It analyzes
- * the geometry of elements, and observes when another responder (scroll view
- * etc) has stolen the touch lock. It notifies your component when it should
- * give feedback to the user. (bouncing/highlighting/unhighlighting).
- *
- * - When a touch was activated (typically you highlight)
- * - When a touch was deactivated (typically you unhighlight)
- * - When a touch was "pressed" - a touch ended while still within the geometry
- *   of the element, and no other element (like scroller) has "stolen" touch
- *   lock ("responder") (Typically you bounce the element).
- *
- * A good tap interaction isn't as simple as you might think. There should be a
- * slight delay before showing a highlight when starting a touch. If a
- * subsequent touch move exceeds the boundary of the element, it should
- * unhighlight, but if that same touch is brought back within the boundary, it
- * should rehighlight again. A touch can move in and out of that boundary
- * several times, each time toggling highlighting, but a "press" is only
- * triggered if that touch ends while within the element's boundary and no
- * scroller (or anything else) has stolen the lock on touches.
- *
- * To create a new type of component that handles interaction using the
- * `Touchable` mixin, do the following:
- *
- * - Initialize the `Touchable` state.
- *
- *   getInitialState: function() {
- *     return merge(this.touchableGetInitialState(), yourComponentState);
- *   }
- *
- * - Choose the rendered component who's touches should start the interactive
- *   sequence. On that rendered node, forward all `Touchable` responder
- *   handlers. You can choose any rendered node you like. Choose a node whose
- *   hit target you'd like to instigate the interaction sequence:
- *
- *   // In render function:
- *   return (
- *     <View
- *       onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
- *       onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
- *       onResponderGrant={this.touchableHandleResponderGrant}
- *       onResponderMove={this.touchableHandleResponderMove}
- *       onResponderRelease={this.touchableHandleResponderRelease}
- *       onResponderTerminate={this.touchableHandleResponderTerminate}>
- *       <View>
- *         Even though the hit detection/interactions are triggered by the
- *         wrapping (typically larger) node, we usually end up implementing
- *         custom logic that highlights this inner one.
- *       </View>
- *     </View>
- *   );
- *
- * - You may set up your own handlers for each of these events, so long as you
- *   also invoke the `touchable*` handlers inside of your custom handler.
- *
- * - Implement the handlers on your component class in order to provide
- *   feedback to the user. See documentation for each of these class methods
- *   that you should implement.
- *
- *   touchableHandlePress: function() {
- *      this.performBounceAnimation();  // or whatever you want to do.
- *   },
- *   touchableHandleActivePressIn: function() {
- *     this.beginHighlighting(...);  // Whatever you like to convey activation
- *   },
- *   touchableHandleActivePressOut: function() {
- *     this.endHighlighting(...);  // Whatever you like to convey deactivation
- *   },
- *
- * - There are more advanced methods you can implement (see documentation below):
- *   touchableGetHighlightDelayMS: function() {
- *     return 20;
- *   }
- *   // In practice, *always* use a predeclared constant (conserve memory).
- *   touchableGetPressRectOffset: function() {
- *     return {top: 20, left: 20, right: 20, bottom: 100};
- *   }
- */
-
-/**
  * Touchable states.
  */
 
@@ -964,6 +879,90 @@ const {
 TouchableMixinImpl.withoutDefaultFocusAndBlur =
   TouchableMixinWithoutDefaultFocusAndBlur;
 
+/**
+ * `Touchable`: Taps done right.
+ *
+ * You hook your `ResponderEventPlugin` events into `Touchable`. `Touchable`
+ * will measure time/geometry and tells you when to give feedback to the user.
+ *
+ * ====================== Touchable Tutorial ===============================
+ * The `Touchable` mixin helps you handle the "press" interaction. It analyzes
+ * the geometry of elements, and observes when another responder (scroll view
+ * etc) has stolen the touch lock. It notifies your component when it should
+ * give feedback to the user. (bouncing/highlighting/unhighlighting).
+ *
+ * - When a touch was activated (typically you highlight)
+ * - When a touch was deactivated (typically you unhighlight)
+ * - When a touch was "pressed" - a touch ended while still within the geometry
+ *   of the element, and no other element (like scroller) has "stolen" touch
+ *   lock ("responder") (Typically you bounce the element).
+ *
+ * A good tap interaction isn't as simple as you might think. There should be a
+ * slight delay before showing a highlight when starting a touch. If a
+ * subsequent touch move exceeds the boundary of the element, it should
+ * unhighlight, but if that same touch is brought back within the boundary, it
+ * should rehighlight again. A touch can move in and out of that boundary
+ * several times, each time toggling highlighting, but a "press" is only
+ * triggered if that touch ends while within the element's boundary and no
+ * scroller (or anything else) has stolen the lock on touches.
+ *
+ * To create a new type of component that handles interaction using the
+ * `Touchable` mixin, do the following:
+ *
+ * - Initialize the `Touchable` state.
+ *
+ *   getInitialState: function() {
+ *     return merge(this.touchableGetInitialState(), yourComponentState);
+ *   }
+ *
+ * - Choose the rendered component who's touches should start the interactive
+ *   sequence. On that rendered node, forward all `Touchable` responder
+ *   handlers. You can choose any rendered node you like. Choose a node whose
+ *   hit target you'd like to instigate the interaction sequence:
+ *
+ *   // In render function:
+ *   return (
+ *     <View
+ *       onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
+ *       onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
+ *       onResponderGrant={this.touchableHandleResponderGrant}
+ *       onResponderMove={this.touchableHandleResponderMove}
+ *       onResponderRelease={this.touchableHandleResponderRelease}
+ *       onResponderTerminate={this.touchableHandleResponderTerminate}>
+ *       <View>
+ *         Even though the hit detection/interactions are triggered by the
+ *         wrapping (typically larger) node, we usually end up implementing
+ *         custom logic that highlights this inner one.
+ *       </View>
+ *     </View>
+ *   );
+ *
+ * - You may set up your own handlers for each of these events, so long as you
+ *   also invoke the `touchable*` handlers inside of your custom handler.
+ *
+ * - Implement the handlers on your component class in order to provide
+ *   feedback to the user. See documentation for each of these class methods
+ *   that you should implement.
+ *
+ *   touchableHandlePress: function() {
+ *      this.performBounceAnimation();  // or whatever you want to do.
+ *   },
+ *   touchableHandleActivePressIn: function() {
+ *     this.beginHighlighting(...);  // Whatever you like to convey activation
+ *   },
+ *   touchableHandleActivePressOut: function() {
+ *     this.endHighlighting(...);  // Whatever you like to convey deactivation
+ *   },
+ *
+ * - There are more advanced methods you can implement (see documentation below):
+ *   touchableGetHighlightDelayMS: function() {
+ *     return 20;
+ *   }
+ *   // In practice, *always* use a predeclared constant (conserve memory).
+ *   touchableGetPressRectOffset: function() {
+ *     return {top: 20, left: 20, right: 20, bottom: 100};
+ *   }
+ */
 const TouchableImpl = {
   Mixin: TouchableMixinImpl,
   /**

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -85,102 +85,6 @@ type TouchableHighlightState = Readonly<{
   extraStyles: ?ExtraStyles,
 }>;
 
-/**
- * A wrapper for making views respond properly to touches.
- * On press down, the opacity of the wrapped view is decreased, which allows
- * the underlay color to show through, darkening or tinting the view.
- *
- * The underlay comes from wrapping the child in a new View, which can affect
- * layout, and sometimes cause unwanted visual artifacts if not used correctly,
- * for example if the backgroundColor of the wrapped view isn't explicitly set
- * to an opaque color.
- *
- * TouchableHighlight must have one child (not zero or more than one).
- * If you wish to have several child components, wrap them in a View.
- *
- * Example:
- *
- * ```
- * renderButton: function() {
- *   return (
- *     <TouchableHighlight onPress={this._onPressButton}>
- *       <Image
- *         style={styles.button}
- *         source={require('./myButton.png')}
- *       />
- *     </TouchableHighlight>
- *   );
- * },
- * ```
- *
- *
- * ### Example
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react'
- * import {
- *   AppRegistry,
- *   StyleSheet,
- *   TouchableHighlight,
- *   Text,
- *   View,
- * } from 'react-native'
- *
- * class App extends Component {
- *   constructor(props) {
- *     super(props)
- *     this.state = { count: 0 }
- *   }
- *
- *   onPress = () => {
- *     this.setState({
- *       count: this.state.count+1
- *     })
- *   }
- *
- *  render() {
- *     return (
- *       <View style={styles.container}>
- *         <TouchableHighlight
- *          style={styles.button}
- *          onPress={this.onPress}
- *         >
- *          <Text> Touch Here </Text>
- *         </TouchableHighlight>
- *         <View style={[styles.countContainer]}>
- *           <Text style={[styles.countText]}>
- *             { this.state.count !== 0 ? this.state.count: null}
- *           </Text>
- *         </View>
- *       </View>
- *     )
- *   }
- * }
- *
- * const styles = StyleSheet.create({
- *   container: {
- *     flex: 1,
- *     justifyContent: 'center',
- *     paddingHorizontal: 10
- *   },
- *   button: {
- *     alignItems: 'center',
- *     backgroundColor: '#DDDDDD',
- *     padding: 10
- *   },
- *   countContainer: {
- *     alignItems: 'center',
- *     padding: 10
- *   },
- *   countText: {
- *     color: '#FF00FF'
- *   }
- * })
- *
- * AppRegistry.registerComponent('App', () => App)
- * ```
- *
- */
 class TouchableHighlightImpl extends React.Component<
   TouchableHighlightProps,
   TouchableHighlightState,
@@ -424,6 +328,104 @@ class TouchableHighlightImpl extends React.Component<
   }
 }
 
+/**
+ * A wrapper for making views respond properly to touches.
+ * On press down, the opacity of the wrapped view is decreased, which allows
+ * the underlay color to show through, darkening or tinting the view.
+ *
+ * The underlay comes from wrapping the child in a new View, which can affect
+ * layout, and sometimes cause unwanted visual artifacts if not used correctly,
+ * for example if the backgroundColor of the wrapped view isn't explicitly set
+ * to an opaque color.
+ *
+ * TouchableHighlight must have one child (not zero or more than one).
+ * If you wish to have several child components, wrap them in a View.
+ *
+ * @see https://reactnative.dev/docs/touchablehighlight
+ *
+ * Example:
+ *
+ * ```
+ * renderButton: function() {
+ *   return (
+ *     <TouchableHighlight onPress={this._onPressButton}>
+ *       <Image
+ *         style={styles.button}
+ *         source={require('./myButton.png')}
+ *       />
+ *     </TouchableHighlight>
+ *   );
+ * },
+ * ```
+ *
+ *
+ * ### Example
+ *
+ * ```ReactNativeWebPlayer
+ * import React, { Component } from 'react'
+ * import {
+ *   AppRegistry,
+ *   StyleSheet,
+ *   TouchableHighlight,
+ *   Text,
+ *   View,
+ * } from 'react-native'
+ *
+ * class App extends Component {
+ *   constructor(props) {
+ *     super(props)
+ *     this.state = { count: 0 }
+ *   }
+ *
+ *   onPress = () => {
+ *     this.setState({
+ *       count: this.state.count+1
+ *     })
+ *   }
+ *
+ *  render() {
+ *     return (
+ *       <View style={styles.container}>
+ *         <TouchableHighlight
+ *          style={styles.button}
+ *          onPress={this.onPress}
+ *         >
+ *          <Text> Touch Here </Text>
+ *         </TouchableHighlight>
+ *         <View style={[styles.countContainer]}>
+ *           <Text style={[styles.countText]}>
+ *             { this.state.count !== 0 ? this.state.count: null}
+ *           </Text>
+ *         </View>
+ *       </View>
+ *     )
+ *   }
+ * }
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     justifyContent: 'center',
+ *     paddingHorizontal: 10
+ *   },
+ *   button: {
+ *     alignItems: 'center',
+ *     backgroundColor: '#DDDDDD',
+ *     padding: 10
+ *   },
+ *   countContainer: {
+ *     alignItems: 'center',
+ *     padding: 10
+ *   },
+ *   countText: {
+ *     color: '#FF00FF'
+ *   }
+ * })
+ *
+ * AppRegistry.registerComponent('App', () => App)
+ * ```
+ *
+ */
 const TouchableHighlight: component(
   ref?: React.RefSetter<TouchableHighlightInstance>,
   ...props: Readonly<Omit<TouchableHighlightProps, 'hostRef'>>

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -98,6 +98,8 @@ type TouchableOpacityState = Readonly<{
  * Opacity is controlled by wrapping the children in an Animated.View, which is
  * added to the view hierarchy.  Be aware that this can affect layout.
  *
+ * @see https://reactnative.dev/docs/touchableopacity
+ *
  * Example:
  *
  * ```

--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -145,12 +145,12 @@ export type AccessibilityActionName =
   /**
    * Generated when a VoiceOver user places focus on or inside the component and double taps with two fingers.
    * @platform ios
-   * */
+   */
   | 'magicTap'
   /**
    * Generated when a VoiceOver user places focus on or inside the component and performs a two finger scrub gesture (left, right, left).
    * @platform ios
-   * */
+   */
   | 'escape';
 
 // the info associated with an accessibility action
@@ -249,9 +249,15 @@ export type AccessibilityPropsAndroid = Readonly<{
   'aria-live'?: ?('polite' | 'assertive' | 'off'),
 
   /**
-   * Controls how view is important for accessibility which is if it
-   * fires accessibility events and if it is reported to accessibility services
-   * that query the screen. Works for Android only.
+   * Controls how view is important for accessibility which is if it fires accessibility events
+   * and if it is reported to accessibility services that query the screen.
+   * Works for Android only. See http://developer.android.com/reference/android/R.attr.html#importantForAccessibility for references.
+   *
+   * Possible values:
+   *      'auto' - The system determines whether the view is important for accessibility - default (recommended).
+   *      'yes' - The view is important for accessibility.
+   *      'no' - The view is not important for accessibility.
+   *      'no-hide-descendants' - The view is not important for accessibility, nor are any of its descendant views.
    *
    * @platform android
    *
@@ -288,6 +294,9 @@ export type AccessibilityPropsIOS = Readonly<{
   accessibilityViewIsModal?: ?boolean,
 
   /**
+   * A Boolean value that indicates whether or not to show the item in the large content viewer.
+   * Available on iOS 13.0+
+   *
    * @platform ios
    *
    * See https://reactnative.dev/docs/view#accessibilityshowslargecontentviewer
@@ -295,6 +304,8 @@ export type AccessibilityPropsIOS = Readonly<{
   accessibilityShowsLargeContentViewer?: ?boolean,
 
   /**
+   * When `accessibilityShowsLargeContentViewer` is set, this string will be used as title for the large content viewer.
+   *
    * @platform ios
    *
    * See https://reactnative.dev/docs/view#accessibilitylargecontenttitle

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -112,8 +112,18 @@ type PointerEventProps = Readonly<{
 }>;
 
 type FocusEventProps = Readonly<{
+  /**
+   * Callback that is called when the view is blurred.
+   *
+   * Note: This will only be called if the view is focusable.
+   */
   onBlur?: ?(event: BlurEvent) => void,
   onBlurCapture?: ?(event: BlurEvent) => void,
+  /**
+   * Callback that is called when the view is focused.
+   *
+   * Note: This will only be called if the view is focusable.
+   */
   onFocus?: ?(event: FocusEvent) => void,
   onFocusCapture?: ?(event: FocusEvent) => void,
 }>;
@@ -371,6 +381,7 @@ export type TVViewPropsIOS = Readonly<{
    * *(Apple TV only)* May be set to true to force the Apple TV focus engine to move focus to this view.
    *
    * @platform ios
+   * @deprecated Use `focusable` instead
    */
   hasTVPreferredFocus?: boolean,
 

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -19,8 +19,22 @@ import Platform from '../Utilities/Platform';
 import RCTDeviceEventEmitter from './RCTDeviceEventEmitter';
 import invariant from 'invariant';
 
+/**
+ * The React Native implementation of the IOS RCTEventEmitter which is required when creating
+ * a module that communicates with IOS
+ */
 interface NativeModule {
+  /**
+   * Add the provided eventType as an active listener
+   * @param eventType name of the event for which we are registering listener
+   */
   addListener(eventType: string): void;
+  /**
+   * Remove a specified number of events.  There are no eventTypes in this case, as
+   * the native side doesn't remove the name, but only manages a counter of total
+   * listeners
+   * @param count number of listeners to remove (of any type)
+   */
   removeListeners(count: number): void;
 }
 
@@ -52,6 +66,10 @@ export default class NativeEventEmitter<
 {
   _nativeModule: ?NativeModule;
 
+  /**
+   * @param nativeModule the NativeModule implementation.  This is required on IOS and will throw
+   *      an invariant error if undefined.
+   */
   constructor(nativeModule?: ?NativeModule) {
     if (Platform.OS === 'ios') {
       invariant(
@@ -83,6 +101,14 @@ export default class NativeEventEmitter<
     }
   }
 
+  /**
+   * Add the specified listener, this call passes through to the NativeModule
+   * addListener
+   *
+   * @param eventType name of the event for which we are registering listener
+   * @param listener the listener function
+   * @param context context of the listener
+   */
   addListener<TEvent extends keyof TEventToArgsMap>(
     eventType: TEvent,
     listener: (...args: TEventToArgsMap[TEvent]) => unknown,
@@ -116,6 +142,9 @@ export default class NativeEventEmitter<
     RCTDeviceEventEmitter.emit(eventType, ...args);
   }
 
+  /**
+   * @param eventType  name of the event whose registered listeners to remove
+   */
   removeAllListeners<TEvent extends keyof TEventToArgsMap>(
     eventType?: ?TEvent,
   ): void {

--- a/packages/react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.js
@@ -11,8 +11,11 @@
 import RCTDeviceEventEmitter from './RCTDeviceEventEmitter';
 
 /**
+ * Receive events from native-code
  * Deprecated - subclass NativeEventEmitter to create granular event modules instead of
  * adding all event listeners directly to RCTNativeAppEventEmitter.
+ * @see https://github.com/facebook/react-native/blob/0.34-stable\Libraries\EventEmitter\RCTNativeAppEventEmitter.js
+ * @see https://reactnative.dev/docs/native-modules-ios#sending-events-to-javascript
  */
 const RCTNativeAppEventEmitter = RCTDeviceEventEmitter;
 export default RCTNativeAppEventEmitter;

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -67,7 +67,9 @@ export type ImagePropsIOS = Readonly<{
    */
   defaultSource?: ?ImageSource,
   /**
-   * Invoked when a partial load of the image is complete.
+   * Invoked when a partial load of the image is complete. The definition of
+   * what constitutes a "partial load" is loader specific though this is meant
+   * for progressive JPEG loads.
    *
    * See https://reactnative.dev/docs/image#onpartialload
    */
@@ -88,6 +90,11 @@ export type ImagePropsAndroid = Readonly<{
    */
   loadingIndicatorSource?: ?(number | Readonly<ImageURISource>),
   progressiveRenderingEnabled?: ?boolean,
+  /**
+   * Duration of fade in animation in ms. Defaults to 300
+   *
+   * @platform android
+   */
   fadeDuration?: ?number,
 
   /**
@@ -176,6 +183,11 @@ export type ImagePropsBase = Readonly<{
   blurRadius?: ?number,
 
   /**
+   * When the image is resized, the corners of the size specified by capInsets will stay a fixed size,
+   * but the center content and borders of the image will be stretched.
+   * This is useful for creating resizable rounded buttons, shadows, and other resizable assets.
+   * More info on Apple documentation
+   *
    * See https://reactnative.dev/docs/image#capinsets
    */
   capInsets?: ?EdgeInsetsProp,

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -25,101 +25,6 @@ const previousCentroidYOfTouchesChangedAfter =
 const currentCentroidX = TouchHistoryMath.currentCentroidX;
 const currentCentroidY = TouchHistoryMath.currentCentroidY;
 
-/**
- * `PanResponder` reconciles several touches into a single gesture. It makes
- * single-touch gestures resilient to extra touches, and can be used to
- * recognize simple multi-touch gestures.
- *
- * It provides a predictable wrapper of the responder handlers provided by the
- * [gesture responder system](docs/gesture-responder-system.html).
- * For each handler, it provides a new `gestureState` object alongside the
- * native event object:
- *
- * ```
- * onPanResponderMove: (event, gestureState) => {}
- * ```
- *
- * A native event is a synthetic touch event with the following form:
- *
- *  - `nativeEvent`
- *      + `changedTouches` - Array of all touch events that have changed since the last event
- *      + `identifier` - The ID of the touch
- *      + `locationX` - The X position of the touch, relative to the element
- *      + `locationY` - The Y position of the touch, relative to the element
- *      + `pageX` - The X position of the touch, relative to the root element
- *      + `pageY` - The Y position of the touch, relative to the root element
- *      + `target` - The node id of the element receiving the touch event
- *      + `timestamp` - A time identifier for the touch, useful for velocity calculation
- *      + `touches` - Array of all current touches on the screen
- *
- * A `gestureState` object has the following:
- *
- *  - `stateID` - ID of the gestureState- persisted as long as there at least
- *     one touch on screen
- *  - `moveX` - the latest screen coordinates of the recently-moved touch
- *  - `moveY` - the latest screen coordinates of the recently-moved touch
- *  - `x0` - the screen coordinates of the responder grant
- *  - `y0` - the screen coordinates of the responder grant
- *  - `dx` - accumulated distance of the gesture since the touch started
- *  - `dy` - accumulated distance of the gesture since the touch started
- *  - `vx` - current velocity of the gesture
- *  - `vy` - current velocity of the gesture
- *  - `numberActiveTouches` - Number of touches currently on screen
- *
- * ### Basic Usage
- *
- * ```
- *   componentWillMount: function() {
- *     this._panResponder = PanResponder.create({
- *       // Ask to be the responder:
- *       onStartShouldSetPanResponder: (evt, gestureState) => true,
- *       onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
- *       onMoveShouldSetPanResponder: (evt, gestureState) => true,
- *       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
- *
- *       onPanResponderGrant: (evt, gestureState) => {
- *         // The gesture has started. Show visual feedback so the user knows
- *         // what is happening!
- *
- *         // gestureState.d{x,y} will be set to zero now
- *       },
- *       onPanResponderMove: (evt, gestureState) => {
- *         // The most recent move distance is gestureState.move{X,Y}
- *
- *         // The accumulated gesture distance since becoming responder is
- *         // gestureState.d{x,y}
- *       },
- *       onPanResponderTerminationRequest: (evt, gestureState) => true,
- *       onPanResponderRelease: (evt, gestureState) => {
- *         // The user has released all touches while this view is the
- *         // responder. This typically means a gesture has succeeded
- *       },
- *       onPanResponderTerminate: (evt, gestureState) => {
- *         // Another component has become the responder, so this gesture
- *         // should be cancelled
- *       },
- *       onShouldBlockNativeResponder: (evt, gestureState) => {
- *         // Returns whether this component should block native components from becoming the JS
- *         // responder. Returns true by default. Is currently only supported on android.
- *         return true;
- *       },
- *     });
- *   },
- *
- *   render: function() {
- *     return (
- *       <View {...this._panResponder.panHandlers} />
- *     );
- *   },
- *
- * ```
- *
- * ### Working Example
- *
- * To see it in action, try the
- * [PanResponder example in RNTester](https://github.com/facebook/react-native/blob/HEAD/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js)
- */
-
 export type PanResponderGestureState = {
   /**
    * ID of the gestureState - persisted as long as there at least one touch on screen
@@ -225,6 +130,100 @@ export type PanResponderCallbacks = Readonly<{
   onShouldBlockNativeResponder?: ?ActiveCallback,
 }>;
 
+/**
+ * `PanResponder` reconciles several touches into a single gesture. It makes
+ * single-touch gestures resilient to extra touches, and can be used to
+ * recognize simple multi-touch gestures.
+ *
+ * It provides a predictable wrapper of the responder handlers provided by the
+ * [gesture responder system](docs/gesture-responder-system.html).
+ * For each handler, it provides a new `gestureState` object alongside the
+ * native event object:
+ *
+ * ```
+ * onPanResponderMove: (event, gestureState) => {}
+ * ```
+ *
+ * A native event is a synthetic touch event with the following form:
+ *
+ *  - `nativeEvent`
+ *      + `changedTouches` - Array of all touch events that have changed since the last event
+ *      + `identifier` - The ID of the touch
+ *      + `locationX` - The X position of the touch, relative to the element
+ *      + `locationY` - The Y position of the touch, relative to the element
+ *      + `pageX` - The X position of the touch, relative to the root element
+ *      + `pageY` - The Y position of the touch, relative to the root element
+ *      + `target` - The node id of the element receiving the touch event
+ *      + `timestamp` - A time identifier for the touch, useful for velocity calculation
+ *      + `touches` - Array of all current touches on the screen
+ *
+ * A `gestureState` object has the following:
+ *
+ *  - `stateID` - ID of the gestureState- persisted as long as there at least
+ *     one touch on screen
+ *  - `moveX` - the latest screen coordinates of the recently-moved touch
+ *  - `moveY` - the latest screen coordinates of the recently-moved touch
+ *  - `x0` - the screen coordinates of the responder grant
+ *  - `y0` - the screen coordinates of the responder grant
+ *  - `dx` - accumulated distance of the gesture since the touch started
+ *  - `dy` - accumulated distance of the gesture since the touch started
+ *  - `vx` - current velocity of the gesture
+ *  - `vy` - current velocity of the gesture
+ *  - `numberActiveTouches` - Number of touches currently on screen
+ *
+ * ### Basic Usage
+ *
+ * ```
+ *   componentWillMount: function() {
+ *     this._panResponder = PanResponder.create({
+ *       // Ask to be the responder:
+ *       onStartShouldSetPanResponder: (evt, gestureState) => true,
+ *       onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
+ *       onMoveShouldSetPanResponder: (evt, gestureState) => true,
+ *       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
+ *
+ *       onPanResponderGrant: (evt, gestureState) => {
+ *         // The gesture has started. Show visual feedback so the user knows
+ *         // what is happening!
+ *
+ *         // gestureState.d{x,y} will be set to zero now
+ *       },
+ *       onPanResponderMove: (evt, gestureState) => {
+ *         // The most recent move distance is gestureState.move{X,Y}
+ *
+ *         // The accumulated gesture distance since becoming responder is
+ *         // gestureState.d{x,y}
+ *       },
+ *       onPanResponderTerminationRequest: (evt, gestureState) => true,
+ *       onPanResponderRelease: (evt, gestureState) => {
+ *         // The user has released all touches while this view is the
+ *         // responder. This typically means a gesture has succeeded
+ *       },
+ *       onPanResponderTerminate: (evt, gestureState) => {
+ *         // Another component has become the responder, so this gesture
+ *         // should be cancelled
+ *       },
+ *       onShouldBlockNativeResponder: (evt, gestureState) => {
+ *         // Returns whether this component should block native components from becoming the JS
+ *         // responder. Returns true by default. Is currently only supported on android.
+ *         return true;
+ *       },
+ *     });
+ *   },
+ *
+ *   render: function() {
+ *     return (
+ *       <View {...this._panResponder.panHandlers} />
+ *     );
+ *   },
+ *
+ * ```
+ *
+ * ### Working Example
+ *
+ * To see it in action, try the
+ * [PanResponder example in RNTester](https://github.com/facebook/react-native/blob/HEAD/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js)
+ */
 const PanResponder = {
   /**
    *

--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -41,6 +41,9 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
 
   /**
    * Try to open the given `url` with any of the installed apps.
+   * You can use other URLs, like a location (e.g. "geo:37.484847,-122.148386"), a contact, or any other URL that can be opened with the installed apps.
+   * NOTE: This method will fail if the system doesn't know how to open the specified URL. If you're passing in a non-http(s) URL, it's best to check {@code canOpenURL} first.
+   * NOTE: For web URLs, the protocol ("http://", "https://") must be set accordingly!
    *
    * See https://reactnative.dev/docs/linking#openurl
    */
@@ -55,6 +58,9 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
 
   /**
    * Determine whether or not an installed app can handle a given URL.
+   * NOTE: For web URLs, the protocol ("http://", "https://") must be set accordingly!
+   * NOTE: As of iOS 9, your app needs to provide the LSApplicationQueriesSchemes key inside Info.plist.
+   * @param URL the URL to open
    *
    * See https://reactnative.dev/docs/linking#canopenurl
    */
@@ -68,7 +74,7 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   }
 
   /**
-   * Open app settings.
+   * Open the Settings app and displays the app’s custom settings, if it has any.
    *
    * See https://reactnative.dev/docs/linking#opensettings
    */
@@ -83,6 +89,7 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   /**
    * If the app launch was triggered by an app link,
    * it will give the link url, otherwise it will give `null`
+   * NOTE: To support deep linking on Android, refer http://developer.android.com/training/app-indexing/deep-linking.html#handling-intents
    *
    * See https://reactnative.dev/docs/linking#getinitialurl
    */
@@ -92,8 +99,9 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
       : nullthrows(NativeLinkingManager).getInitialURL();
   }
 
-  /*
-   * Launch an Android intent with extras (optional)
+  /**
+   * Sends an Android Intent - a broad surface to express Android functions.  Useful for deep-linking to settings pages,
+   * opening an SMS app with a message draft in place, and more.  See https://developer.android.com/reference/kotlin/android/content/Intent?hl=en
    *
    * @platform android
    *

--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -222,6 +222,9 @@ export default class SectionList<
     }
   }
 
+  /**
+   * Provides a handle to the underlying scroll node.
+   */
   getScrollableNode(): any {
     const listRef = this._wrapperListRef && this._wrapperListRef.getListRef();
     if (listRef) {

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -46,6 +46,9 @@ function convertLegacyComponentStack(componentStack: Stack): Stack {
 
 export type {LogData, ExtendedExceptionData, IgnorePattern};
 
+/**
+ * LogBox displays logs in the app.
+ */
 let LogBox;
 
 interface ILogBox {
@@ -60,9 +63,6 @@ interface ILogBox {
   addException(error: ExtendedExceptionData): void;
 }
 
-/**
- * LogBox displays logs in the app.
- */
 if (__DEV__) {
   const LogBoxData = require('./Data/LogBoxData');
   const {

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -47,12 +47,6 @@ const ModalEventEmitter =
       )
     : null;
 
-/**
- * The Modal component is a simple way to present content above an enclosing view.
- *
- * See https://reactnative.dev/docs/modal
- */
-
 // In order to route onDismiss callbacks, we need to uniquely identifier each
 // <Modal> on screen. There can be different ones, either nested or as siblings.
 // We cannot pass the onDismiss callback to native as the view will be
@@ -218,6 +212,11 @@ type ModalState = {
   isRendered: boolean,
 };
 
+/**
+ * The Modal component is a simple way to present content above an enclosing view.
+ *
+ * See https://reactnative.dev/docs/modal
+ */
 class Modal extends React.Component<ModalProps, ModalState> {
   static defaultProps: {hardwareAccelerated: boolean, visible: boolean} = {
     visible: true,

--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -129,13 +129,14 @@ const PERMISSIONS = Object.freeze({
   ACCESS_LOCAL_NETWORK: 'android.permission.ACCESS_LOCAL_NETWORK',
 }) as PermissionsType;
 
-/**
- * `PermissionsAndroid` provides access to Android M's new permissions model.
- *
- * See https://reactnative.dev/docs/permissionsandroid
- */
 class PermissionsAndroidImpl {
+  /**
+   * A list of specified "dangerous" permissions that require prompting the user
+   */
   PERMISSIONS: PermissionsType = PERMISSIONS;
+  /**
+   * A list of permission results that are returned
+   */
   RESULTS: Readonly<{
     DENIED: 'denied',
     GRANTED: 'granted',
@@ -227,6 +228,12 @@ class PermissionsAndroidImpl {
    * Prompts the user to enable a permission and returns a promise resolving to a
    * string value indicating whether the user allowed or denied the request
    *
+   * If the optional rationale argument is included (which is an object with a
+   * title and message), this function checks with the OS whether it is necessary
+   * to show a dialog explaining why the permission is needed
+   * (https://developer.android.com/training/permissions/requesting.html#explain)
+   * and then shows the system permission dialog
+   *
    * See https://reactnative.dev/docs/permissionsandroid#request
    */
   async request(
@@ -300,6 +307,11 @@ class PermissionsAndroidImpl {
   }
 }
 
+/**
+ * `PermissionsAndroid` provides access to Android M's new permissions model.
+ *
+ * See https://reactnative.dev/docs/permissionsandroid
+ */
 const PermissionsAndroidInstance: PermissionsAndroidImpl =
   new PermissionsAndroidImpl();
 export default PermissionsAndroidInstance;

--- a/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -185,6 +185,10 @@ class PushNotificationIOS {
   _remoteNotificationCompleteCallbackCalled: boolean;
   _threadID: string;
 
+  /**
+   * iOS fetch results that best describe the result of a finished remote notification handler.
+   * For a list of possible values, see `PushNotificationIOS.FetchResult`.
+   */
   static FetchResult: FetchResult = {
     NewData: 'UIBackgroundFetchResultNewData',
     NoData: 'UIBackgroundFetchResultNoData',

--- a/packages/react-native/Libraries/ReactNative/AppRegistry.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.js
@@ -10,9 +10,19 @@
 
 import registerCallableModule from '../Core/registerCallableModule';
 /**
- * `AppRegistry` is the JavaScript entry point to running all React Native apps.
+ * `AppRegistry` is the JS entry point to running all React Native apps.  App
+ * root components should register themselves with
+ * `AppRegistry.registerComponent`, then the native system can load the bundle
+ * for the app and then actually run the app when it's ready by invoking
+ * `AppRegistry.runApplication`.
  *
- * See https://reactnative.dev/docs/appregistry
+ * To "stop" an application when a view should be destroyed, call
+ * `AppRegistry.unmountApplicationComponentAtRootTag` with the tag that was
+ * pass into `runApplication`. These should always be used as a pair.
+ *
+ * `AppRegistry` should be `require`d early in the `require` sequence to make
+ * sure the JS execution environment is setup before other modules are
+ * `require`d.
  */
 import * as AppRegistry from './AppRegistryImpl';
 

--- a/packages/react-native/Libraries/ReactNative/UIManager.js
+++ b/packages/react-native/Libraries/ReactNative/UIManager.js
@@ -26,6 +26,25 @@ const UIManagerImpl: UIManagerJSInterface =
 // $FlowFixMe[cannot-spread-interface]
 const UIManager: UIManagerJSInterface = {
   ...UIManagerImpl,
+  /**
+   * Determines the location on screen, width, and height of the given view and
+   * returns the values via an async callback. If successful, the callback will
+   * be called with the following arguments:
+   *
+   *  - x
+   *  - y
+   *  - width
+   *  - height
+   *  - pageX
+   *  - pageY
+   *
+   * Note that these measurements are not available until after the rendering
+   * has been completed in native. If you need the measurements as soon as
+   * possible, consider using the [`onLayout`
+   * prop](docs/view.html#onlayout) instead.
+   *
+   * @deprecated Use `ref.measure` instead.
+   */
   measure(
     reactTag: number,
     callback: (
@@ -54,6 +73,23 @@ const UIManager: UIManagerJSInterface = {
     }
   },
 
+  /**
+   * Determines the location of the given view in the window and returns the
+   * values via an async callback. If the React root view is embedded in
+   * another native view, this will give you the absolute coordinates. If
+   * successful, the callback will be called with the following
+   * arguments:
+   *
+   *  - x
+   *  - y
+   *  - width
+   *  - height
+   *
+   * Note that these measurements are not available until after the rendering
+   * has been completed in native.
+   *
+   * @deprecated Use `ref.measureInWindow` instead.
+   */
   measureInWindow(
     reactTag: number,
     callback: (
@@ -80,6 +116,16 @@ const UIManager: UIManagerJSInterface = {
     }
   },
 
+  /**
+   * Like [`measure()`](#measure), but measures the view relative an ancestor,
+   * specified as `relativeToNativeNode`. This means that the returned x, y
+   * are relative to the origin x, y of the ancestor view.
+   *
+   * As always, to obtain a native node handle for a component, you can use
+   * `React.findNodeHandle(component)`.
+   *
+   * @deprecated Use `ref.measureLayout` instead.
+   */
   measureLayout(
     reactTag: number,
     ancestorReactTag: number,
@@ -154,6 +200,13 @@ const UIManager: UIManagerJSInterface = {
     }
   },
 
+  /**
+   * Used to call a native view method from JavaScript
+   *
+   * reactTag - Id of react view.
+   * commandID - Id of the native method that should be called.
+   * commandArgs - Args of the native method that we can pass from JS to native.
+   */
   dispatchViewManagerCommand(
     reactTag: number,
     commandName: number | string,

--- a/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.js.flow
+++ b/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.js.flow
@@ -11,6 +11,12 @@
 import type {ProcessedColorValue} from './processColor';
 import type {NativeColorValue} from './StyleSheet';
 
+/**
+ * Select native platform color
+ * The color must match the string that exists on the native platform
+ *
+ * @see https://reactnative.dev/docs/platformcolor#example
+ */
 declare export function PlatformColor(
   ...names: Array<string>
 ): NativeColorValue;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -845,6 +845,10 @@ export type ____ViewStyle_InternalBase = Readonly<{
   backfaceVisibility?: 'visible' | 'hidden',
   backgroundColor?: ____ColorValue_Internal,
   borderColor?: ____ColorValue_Internal,
+  /**
+   * On iOS 13+, it is possible to change the corner curve of borders.
+   * @platform ios
+   */
   borderCurve?: 'circular' | 'continuous',
   borderBottomColor?: ____ColorValue_Internal,
   borderEndColor?: ____ColorValue_Internal,
@@ -881,7 +885,18 @@ export type ____ViewStyle_InternalBase = Readonly<{
   outlineOffset?: number,
   outlineStyle?: 'solid' | 'dotted' | 'dashed',
   outlineWidth?: number,
+  /**
+   * Sets the elevation of a view, using Android's underlying
+   * [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation).
+   * This adds a drop shadow to the item and affects z-order for overlapping views.
+   * Only supported on Android 5.0+, has no effect on earlier versions.
+   *
+   * @platform android
+   */
   elevation?: number,
+  /**
+   * Controls whether the View can be the target of touch events.
+   */
   pointerEvents?: 'auto' | 'none' | 'box-none' | 'box-only',
   cursor?: CursorValue,
   boxShadow?: ReadonlyArray<BoxShadowValue> | string,
@@ -1001,6 +1016,11 @@ type ____TextStyle_InternalBase = Readonly<{
   fontFamily?: string,
   fontSize?: number,
   fontStyle?: 'normal' | 'italic',
+  /**
+   * Specifies font weight. The values 'normal' and 'bold' are supported
+   * for most fonts. Not all fonts have a variant for each of the numeric
+   * values, in that case the closest one is chosen.
+   */
   fontWeight?: ____FontWeight_Internal,
   fontVariant?: ____FontVariantArray_Internal | string,
   textShadowOffset?: Readonly<{

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -76,6 +76,9 @@ export type LayoutChangeEvent = NativeSyntheticEvent<
   }>,
 >;
 
+/**
+ * @deprecated Use `TextLayoutEvent` instead.
+ */
 type TextLayoutEventData = Readonly<{
   lines: Array<TextLayoutLine>,
 }>;

--- a/packages/react-native/Libraries/Utilities/BackHandler.js.flow
+++ b/packages/react-native/Libraries/Utilities/BackHandler.js.flow
@@ -12,6 +12,11 @@
 
 export type BackPressEventName = 'backPress' | 'hardwareBackPress';
 
+/**
+ * Event dispatched when the hardware back button is pressed.
+ * The `timeStamp` property reflects the native timestamp captured
+ * when the back press was emitted.
+ */
 export interface HardwareBackPressEvent {
   readonly type: string;
   readonly timeStamp: number;
@@ -25,6 +30,17 @@ type TBackHandler = {
   ): {remove: () => void, ...},
 };
 
+/**
+ * Detect hardware back button presses, and programmatically invoke the
+ * default back button functionality to exit the app if there are no
+ * listeners or if none of the listeners return true.
+ * The event subscriptions are called in reverse order
+ * (i.e. last registered subscription first), and if one subscription
+ * returns true then subscriptions registered earlier
+ * will not be called.
+ *
+ * @see https://reactnative.dev/docs/backhandler
+ */
 declare const BackHandler: TBackHandler;
 
 declare export default typeof BackHandler;

--- a/packages/react-native/Libraries/Vibration/Vibration.js
+++ b/packages/react-native/Libraries/Vibration/Vibration.js
@@ -12,12 +12,6 @@ import NativeVibration from './NativeVibration';
 
 const Platform = require('../Utilities/Platform').default;
 
-/**
- * Vibration API
- *
- * See https://reactnative.dev/docs/vibration
- */
-
 let _vibrating: boolean = false;
 let _id: number = 0; // _id is necessary to prevent race condition.
 const _default_vibration_length = 400;
@@ -64,6 +58,11 @@ function vibrateScheduler(
   );
 }
 
+/**
+ * Vibration API
+ *
+ * See https://reactnative.dev/docs/vibration
+ */
 const Vibration = {
   /**
    * Trigger a vibration with specified `pattern`.


### PR DESCRIPTION
Summary:

Surface documentation on hover for more APIs in the generated TypeScript types (`types_generated/`).

**Changes**

- Fix doc comments that were previously detached from the intended symbol (`Modal`, `Button`, `TextInput`, `ScrollView`, and others).
- Migrate doc comments/extra detail present in the legacy hand-written `.d.ts` files but missing from Flow source.
    - (**Note**: The quality of these vary — but lift the equivalent current state into Flow land.)
- Reformat malformed JSDoc comments across the codebase.

Comments only — no code or type changes. Does not look to audit/improve doc comments beyond today's manual TS API baseline.

Changelog: [Internal]

Differential Revision: D109316360
