### PR TITLE
Migrate/audit JSDoc on public APIs (Components)

### DIFF
--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -30,132 +30,124 @@ import * as React from 'react';
 /** @build-types emit-as-interface Uniwind compatibility */
 export type ButtonProps = Readonly<{
   /**
-    Text to display inside the button. On Android the given title will be
-    converted to the uppercased form.
+   * Text to display inside the button. On Android the given title will be
+   * converted to the uppercased form.
    */
   title: string,
 
   /**
-    Handler to be called when the user taps the button. The first function
-    argument is an event in form of [GestureResponderEvent](pressevent).
+   * Handler called when the user taps the button.
    */
   onPress?: (event?: GestureResponderEvent) => unknown,
 
   /**
-    If `true`, doesn't play system sound on touch.
-
-    @platform android
-
-    @default false
+   * If `true`, doesn't play system sound on touch.
+   *
+   * @platform android
+   *
+   * @default `false`
    */
   touchSoundDisabled?: ?boolean,
 
   /**
-    Color of the text (iOS), or background color of the button (Android).
-
-    @default {@platform android} '#2196F3'
-    @default {@platform ios} '#007AFF'
+   * Color of the text (iOS), or background color of the button (Android).
+   *
+   * @default {@platform android} `'#2196F3'`
+   * @default {@platform ios} `'#007AFF'`
    */
   color?: ?ColorValue,
 
   /**
-    TV preferred focus.
-
-    @platform tv
-
-    @default false
-    @deprecated Use `focusable` instead
+   * TV preferred focus.
+   *
+   * @platform tv
+   *
+   * @default `false`
+   * @deprecated Use `focusable` instead
    */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-    Designates the next view to receive focus when the user navigates down. See
-    the [Android documentation][android:nextFocusDown].
-
-    [android:nextFocusDown]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates down. See
+   * the [Android documentation][android:nextFocusDown].
+   *
+   * [android:nextFocusDown]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
+   *
+   * @platform android, tv
    */
   nextFocusDown?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates forward.
-    See the [Android documentation][android:nextFocusForward].
-
-    [android:nextFocusForward]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates forward.
+   * See the [Android documentation][android:nextFocusForward].
+   *
+   * [android:nextFocusForward]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
+   *
+   * @platform android, tv
    */
   nextFocusForward?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates left. See
-    the [Android documentation][android:nextFocusLeft].
-
-    [android:nextFocusLeft]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates left. See
+   * the [Android documentation][android:nextFocusLeft].
+   *
+   * [android:nextFocusLeft]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
+   *
+   * @platform android, tv
    */
   nextFocusLeft?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates right. See
-    the [Android documentation][android:nextFocusRight].
-
-    [android:nextFocusRight]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates right. See
+   * the [Android documentation][android:nextFocusRight].
+   *
+   * [android:nextFocusRight]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
+   *
+   * @platform android, tv
    */
   nextFocusRight?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates up. See
-    the [Android documentation][android:nextFocusUp].
-
-    [android:nextFocusUp]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates up. See
+   * the [Android documentation][android:nextFocusUp].
+   *
+   * [android:nextFocusUp]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
+   *
+   * @platform android, tv
    */
   nextFocusUp?: ?number,
 
   /**
-    Text to display for blindness accessibility features.
+   * Text to display for blindness accessibility features.
    */
   accessibilityLabel?: ?string,
+
   /**
-   * Alias for accessibilityLabel  https://reactnative.dev/docs/view#accessibilitylabel
-   * https://github.com/facebook/react-native/issues/34424
+   * Alias for `accessibilityLabel`.
    */
   'aria-label'?: ?string,
-  /**
-    If `true`, disable all interactions for this component.
 
-    @default false
+  /**
+   * If `true`, disable all interactions for this component.
+   *
+   * @default `false`
    */
   disabled?: ?boolean,
 
-  /**
-    Used to locate this view in end-to-end tests.
-   */
   testID?: ?string,
 
-  /**
-   * Accessibility props.
-   */
   accessible?: ?boolean,
   accessibilityActions?: ?ReadonlyArray<AccessibilityActionInfo>,
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => unknown,
   accessibilityState?: ?AccessibilityState,
 
   /**
-   * alias for accessibilityState
-   *
-   * see https://reactnative.dev/docs/accessibility#accessibilitystate
+   * Alias for `accessibilityState`.
    */
   'aria-busy'?: ?boolean,
   'aria-checked'?: ?boolean | 'mixed',
@@ -163,121 +155,17 @@ export type ButtonProps = Readonly<{
   'aria-expanded'?: ?boolean,
   'aria-selected'?: ?boolean,
 
-  /**
-   * [Android] Controlling if a view fires accessibility events and if it is reported to accessibility services.
-   */
   importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
   accessibilityHint?: ?string,
+
+  /**
+   * A BCP 47 language tag for the screen reader to use when reading text
+   * content.
+   *
+   * @platform ios
+   */
   accessibilityLanguage?: ?Stringish,
 }>;
-
-/**
-  A basic button component that should render nicely on any platform. Supports a
-  minimal level of customization.
-
-  If this button doesn't look right for your app, you can build your own button
-  using [TouchableOpacity](touchableopacity) or
-  [TouchableWithoutFeedback](touchablewithoutfeedback). For inspiration, look at
-  the [source code for this button component][button:source]. Or, take a look at
-  the [wide variety of button components built by the community]
-  [button:examples].
-
-  [button:source]:
-  https://github.com/facebook/react-native/blob/HEAD/Libraries/Components/Button.js
-
-  ```jsx
-  <Button
-    onPress={onPressLearnMore}
-    title="Learn More"
-    color="#841584"
-    accessibilityLabel="Learn more about this purple button"
-  />
-  ```
-
-  ```SnackPlayer name=Button%20Example
-  import React from 'react';
-  import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
-
-  const Separator = () => (
-    <View style={styles.separator} />
-  );
-
-  const App = () => (
-    <SafeAreaView style={styles.container}>
-      <View>
-        <Text style={styles.title}>
-          The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
-        </Text>
-        <Button
-          title="Press me"
-          onPress={() => Alert.alert('Simple Button pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
-        </Text>
-        <Button
-          title="Press me"
-          color="#f194ff"
-          onPress={() => Alert.alert('Button with adjusted color pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          All interaction for the component are disabled.
-        </Text>
-        <Button
-          title="Press me"
-          disabled
-          onPress={() => Alert.alert('Cannot press this one')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          This layout strategy lets the title define the width of the button.
-        </Text>
-        <View style={styles.fixToText}>
-          <Button
-            title="Left button"
-            onPress={() => Alert.alert('Left button pressed')}
-          />
-          <Button
-            title="Right button"
-            onPress={() => Alert.alert('Right button pressed')}
-          />
-        </View>
-      </View>
-    </SafeAreaView>
-  );
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      justifyContent: 'center',
-      marginHorizontal: 16,
-    },
-    title: {
-      textAlign: 'center',
-      marginVertical: 8,
-    },
-    fixToText: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-    },
-    separator: {
-      marginVertical: 8,
-      borderBottomColor: '#737373',
-      borderBottomWidth: StyleSheet.hairlineWidth,
-    },
-  });
-
-  export default App;
-  ```
- */
 
 const NativeTouchable:
   | typeof TouchableNativeFeedback
@@ -286,6 +174,26 @@ const NativeTouchable:
 
 export type ButtonInstance = React.ElementRef<typeof NativeTouchable>;
 
+/**
+ * A basic button component that should render nicely on any platform. Supports a
+ * minimal level of customization.
+ *
+ * If this button doesn't look right for your app, you can build your own button
+ * using `Pressable`.
+ *
+ * Example:
+ *
+ * ```tsx
+ * <Button
+ *   onPress={onPressLearnMore}
+ *   title="Learn More"
+ *   color="#841584"
+ *   accessibilityLabel="Learn more about this purple button"
+ * />
+ * ```
+ *
+ * @see https://reactnative.dev/docs/button
+ */
 const Button: component(
   ref?: React.RefSetter<ButtonInstance>,
   ...props: ButtonProps

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -33,35 +33,10 @@ import {createRef} from 'react';
 const DRAWER_STATES = ['Idle', 'Dragging', 'Settling'] as const;
 
 /**
- * React component that wraps the platform `DrawerLayout` (Android only). The
- * Drawer (typically used for navigation) is rendered with `renderNavigationView`
- * and direct children are the main view (where your content goes). The navigation
- * view is initially not visible on the screen, but can be pulled in from the
- * side of the window specified by the `drawerPosition` prop and its width can
- * be set by the `drawerWidth` prop.
+ * React component that wraps the platform `DrawerLayout` (Android only). The Drawer (typically used for navigation) is rendered with `renderNavigationView` and direct children are the main view. The navigation view is initially not visible on the screen, but can be pulled in from the side of the window specified by the `drawerPosition` prop and its width can be set by the `drawerWidth` prop.
  *
- * Example:
- *
- * ```
- * render: function() {
- *   var navigationView = (
- *     <View style={{flex: 1, backgroundColor: '#fff'}}>
- *       <Text style={{margin: 10, fontSize: 15, textAlign: 'left'}}>I'm in the Drawer!</Text>
- *     </View>
- *   );
- *   return (
- *     <DrawerLayoutAndroid
- *       drawerWidth={300}
- *       drawerPosition="left"
- *       renderNavigationView={() => navigationView}>
- *       <View style={{flex: 1, alignItems: 'center'}}>
- *         <Text style={{margin: 10, fontSize: 15, textAlign: 'right'}}>Hello</Text>
- *         <Text style={{margin: 10, fontSize: 15, textAlign: 'right'}}>World!</Text>
- *       </View>
- *     </DrawerLayoutAndroid>
- *   );
- * },
- * ```
+ * @see https://reactnative.dev/docs/drawerlayoutandroid
+ * @platform android
  */
 class DrawerLayoutAndroid
   extends React.Component<DrawerLayoutAndroidProps, DrawerLayoutAndroidState>
@@ -199,42 +174,6 @@ class DrawerLayoutAndroid
   closeDrawer() {
     Commands.closeDrawer(nullthrows(this._nativeRef.current));
   }
-
-  /**
-   * Closing and opening example
-   * Note: To access the drawer you have to give it a ref
-   *
-   * Class component:
-   *
-   * render () {
-   *   this.openDrawer = () => {
-   *     this.refs.DRAWER.openDrawer()
-   *   }
-   *   this.closeDrawer = () => {
-   *     this.refs.DRAWER.closeDrawer()
-   *   }
-   *   return (
-   *     <DrawerLayoutAndroid ref={'DRAWER'}>
-   *      {children}
-   *     </DrawerLayoutAndroid>
-   *   )
-   * }
-   *
-   * Function component:
-   *
-   * const drawerRef = useRef()
-   * const openDrawer = () => {
-   *   drawerRef.current.openDrawer()
-   * }
-   * const closeDrawer = () => {
-   *   drawerRef.current.closeDrawer()
-   * }
-   * return (
-   *   <DrawerLayoutAndroid ref={drawerRef}>
-   *     {children}
-   *   </DrawerLayoutAndroid>
-   * )
-   */
 
   /**
    * Native methods

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
@@ -31,78 +31,65 @@ export type DrawerLayoutAndroidProps = Readonly<{
   ...ViewProps,
 
   /**
-   * Determines whether the keyboard gets dismissed in response to a drag.
-   *   - 'none' (the default), drags do not dismiss the keyboard.
-   *   - 'on-drag', the keyboard is dismissed when a drag begins.
+   * Whether the keyboard is dismissed in response to a drag.
+   *
+   * @default `'none'`
    */
   keyboardDismissMode?: ?('none' | 'on-drag'),
 
   /**
-   * Specifies the background color of the drawer. The default value is white.
-   * If you want to set the opacity of the drawer, use rgba. Example:
+   * Background color of the drawer.
    *
-   * ```
-   * return (
-   *   <DrawerLayoutAndroid drawerBackgroundColor="rgba(0,0,0,0.5)">
-   *   </DrawerLayoutAndroid>
-   * );
-   * ```
+   * @default `'white'`
    */
   drawerBackgroundColor?: ?ColorValue,
 
   /**
-   * Specifies the side of the screen from which the drawer will slide in.
+   * Side of the screen from which the drawer slides in.
+   *
+   * @default `'left'`
    */
   drawerPosition: ?('left' | 'right'),
 
   /**
-   * Specifies the width of the drawer, more precisely the width of the view that be pulled in
-   * from the edge of the window.
+   * Width of the drawer view.
    */
   drawerWidth?: ?number,
 
   /**
-   * Specifies the lock mode of the drawer. The drawer can be locked in 3 states:
-   * - unlocked (default), meaning that the drawer will respond (open/close) to touch gestures.
-   * - locked-closed, meaning that the drawer will stay closed and not respond to gestures.
-   * - locked-open, meaning that the drawer will stay opened and not respond to gestures.
-   * The drawer may still be opened and closed programmatically (`openDrawer`/`closeDrawer`).
+   * Lock mode of the drawer. `'unlocked'` responds to touch gestures, `'locked-closed'` stays closed, `'locked-open'` stays open.
+   *
+   * @default `'unlocked'`
    */
   drawerLockMode?: ?('unlocked' | 'locked-closed' | 'locked-open'),
 
   /**
-   * Function called whenever there is an interaction with the navigation view.
+   * Called when there is an interaction with the navigation view.
    */
   onDrawerSlide?: ?(event: DrawerSlideEvent) => unknown,
 
   /**
-   * Function called when the drawer state has changed. The drawer can be in 3 states:
-   * - Idle, meaning there is no interaction with the navigation view happening at the time
-   * - Dragging, meaning there is currently an interaction with the navigation view
-   * - Settling, meaning that there was an interaction with the navigation view, and the
-   * navigation view is now finishing its closing or opening animation
+   * Called when the drawer state changes. States: idle, dragging, settling.
    */
   onDrawerStateChanged?: ?(state: DrawerStates) => unknown,
 
   /**
-   * Function called whenever the navigation view has been opened.
+   * Called when the navigation view has been opened.
    */
   onDrawerOpen?: ?() => unknown,
 
   /**
-   * Function called whenever the navigation view has been closed.
+   * Called when the navigation view has been closed.
    */
   onDrawerClose?: ?() => unknown,
 
   /**
-   * The navigation view that will be rendered to the side of the screen and can be pulled in.
+   * The navigation view that will be rendered to the side of the screen.
    */
   renderNavigationView: () => React.MixedElement,
 
   /**
-   * Make the drawer take the entire screen and draw the background of the
-   * status bar to allow it to open over the status bar. It will only have an
-   * effect on API 21+.
+   * Makes the drawer take the entire screen and draws the background of the status bar to allow it to open over the status bar. Only has effect on API 21+.
    */
   statusBarBackgroundColor?: ?ColorValue,
 }>;

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -36,19 +36,22 @@ export type KeyboardAvoidingViewProps = Readonly<{
   behavior?: ?('height' | 'position' | 'padding'),
 
   /**
-   * Style of the content container when `behavior` is 'position'.
+   * The style of the content container (View) when `behavior` is 'position'.
    */
   contentContainerStyle?: ?ViewStyleProp,
 
   /**
-   * Controls whether this `KeyboardAvoidingView` instance should take effect.
-   * This is useful when more than one is on the screen. Defaults to true.
+   * Whether the `KeyboardAvoidingView` is enabled.
+   *
+   * @default `true`
    */
   enabled?: ?boolean,
 
   /**
-   * Distance between the top of the user screen and the React Native view. This
-   * may be non-zero in some cases. Defaults to 0.
+   * Distance between the top of the user screen and the React Native view,
+   * may be non-zero in some use cases.
+   *
+   * @default `0`
    */
   keyboardVerticalOffset?: number,
 }>;
@@ -58,8 +61,10 @@ type KeyboardAvoidingViewState = {
 };
 
 /**
- * View that moves out of the way when the keyboard appears by automatically
- * adjusting its height, position, or bottom padding.
+ * Automatically adjusts its height, position, or bottom padding based on the
+ * keyboard height to remain visible while the virtual keyboard is displayed.
+ *
+ * @see https://reactnative.dev/docs/keyboardavoidingview
  */
 class KeyboardAvoidingView extends React.Component<
   KeyboardAvoidingViewProps,

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -44,28 +44,36 @@ type PressableBaseProps = Readonly<{
   cancelable?: ?boolean,
 
   /**
-   * Either children or a render prop that receives a boolean reflecting whether
+   * Either children or a function that receives a boolean reflecting whether
    * the component is currently pressed.
    */
   children?: React.Node | ((state: PressableStateCallbackType) => React.Node),
 
   /**
    * Duration to wait after hover in before calling `onHoverIn`.
+   *
+   * @platform macos windows
    */
   delayHoverIn?: ?number,
 
   /**
    * Duration to wait after hover out before calling `onHoverOut`.
+   *
+   * @platform macos windows
    */
   delayHoverOut?: ?number,
 
   /**
    * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
+   *
+   * @default `500`
    */
   delayLongPress?: ?number,
 
   /**
    * Whether the press behavior is disabled.
+   *
+   * @default `false`
    */
   disabled?: ?boolean,
 
@@ -77,6 +85,8 @@ type PressableBaseProps = Readonly<{
   /**
    * Additional distance outside of this view in which a touch is considered a
    * press before `onPressOut` is triggered.
+   *
+   * @default `{bottom: 30, left: 20, right: 20, top: 20}`
    */
   pressRetentionOffset?: ?RectOrSize,
 
@@ -86,36 +96,38 @@ type PressableBaseProps = Readonly<{
   onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
   /**
-   * Called when the hover is activated to provide visual feedback.
+   * Called when the hover is activated.
    */
   onHoverIn?: ?(event: MouseEvent) => unknown,
 
   /**
-   * Called when the hover is deactivated to undo visual feedback.
+   * Called when the hover is deactivated.
    */
   onHoverOut?: ?(event: MouseEvent) => unknown,
 
   /**
-   * Called when a long-tap gesture is detected.
+   * Called if the time after `onPressIn` lasts longer than `delayLongPress`.
    */
   onLongPress?: ?(event: GestureResponderEvent) => unknown,
 
   /**
-   * Called when a single tap gesture is detected.
+   * Called after `onPressOut`.
    */
   onPress?: ?(event: GestureResponderEvent) => unknown,
 
   /**
-   * Called when a touch is engaged before `onPress`.
+   * Called immediately when a touch is engaged, before `onPressOut` and
+   * `onPress`.
    */
   onPressIn?: ?(event: GestureResponderEvent) => unknown,
+
   /**
    * Called when the press location moves.
    */
   onPressMove?: ?(event: GestureResponderEvent) => unknown,
 
   /**
-   * Called when a touch is released before `onPress`.
+   * Called when a touch is released.
    */
   onPressOut?: ?(event: GestureResponderEvent) => unknown,
 
@@ -139,12 +151,17 @@ type PressableBaseProps = Readonly<{
   testID?: ?string,
 
   /**
-   * If true, doesn't play system sound on touch.
+   * If true, doesn't play Android system sound on press.
+   *
+   * @platform android
+   * @default `false`
    */
   android_disableSound?: ?boolean,
 
   /**
-   * Enables the Android ripple effect and configures its color.
+   * Enables the Android ripple effect and configures its properties.
+   *
+   * @platform android
    */
   android_ripple?: ?PressableAndroidRippleConfig,
 
@@ -154,7 +171,8 @@ type PressableBaseProps = Readonly<{
   testOnly_pressed?: ?boolean,
 
   /**
-   * Duration to wait after press down before calling `onPressIn`.
+   * Duration (in milliseconds) to wait after press down before calling
+   * `onPressIn`.
    */
   unstable_pressDelay?: ?number,
 }>;
@@ -169,8 +187,10 @@ export type PressableProps = Readonly<{
 }>;
 
 /**
- * Component used to build display components that should respond to whether the
- * component is currently pressed or not.
+ * A Core Component wrapper that can detect various stages of press
+ * interactions on any of its defined children.
+ *
+ * @see https://reactnative.dev/docs/pressable
  */
 function Pressable({
   ref: forwardedRef,

--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -24,33 +24,53 @@ const Platform = require('../../Utilities/Platform').default;
 export type RefreshControlPropsIOS = Readonly<{
   /**
    * The color of the refresh indicator.
+   *
+   * @platform ios
    */
   tintColor?: ?ColorValue,
-  /**
-   * Title color.
-   */
-  titleColor?: ?ColorValue,
+
   /**
    * The title displayed under the refresh indicator.
+   *
+   * @platform ios
    */
   title?: ?string,
+
+  /**
+   * The color of the refresh indicator title.
+   *
+   * @platform ios
+   */
+  titleColor?: ?ColorValue,
 }>;
 
 export type RefreshControlPropsAndroid = Readonly<{
   /**
-   * Whether the pull to refresh functionality is enabled.
-   */
-  enabled?: ?boolean,
-  /**
    * The colors (at least one) that will be used to draw the refresh indicator.
+   *
+   * @platform android
    */
   colors?: ?ReadonlyArray<ColorValue>,
+
+  /**
+   * Whether the pull to refresh functionality is enabled.
+   *
+   * @default `true`
+   * @platform android
+   */
+  enabled?: ?boolean,
+
   /**
    * The background color of the refresh indicator.
+   *
+   * @platform android
    */
   progressBackgroundColor?: ?ColorValue,
+
   /**
    * Size of the refresh indicator.
+   *
+   * @platform android
    */
   size?: ?('default' | 'large'),
 }>;
@@ -67,7 +87,9 @@ type RefreshControlBaseProps = Readonly<{
   refreshing: boolean,
 
   /**
-   * Progress view top offset
+   * Progress view top offset.
+   *
+   * @default `0`
    */
   progressViewOffset?: ?number,
 }>;
@@ -81,49 +103,14 @@ export type RefreshControlProps = Readonly<{
 }>;
 
 /**
- * This component is used inside a ScrollView or ListView to add pull to refresh
- * functionality. When the ScrollView is at `scrollY: 0`, swiping down
- * triggers an `onRefresh` event.
+ * Used inside a `ScrollView` to add pull to refresh functionality. When the
+ * `ScrollView` is at `scrollY: 0`, swiping down triggers an `onRefresh` event.
  *
- * ### Usage example
+ * **Note:** `refreshing` is a controlled prop, this is why it needs to be set
+ * to `true` in the `onRefresh` function otherwise the refresh indicator will
+ * stop immediately.
  *
- * ``` js
- * class RefreshableList extends Component {
- *   constructor(props) {
- *     super(props);
- *     this.state = {
- *       refreshing: false,
- *     };
- *   }
- *
- *   _onRefresh() {
- *     this.setState({refreshing: true});
- *     fetchData().then(() => {
- *       this.setState({refreshing: false});
- *     });
- *   }
- *
- *   render() {
- *     return (
- *       <ListView
- *         refreshControl={
- *           <RefreshControl
- *             refreshing={this.state.refreshing}
- *             onRefresh={this._onRefresh.bind(this)}
- *           />
- *         }
- *         ...
- *       >
- *       ...
- *       </ListView>
- *     );
- *   }
- *   ...
- * }
- * ```
- *
- * __Note:__ `refreshing` is a controlled prop, this is why it needs to be set to true
- * in the `onRefresh` function otherwise the refresh indicator will stop immediately.
+ * @see https://reactnative.dev/docs/refreshcontrol
  */
 class RefreshControl extends React.Component<RefreshControlProps> {
   _nativeRef: ?React.ElementRef<

--- a/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -18,14 +18,11 @@ import * as React from 'react';
 export type SafeAreaViewInstance = HostInstance;
 
 /**
- * Renders nested content and automatically applies paddings reflect the portion
- * of the view that is not covered by navigation bars, tab bars, toolbars, and
- * other ancestor views.
+ * Renders content within the safe area boundaries of a device. Currently only applicable to iOS devices with iOS version 11 or later. Automatically applies padding to reflect the portion of the view not covered by navigation bars, tab bars, toolbars, and other ancestor views.
  *
- * Moreover, and most importantly, Safe Area's paddings reflect physical
- * limitation of the screen, such as rounded corners or camera notches (aka
- * sensor housing area on iPhone X).
- * @deprecated Use `react-native-safe-area-context` instead. This component will be removed in a future release.
+ * @see https://reactnative.dev/docs/safeareaview
+ * @deprecated Use `react-native-safe-area-context` instead.
+ * @platform ios
  */
 const SafeAreaView: component(
   ref?: React.RefSetter<SafeAreaViewInstance>,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -135,17 +135,48 @@ export interface ScrollViewScrollToOptions {
 
 // Public methods for ScrollView
 export interface ScrollViewImperativeMethods {
+  /**
+   * Returns a reference to the underlying scroll responder, which supports
+   * operations like `scrollTo`. All ScrollView-like components should
+   * implement this method so that they can be composed while providing access
+   * to the underlying scroll responder's methods.
+   */
   readonly getScrollResponder: () => ScrollResponderType;
   readonly getScrollableNode: () => ?number;
   readonly getInnerViewNode: () => ?number;
   readonly getInnerViewRef: () => InnerViewInstance | null;
+  /**
+   * Returns a reference to the underlying native scroll view, or null if the
+   * native instance is not mounted.
+   */
   readonly getNativeScrollRef: () => ScrollViewInstance | null;
+  /**
+   * Scrolls to a given x, y offset, either immediately or with a smooth animation.
+   * Syntax:
+   *
+   * scrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})
+   *
+   * Note: The weird argument signature is due to the fact that, for historical reasons,
+   * the function also accepts separate arguments as an alternative to the options object.
+   * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
+   */
   readonly scrollTo: (
     options?: ScrollViewScrollToOptions | number,
     deprecatedX?: number,
     deprecatedAnimated?: boolean,
   ) => void;
+  /**
+   * A helper function that scrolls to the end of the scrollview;
+   * If this is a vertical ScrollView, it scrolls to the bottom.
+   * If this is a horizontal ScrollView scrolls to the right.
+   *
+   * The options object has an animated prop, that enables the scrolling animation or not.
+   * The animated prop defaults to true
+   */
   readonly scrollToEnd: (options?: ?ScrollViewScrollToOptions) => void;
+  /**
+   * Displays the scroll indicators momentarily.
+   */
   readonly flashScrollIndicators: () => void;
   readonly scrollResponderZoomTo: (
     rect: {
@@ -177,33 +208,44 @@ export type ScrollViewPropsIOS = Readonly<{
   /**
    * Controls whether iOS should automatically adjust the content inset
    * for scroll views that are placed behind a navigation bar or
-   * tab bar/ toolbar. The default value is true.
+   * tab bar/toolbar.
+   *
+   * @default `true`
    * @platform ios
    */
   automaticallyAdjustContentInsets?: ?boolean,
+
   /**
    * Controls whether the ScrollView should automatically adjust its `contentInset`
-   * and `scrollViewInsets` when the Keyboard changes its size. The default value is false.
+   * and `scrollViewInsets` when the Keyboard changes its size.
+   *
+   * @default `false`
    * @platform ios
    */
   automaticallyAdjustKeyboardInsets?: ?boolean,
   /**
    * Controls whether iOS should automatically adjust the scroll indicator
-   * insets. The default value is true. Available on iOS 13 and later.
+   * insets. Available on iOS 13 and later.
+   *
+   * @default `true`
    * @platform ios
    */
   automaticallyAdjustsScrollIndicatorInsets?: ?boolean,
   /**
    * The amount by which the scroll view content is inset from the edges
-   * of the scroll view. Defaults to `{top: 0, left: 0, bottom: 0, right: 0}`.
+   * of the scroll view.
+   *
+   * @default `{top: 0, left: 0, bottom: 0, right: 0}`
    * @platform ios
    */
   contentInset?: ?EdgeInsetsProp,
   /**
    * When true, the scroll view bounces when it reaches the end of the
-   * content if the content is larger then the scroll view along the axis of
-   * the scroll direction. When false, it disables all bouncing even if
-   * the `alwaysBounce*` props are true. The default value is true.
+   * content if the content is larger than the scroll view along the axis of
+   * the scroll direction. When `false`, it disables all bouncing even if
+   * the `alwaysBounce*` props are `true`.
+   *
+   * @default `true`
    * @platform ios
    */
   bounces?: ?boolean,
@@ -223,23 +265,28 @@ export type ScrollViewPropsIOS = Readonly<{
   bouncesZoom?: ?boolean,
   /**
    * When true, the scroll view bounces horizontally when it reaches the end
-   * even if the content is smaller than the scroll view itself. The default
-   * value is true when `horizontal={true}` and false otherwise.
+   * even if the content is smaller than the scroll view itself.
+   *
+   * @default {@platform horizontal} `true`
    * @platform ios
    */
   alwaysBounceHorizontal?: ?boolean,
+
   /**
    * When true, the scroll view bounces vertically when it reaches the end
-   * even if the content is smaller than the scroll view itself. The default
-   * value is false when `horizontal={true}` and true otherwise.
+   * even if the content is smaller than the scroll view itself.
+   *
+   * @default {@platform horizontal} `false`
    * @platform ios
    */
   alwaysBounceVertical?: ?boolean,
+
   /**
    * When true, the scroll view automatically centers the content when the
    * content is smaller than the scroll view bounds; when the content is
-   * larger than the scroll view, this property has no effect. The default
-   * value is false.
+   * larger than the scroll view, this property has no effect.
+   *
+   * @default `false`
    * @platform ios
    */
   centerContent?: ?boolean,
@@ -255,48 +302,68 @@ export type ScrollViewPropsIOS = Readonly<{
   indicatorStyle?: ?('default' | 'black' | 'white'),
   /**
    * When true, the ScrollView will try to lock to only vertical or horizontal
-   * scrolling while dragging.  The default value is false.
+   * scrolling while dragging.
+   *
+   * @default `false`
    * @platform ios
    */
   directionalLockEnabled?: ?boolean,
+
   /**
-   * When false, once tracking starts, won't try to drag if the touch moves.
-   * The default value is true.
+   * When false, once tracking starts, the scroll view will not try to drag
+   * if the touch moves.
+   *
+   * @default `true`
    * @platform ios
    */
   canCancelContentTouches?: ?boolean,
+
   /**
-   * The maximum allowed zoom scale. The default value is 1.0.
+   * The maximum allowed zoom scale.
+   *
+   * @default `1.0`
    * @platform ios
    */
   maximumZoomScale?: ?number,
+
   /**
-   * The minimum allowed zoom scale. The default value is 1.0.
+   * The minimum allowed zoom scale.
+   *
+   * @default `1.0`
    * @platform ios
    */
   minimumZoomScale?: ?number,
+
   /**
    * When true, ScrollView allows use of pinch gestures to zoom in and out.
-   * The default value is true.
+   *
+   * @default `true`
    * @platform ios
    */
   pinchGestureEnabled?: ?boolean,
   /**
    * The amount by which the scroll view indicators are inset from the edges
    * of the scroll view. This should normally be set to the same value as
-   * the `contentInset`. Defaults to `{0, 0, 0, 0}`.
+   * the `contentInset`.
+   *
+   * @default `{top: 0, left: 0, bottom: 0, right: 0}`
    * @platform ios
    */
   scrollIndicatorInsets?: ?EdgeInsetsProp,
+
   /**
    * When true, the scroll view can be programmatically scrolled beyond its
-   * content size. The default value is false.
+   * content size.
+   *
+   * @default `false`
    * @platform ios
    */
   scrollToOverflowEnabled?: ?boolean,
+
   /**
    * When true, the scroll view scrolls to top when the status bar is tapped.
-   * The default value is true.
+   *
+   * @default `true`
    * @platform ios
    */
   scrollsToTop?: ?boolean,
@@ -307,18 +374,23 @@ export type ScrollViewPropsIOS = Readonly<{
   onScrollToTop?: (event: ScrollEvent) => void,
   /**
    * When true, shows a horizontal scroll indicator.
-   * The default value is true.
+   *
+   * @default `true`
    */
   showsHorizontalScrollIndicator?: ?boolean,
+
   /**
-   * The current scale of the scroll view content. The default value is 1.0.
+   * The current scale of the scroll view content.
+   *
+   * @default `1.0`
    * @platform ios
    */
   zoomScale?: ?number,
   /**
    * This property specifies how the safe area insets are used to modify the
-   * content area of the scroll view. The default value of this property is
-   * "never".
+   * content area of the scroll view.
+   *
+   * @default `'never'`
    * @platform ios
    */
   contentInsetAdjustmentBehavior?: ?(
@@ -331,8 +403,10 @@ export type ScrollViewPropsIOS = Readonly<{
 
 export type ScrollViewPropsAndroid = Readonly<{
   /**
-   * Enables nested scrolling for Android API level 21+.
-   * Nested scrolling is supported by default on iOS
+   * Enables nested scrolling for Android API level 21+. Nested scrolling is
+   * supported by default on iOS.
+   *
+   * @default `false`
    * @platform android
    */
   nestedScrollEnabled?: ?boolean,
@@ -367,8 +441,8 @@ export type ScrollViewPropsAndroid = Readonly<{
   overScrollMode?: ?('auto' | 'always' | 'never'),
   /**
    * Causes the scrollbars not to turn transparent when they are not in use.
-   * The default value is false.
    *
+   * @default `false`
    * @platform android
    */
   persistentScrollbar?: ?boolean,
@@ -390,8 +464,9 @@ export type ScrollViewPropsAndroid = Readonly<{
   /**
    * When false, the ScrollView will not automatically scroll to a focused child when
    * the child requests focus. This can be useful when you want to control the scroll
-   * position programmatically. The default value is true.
+   * position programmatically.
    *
+   * @default `true`
    * @platform android
    */
   scrollsChildToFocus?: ?boolean,
@@ -405,9 +480,11 @@ type StickyHeaderComponentType = component(
 type ScrollViewBaseProps = Readonly<{
   /**
    * These styles will be applied to the scroll view content container which
-   * wraps all of the child views. Example:
+   * wraps all of the child views.
    *
-   * ```
+   * Example:
+   *
+   * ```tsx
    * return (
    *   <ScrollView contentContainerStyle={styles.contentContainer}>
    *   </ScrollView>
@@ -423,14 +500,18 @@ type ScrollViewBaseProps = Readonly<{
   contentContainerStyle?: ?ViewStyleProp,
   /**
    * Used to manually set the starting scroll offset.
-   * The default value is `{x: 0, y: 0}`.
+   *
+   * @default `{x: 0, y: 0}`
    */
   contentOffset?: ?PointProp,
+
   /**
    * When true, the scroll view stops on the next index (in relation to scroll
    * position at release) regardless of how fast the gesture is. This can be
    * used for pagination when the page is less than the width of the
-   * horizontal ScrollView or the height of the vertical ScrollView. The default value is false.
+   * horizontal ScrollView or the height of the vertical ScrollView.
+   *
+   * @default `false`
    */
   disableIntervalMomentum?: ?boolean,
   /**
@@ -440,27 +521,31 @@ type ScrollViewBaseProps = Readonly<{
    * for `UIScrollViewDecelerationRateNormal` and
    * `UIScrollViewDecelerationRateFast` respectively.
    *
-   *   - `'normal'`: 0.998 on iOS, 0.985 on Android (the default)
+   *   - `'normal'`: 0.998 on iOS, 0.985 on Android
    *   - `'fast'`: 0.99 on iOS, 0.9 on Android
+   *
+   * @default `'normal'`
    */
   decelerationRate?: ?DecelerationRateType,
 
   /**
    * *Experimental, iOS Only*. The API is experimental and will change in future releases.
    *
-   * Controls how much distance is travelled after user stops scrolling.
-   * Value greater than 1 will increase the distance travelled.
-   * Value less than 1 will decrease the distance travelled.
+   * Controls how much distance is traveled after user stops scrolling.
+   * A value greater than 1 will increase the distance traveled.
+   * A value less than 1 will decrease the distance traveled.
    *
    * @deprecated
    *
-   * The default value is 1.
+   * @default `1`
    */
   experimental_endDraggingSensitivityMultiplier?: ?number,
 
   /**
    * When true, the scroll view's children are arranged horizontally in a row
-   * instead of vertically in a column. The default value is false.
+   * instead of vertically in a column.
+   *
+   * @default `false`
    */
   horizontal?: ?boolean,
   /**
@@ -473,14 +558,16 @@ type ScrollViewBaseProps = Readonly<{
    *
    * *Cross platform*
    *
-   *   - `'none'` (the default), drags do not dismiss the keyboard.
+   *   - `'none'`, drags do not dismiss the keyboard.
    *   - `'on-drag'`, the keyboard is dismissed when a drag begins.
    *
    * *iOS Only*
    *
    *   - `'interactive'`, the keyboard is dismissed interactively with the drag and moves in
    *     synchrony with the touch; dragging upwards cancels the dismissal.
-   *     On android this is not supported and it will have the same behavior as 'none'.
+   *     On Android this is not supported and it will have the same behavior as `'none'`.
+   *
+   * @default `'none'`
    */
   keyboardDismissMode?: ?// default
   // cross-platform
@@ -488,14 +575,16 @@ type ScrollViewBaseProps = Readonly<{
   /**
    * Determines when the keyboard should stay visible after a tap.
    *
-   *   - `'never'` (the default), tapping outside of the focused text input when the keyboard
-   *     is up dismisses the keyboard. When this happens, children won't receive the tap.
+   *   - `'never'`, tapping outside of the focused text input when the keyboard
+   *     is up dismisses the keyboard. When this happens, children will not receive the tap.
    *   - `'always'`, the keyboard will not dismiss automatically, and the scroll view will not
    *     catch taps, but children of the scroll view can catch taps.
    *   - `'handled'`, the keyboard will not dismiss automatically when the tap was handled by
-   *     a children, (or captured by an ancestor).
-   *   - `false`, deprecated, use 'never' instead
-   *   - `true`, deprecated, use 'always' instead
+   *     children, (or captured by an ancestor).
+   *   - `false`, deprecated, use `'never'` instead.
+   *   - `true`, deprecated, use `'always'` instead.
+   *
+   * @default `'never'`
    */
   keyboardShouldPersistTaps?: ?('always' | 'never' | 'handled' | true | false),
   /**
@@ -563,32 +652,42 @@ type ScrollViewBaseProps = Readonly<{
   onKeyboardWillHide?: (event: KeyboardEvent) => void,
   /**
    * When true, the scroll view stops on multiples of the scroll view's size
-   * when scrolling. This can be used for horizontal pagination. The default
-   * value is false.
+   * when scrolling. This can be used for horizontal pagination.
+   *
+   * @default `false`
    */
   pagingEnabled?: ?boolean,
+
   /**
    * When false, the view cannot be scrolled via touch interaction.
-   * The default value is true.
-   *
    * Note that the view can always be scrolled by calling `scrollTo`.
+   *
+   * @default `true`
    */
   scrollEnabled?: ?boolean,
+
   /**
    * Limits how often scroll events will be fired while scrolling, specified as
    * a time interval in ms. This may be useful when expensive work is performed
    * in response to scrolling. Values <= `16` will disable throttling,
    * regardless of the refresh rate of the device.
+   *
+   * @default `0`
    */
   scrollEventThrottle?: ?number,
+
   /**
    * When true, shows a vertical scroll indicator.
-   * The default value is true.
+   *
+   * @default `true`
    */
   showsVerticalScrollIndicator?: ?boolean,
+
   /**
-   * When true, Sticky header is hidden when scrolling down, and dock at the top
-   * when scrolling up
+   * When true, the sticky header is hidden when scrolling down, and docks
+   * at the top when scrolling up.
+   *
+   * @default `false`
    */
   stickyHeaderHiddenOnScroll?: ?boolean,
   /**
@@ -607,12 +706,14 @@ type ScrollViewBaseProps = Readonly<{
    */
   StickyHeaderComponent?: StickyHeaderComponentType,
   /**
-   * When `snapToInterval` is set, `snapToAlignment` will define the relationship
+   * When `snapToInterval` is set, `snapToAlignment` defines the relationship
    * of the snapping to the scroll view.
    *
-   *   - `'start'` (the default) will align the snap at the left (horizontal) or top (vertical)
-   *   - `'center'` will align the snap in the center
-   *   - `'end'` will align the snap at the right (horizontal) or bottom (vertical)
+   *   - `'start'`, aligns the snap at the left (horizontal) or top (vertical).
+   *   - `'center'`, aligns the snap in the center.
+   *   - `'end'`, aligns the snap at the right (horizontal) or bottom (vertical).
+   *
+   * @default `'start'`
    */
   snapToAlignment?: ?('start' | 'center' | 'end'),
   /**
@@ -635,25 +736,30 @@ type ScrollViewBaseProps = Readonly<{
   snapToOffsets?: ?ReadonlyArray<number>,
   /**
    * Use in conjunction with `snapToOffsets`. By default, the beginning
-   * of the list counts as a snap offset. Set `snapToStart` to false to disable
+   * of the list counts as a snap offset. Set `snapToStart` to `false` to disable
    * this behavior and allow the list to scroll freely between its start and
    * the first `snapToOffsets` offset.
-   * The default value is true.
+   *
+   * @default `true`
    */
   snapToStart?: ?boolean,
+
   /**
    * Use in conjunction with `snapToOffsets`. By default, the end
-   * of the list counts as a snap offset. Set `snapToEnd` to false to disable
+   * of the list counts as a snap offset. Set `snapToEnd` to `false` to disable
    * this behavior and allow the list to scroll freely between its end and
    * the last `snapToOffsets` offset.
-   * The default value is true.
+   *
+   * @default `true`
    */
   snapToEnd?: ?boolean,
+
   /**
    * Experimental: When true, offscreen child views (whose `overflow` value is
    * `hidden`) are removed from their native backing superview when offscreen.
-   * This can improve scrolling performance on long lists. The default value is
-   * true.
+   * This can improve scrolling performance on long lists.
+   *
+   * @default `true`
    */
   removeClippedSubviews?: ?boolean,
   /**
@@ -732,6 +838,8 @@ export type ScrollViewComponentStatics = Readonly<{
  * `FlatList` is also handy if you want to render separators between your items,
  * multiple columns, infinite scroll loading, or any number of other features it
  * supports out of the box.
+ *
+ * @see https://reactnative.dev/docs/scrollview
  */
 class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
   static Context: typeof ScrollViewContext = ScrollViewContext;

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -66,18 +66,21 @@ export type StatusBarPropsAndroid = Readonly<{
   /**
    * The background color of the status bar.
    *
-   * Please note that this prop has no effect on Android 15+
+   * @deprecated Has no effect on API level 35+ (Android 15+) due to
+   * edge-to-edge enforcement.
    *
    * @platform android
    */
   backgroundColor?: ?ColorValue,
+
   /**
-   * If the status bar is translucent.
-   * When translucent is set to true, the app will draw under the status bar.
-   * This is useful when using a semi transparent status bar color.
+   * If the status bar is translucent. When `true`, the app draws under the
+   * status bar. This is useful when using a semi-transparent status bar color.
    *
-   * Please note that this prop has no effect on Android 15+
+   * @deprecated Has no effect on API level 35+ (Android 15+) due to
+   * edge-to-edge enforcement.
    *
+   * @default `false`
    * @platform android
    */
   translucent?: ?boolean,
@@ -87,13 +90,16 @@ export type StatusBarPropsIOS = Readonly<{
   /**
    * If the network activity indicator should be visible.
    *
+   * @default `false`
    * @platform ios
    */
   networkActivityIndicatorVisible?: ?boolean,
+
   /**
-   * The transition effect when showing and hiding the status bar using the `hidden`
-   * prop. Defaults to 'fade'.
+   * The transition effect when showing and hiding the status bar using the
+   * `hidden` prop.
    *
+   * @default `'fade'`
    * @platform ios
    */
   showHideTransition?: ?('fade' | 'slide' | 'none'),
@@ -102,15 +108,23 @@ export type StatusBarPropsIOS = Readonly<{
 type StatusBarBaseProps = Readonly<{
   /**
    * If the status bar is hidden.
+   *
+   * @default `false`
    */
   hidden?: ?boolean,
+
   /**
    * If the transition between status bar property changes should be animated.
-   * Supported for backgroundColor, barStyle and hidden.
+   * Supported for `backgroundColor`, `barStyle`, and `hidden`.
+   *
+   * @default `false`
    */
   animated?: ?boolean,
+
   /**
    * Sets the color of the status bar text.
+   *
+   * @default `'default'`
    */
   barStyle?: ?('default' | 'auto' | 'light-content' | 'dark-content'),
 }>;
@@ -212,11 +226,12 @@ function createStackEntry(props: StatusBarProps): StackProps {
 }
 
 /**
- * Component to control the app status bar.
+ * Component to control the app's status bar. The status bar is the zone,
+ * typically at the top of the screen, that displays the current time, Wi-Fi and
+ * cellular network information, battery level and/or other status icons.
  *
- * It is possible to have multiple `StatusBar` components mounted at the same
- * time. The props will be merged in the order the `StatusBar` components were
- * mounted.
+ * Multiple `StatusBar` components can be mounted simultaneously; props merge in
+ * mount order.
  *
  * ### Imperative API
  *
@@ -228,7 +243,9 @@ function createStackEntry(props: StatusBarProps): StackProps {
  * before launching a third-party native UI component, and then call
  * `StatusBar.popStackEntry` when completed.
  *
- * ```
+ * Example:
+ *
+ * ```tsx
  * const openThirdPartyBugReporter = async () => {
  *   // The bug reporter has a dark background, so we push a new status bar style.
  *   const stackEntry = StatusBar.pushStackEntry({barStyle: 'light-content'});
@@ -252,6 +269,8 @@ function createStackEntry(props: StatusBarProps): StackProps {
  * ### Constants
  *
  * `currentHeight` (Android only) The height of the status bar.
+ *
+ * @see https://reactnative.dev/docs/statusbar
  */
 class StatusBar extends React.Component<StatusBarProps> {
   static _propsStack: Array<StackProps> = [];
@@ -329,10 +348,13 @@ class StatusBar extends React.Component<StatusBarProps> {
   }
 
   /**
-   * DEPRECATED - The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+   * DEPRECATED - The status bar network activity indicator is not supported in
+   * iOS 13 and later. This will be removed in a future release.
+   *
    * @param visible Show the indicator.
    *
-   * @deprecated
+   * @deprecated The status bar network activity indicator is not supported in
+   * iOS 13 and later.
    */
   static setNetworkActivityIndicatorVisible(visible: boolean) {
     if (Platform.OS !== 'ios') {

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -60,55 +60,54 @@ export type SwitchChangeEvent = NativeSyntheticEvent<SwitchChangeEventData>;
 
 type SwitchPropsBase = {
   /**
-    If true the user won't be able to toggle the switch.
-
-    @default false
+   * If true, the user won't be able to toggle the switch.
+   *
+   * @default `false`
    */
   disabled?: ?boolean,
 
   /**
-      The value of the switch. If true the switch will be turned on.
-
-      @default false
-     */
+   * The value of the switch. If true the switch will be turned on.
+   *
+   * @default `false`
+   */
   value?: ?boolean,
 
   /**
-      Color of the foreground switch grip. If this is set on iOS, the switch grip will lose its drop shadow.
-     */
+   * Color of the foreground switch grip. If set on iOS, the switch grip
+   * loses its drop shadow.
+   */
   thumbColor?: ?ColorValue,
 
   /**
-      Custom colors for the switch track.
-
-      _iOS_: When the switch value is false, the track shrinks into the border. If you want to change the
-      color of the background exposed by the shrunken track, use
-       [`ios_backgroundColor`](https://reactnative.dev/docs/switch#ios_backgroundColor).
-     */
+   * Custom colors for the switch track. On iOS, when the switch value is
+   * false, the track shrinks into the border.
+   */
   trackColor?: ?Readonly<{
     false?: ?ColorValue,
     true?: ?ColorValue,
   }>,
 
   /**
-      On iOS, custom color for the background. This background color can be
-      seen either when the switch value is false or when the switch is
-      disabled (and the switch is translucent).
-     */
+   * Custom color for the background. Can be seen when the switch value is
+   * false or when the switch is disabled (and the switch is translucent).
+   *
+   * @platform ios
+   */
   ios_backgroundColor?: ?ColorValue,
 
   /**
-      Invoked when the user tries to change the value of the switch. Receives
-      the change event as an argument. If you want to only receive the new
-      value, use `onValueChange` instead.
-     */
+   * Invoked when the user tries to change the value of the switch. Receives
+   * the change event as an argument. Use `onValueChange` to receive just
+   * the new value instead.
+   */
   onChange?: ?(event: SwitchChangeEvent) => Promise<void> | void,
 
   /**
-      Invoked when the user tries to change the value of the switch. Receives
-      the new value as an argument. If you want to instead receive an event,
-      use `onChange`.
-     */
+   * Invoked when the user tries to change the value of the switch. Receives
+   * the new value as an argument. Use `onChange` to receive the event
+   * instead.
+   */
   onValueChange?: ?(value: boolean) => Promise<void> | void,
 };
 
@@ -123,45 +122,49 @@ const returnsFalse = () => false;
 const returnsTrue = () => true;
 
 /**
-  Renders a boolean input.
-
-  This is a controlled component that requires an `onValueChange`
-  callback that updates the `value` prop in order for the component to
-  reflect user actions. If the `value` prop is not updated, the
-  component will continue to render the supplied `value` prop instead of
-  the expected result of any user actions.
-
-  ```SnackPlayer name=Switch
-  import React, { useState } from "react";
-  import { View, Switch, StyleSheet } from "react-native";
-
-  const App = () => {
-    const [isEnabled, setIsEnabled] = useState(false);
-    const toggleSwitch = () => setIsEnabled(previousState => !previousState);
-
-    return (
-      <View style={styles.container}>
-        <Switch
-          trackColor={{ false: "#767577", true: "#81b0ff" }}
-          thumbColor={isEnabled ? "#f5dd4b" : "#f4f3f4"}
-          ios_backgroundColor="#3e3e3e"
-          onValueChange={toggleSwitch}
-          value={isEnabled}
-        />
-      </View>
-    );
-  }
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      alignItems: "center",
-      justifyContent: "center"
-    }
-  });
-
-  export default App;
-  ```
+ * Renders a boolean input.
+ *
+ * This is a controlled component that requires an `onValueChange` callback
+ * that updates the `value` prop in order for the component to reflect user
+ * actions. If the `value` prop is not updated, the component will continue to
+ * render the supplied `value` prop instead of the expected result of any user
+ * actions.
+ *
+ * Example:
+ *
+ * ```tsx
+ * import React, {useState} from 'react';
+ * import {View, Switch, StyleSheet} from 'react-native';
+ *
+ * const App = () => {
+ *   const [isEnabled, setIsEnabled] = useState(false);
+ *   const toggleSwitch = () => setIsEnabled(previousState => !previousState);
+ *
+ *   return (
+ *     <View style={styles.container}>
+ *       <Switch
+ *         trackColor={{false: '#767577', true: '#81b0ff'}}
+ *         thumbColor={isEnabled ? '#f5dd4b' : '#f4f3f4'}
+ *         ios_backgroundColor="#3e3e3e"
+ *         onValueChange={toggleSwitch}
+ *         value={isEnabled}
+ *       />
+ *     </View>
+ *   );
+ * };
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     alignItems: 'center',
+ *     justifyContent: 'center',
+ *   },
+ * });
+ *
+ * export default App;
+ * ```
+ *
+ * @see https://reactnative.dev/docs/switch
  */
 const Switch: component(
   ref?: React.RefSetter<SwitchInstance>,

--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
@@ -18,76 +18,27 @@ import useWindowDimensions from '../../Utilities/useWindowDimensions';
 import RCTInputAccessoryViewNativeComponent from './RCTInputAccessoryViewNativeComponent';
 import * as React from 'react';
 
-/**
- * Note: iOS only
- *
- * A component which enables customization of the keyboard input accessory view.
- * The input accessory view is displayed above the keyboard whenever a TextInput
- * has focus. This component can be used to create custom toolbars.
- *
- * To use this component wrap your custom toolbar with the
- * InputAccessoryView component, and set a nativeID. Then, pass that nativeID
- * as the inputAccessoryViewID of whatever TextInput you desire. A simple
- * example:
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react';
- * import { AppRegistry, TextInput, InputAccessoryView, Button } from 'react-native';
- *
- * export default class UselessTextInput extends Component {
- *   constructor(props) {
- *     super(props);
- *     this.state = {text: 'Placeholder Text'};
- *   }
- *
- *   render() {
- *     const inputAccessoryViewID = "uniqueID";
- *     return (
- *       <View>
- *         <ScrollView keyboardDismissMode="interactive">
- *           <TextInput
- *             style={{
- *               padding: 10,
- *               paddingTop: 50,
- *             }}
- *             inputAccessoryViewID=inputAccessoryViewID
- *             onChangeText={text => this.setState({text})}
- *             value={this.state.text}
- *           />
- *         </ScrollView>
- *         <InputAccessoryView nativeID=inputAccessoryViewID>
- *           <Button
- *             onPress={() => this.setState({text: 'Placeholder Text'})}
- *             title="Reset Text"
- *           />
- *         </InputAccessoryView>
- *       </View>
- *     );
- *   }
- * }
- *
- * // skip this line if using Create React Native App
- * AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
- * ```
- *
- * This component can also be used to create sticky text inputs (text inputs
- * which are anchored to the top of the keyboard). To do this, wrap a
- * TextInput with the InputAccessoryView component, and don't set a nativeID.
- * For an example, look at InputAccessoryViewExample.js in RNTester.
- */
-
 /** @build-types emit-as-interface Expo compatibility */
 export type InputAccessoryViewProps = Readonly<{
   readonly children: React.Node,
   /**
-   * An ID which is used to associate this `InputAccessoryView` to
-   * specified TextInput(s).
+   * An ID used to associate this `InputAccessoryView` to specified `TextInput`(s).
    */
   nativeID?: ?string,
   style?: ?ViewStyleProp,
   backgroundColor?: ?ColorValue,
 }>;
 
+/**
+ * A component which enables customization of the keyboard input accessory view on iOS. The input accessory view is displayed above the keyboard whenever a `TextInput` has focus. This component can be used to create custom toolbars.
+ *
+ * To use this component, wrap your custom toolbar with `InputAccessoryView` and set a `nativeID`. Then, pass that `nativeID` as the `inputAccessoryViewID` of whatever `TextInput` you desire.
+ *
+ * This component can also be used to create sticky text inputs (text inputs which are anchored to the top of the keyboard). To do this, wrap a `TextInput` with `InputAccessoryView` and don't set a `nativeID`.
+ *
+ * @see https://reactnative.dev/docs/inputaccessoryview
+ * @platform ios
+ */
 const InputAccessoryView: React.ComponentType<InputAccessoryViewProps> = (
   props: InputAccessoryViewProps,
 ) => {

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -43,25 +43,29 @@ type IOSProps = Readonly<{
 
 type TouchableHighlightBaseProps = Readonly<{
   /**
-   * Determines what the opacity of the wrapped view should be when touch is active.
+   * Opacity of the wrapped view when touch is active. Requires `underlayColor` to be set.
+   *
+   * @default `0.85`
    */
   activeOpacity?: ?number,
+
   /**
-   * The color of the underlay that will show through when the touch is active.
+   * Color of the underlay shown when touch is active.
    */
   underlayColor?: ?ColorValue,
-  /**
-   * @see https://reactnative.dev/docs/view#style
-   */
+
   style?: ?ViewStyleProp,
+
   /**
-   * Called immediately after the underlay is shown
+   * Called immediately after the underlay is shown.
    */
   onShowUnderlay?: ?() => void,
+
   /**
-   * Called immediately after the underlay is hidden
+   * Called immediately after the underlay is hidden.
    */
   onHideUnderlay?: ?() => void,
+
   testOnly_pressed?: ?boolean,
 
   hostRef?: React.RefSetter<TouchableHighlightInstance>,
@@ -85,102 +89,6 @@ type TouchableHighlightState = Readonly<{
   extraStyles: ?ExtraStyles,
 }>;
 
-/**
- * A wrapper for making views respond properly to touches.
- * On press down, the opacity of the wrapped view is decreased, which allows
- * the underlay color to show through, darkening or tinting the view.
- *
- * The underlay comes from wrapping the child in a new View, which can affect
- * layout, and sometimes cause unwanted visual artifacts if not used correctly,
- * for example if the backgroundColor of the wrapped view isn't explicitly set
- * to an opaque color.
- *
- * TouchableHighlight must have one child (not zero or more than one).
- * If you wish to have several child components, wrap them in a View.
- *
- * Example:
- *
- * ```
- * renderButton: function() {
- *   return (
- *     <TouchableHighlight onPress={this._onPressButton}>
- *       <Image
- *         style={styles.button}
- *         source={require('./myButton.png')}
- *       />
- *     </TouchableHighlight>
- *   );
- * },
- * ```
- *
- *
- * ### Example
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react'
- * import {
- *   AppRegistry,
- *   StyleSheet,
- *   TouchableHighlight,
- *   Text,
- *   View,
- * } from 'react-native'
- *
- * class App extends Component {
- *   constructor(props) {
- *     super(props)
- *     this.state = { count: 0 }
- *   }
- *
- *   onPress = () => {
- *     this.setState({
- *       count: this.state.count+1
- *     })
- *   }
- *
- *  render() {
- *     return (
- *       <View style={styles.container}>
- *         <TouchableHighlight
- *          style={styles.button}
- *          onPress={this.onPress}
- *         >
- *          <Text> Touch Here </Text>
- *         </TouchableHighlight>
- *         <View style={[styles.countContainer]}>
- *           <Text style={[styles.countText]}>
- *             { this.state.count !== 0 ? this.state.count: null}
- *           </Text>
- *         </View>
- *       </View>
- *     )
- *   }
- * }
- *
- * const styles = StyleSheet.create({
- *   container: {
- *     flex: 1,
- *     justifyContent: 'center',
- *     paddingHorizontal: 10
- *   },
- *   button: {
- *     alignItems: 'center',
- *     backgroundColor: '#DDDDDD',
- *     padding: 10
- *   },
- *   countContainer: {
- *     alignItems: 'center',
- *     padding: 10
- *   },
- *   countText: {
- *     color: '#FF00FF'
- *   }
- * })
- *
- * AppRegistry.registerComponent('App', () => App)
- * ```
- *
- */
 class TouchableHighlightImpl extends React.Component<
   TouchableHighlightProps,
   TouchableHighlightState,
@@ -424,6 +332,17 @@ class TouchableHighlightImpl extends React.Component<
   }
 }
 
+/**
+ * A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
+ *
+ * The underlay comes from wrapping the child in a new View, which can affect layout.
+ *
+ * Must have exactly one child (not zero or more than one). If you wish to have several child components, wrap them in a View.
+ *
+ * If you need more extensive and future-proof touch handling, use `Pressable`.
+ *
+ * @see https://reactnative.dev/docs/touchablehighlight
+ */
 const TouchableHighlight: component(
   ref?: React.RefSetter<TouchableHighlightInstance>,
   ...props: Readonly<Omit<TouchableHighlightProps, 'hostRef'>>

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -74,18 +74,11 @@ export type TouchableNativeFeedbackProps = Readonly<{
   ...TouchableWithoutFeedbackProps,
   ...TouchableNativeFeedbackTVProps,
   /**
-   * Determines the type of background drawable that's going to be used to display feedback.
-   * It takes an object with type property and extra data depending on the type.
-   * It's recommended to use one of the following static methods to generate that dictionary:
-   *      1) TouchableNativeFeedback.SelectableBackground() - will create object that represents android theme's
-   *         default background for selectable elements (?android:attr/selectableItemBackground)
-   *      2) TouchableNativeFeedback.SelectableBackgroundBorderless() - will create object that represent android
-   *         theme's default background for borderless selectable elements
-   *         (?android:attr/selectableItemBackgroundBorderless). Available on android API level 21+
-   *      3) TouchableNativeFeedback.Ripple(color, borderless) - will create object that represents ripple drawable
-   *         with specified color (as a string). If property borderless evaluates to true the ripple will render
-   *         outside of the view bounds (see native actionbar buttons as an example of that behavior). This background
-   *         type is available on Android API level 21+
+   * Determines the type of background drawable used to display touch feedback. Use one of the static methods to generate this value:
+   *
+   * - `TouchableNativeFeedback.SelectableBackground()` - Default background for selectable elements.
+   * - `TouchableNativeFeedback.SelectableBackgroundBorderless()` - Default background for borderless selectable elements. API 21+.
+   * - `TouchableNativeFeedback.Ripple(color, borderless)` - Ripple drawable with the specified color.
    */
   background?: ?(
     | Readonly<{
@@ -103,14 +96,9 @@ export type TouchableNativeFeedbackProps = Readonly<{
       }>
   ),
   /**
-   * Set to true to add the ripple effect to the foreground of the view, instead
-   * of the background. This is useful if one of your child views has a
-   * background of its own, or you're e.g. displaying images, and you don't want
-   * the ripple to be covered by them.
+   * If `true`, adds the ripple effect to the foreground of the view instead of the background. Useful if a child view has its own background, or you are displaying images.
    *
-   * Check TouchableNativeFeedback.canUseNativeForeground() first, as this is
-   * only available on Android 6.0 and above. If you try to use this on older
-   * versions, this will fallback to background.
+   * Check `TouchableNativeFeedback.canUseNativeForeground()` first, as this is only available on Android 6.0 and above. On older versions, this falls back to background.
    */
   useForeground?: ?boolean,
 }>;
@@ -120,14 +108,12 @@ type TouchableNativeFeedbackState = Readonly<{
 }>;
 
 /**
- * A wrapper for making views respond properly to touches (Android only).
- * On Android this component uses native state drawable to display touch feedback.
- * At the moment it only supports having a single View instance as a child node,
- * as it's implemented by replacing that View with another instance of RCTView node with some additional properties set.
+ * A wrapper for making views respond properly to touches (Android only). Uses native state drawable to display touch feedback.
  *
- * Background drawable of native feedback touchable can be customized with background property.
+ * Supports only a single View instance as a child. If you need more extensive and future-proof touch handling, use `Pressable`.
  *
- * @see https://reactnative.dev/docs/touchablenativefeedback#content
+ * @see https://reactnative.dev/docs/touchablenativefeedback
+ * @platform android
  */
 class TouchableNativeFeedback extends React.Component<
   TouchableNativeFeedbackProps,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -71,10 +71,12 @@ export type TouchableOpacityTVProps = Readonly<{
 
 type TouchableOpacityBaseProps = Readonly<{
   /**
-   * Determines what the opacity of the wrapped view should be when touch is active.
-   * Defaults to 0.2
+   * Opacity of the wrapped view when touch is active.
+   *
+   * @default `0.2`
    */
   activeOpacity?: ?number,
+
   style?: ?Animated.WithAnimatedValue<ViewStyleProp>,
 
   hostRef?: ?React.RefSetter<TouchableOpacityInstance>,
@@ -92,88 +94,13 @@ type TouchableOpacityState = Readonly<{
 }>;
 
 /**
- * A wrapper for making views respond properly to touches.
- * On press down, the opacity of the wrapped view is decreased, dimming it.
+ * A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
  *
- * Opacity is controlled by wrapping the children in an Animated.View, which is
- * added to the view hierarchy.  Be aware that this can affect layout.
+ * Opacity is controlled by wrapping the children in an `Animated.View`, which is added to the view hierarchy. Be aware that this can affect layout.
  *
- * Example:
+ * If you need more extensive and future-proof touch handling, use `Pressable`.
  *
- * ```
- * renderButton: function() {
- *   return (
- *     <TouchableOpacity onPress={this._onPressButton}>
- *       <Image
- *         style={styles.button}
- *         source={require('./myButton.png')}
- *       />
- *     </TouchableOpacity>
- *   );
- * },
- * ```
- * ### Example
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react'
- * import {
- *   AppRegistry,
- *   StyleSheet,
- *   TouchableOpacity,
- *   Text,
- *   View,
- * } from 'react-native'
- *
- * class App extends Component {
- *   state = { count: 0 }
- *
- *   onPress = () => {
- *     this.setState(state => ({
- *       count: state.count + 1
- *     }));
- *   };
- *
- *  render() {
- *    return (
- *      <View style={styles.container}>
- *        <TouchableOpacity
- *          style={styles.button}
- *          onPress={this.onPress}>
- *          <Text> Touch Here </Text>
- *        </TouchableOpacity>
- *        <View style={[styles.countContainer]}>
- *          <Text style={[styles.countText]}>
- *             { this.state.count !== 0 ? this.state.count: null}
- *           </Text>
- *         </View>
- *       </View>
- *     )
- *   }
- * }
- *
- * const styles = StyleSheet.create({
- *   container: {
- *     flex: 1,
- *     justifyContent: 'center',
- *     paddingHorizontal: 10
- *   },
- *   button: {
- *     alignItems: 'center',
- *     backgroundColor: '#DDDDDD',
- *     padding: 10
- *   },
- *   countContainer: {
- *     alignItems: 'center',
- *     padding: 10
- *   },
- *   countText: {
- *     color: '#FF00FF'
- *   }
- * })
- *
- * AppRegistry.registerComponent('App', () => App)
- * ```
- *
+ * @see https://reactnative.dev/docs/touchableopacity
  */
 class TouchableOpacity extends React.Component<
   TouchableOpacityProps,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -156,9 +156,9 @@ const PASSTHROUGH_PROPS = [
 ] as const;
 
 /**
- * Do not use unless you have a very good reason.
- * All the elements that respond to press should have a visual feedback when touched.
- * This is one of the primary reason a "web" app doesn't feel "native".
+ * Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
+ *
+ * Supports only one child. If you need more extensive and future-proof touch handling, use `Pressable`.
  *
  * @see https://reactnative.dev/docs/touchablewithoutfeedback
  */

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -19,9 +19,12 @@ import {use} from 'react';
 export type ViewInstance = HostInstance;
 
 /**
- * The most fundamental component for building a UI, View is a container that
+ * The most fundamental component for building a UI. `View` is a container that
  * supports layout with flexbox, style, some touch handling, and accessibility
- * controls.
+ * controls. `View` maps directly to the native view equivalent on whatever
+ * platform React Native is running on, whether that is a `UIView`, `<div>`,
+ * `android.view`, etc. `View` is designed to be nested inside other views and
+ * can have 0 to many children of any type.
  *
  * @see https://reactnative.dev/docs/view
  */

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -112,8 +112,18 @@ type PointerEventProps = Readonly<{
 }>;
 
 type FocusEventProps = Readonly<{
+  /**
+   * Callback that is called when the view is blurred.
+   *
+   * Note: This will only be called if the view is focusable.
+   */
   onBlur?: ?(event: BlurEvent) => void,
   onBlurCapture?: ?(event: BlurEvent) => void,
+  /**
+   * Callback that is called when the view is focused.
+   *
+   * Note: This will only be called if the view is focusable.
+   */
   onFocus?: ?(event: FocusEvent) => void,
   onFocusCapture?: ?(event: FocusEvent) => void,
 }>;
@@ -281,9 +291,17 @@ export type ViewPropsAndroid = Readonly<{
    * Whether this `View` should render itself (and all of its children) into a
    * single hardware texture on the GPU.
    *
-   * @platform android
+   * On Android, this is useful for animations and interactions that only
+   * modify opacity, rotation, translation and/or scale: in those cases, the
+   * view does not have to be redrawn and display lists do not need to be
+   * re-executed. The texture can be re-used and re-composited with different
+   * parameters. The downside is that this can use up limited video memory, so
+   * this prop should be set back to `false` at the end of the interaction/
+   * animation.
    *
-   * See https://reactnative.dev/docs/view#rendertohardwaretextureandroid
+   * @default `false`
+   *
+   * @platform android
    */
   renderToHardwareTextureAndroid?: ?boolean,
 
@@ -296,35 +314,40 @@ export type ViewPropsAndroid = Readonly<{
   hasTVPreferredFocus?: ?boolean,
 
   /**
-   * TV next focus down (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates down.
+   * The value is the `nativeID` of the target view.
    *
    * @platform android
    */
   nextFocusDown?: ?number,
 
   /**
-   * TV next focus forward (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates
+   * forward. The value is the `nativeID` of the target view.
    *
    * @platform android
    */
   nextFocusForward?: ?number,
 
   /**
-   * TV next focus left (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates left.
+   * The value is the `nativeID` of the target view.
    *
    * @platform android
    */
   nextFocusLeft?: ?number,
 
   /**
-   * TV next focus right (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates right.
+   * The value is the `nativeID` of the target view.
    *
    * @platform android
    */
   nextFocusRight?: ?number,
 
   /**
-   * TV next focus up (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates up.
+   * The value is the `nativeID` of the target view.
    *
    * @platform android
    */
@@ -371,6 +394,7 @@ export type TVViewPropsIOS = Readonly<{
    * *(Apple TV only)* May be set to true to force the Apple TV focus engine to move focus to this view.
    *
    * @platform ios
+   * @deprecated Use `focusable` instead
    */
   hasTVPreferredFocus?: boolean,
 
@@ -407,9 +431,18 @@ export type ViewPropsIOS = Readonly<{
   /**
    * Whether this `View` should be rendered as a bitmap before compositing.
    *
-   * @platform ios
+   * On iOS, this is useful for animations and interactions that do not
+   * modify this component's dimensions nor its children; for example, when
+   * translating the position of a static view, rasterization allows the
+   * renderer to skip re-rendering the view frame and re-use the cached
+   * bitmap.
    *
-   * See https://reactnative.dev/docs/view#shouldrasterizeios
+   * Rasterization incurs an offscreen drawing pass and the bitmap consumes
+   * memory. Test and measure when using this property.
+   *
+   * @default `false`
+   *
+   * @platform ios
    */
   shouldRasterizeIOS?: ?boolean,
 }>;
@@ -424,7 +457,7 @@ type ViewBaseProps = Readonly<{
    * optimization. Set this property to `false` to disable this optimization and
    * ensure that this `View` exists in the native view hierarchy.
    *
-   * See https://reactnative.dev/docs/view#collapsable
+   * @default `true`
    */
   collapsable?: ?boolean,
 
@@ -432,6 +465,8 @@ type ViewBaseProps = Readonly<{
    * Setting to false prevents direct children of the view from being removed
    * from the native view hierarchy, similar to the effect of setting
    * `collapsable={false}` on each child.
+   *
+   * @default `true`
    */
   collapsableChildren?: ?boolean,
 
@@ -463,10 +498,21 @@ type ViewBaseProps = Readonly<{
   nativeID?: ?string,
 
   /**
-   * Whether this `View` needs to rendered offscreen and composited with an
+   * Whether this `View` needs to be rendered offscreen and composited with an
    * alpha in order to preserve 100% correct colors and blending behavior.
+   * The default (`false`) falls back to drawing the component and its children
+   * with reduced alpha applied to the paint used to draw each element
+   * instead of rendering the full component offscreen and compositing it back
+   * with an alpha value. This default may be noticeable and undesired in the
+   * case where the `View` you are setting an opacity on has multiple
+   * overlapping elements (e.g. multiple overlapping `View`s, or text and a
+   * background).
    *
-   * See https://reactnative.dev/docs/view#needsoffscreenalphacompositing
+   * Rendering offscreen to preserve correct alpha behavior is extremely
+   * expensive and hard to debug for non-native developers, which is why it is
+   * not turned on by default.
+   *
+   * @default `false`
    */
   needsOffscreenAlphaCompositing?: ?boolean,
 
@@ -486,7 +532,12 @@ type ViewBaseProps = Readonly<{
   /**
    * Controls whether the `View` can be the target of touch events.
    *
-   * See https://reactnative.dev/docs/view#pointerevents
+   * - `'auto'`: The view can be the target of touch events.
+   * - `'none'`: The view is never the target of touch events.
+   * - `'box-none'`: The view is never the target of touch events but its
+   *   subviews can be.
+   * - `'box-only'`: The view can be the target of touch events but its
+   *   subviews cannot be.
    */
   pointerEvents?: ?('auto' | 'box-none' | 'box-only' | 'none'),
 

--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -20,28 +20,34 @@ import * as React from 'react';
 export type {ImageBackgroundProps} from './ImageProps';
 
 /**
- * Very simple drop-in replacement for <Image> which supports nesting views.
+ * A common way to set a background image, similar to `background-image` in
+ * CSS. Accepts the same props as `Image` and allows adding children that
+ * layer on top of the background image. You must specify `width` and `height`
+ * style attributes.
  *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react';
- * import { AppRegistry, View, ImageBackground, Text } from 'react-native';
+ * Example:
  *
- * class DisplayAnImageBackground extends Component {
- *   render() {
- *     return (
- *       <ImageBackground
- *         style={{width: 50, height: 50}}
- *         source={{uri: 'https://reactnative.dev/img/opengraph.png'}}
- *       >
- *         <Text>React</Text>
- *       </ImageBackground>
- *     );
- *   }
- * }
+ * ```tsx
+ * import React from 'react';
+ * import {ImageBackground, StyleSheet, Text} from 'react-native';
  *
- * // App registration and rendering
- * AppRegistry.registerComponent('DisplayAnImageBackground', () => DisplayAnImageBackground);
+ * const App = () => (
+ *   <ImageBackground
+ *     style={styles.background}
+ *     source={{uri: 'https://reactnative.dev/img/opengraph.png'}}>
+ *     <Text>React</Text>
+ *   </ImageBackground>
+ * );
+ *
+ * const styles = StyleSheet.create({
+ *   background: {
+ *     width: 200,
+ *     height: 200,
+ *   },
+ * });
  * ```
+ *
+ * @see https://reactnative.dev/docs/imagebackground
  */
 class ImageBackground extends React.Component<ImageBackgroundProps> {
   setNativeProps(props: {...}) {

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -63,64 +63,86 @@ export type ImagePropsIOS = Readonly<{
   /**
    * A static image to display while loading the image source.
    *
-   * See https://reactnative.dev/docs/image#defaultsource
+   * @platform ios
    */
   defaultSource?: ?ImageSource,
+
   /**
-   * Invoked when a partial load of the image is complete.
+   * Invoked when a partial load of the image is complete. Definition of what
+   * constitutes a "partial load" is loader specific though this is meant for
+   * progressive JPEG loads.
    *
-   * See https://reactnative.dev/docs/image#onpartialload
+   * @platform ios
    */
   onPartialLoad?: ?() => void,
+
   /**
-   * Invoked on download progress with `{nativeEvent: {loaded, total}}`.
+   * Invoked on download progress.
    *
-   * See https://reactnative.dev/docs/image#onprogress
+   * @platform ios
    */
   onProgress?: ?(event: ImageProgressEventIOS) => void,
 }>;
 
 export type ImagePropsAndroid = Readonly<{
   /**
-   * similarly to `source`, this property represents the resource used to render
-   * the loading indicator for the image, displayed until image is ready to be
-   * displayed, typically after when it got downloaded from network.
+   * Resource used to render a loading indicator for the image, displayed
+   * until the image is ready to be displayed.
+   *
+   * @platform android
    */
   loadingIndicatorSource?: ?(number | Readonly<ImageURISource>),
+
+  /**
+   * When `true`, enables progressive JPEG streaming.
+   *
+   * @default `false`
+   * @platform android
+   */
   progressiveRenderingEnabled?: ?boolean,
+
+  /**
+   * Duration of the fade-in animation in milliseconds.
+   *
+   * @default `300`
+   * @platform android
+   */
   fadeDuration?: ?number,
 
   /**
-   * The mechanism that should be used to resize the image when the image's dimensions
-   * differ from the image view's dimensions. Defaults to `auto`.
+   * The mechanism that should be used to resize the image when the image's
+   * dimensions differ from the image view's dimensions.
    *
    * - `auto`: Use heuristics to pick between `resize` and `scale`.
    *
-   * - `resize`: A software operation which changes the encoded image in memory before it
-   * gets decoded. This should be used instead of `scale` when the image is much larger
-   * than the view.
+   * - `resize`: A software operation which changes the encoded image in memory
+   *   before it gets decoded. This should be used instead of `scale` when the
+   *   image is much larger than the view.
    *
-   * - `scale`: The image gets drawn downscaled or upscaled. Compared to `resize`, `scale` is
-   * faster (usually hardware accelerated) and produces higher quality images. This
-   * should be used if the image is smaller than the view. It should also be used if the
-   * image is slightly bigger than the view.
+   * - `scale`: The image gets drawn downscaled or upscaled. Compared to
+   *   `resize`, `scale` is faster (usually hardware accelerated) and produces
+   *   higher quality images. This should be used if the image is smaller than
+   *   the view. It should also be used if the image is slightly bigger than
+   *   the view.
    *
-   * - `none`: No sampling is performed and the image is displayed in its full resolution. This
-   * should only be used in rare circumstances because it is considered unsafe as Android will
-   * throw a runtime exception when trying to render images that consume too much memory.
+   * - `none`: No sampling is performed and the image is displayed in its full
+   *   resolution. This should only be used in rare circumstances because it is
+   *   considered unsafe as Android throws a runtime exception when trying to
+   *   render images that consume too much memory.
    *
-   * More details about `resize` and `scale` can be found at http://frescolib.org/docs/resizing-rotating.html.
-   *
+   * @default `'auto'`
    * @platform android
    */
   resizeMethod?: ?('auto' | 'resize' | 'scale' | 'none'),
 
   /**
-   * When the `resizeMethod` is set to `resize`, the destination dimensions are
+   * When `resizeMethod` is set to `resize`, the destination dimensions are
    * multiplied by this value. The `scale` method is used to perform the
-   * remainder of the resize.
-   * This is used to produce higher quality images when resizing to small dimensions.
-   * Defaults to 1.0.
+   * remainder of the resize. This is used to produce higher quality images
+   * when resizing to small dimensions.
+   *
+   * @default `1.0`
+   * @platform android
    */
   resizeMultiplier?: ?number,
 }>;
@@ -128,138 +150,120 @@ export type ImagePropsAndroid = Readonly<{
 /** @build-types emit-as-interface Expo compatibility */
 export type ImagePropsBase = Readonly<{
   ...Omit<ViewProps, 'style'>,
+
   /**
-   * When true, indicates the image is an accessibility element.
-   *
-   * See https://reactnative.dev/docs/image#accessible
+   * When `true`, indicates the image is an accessibility element.
    */
   accessible?: ?boolean,
 
   /**
-   * Internal prop to set an "Analytics Tag" that can will be set on the Image
+   * Internal prop to set an "Analytics Tag" that can will be set on the Image.
    */
   internal_analyticTag?: ?string,
 
   /**
    * The text that's read by the screen reader when the user interacts with
    * the image.
-   *
-   * See https://reactnative.dev/docs/image#accessibilitylabel
    */
   accessibilityLabel?: ?Stringish,
 
   /**
-   * Alias for accessibilityLabel
-   * See https://reactnative.dev/docs/image#accessibilitylabel
+   * Alias for `accessibilityLabel`.
    */
   'aria-label'?: ?Stringish,
 
   /**
-   * Represents the nativeID of the associated label. When the assistive technology focuses on the component with this props.
+   * Represents the `nativeID` of the associated label. When the assistive
+   * technology focuses on the component with this prop.
    *
    * @platform android
    */
   'aria-labelledby'?: ?string,
+
   /**
-   * The text that's read by the screen reader when the user interacts with
-   * the image.
-   *
-   * See https://reactnative.dev/docs/image#alt
+   * Alternative text description of the image, read by the screen reader
+   * when the user interacts with it. Automatically marks the element as
+   * accessible.
    */
   alt?: ?Stringish,
 
   /**
-   * blurRadius: the blur radius of the blur filter added to the image
-   *
-   * See https://reactnative.dev/docs/image#blurradius
+   * The blur radius of the blur filter added to the image. On iOS, needs to
+   * be more than 5.
    */
   blurRadius?: ?number,
 
   /**
-   * See https://reactnative.dev/docs/image#capinsets
+   * When the image is resized, the corners of the size specified by
+   * `capInsets` stay a fixed size, but the center content and borders of
+   * the image are stretched. This is useful for creating resizable rounded
+   * buttons, shadows, and other resizable assets.
+   *
+   * @platform ios
    */
   capInsets?: ?EdgeInsetsProp,
 
   /**
-   * Adds the CORS related header to the request.
-   * Similar to crossorigin from HTML.
+   * CORS mode for fetching the image resource. When unset, the image
+   * request is made without the CORS header.
    *
-   * See https://reactnative.dev/docs/image#crossorigin
+   * @default `'anonymous'`
    */
   crossOrigin?: ?('anonymous' | 'use-credentials'),
 
   /**
    * Height of the image component.
-   *
-   * See https://reactnative.dev/docs/image#height
    */
   height?: number,
 
   /**
    * Width of the image component.
-   *
-   * See https://reactnative.dev/docs/image#width
    */
   width?: number,
 
   /**
-   * Invoked on load error with `{nativeEvent: {error}}`.
-   *
-   * See https://reactnative.dev/docs/image#onerror
+   * Invoked on load error.
    */
   onError?: ?(event: ImageErrorEvent) => void,
 
   /**
-   * onLayout function
-   *
-   * Invoked on mount and layout changes with
-   *
-   * {nativeEvent: { layout: {x, y, width, height} }}.
-   *
-   * See https://reactnative.dev/docs/image#onlayout
+   * Invoked on mount and on layout changes.
    */
-
   onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
   /**
    * Invoked when load completes successfully.
-   *
-   * See https://reactnative.dev/docs/image#onload
    */
   onLoad?: ?(event: ImageLoadEvent) => void,
 
   /**
    * Invoked when load either succeeds or fails.
-   *
-   * See https://reactnative.dev/docs/image#onloadend
    */
   onLoadEnd?: ?() => void,
 
   /**
    * Invoked on load start.
-   *
-   * See https://reactnative.dev/docs/image#onloadstart
    */
   onLoadStart?: ?() => void,
 
   /**
    * The image source (either a remote URL or a local file resource).
    *
-   * This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments.
-   * The native side will then choose the best uri to display based on the measured size of the image container.
-   * A cache property can be added to control how networked request interacts with the local cache.
+   * This prop can also contain several remote URLs, specified together with
+   * their width and height and potentially with scale/other URI arguments.
+   * The native side then chooses the best URI to display based on the
+   * measured size of the image container. A `cache` property can be added to
+   * control how networked request interacts with the local cache.
    *
-   * The currently supported formats are png, jpg, jpeg, bmp, gif, webp (Android only), psd (iOS only).
-   *
-   * See https://reactnative.dev/docs/image#source
+   * The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`,
+   * `webp` (Android only), and `psd` (iOS only).
    */
   source?: ?ImageSource,
 
   /**
-   * A string indicating which referrer to use when fetching the resource.
-   * Similar to referrerpolicy from HTML.
+   * Which referrer to use when fetching the image resource.
    *
-   * See https://reactnative.dev/docs/image#referrerpolicy
+   * @default `'strict-origin-when-cross-origin'`
    */
   referrerPolicy?: ?(
     | 'no-referrer'
@@ -276,59 +280,50 @@ export type ImagePropsBase = Readonly<{
    * Determines how to resize the image when the frame doesn't match the raw
    * image dimensions.
    *
-   * 'cover': Scale the image uniformly (maintain the image's aspect ratio)
-   * so that both dimensions (width and height) of the image will be equal
-   * to or larger than the corresponding dimension of the view (minus padding).
+   * - `cover`: Scale the image uniformly (maintain the image's aspect ratio)
+   *   so that both dimensions (width and height) of the image are equal to
+   *   or larger than the corresponding dimension of the view (minus padding).
    *
-   * 'contain': Scale the image uniformly (maintain the image's aspect ratio)
-   * so that both dimensions (width and height) of the image will be equal to
-   * or less than the corresponding dimension of the view (minus padding).
+   * - `contain`: Scale the image uniformly (maintain the image's aspect
+   *   ratio) so that both dimensions (width and height) of the image are
+   *   equal to or less than the corresponding dimension of the view (minus
+   *   padding).
    *
-   * 'stretch': Scale width and height independently, This may change the
-   * aspect ratio of the src.
+   * - `stretch`: Scale width and height independently. This may change the
+   *   aspect ratio of the source.
    *
-   * 'repeat': Repeat the image to cover the frame of the view.
-   * The image will keep it's size and aspect ratio. (iOS only)
+   * - `repeat`: Repeat the image to cover the frame of the view. The image
+   *   keeps its size and aspect ratio (iOS only).
    *
-   * 'center': Scale the image down so that it is completely visible,
-   * if bigger than the area of the view.
-   * The image will not be scaled up.
+   * - `center`: Scale the image down so that it is completely visible, if
+   *   bigger than the area of the view. The image is not scaled up.
    *
-   * 'none': Do not resize the image. The image will be displayed at its intrinsic size.
+   * - `none`: Do not resize the image. The image is displayed at its
+   *   intrinsic size.
    *
-   * See https://reactnative.dev/docs/image#resizemode
+   * @default `'cover'`
    */
   resizeMode?: ?ImageResizeMode,
 
-  /**
-   * A unique identifier for this element to be used in UI Automation
-   * testing scripts.
-   *
-   * See https://reactnative.dev/docs/image#testid
-   */
   testID?: ?string,
 
   /**
-   * Changes the color of all the non-transparent pixels to the tintColor.
-   *
-   * See https://reactnative.dev/docs/image#tintcolor
+   * Changes the color of all non-transparent pixels to the `tintColor`.
    */
   tintColor?: ColorValue,
 
   /**
-   * A string representing the resource identifier for the image. Similar to
-   * src from HTML.
-   *
-   * See https://reactnative.dev/docs/image#src
+   * A remote URL string for the image resource. Takes precedence over
+   * `source`.
    */
   src?: ?string,
 
   /**
-   * Similar to srcset from HTML.
-   *
-   * See https://reactnative.dev/docs/image#srcset
+   * Comma-separated list of candidate image sources with pixel density
+   * descriptors.
    */
   srcSet?: ?string,
+
   children?: empty,
 }>;
 
@@ -338,7 +333,7 @@ export type ImageProps = Readonly<{
   ...ImagePropsBase,
 
   /**
-   * See https://reactnative.dev/docs/image#style
+   * Style applied to the `Image` component.
    */
   style?: ?ImageStyleProp,
 }>;
@@ -349,23 +344,19 @@ export type ImageBackgroundProps = Readonly<{
   children?: React.Node,
 
   /**
-   * Style applied to the outer View component
-   *
-   * See https://reactnative.dev/docs/imagebackground#style
+   * Style applied to the outer `View` wrapper. Accepts `ViewStyle` props
+   * rather than `ImageStyle` props.
    */
   style?: ?ViewStyleProp,
 
   /**
-   * Style applied to the inner Image component
-   *
-   * See https://reactnative.dev/docs/imagebackground#imagestyle
+   * Style applied to the inner `Image` component.
    */
   imageStyle?: ?ImageStyleProp,
 
   /**
-   * Allows to set a reference to the inner Image component
-   *
-   * See https://reactnative.dev/docs/imagebackground#imageref
+   * A ref setter assigned the element node of the inner `Image` component
+   * when mounted.
    */
   imageRef?: React.RefSetter<React.ElementRef<ImageType>>,
 }>;

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -47,12 +47,6 @@ const ModalEventEmitter =
       )
     : null;
 
-/**
- * The Modal component is a simple way to present content above an enclosing view.
- *
- * See https://reactnative.dev/docs/modal
- */
-
 // In order to route onDismiss callbacks, we need to uniquely identifier each
 // <Modal> on screen. There can be different ones, either nested or as siblings.
 // We cannot pass the onDismiss callback to native as the view will be
@@ -66,42 +60,50 @@ type OrientationChangeEvent = Readonly<{
 /** @build-types emit-as-interface Uniwind compatibility */
 export type ModalBaseProps = {
   /**
-   * @deprecated Use animationType instead
+   * @deprecated Use `animationType` instead.
    */
   animated?: boolean,
+
   /**
-   * The `animationType` prop controls how the modal animates.
+   * Controls how the modal animates. `'slide'` slides in from the bottom,
+   * `'fade'` fades into view, `'none'` appears without animation.
    *
-   * - `slide` slides in from the bottom
-   * - `fade` fades into view
-   * - `none` appears without an animation
+   * @default `'none'`
    */
   animationType?: ?('none' | 'slide' | 'fade'),
+
   /**
-   * The `transparent` prop determines whether your modal will fill the entire view.
-   * Setting this to `true` will render the modal over a transparent background.
+   * Whether the modal fills the entire view. Setting to `true` renders the
+   * modal over a transparent background.
+   *
+   * @default `false`
    */
   transparent?: ?boolean,
+
   /**
-   * The `visible` prop determines whether your modal is visible.
+   * Whether the modal is visible.
+   *
+   * @default `true`
    */
   visible?: ?boolean,
+
   /**
-   * The `onRequestClose` callback is called when the user taps the hardware back button on Android, dismisses the sheet using a gesture on iOS (when `allowSwipeDismissal` is set to true) or the menu button on Apple TV.
-   *
-   * This is required on iOS and Android.
+   * Called when the user taps the hardware back button on Android, the menu
+   * button on Apple TV, or the modal is dismissed via drag gesture on iOS
+   * (when `allowSwipeDismissal` is `true`). Required on Android and TV.
    */
   // onRequestClose?: (event: NativeSyntheticEvent<any>) => void;
   onRequestClose?: ?DirectEventHandler<null>,
+
   /**
-   * The `onShow` prop allows passing a function that will be called once the modal has been shown.
+   * Called once the modal has been shown.
    */
   // onShow?: (event: NativeSyntheticEvent<any>) => void;
   onShow?: ?DirectEventHandler<null>,
 
   /**
-   * The `backdropColor` props sets the background color of the modal's container.
-   * Defaults to `white` if not provided and transparent is `false`. Ignored if `transparent` is `true`.
+   * The backdrop color of the modal's container. Defaults to `white` if
+   * `transparent` is `false`. Ignored if `transparent` is `true`.
    */
   backdropColor?: ColorValue,
 
@@ -113,7 +115,11 @@ export type ModalBaseProps = {
 
 export type ModalPropsIOS = {
   /**
-   * The `presentationStyle` determines the style of modal to show
+   * Controls how the modal appears.
+   *
+   * @default `'fullScreen'` if `transparent` is `false`, `'overFullScreen'` if `transparent` is `true`.
+   *
+   * @platform ios
    */
   presentationStyle?: ?(
     | 'fullScreen'
@@ -123,8 +129,13 @@ export type ModalPropsIOS = {
   ),
 
   /**
-   * The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations.
-   * On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
+   * Array of orientations the modal can be rotated to. On iOS, the modal is
+   * still restricted by what is specified in your app's Info.plist
+   * `UISupportedInterfaceOrientations` field.
+   *
+   * @default `['portrait']`
+   *
+   * @platform ios
    */
   supportedOrientations?: ?ReadonlyArray<
     | 'portrait'
@@ -135,14 +146,19 @@ export type ModalPropsIOS = {
   >,
 
   /**
-   * The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
+   * Called once the modal has been dismissed.
+   *
+   * @platform ios
    */
   // onDismiss?: (() => void) | undefined;
   onDismiss?: ?() => void,
 
   /**
-   * The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed.
-   * The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
+   * Called when the orientation changes while the modal is displayed. The
+   * orientation provided is only `'portrait'` or `'landscape'`. This callback
+   * is also called on initial render, regardless of the current orientation.
+   *
+   * @platform ios
    */
   // onOrientationChange?:
   //   | ((event: NativeSyntheticEvent<any>) => void)
@@ -150,25 +166,42 @@ export type ModalPropsIOS = {
   onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
 
   /**
-   * Controls whether the modal can be dismissed by swiping down on iOS.
-   * This requires you to implement the `onRequestClose` prop to handle the dismissal.
+   * Controls whether the modal can be dismissed by swiping down. Requires
+   * `onRequestClose` to be set.
+   *
+   * @default `false`
+   *
+   * @platform ios
    */
   allowSwipeDismissal?: ?boolean,
 };
 
 export type ModalPropsAndroid = {
   /**
-   *  Controls whether to force hardware acceleration for the underlying window.
+   * Controls whether to force hardware acceleration for the underlying window.
+   *
+   * @default `false`
+   *
+   * @platform android
    */
   hardwareAccelerated?: ?boolean,
 
   /**
-   *  Determines whether your modal should go under the system statusbar.
+   * Whether the modal should go under the system statusbar.
+   *
+   * @default `false`
+   *
+   * @platform android
    */
   statusBarTranslucent?: ?boolean,
 
   /**
-   *  Determines whether your modal should go under the system navigationbar.
+   * Whether the modal should go under the system navigation bar.
+   * `statusBarTranslucent` also needs to be `true`.
+   *
+   * @default `false`
+   *
+   * @platform android
    */
   navigationBarTranslucent?: ?boolean,
 };
@@ -218,6 +251,11 @@ type ModalState = {
   isRendered: boolean,
 };
 
+/**
+ * A basic way to present content above an enclosing view.
+ *
+ * @see https://reactnative.dev/docs/modal
+ */
 class Modal extends React.Component<ModalProps, ModalState> {
   static defaultProps: {hardwareAccelerated: boolean, visible: boolean} = {
     visible: true,

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -36,7 +36,11 @@ export type TextInstance = HostInstance;
 export type {TextProps} from './TextProps';
 
 /**
- * Text is the fundamental component for displaying text.
+ * A React component for displaying text. `Text` supports nesting, styling,
+ * and touch handling.
+ *
+ * `Text` uses text layout instead of flexbox — elements inside wrap at end of
+ * line rather than being positioned as rectangles.
  *
  * @see https://reactnative.dev/docs/text
  */

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -40,14 +40,19 @@ type TextPointerEventProps = Readonly<{
 
 export type TextPropsIOS = {
   /**
-   * Specifies whether font should be scaled down automatically to fit given style constraints.
+   * Whether fonts should be scaled down to fit style constraints.
    *
-   * See https://reactnative.dev/docs/text#adjustsfontsizetofit
+   * @default `false`
+   * @platform ios
    */
   adjustsFontSizeToFit?: ?boolean,
 
   /**
-   * The Dynamic Type scale ramp to apply to this element on iOS.
+   * The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/textstyle)
+   * ramp to apply.
+   *
+   * @default `'body'`
+   * @platform ios
    */
   dynamicTypeRamp?: ?(
     | 'caption2'
@@ -67,14 +72,16 @@ export type TextPropsIOS = {
    * When `true`, no visual change is made when text is pressed down. By
    * default, a gray oval highlights the text on press down.
    *
-   * See https://reactnative.dev/docs/text#supperhighlighting
+   * @default `false`
+   * @platform ios
    */
   suppressHighlighting?: ?boolean,
 
   /**
-   * Set line break strategy on iOS.
+   * Line break strategy on iOS.
    *
-   * See https://reactnative.dev/docs/text.html#linebreakstrategyios
+   * @default `'none'`
+   * @platform ios
    */
   lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
 };
@@ -83,40 +90,40 @@ export type TextPropsAndroid = {
   /**
    * Specifies the disabled state of the text view for testing purposes.
    *
-   * See https://reactnative.dev/docs/text#disabled
+   * @platform android
    */
   disabled?: ?boolean,
 
   /**
-   * The highlight color of the text.
+   * Highlight color of the text when selected.
    *
-   * See https://reactnative.dev/docs/text#selectioncolor
+   * @platform android
    */
   selectionColor?: ?ColorValue,
 
   /**
-   * Determines the types of data converted to clickable URLs in the text element.
-   * By default no data types are detected.
+   * Types of data converted to clickable URLs in the text element.
+   *
+   * @default `'none'`
+   * @platform android
    */
   dataDetectorType?: ?('phoneNumber' | 'link' | 'email' | 'none' | 'all'),
 
   /**
-   * Set text break strategy on Android API Level 23+
-   * default is `highQuality`.
+   * Text break strategy on Android.
    *
-   * See https://reactnative.dev/docs/text#textbreakstrategy
+   * @default `'highQuality'`
+   * @platform android
    */
   textBreakStrategy?: ?('balanced' | 'highQuality' | 'simple'),
 
-  /**
-   * iOS Only
-   */
   adjustsFontSizeToFit?: ?boolean,
 
   /**
-   * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
+   * Smallest possible font scale when `adjustsFontSizeToFit` is enabled
+   * (values 0.01-1.0).
    *
-   * See https://reactnative.dev/docs/text#minimumfontscale
+   * @platform ios
    */
   minimumFontScale?: ?number,
 };
@@ -126,110 +133,68 @@ type TextBaseProps = Readonly<{
 
   /**
    * Controls whether the `Text` can be the target of touch events.
-   *
-   * See https://reactnative.dev/docs/view#pointerevents
    */
   pointerEvents?: ?('auto' | 'box-none' | 'box-only' | 'none'),
 
   /**
    * Whether fonts should scale to respect Text Size accessibility settings.
-   * The default is `true`.
    *
-   * See https://reactnative.dev/docs/text#allowfontscaling
+   * @default `true`
    */
   allowFontScaling?: ?boolean,
 
   /**
-   * Set hyphenation strategy on Android.
+   * Sets automatic hyphenation frequency.
    *
+   * @default `'none'`
+   * @platform android
    */
   android_hyphenationFrequency?: ?('normal' | 'none' | 'full'),
+
   children?: ?React.Node,
 
   /**
-   * When `numberOfLines` is set, this prop defines how text will be
-   * truncated.
+   * How text is truncated when `numberOfLines` is set. On Android with
+   * `numberOfLines` greater than 1, only `'tail'` works correctly.
    *
-   * This can be one of the following values:
-   *
-   * - `head` - The line is displayed so that the end fits in the container and the missing text
-   * at the beginning of the line is indicated by an ellipsis glyph. e.g., "...wxyz"
-   * - `middle` - The line is displayed so that the beginning and end fit in the container and the
-   * missing text in the middle is indicated by an ellipsis glyph. "ab...yz"
-   * - `tail` - The line is displayed so that the beginning fits in the container and the
-   * missing text at the end of the line is indicated by an ellipsis glyph. e.g., "abcd..."
-   * - `clip` - Lines are not drawn past the edge of the text container.
-   *
-   * The default is `tail`.
-   *
-   * `numberOfLines` must be set in conjunction with this prop.
-   *
-   * > `clip` is working only for iOS
-   *
-   * See https://reactnative.dev/docs/text#ellipsizemode
+   * @default `'tail'`
    */
   ellipsizeMode?: ?('clip' | 'head' | 'middle' | 'tail'),
 
-  /**
-   * Used to reference react managed views from native code.
-   *
-   * See https://reactnative.dev/docs/text#nativeid
-   */
   id?: string,
 
   /**
-   * Specifies largest possible scale a font can reach when `allowFontScaling` is enabled.
-   * Possible values:
-   * `null/undefined` (default): inherit from the parent node or the global default (0)
-   * `0`: no max, ignore parent/global default
-   * `>= 1`: sets the maxFontSizeMultiplier of this node to this value
+   * Largest possible font scale when `allowFontScaling` is enabled.
+   * `null`/`undefined` inherits from the parent node or the global default (0).
+   * `0` means no max (ignores parent/global default). `>= 1` sets the
+   * `maxFontSizeMultiplier` of this node to this value.
    */
   maxFontSizeMultiplier?: ?number,
 
-  /**
-   * Used to locate this view from native code.
-   *
-   * See https://reactnative.dev/docs/text#nativeid
-   */
   nativeID?: ?string,
 
   /**
-   * Used to truncate the text with an ellipsis after computing the text
-   * layout, including line wrapping, such that the total number of lines
-   * does not exceed this number.
+   * Truncate text with an ellipsis after this many lines. `0` means no
+   * restriction.
    *
-   * This prop is commonly used with `ellipsizeMode`.
-   *
-   * See https://reactnative.dev/docs/text#numberoflines
+   * @default `0`
    */
   numberOfLines?: ?number,
 
-  /**
-   * Invoked on mount and layout changes.
-   *
-   * {nativeEvent: { layout: {x, y, width, height}}}.
-   *
-   * See https://reactnative.dev/docs/text#onlayout
-   */
   onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
-  /**
-   * This function is called on long press.
-   * e.g., `onLongPress={this.increaseSize}>`
-   *
-   * See https://reactnative.dev/docs/text#onlongpress
-   */
+  /** Called on long press. */
   onLongPress?: ?(event: GestureResponderEvent) => unknown,
 
-  /**
-   * This function is called on press.
-   * Text intrinsically supports press handling with a default highlight state (which can be disabled with suppressHighlighting).
-   *
-   * See https://reactnative.dev/docs/text#onpress
-   */
+  /** Called on press, triggered after `onPressOut`. */
   onPress?: ?(event: GestureResponderEvent) => unknown,
+
+  /** Called immediately when a touch is engaged. */
   onPressIn?: ?(event: GestureResponderEvent) => unknown,
+
+  /** Called when a touch is released. */
   onPressOut?: ?(event: GestureResponderEvent) => unknown,
+
   onResponderGrant?: ?(event: GestureResponderEvent) => void,
   onResponderMove?: ?(event: GestureResponderEvent) => void,
   onResponderRelease?: ?(event: GestureResponderEvent) => void,
@@ -237,13 +202,13 @@ type TextBaseProps = Readonly<{
   onResponderTerminationRequest?: ?() => boolean,
   onStartShouldSetResponder?: ?() => boolean,
   onMoveShouldSetResponder?: ?() => boolean,
+
+  /** Invoked on text layout change. */
   onTextLayout?: ?(event: TextLayoutEvent) => unknown,
 
   /**
    * Defines how far your touch may move off of the button, before
    * deactivating the button.
-   *
-   * See https://reactnative.dev/docs/text#pressretentionoffset
    */
   pressRetentionOffset?: ?PressRetentionOffset,
 
@@ -253,22 +218,14 @@ type TextBaseProps = Readonly<{
   role?: ?Role,
 
   /**
-   * Lets the user select text.
+   * Lets the user select text for native copy and paste.
    *
-   * See https://reactnative.dev/docs/text#selectable
+   * @default `false`
    */
   selectable?: ?boolean,
 
-  /**
-   * @see https://reactnative.dev/docs/text#style
-   */
   style?: ?TextStyleProp,
 
-  /**
-   * Used to locate this view in end-to-end tests.
-   *
-   * See https://reactnative.dev/docs/text#testid
-   */
   testID?: ?string,
 }>;
 


### PR DESCRIPTION
Summary:
**Context**

Strict TypeScript API readiness: High quality inline docs should reach users via TypeScript in their IDEs.

**This diff**

I asked Claude to crawl reactnative.dev and insert JSDoc comments into our core components, based on some manual-pass starting points.

This is also a quality pass on all modules touched, standardising JSDoc use, and in some cases merging/removing redundant information (preferring the docs we’ve maintained more carefully on the website).

Commit 1 of 2 (Components).

Replaces https://github.com/react/react-native/pull/57380.

Changelog: [Internal]

Differential Revision: D110195869


