### PR TITLE
Migrate/audit JSDoc on public APIs (APIs)

### DIFF
--- a/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -38,6 +38,10 @@ export type ShareActionSheetIOSOptions = Readonly<{
   tintColor?: ?number,
   cancelButtonTintColor?: ?number,
   disabledButtonTintColor?: ?number,
+  /**
+   * The activities to exclude from the ActionSheet.
+   * For example: ['com.apple.UIKit.activity.PostToTwitter']
+   */
   excludedActivityTypes?: ?Array<string>,
   userInterfaceStyle?: ?string,
 }>;
@@ -50,9 +54,10 @@ export type ShareActionSheetError = Readonly<{
 }>;
 
 /**
- * Display action sheets and share sheets on iOS.
+ * Displays native iOS action sheets and share sheets.
  *
- * See https://reactnative.dev/docs/actionsheetios
+ * @see https://reactnative.dev/docs/actionsheetios
+ * @platform ios
  */
 const ActionSheetIOS = {
   /**
@@ -62,15 +67,13 @@ const ActionSheetIOS = {
    *
    * - `options` (array of strings) - a list of button titles (required)
    * - `cancelButtonIndex` (int) - index of cancel button in `options`
-   * - `destructiveButtonIndex` (int or array of ints) - index or indices of destructive buttons in `options`
+   * - `destructiveButtonIndex` (int or array of ints) - indices of destructive buttons in `options`
    * - `title` (string) - a title to show above the action sheet
    * - `message` (string) - a message to show below the title
    * - `disabledButtonIndices` (array of numbers) - a list of button indices which should be disabled
    *
-   * The 'callback' function takes one parameter, the zero-based index
-   * of the selected item.
-   *
-   * See https://reactnative.dev/docs/actionsheetios#showactionsheetwithoptions
+   * The `callback` function receives the zero-based index of the selected
+   * item.
    */
   showActionSheetWithOptions(
     options: ActionSheetIOSOptions,
@@ -136,27 +139,19 @@ const ActionSheetIOS = {
   },
 
   /**
-   * Display the iOS share sheet. The `options` object should contain
-   * one or both of `message` and `url` and can additionally have
-   * a `subject` or `excludedActivityTypes`:
+   * Display the iOS share sheet. The `options` object should contain one or
+   * both of `message` and `url` and can additionally have a `subject` or
+   * `excludedActivityTypes`:
    *
    * - `url` (string) - a URL to share
    * - `message` (string) - a message to share
    * - `subject` (string) - a subject for the message
-   * - `excludedActivityTypes` (array) - the activities to exclude from
-   *   the ActionSheet
+   * - `excludedActivityTypes` (array) - the activities to exclude from the ActionSheet
    * - `tintColor` (color) - tint color of the buttons
    *
-   * The 'failureCallback' function takes one parameter, an error object.
-   * The only property defined on this object is an optional `stack` property
-   * of type `string`.
-   *
-   * The 'successCallback' function takes two parameters:
-   *
-   * - a boolean value signifying success or failure
-   * - a string that, in the case of success, indicates the method of sharing
-   *
-   * See https://reactnative.dev/docs/actionsheetios#showshareactionsheetwithoptions
+   * The `failureCallback` function receives an error object. The
+   * `successCallback` function receives a boolean indicating success and a
+   * string describing the sharing method used.
    */
   showShareActionSheetWithOptions(
     options: ShareActionSheetIOSOptions,
@@ -186,8 +181,8 @@ const ActionSheetIOS = {
   },
 
   /**
-   * Dismisses the most upper iOS action sheet presented, if no action sheet is
-   * present a warning is displayed.
+   * Dismiss the most upper action sheet currently presented. Displays a
+   * warning if no action sheet is present.
    */
   dismissActionSheet: () => {
     invariant(RCTActionSheetManager, "ActionSheetManager doesn't exist");

--- a/packages/react-native/Libraries/Alert/Alert.js
+++ b/packages/react-native/Libraries/Alert/Alert.js
@@ -57,9 +57,43 @@ export type AlertOptions = {
  * alerts. On iOS, you can show an alert that prompts the user to enter
  * some information.
  *
- * See https://reactnative.dev/docs/alert
+ * ## iOS
+ *
+ * On iOS you can specify any number of buttons. Each button can optionally
+ * specify a style, which is one of 'default', 'cancel' or 'destructive'.
+ *
+ * ## Android
+ *
+ * On Android at most three buttons can be specified. Android has a concept
+ * of a neutral, negative and a positive button:
+ *
+ *   - If you specify one button, it will be the 'positive' one (such as 'OK')
+ *   - Two buttons mean 'negative', 'positive' (such as 'Cancel', 'OK')
+ *   - Three buttons mean 'neutral', 'negative', 'positive' (such as 'Later', 'Cancel', 'OK')
+ *
+ * Example:
+ *
+ * ```tsx
+ * // Works on both iOS and Android
+ * Alert.alert(
+ *   'Alert Title',
+ *   'My Alert Msg',
+ *   [
+ *     {text: 'Ask me later', onPress: () => console.log('Ask me later pressed')},
+ *     {text: 'Cancel', onPress: () => console.log('Cancel Pressed'), style: 'cancel'},
+ *     {text: 'OK', onPress: () => console.log('OK Pressed')},
+ *   ]
+ * )
+ * ```
+ *
+ * @see https://reactnative.dev/docs/alert
  */
 class Alert {
+  /**
+   * Display an alert dialog with the specified title, message, and buttons.
+   * On Android, at most three buttons can be specified. On iOS, any number of
+   * buttons can be used.
+   */
   static alert(
     title: ?string,
     message?: ?string,
@@ -140,6 +174,9 @@ class Alert {
   }
 
   /**
+   * Create and display a prompt to enter text. Accepts a title, message,
+   * callback or buttons, input type, default value, keyboard type, and options.
+   *
    * @platform ios
    */
   static prompt(

--- a/packages/react-native/Libraries/Animated/AnimatedExports.js
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js
@@ -24,21 +24,43 @@ const Animated: typeof AnimatedImplementation = Platform.isDisableAnimations
   : AnimatedImplementation;
 
 export default {
+  /**
+   * FlatList and SectionList infer generic Type defined under their `data` and `section` props.
+   */
   get FlatList(): AnimatedFlatList<any> {
     return require('./components/AnimatedFlatList').default;
   },
+  /**
+   * Animated variants of the basic native views. Accepts Animated.Value for
+   * props and style.
+   */
   get Image(): AnimatedImage {
     return require('./components/AnimatedImage').default;
   },
+  /**
+   * Animated variants of the basic native views. Accepts Animated.Value for
+   * props and style.
+   */
   get ScrollView(): AnimatedScrollView {
     return require('./components/AnimatedScrollView').default;
   },
+  /**
+   * FlatList and SectionList infer generic Type defined under their `data` and `section` props.
+   */
   get SectionList(): AnimatedSectionList<any, any> {
     return require('./components/AnimatedSectionList').default;
   },
+  /**
+   * Animated variants of the basic native views. Accepts Animated.Value for
+   * props and style.
+   */
   get Text(): AnimatedText {
     return require('./components/AnimatedText').default;
   },
+  /**
+   * Animated variants of the basic native views. Accepts Animated.Value for
+   * props and style.
+   */
   get View(): AnimatedView {
     return require('./components/AnimatedView').default;
   },

--- a/packages/react-native/Libraries/Animated/AnimatedImplementation.js
+++ b/packages/react-native/Libraries/Animated/AnimatedImplementation.js
@@ -40,8 +40,29 @@ import AnimatedValue from './nodes/AnimatedValue';
 import AnimatedValueXY from './nodes/AnimatedValueXY';
 
 export type CompositeAnimation = {
+  /**
+   * Animations are started by calling start() on your animation.
+   * start() takes a completion callback that will be called when the
+   * animation is done or when the animation is done because stop() was
+   * called on it before it could finish.
+   *
+   * @param callback - Optional function that will be called
+   *      after the animation finished running normally or when the animation
+   *      is done because stop() was called on it before it could finish
+   *
+   * @example
+   *   Animated.timing({}).start(({ finished }) => {
+   *    // completion callback
+   *   });
+   */
   start: (callback?: ?EndCallback, isLooping?: boolean) => void,
+  /**
+   * Stops any running animation.
+   */
   stop: () => void,
+  /**
+   * Stops any running animation and resets the value to its original.
+   */
   reset: () => void,
   _startNativeLoop: (iterations?: number) => void,
   _isUsingNativeDriver: () => boolean,
@@ -621,21 +642,104 @@ export default {
    * See https://reactnative.dev/docs/animated#node
    */
   Node: AnimatedNode,
+  /**
+   * Animates a value from an initial velocity to zero based on a decay
+   * coefficient.
+   */
   decay: decayImpl,
+  /**
+   * Animates a value along a timed easing curve.  The `Easing` module has tons
+   * of pre-defined curves, or you can use your own function.
+   */
   timing: timingImpl,
+  /**
+   * Spring animation based on Rebound and Origami.  Tracks velocity state to
+   * create fluid motions as the `toValue` updates, and can be chained together.
+   */
   spring: springImpl,
+  /**
+   * Creates a new Animated value composed from two Animated values added
+   * together.
+   */
   add: addImpl,
+  /**
+   * Creates a new Animated value composed by subtracting the second Animated
+   * value from the first Animated value.
+   */
   subtract: subtractImpl,
+  /**
+   * Creates a new Animated value composed by dividing the first Animated
+   * value by the second Animated value.
+   */
   divide: divideImpl,
+  /**
+   * Creates a new Animated value composed from two Animated values multiplied
+   * together.
+   */
   multiply: multiplyImpl,
+  /**
+   * Creates a new Animated value that is the (non-negative) modulo of the
+   * provided Animated value
+   */
   modulo: moduloImpl,
+  /**
+   * Create a new Animated value that is limited between 2 values. It uses the
+   * difference between the last value so even if the value is far from the bounds
+   * it will start changing when the value starts getting closer again.
+   * (`value = clamp(value + diff, min, max)`).
+   *
+   * This is useful with scroll events, for example, to show the navbar when
+   * scrolling up and to hide it when scrolling down.
+   */
   diffClamp: diffClampImpl,
+  /**
+   * Starts an animation after the given delay.
+   */
   delay: delayImpl,
+  /**
+   * Starts an array of animations in order, waiting for each to complete
+   * before starting the next.  If the current running animation is stopped, no
+   * following animations will be started.
+   */
   sequence: sequenceImpl,
+  /**
+   * Starts an array of animations all at the same time.  By default, if one
+   * of the animations is stopped, they will all be stopped.  You can override
+   * this with the `stopTogether` flag.
+   */
   parallel: parallelImpl,
+  /**
+   * Array of animations may run in parallel (overlap), but are started in
+   * sequence with successive delays.  Nice for doing trailing effects.
+   */
   stagger: staggerImpl,
+  /**
+   * Loops a given animation continuously, so that each time it reaches the end,
+   * it resets and begins again from the start. Can specify number of times to
+   * loop using the key 'iterations' in the config. Will loop without blocking
+   * the UI thread if the child animation is set to 'useNativeDriver'.
+   */
   loop: loopImpl,
+  /**
+   *  Takes an array of mappings and extracts values from each arg accordingly,
+   *  then calls `setValue` on the mapped outputs.  e.g.
+   *
+   *```javascript
+   *  onScroll={Animated.event(
+   *    [{nativeEvent: {contentOffset: {x: this._scrollX}}}]
+   *    {listener},          // Optional async listener
+   *  )
+   *  ...
+   *  onPanResponderMove: Animated.event([
+   *    null,                // raw event arg ignored
+   *    {dx: this._panX},    // gestureState arg
+   *  ]),
+   *```
+   */
   event: eventImpl,
+  /**
+   * Make any React component Animatable.  Used to create `Animated.View`, etc.
+   */
   createAnimatedComponent,
   attachNativeEvent: attachNativeEventImpl,
   forkEvent: forkEventImpl,

--- a/packages/react-native/Libraries/Animated/Easing.js
+++ b/packages/react-native/Libraries/Animated/Easing.js
@@ -15,9 +15,8 @@ let ease;
 export type EasingFunction = (t: number) => number;
 
 /**
- * The `Easing` module implements common easing functions. This module is used
- * by [Animate.timing()](docs/animate.html#timing) to convey physically
- * believable motion in animations.
+ * Implements common easing functions for use with `Animated.timing()` to convey
+ * physically believable motion in animations.
  *
  * You can find a visualization of some common easing functions at
  * http://easings.net/
@@ -58,6 +57,8 @@ export type EasingFunction = (t: number) => number;
  * - [`in`](docs/easing.html#in) runs an easing function forwards
  * - [`inOut`](docs/easing.html#inout) makes any easing function symmetrical
  * - [`out`](docs/easing.html#out) runs an easing function backwards
+ *
+ * @see https://reactnative.dev/docs/easing
  */
 const EasingStatic = {
   /**

--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -15,13 +15,18 @@ import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import NativeAppState from './NativeAppState';
 
 /**
- * active - The app is running in the foreground
- * background - The app is running in the background. The user is either:
- *   - in another app
- *   - on the home screen
- *   - [Android only] on another Activity, including temporary system activities such
- *     as autofill credential pickers (even if launched by your app or the system)
- * @platform ios - inactive - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
+ * The app's current state.
+ *
+ * - `active` — The app is running in the foreground.
+ * - `background` — The app is running in the background. The user is either
+ *   in another app, on the home screen, or (Android only) on another Activity,
+ *   including temporary system activities such as autofill credential pickers.
+ * - `inactive` — A transitional state that occurs when moving between
+ *   foreground and background, and during periods of inactivity such as
+ *   entering the multitasking view, opening the Notification Center, or in the
+ *   event of an incoming call.
+ *
+ * @platform ios `inactive`
  */
 export type AppStateStatus =
   | 'inactive'
@@ -31,10 +36,15 @@ export type AppStateStatus =
   | 'unknown';
 
 /**
- * change - This even is received when the app state has changed.
- * memoryWarning - This event is used in the need of throwing memory warning or releasing it.
- * @platform android - focus - Received when the app gains focus (the user is interacting with the app).
- * @platform android - blur - Received when the user is not actively interacting with the app.
+ * Events emitted by `AppState`.
+ *
+ * - `change` — Received when the app state has changed.
+ * - `memoryWarning` — Received when the system issues a memory warning.
+ * - `focus` — Received when the app gains focus (the user is interacting
+ *   with the app).
+ * - `blur` — Received when the user is not actively interacting with the app.
+ *
+ * @platform android `focus`, `blur`
  */
 type AppStateEventDefinitions = {
   change: [AppStateStatus],
@@ -52,13 +62,18 @@ type NativeAppStateEventDefinitions = {
 };
 
 /**
- * `AppState` can tell you if the app is in the foreground or background,
- * and notify you when the state changes.
+ * Reports the app's current state (`active`, `background`, or `inactive`) and
+ * notifies when it changes. Frequently used to handle push notification
+ * behavior.
  *
- * See https://reactnative.dev/docs/appstate
+ * @see https://reactnative.dev/docs/appstate
  */
 class AppStateImpl {
+  /**
+   * The current app state. Can be `null` until the initial value is set.
+   */
   currentState: ?string = null;
+
   isAvailable: boolean;
 
   _emitter: ?NativeEventEmitter<NativeAppStateEventDefinitions>;
@@ -106,10 +121,9 @@ class AppStateImpl {
   }
 
   /**
-   * Add a handler to AppState changes by listening to the `change` event type
-   * and providing the handler.
-   *
-   * See https://reactnative.dev/docs/appstate#addeventlistener
+   * Add a handler to `AppState` changes by listening to the `change` event
+   * type and providing the handler. See `AppStateEvent` for the list of
+   * available events.
    */
   addEventListener<K extends AppStateEvent>(
     type: K,

--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -180,6 +180,13 @@ function updateErrorWithErrorData(
   return Object.assign(error, errorData || {});
 }
 
+/**
+ * Native Modules written in ObjectiveC/Swift/Java exposed via the RCTBridge
+ * Define lazy getters for each module. These will return the module if already loaded, or load it if not.
+ * See https://reactnative.dev/docs/native-modules-ios
+ * @example
+ * const MyModule = NativeModules.ModuleName
+ */
 /* $FlowFixMe[unclear-type] unclear type of NativeModules */
 let NativeModules: {[moduleName: string]: any, ...} = {};
 if (global.nativeModuleProxy) {

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -73,13 +73,9 @@ const EventNames: Map<keyof AccessibilityEventDefinitions, string> =
       ]);
 
 /**
- * Sometimes it's useful to know whether or not the device has a screen reader
- * that is currently active. The `AccessibilityInfo` API is designed for this
- * purpose. You can use it to query the current state of the screen reader as
- * well as to register to be notified when the state of the screen reader
- * changes.
+ * Provides information about the device's accessibility features, such as whether a screen reader is active. Can be used to query the current state and register for change notifications.
  *
- * See https://reactnative.dev/docs/accessibilityinfo
+ * @see https://reactnative.dev/docs/accessibilityinfo
  */
 const AccessibilityInfo = {
   /**
@@ -88,7 +84,7 @@ const AccessibilityInfo = {
    * Returns a promise which resolves to a boolean.
    * The result is `true` when bold text is enabled and `false` otherwise.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#isBoldTextEnabled
+   * @platform ios
    */
   isBoldTextEnabled(): Promise<boolean> {
     if (Platform.OS === 'android') {
@@ -113,7 +109,7 @@ const AccessibilityInfo = {
    * Returns a promise which resolves to a boolean.
    * The result is `true` when grayscale is enabled and `false` otherwise.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#isGrayscaleEnabled
+   * @platform ios
    */
   isGrayscaleEnabled(): Promise<boolean> {
     if (Platform.OS === 'android') {
@@ -148,7 +144,7 @@ const AccessibilityInfo = {
    * Returns a promise which resolves to a boolean.
    * The result is `true` when invert color is enabled and `false` otherwise.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#isInvertColorsEnabled
+   * @platform ios
    */
   isInvertColorsEnabled(): Promise<boolean> {
     if (Platform.OS === 'android') {
@@ -182,8 +178,6 @@ const AccessibilityInfo = {
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when a reduce motion is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#isReduceMotionEnabled
    */
   isReduceMotionEnabled(): Promise<boolean> {
     return new Promise((resolve, reject) => {
@@ -207,12 +201,12 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Query whether high text contrast is currently enabled. Android only.
+   * Query whether high text contrast is currently enabled.
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when high text contrast is enabled and `false` otherwise.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#ishightextcontrastenabled-android
+   * @platform android
    */
   isHighTextContrastEnabled(): Promise<boolean> {
     if (Platform.OS === 'android') {
@@ -233,12 +227,12 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Query whether dark system colors is currently enabled. iOS only.
+   * Query whether darker system colors is currently enabled.
    *
    * Returns a promise which resolves to a boolean.
-   * The result is `true` when dark system colors is enabled and `false` otherwise.
+   * The result is `true` when darker system colors is enabled and `false` otherwise.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#isdarkersystemcolorsenabled-ios
+   * @platform ios
    */
   isDarkerSystemColorsEnabled(): Promise<boolean> {
     if (Platform.OS === 'android') {
@@ -265,12 +259,12 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Query whether reduce motion and prefer cross-fade transitions settings are currently enabled.
+   * Query whether cross-fade transitions are preferred over slide transitions.
    *
    * Returns a promise which resolves to a boolean.
-   * The result is `true` when  prefer cross-fade transitions is enabled and `false` otherwise.
+   * The result is `true` when cross-fade transitions are preferred and `false` otherwise.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#prefersCrossFadeTransitions
+   * @platform ios
    */
   prefersCrossFadeTransitions(): Promise<boolean> {
     if (Platform.OS === 'android') {
@@ -302,7 +296,7 @@ const AccessibilityInfo = {
    * Returns a promise which resolves to a boolean.
    * The result is `true` when a reduce transparency is enabled and `false` otherwise.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#isReduceTransparencyEnabled
+   * @platform ios
    */
   isReduceTransparencyEnabled(): Promise<boolean> {
     if (Platform.OS === 'android') {
@@ -326,8 +320,6 @@ const AccessibilityInfo = {
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when a screen reader is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#isScreenReaderEnabled
    */
   isScreenReaderEnabled(): Promise<boolean> {
     return new Promise((resolve, reject) => {
@@ -357,8 +349,6 @@ const AccessibilityInfo = {
    * The result is `true` when any service is enabled and `false` otherwise.
    *
    * @platform android
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo/#isaccessibilityserviceenabled-android
    */
   isAccessibilityServiceEnabled(): Promise<boolean> {
     return new Promise((resolve, reject) => {
@@ -425,8 +415,6 @@ const AccessibilityInfo = {
    * - `highTextContrastChanged`: Android-only event. Fires when the state of the high text contrast
    *   toggle changes. The argument to the event handler is a boolean. The boolean is `true` when
    *   high text contrast is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#addeventlistener
    */
   addEventListener<K extends keyof AccessibilityEventDefinitions>(
     eventName: K,
@@ -443,8 +431,6 @@ const AccessibilityInfo = {
   /**
    * Set accessibility focus to a React component.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#setaccessibilityfocus
-   *
    * @deprecated Use `sendAccessibilityEvent` with eventType `focus` instead.
    */
   setAccessibilityFocus(reactTag: number): void {
@@ -452,7 +438,8 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Send a named accessibility event to a HostComponent.
+   * Trigger an accessibility event on a host instance. The `eventType` can be
+   * `'focus'`, `'click'`, `'viewHoverEnter'`, or `'windowStateChange'`.
    */
   sendAccessibilityEvent(
     handle: HostInstance,
@@ -468,8 +455,6 @@ const AccessibilityInfo = {
 
   /**
    * Post a string to be announced by the screen reader.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#announceforaccessibility
    */
   announceForAccessibility(announcement: string): void {
     if (Platform.OS === 'android') {
@@ -480,7 +465,8 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Post a string to be announced by the screen reader.
+   * Post a string to be announced by the screen reader with options.
+   *
    * - `announcement`: The string announced by the screen reader.
    * - `options`: An object that configures the reading options.
    *   - `queue`: The announcement will be queued behind existing announcements. iOS only.
@@ -509,9 +495,10 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Get the recommended timeout for changes to the UI needed by this user.
+   * Get the recommended timeout in milliseconds the user needs, as specified
+   * in the device's Accessibility settings.
    *
-   * See https://reactnative.dev/docs/accessibilityinfo#getrecommendedtimeoutmillis
+   * @platform android
    */
   getRecommendedTimeoutMillis(originalTimeout: number): Promise<number> {
     if (Platform.OS === 'android') {

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+
 import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {ViewProps} from '../View/ViewPropTypes';
 
@@ -30,39 +31,77 @@ type IndicatorSize = number | 'small' | 'large';
 
 type ActivityIndicatorIOSProps = Readonly<{
   /**
-    Whether the indicator should hide when not animating.
-
-    @platform ios
-  */
+   * Whether the indicator should hide when not animating.
+   *
+   * @platform ios
+   */
   hidesWhenStopped?: ?boolean,
 }>;
+
 /** @build-types emit-as-interface Uniwind compatibility */
 export type ActivityIndicatorProps = Readonly<{
   ...ViewProps,
   ...ActivityIndicatorIOSProps,
 
   /**
-   	Whether to show the indicator (`true`) or hide it (`false`).
+   * Whether to show the indicator (`true`) or hide it (`false`).
    */
   animating?: ?boolean,
 
   /**
-    The foreground color of the spinner.
-
-    @default {@platform android} `null` (system accent default color)
-    @default {@platform ios} '#999999'
-  */
+   * The foreground color of the spinner.
+   *
+   * @default {@platform android} `null` (system accent default color)
+   * @default {@platform ios} '#999999'
+   */
   color?: ?ColorValue,
 
   /**
-    Size of the indicator.
-
-    @type enum(`'small'`, `'large'`)
-    @type {@platform android} number
-  */
+   * Size of the indicator.
+   *
+   * Small has a height of 20, large has a height of 36.
+   *
+   * @type enum(`'small'`, `'large'`)
+   * @type {@platform android} number
+   */
   size?: ?IndicatorSize,
 }>;
 
+/**
+ * Displays a circular loading indicator.
+ *
+ * Example:
+ *
+ * ```tsx
+ * import React from 'react';
+ * import {ActivityIndicator, StyleSheet, View} from 'react-native';
+ *
+ * const App = () => (
+ *   <View style={[styles.container, styles.horizontal]}>
+ *     <ActivityIndicator />
+ *     <ActivityIndicator size="large" />
+ *     <ActivityIndicator size="small" color="#0000ff" />
+ *     <ActivityIndicator size="large" color="#00ff00" />
+ *   </View>
+ * );
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     justifyContent: 'center',
+ *   },
+ *   horizontal: {
+ *     flexDirection: 'row',
+ *     justifyContent: 'space-around',
+ *     padding: 10,
+ *   },
+ * });
+ *
+ * export default App;
+ * ```
+ *
+ * @see https://reactnative.dev/docs/activityindicator
+ */
 const ActivityIndicator: component(
   ref?: React.RefSetter<ActivityIndicatorInstance>,
   ...props: ActivityIndicatorProps
@@ -128,38 +167,6 @@ const ActivityIndicator: component(
     </View>
   );
 };
-
-/**
-  Displays a circular loading indicator.
-
-  ```SnackPlayer name=ActivityIndicator%20Example
-  import React from 'react';
-  import {ActivityIndicator, StyleSheet, View} from 'react-native';
-
-  const App = () => (
-    <View style={[styles.container, styles.horizontal]}>
-      <ActivityIndicator />
-      <ActivityIndicator size="large" />
-      <ActivityIndicator size="small" color="#0000ff" />
-      <ActivityIndicator size="large" color="#00ff00" />
-    </View>
-  );
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      justifyContent: 'center',
-    },
-    horizontal: {
-      flexDirection: 'row',
-      justifyContent: 'space-around',
-      padding: 10,
-    },
-  });
-
-  export default App;
-```
-*/
 
 ActivityIndicator.displayName = 'ActivityIndicator';
 

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -30,132 +30,124 @@ import * as React from 'react';
 /** @build-types emit-as-interface Uniwind compatibility */
 export type ButtonProps = Readonly<{
   /**
-    Text to display inside the button. On Android the given title will be
-    converted to the uppercased form.
+   * Text to display inside the button. On Android the given title will be
+   * converted to the uppercased form.
    */
   title: string,
 
   /**
-    Handler to be called when the user taps the button. The first function
-    argument is an event in form of [GestureResponderEvent](pressevent).
+   * Handler called when the user taps the button.
    */
   onPress?: (event?: GestureResponderEvent) => unknown,
 
   /**
-    If `true`, doesn't play system sound on touch.
-
-    @platform android
-
-    @default false
+   * If `true`, doesn't play system sound on touch.
+   *
+   * @platform android
+   *
+   * @default `false`
    */
   touchSoundDisabled?: ?boolean,
 
   /**
-    Color of the text (iOS), or background color of the button (Android).
-
-    @default {@platform android} '#2196F3'
-    @default {@platform ios} '#007AFF'
+   * Color of the text (iOS), or background color of the button (Android).
+   *
+   * @default {@platform android} `'#2196F3'`
+   * @default {@platform ios} `'#007AFF'`
    */
   color?: ?ColorValue,
 
   /**
-    TV preferred focus.
-
-    @platform tv
-
-    @default false
-    @deprecated Use `focusable` instead
+   * TV preferred focus.
+   *
+   * @platform tv
+   *
+   * @default `false`
+   * @deprecated Use `focusable` instead
    */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-    Designates the next view to receive focus when the user navigates down. See
-    the [Android documentation][android:nextFocusDown].
-
-    [android:nextFocusDown]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates down. See
+   * the [Android documentation][android:nextFocusDown].
+   *
+   * [android:nextFocusDown]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
+   *
+   * @platform android, tv
    */
   nextFocusDown?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates forward.
-    See the [Android documentation][android:nextFocusForward].
-
-    [android:nextFocusForward]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates forward.
+   * See the [Android documentation][android:nextFocusForward].
+   *
+   * [android:nextFocusForward]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
+   *
+   * @platform android, tv
    */
   nextFocusForward?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates left. See
-    the [Android documentation][android:nextFocusLeft].
-
-    [android:nextFocusLeft]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates left. See
+   * the [Android documentation][android:nextFocusLeft].
+   *
+   * [android:nextFocusLeft]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
+   *
+   * @platform android, tv
    */
   nextFocusLeft?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates right. See
-    the [Android documentation][android:nextFocusRight].
-
-    [android:nextFocusRight]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates right. See
+   * the [Android documentation][android:nextFocusRight].
+   *
+   * [android:nextFocusRight]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
+   *
+   * @platform android, tv
    */
   nextFocusRight?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates up. See
-    the [Android documentation][android:nextFocusUp].
-
-    [android:nextFocusUp]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
-
-    @platform android, tv
+   * Designates the next view to receive focus when the user navigates up. See
+   * the [Android documentation][android:nextFocusUp].
+   *
+   * [android:nextFocusUp]:
+   * https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
+   *
+   * @platform android, tv
    */
   nextFocusUp?: ?number,
 
   /**
-    Text to display for blindness accessibility features.
+   * Text to display for blindness accessibility features.
    */
   accessibilityLabel?: ?string,
+
   /**
-   * Alias for accessibilityLabel  https://reactnative.dev/docs/view#accessibilitylabel
-   * https://github.com/facebook/react-native/issues/34424
+   * Alias for `accessibilityLabel`.
    */
   'aria-label'?: ?string,
-  /**
-    If `true`, disable all interactions for this component.
 
-    @default false
+  /**
+   * If `true`, disable all interactions for this component.
+   *
+   * @default `false`
    */
   disabled?: ?boolean,
 
-  /**
-    Used to locate this view in end-to-end tests.
-   */
   testID?: ?string,
 
-  /**
-   * Accessibility props.
-   */
   accessible?: ?boolean,
   accessibilityActions?: ?ReadonlyArray<AccessibilityActionInfo>,
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => unknown,
   accessibilityState?: ?AccessibilityState,
 
   /**
-   * alias for accessibilityState
-   *
-   * see https://reactnative.dev/docs/accessibility#accessibilitystate
+   * Alias for `accessibilityState`.
    */
   'aria-busy'?: ?boolean,
   'aria-checked'?: ?boolean | 'mixed',
@@ -163,121 +155,17 @@ export type ButtonProps = Readonly<{
   'aria-expanded'?: ?boolean,
   'aria-selected'?: ?boolean,
 
-  /**
-   * [Android] Controlling if a view fires accessibility events and if it is reported to accessibility services.
-   */
   importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
   accessibilityHint?: ?string,
+
+  /**
+   * A BCP 47 language tag for the screen reader to use when reading text
+   * content.
+   *
+   * @platform ios
+   */
   accessibilityLanguage?: ?Stringish,
 }>;
-
-/**
-  A basic button component that should render nicely on any platform. Supports a
-  minimal level of customization.
-
-  If this button doesn't look right for your app, you can build your own button
-  using [TouchableOpacity](touchableopacity) or
-  [TouchableWithoutFeedback](touchablewithoutfeedback). For inspiration, look at
-  the [source code for this button component][button:source]. Or, take a look at
-  the [wide variety of button components built by the community]
-  [button:examples].
-
-  [button:source]:
-  https://github.com/facebook/react-native/blob/HEAD/Libraries/Components/Button.js
-
-  ```jsx
-  <Button
-    onPress={onPressLearnMore}
-    title="Learn More"
-    color="#841584"
-    accessibilityLabel="Learn more about this purple button"
-  />
-  ```
-
-  ```SnackPlayer name=Button%20Example
-  import React from 'react';
-  import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
-
-  const Separator = () => (
-    <View style={styles.separator} />
-  );
-
-  const App = () => (
-    <SafeAreaView style={styles.container}>
-      <View>
-        <Text style={styles.title}>
-          The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
-        </Text>
-        <Button
-          title="Press me"
-          onPress={() => Alert.alert('Simple Button pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
-        </Text>
-        <Button
-          title="Press me"
-          color="#f194ff"
-          onPress={() => Alert.alert('Button with adjusted color pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          All interaction for the component are disabled.
-        </Text>
-        <Button
-          title="Press me"
-          disabled
-          onPress={() => Alert.alert('Cannot press this one')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          This layout strategy lets the title define the width of the button.
-        </Text>
-        <View style={styles.fixToText}>
-          <Button
-            title="Left button"
-            onPress={() => Alert.alert('Left button pressed')}
-          />
-          <Button
-            title="Right button"
-            onPress={() => Alert.alert('Right button pressed')}
-          />
-        </View>
-      </View>
-    </SafeAreaView>
-  );
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      justifyContent: 'center',
-      marginHorizontal: 16,
-    },
-    title: {
-      textAlign: 'center',
-      marginVertical: 8,
-    },
-    fixToText: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-    },
-    separator: {
-      marginVertical: 8,
-      borderBottomColor: '#737373',
-      borderBottomWidth: StyleSheet.hairlineWidth,
-    },
-  });
-
-  export default App;
-  ```
- */
 
 const NativeTouchable:
   | typeof TouchableNativeFeedback
@@ -286,6 +174,26 @@ const NativeTouchable:
 
 export type ButtonInstance = React.ElementRef<typeof NativeTouchable>;
 
+/**
+ * A basic button component that should render nicely on any platform. Supports a
+ * minimal level of customization.
+ *
+ * If this button doesn't look right for your app, you can build your own button
+ * using `Pressable`.
+ *
+ * Example:
+ *
+ * ```tsx
+ * <Button
+ *   onPress={onPressLearnMore}
+ *   title="Learn More"
+ *   color="#841584"
+ *   accessibilityLabel="Learn more about this purple button"
+ * />
+ * ```
+ *
+ * @see https://reactnative.dev/docs/button
+ */
 const Button: component(
   ref?: React.RefSetter<ButtonInstance>,
   ...props: ButtonProps

--- a/packages/react-native/Libraries/Components/Clipboard/Clipboard.js
+++ b/packages/react-native/Libraries/Components/Clipboard/Clipboard.js
@@ -12,6 +12,11 @@ import NativeClipboard from './NativeClipboard';
 
 /**
  * `Clipboard` gives you an interface for setting and getting content from Clipboard on both iOS and Android
+ *
+ * Clipboard has been extracted from react-native core and will be removed in a future release.
+ * It can now be installed and imported from `@react-native-clipboard/clipboard` instead of 'react-native'.
+ * @see https://github.com/react-native-clipboard/clipboard
+ * @deprecated
  */
 export default {
   /**

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -33,35 +33,10 @@ import {createRef} from 'react';
 const DRAWER_STATES = ['Idle', 'Dragging', 'Settling'] as const;
 
 /**
- * React component that wraps the platform `DrawerLayout` (Android only). The
- * Drawer (typically used for navigation) is rendered with `renderNavigationView`
- * and direct children are the main view (where your content goes). The navigation
- * view is initially not visible on the screen, but can be pulled in from the
- * side of the window specified by the `drawerPosition` prop and its width can
- * be set by the `drawerWidth` prop.
+ * React component that wraps the platform `DrawerLayout` (Android only). The Drawer (typically used for navigation) is rendered with `renderNavigationView` and direct children are the main view. The navigation view is initially not visible on the screen, but can be pulled in from the side of the window specified by the `drawerPosition` prop and its width can be set by the `drawerWidth` prop.
  *
- * Example:
- *
- * ```
- * render: function() {
- *   var navigationView = (
- *     <View style={{flex: 1, backgroundColor: '#fff'}}>
- *       <Text style={{margin: 10, fontSize: 15, textAlign: 'left'}}>I'm in the Drawer!</Text>
- *     </View>
- *   );
- *   return (
- *     <DrawerLayoutAndroid
- *       drawerWidth={300}
- *       drawerPosition="left"
- *       renderNavigationView={() => navigationView}>
- *       <View style={{flex: 1, alignItems: 'center'}}>
- *         <Text style={{margin: 10, fontSize: 15, textAlign: 'right'}}>Hello</Text>
- *         <Text style={{margin: 10, fontSize: 15, textAlign: 'right'}}>World!</Text>
- *       </View>
- *     </DrawerLayoutAndroid>
- *   );
- * },
- * ```
+ * @see https://reactnative.dev/docs/drawerlayoutandroid
+ * @platform android
  */
 class DrawerLayoutAndroid
   extends React.Component<DrawerLayoutAndroidProps, DrawerLayoutAndroidState>
@@ -199,42 +174,6 @@ class DrawerLayoutAndroid
   closeDrawer() {
     Commands.closeDrawer(nullthrows(this._nativeRef.current));
   }
-
-  /**
-   * Closing and opening example
-   * Note: To access the drawer you have to give it a ref
-   *
-   * Class component:
-   *
-   * render () {
-   *   this.openDrawer = () => {
-   *     this.refs.DRAWER.openDrawer()
-   *   }
-   *   this.closeDrawer = () => {
-   *     this.refs.DRAWER.closeDrawer()
-   *   }
-   *   return (
-   *     <DrawerLayoutAndroid ref={'DRAWER'}>
-   *      {children}
-   *     </DrawerLayoutAndroid>
-   *   )
-   * }
-   *
-   * Function component:
-   *
-   * const drawerRef = useRef()
-   * const openDrawer = () => {
-   *   drawerRef.current.openDrawer()
-   * }
-   * const closeDrawer = () => {
-   *   drawerRef.current.closeDrawer()
-   * }
-   * return (
-   *   <DrawerLayoutAndroid ref={drawerRef}>
-   *     {children}
-   *   </DrawerLayoutAndroid>
-   * )
-   */
 
   /**
    * Native methods

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
@@ -31,78 +31,65 @@ export type DrawerLayoutAndroidProps = Readonly<{
   ...ViewProps,
 
   /**
-   * Determines whether the keyboard gets dismissed in response to a drag.
-   *   - 'none' (the default), drags do not dismiss the keyboard.
-   *   - 'on-drag', the keyboard is dismissed when a drag begins.
+   * Whether the keyboard is dismissed in response to a drag.
+   *
+   * @default `'none'`
    */
   keyboardDismissMode?: ?('none' | 'on-drag'),
 
   /**
-   * Specifies the background color of the drawer. The default value is white.
-   * If you want to set the opacity of the drawer, use rgba. Example:
+   * Background color of the drawer.
    *
-   * ```
-   * return (
-   *   <DrawerLayoutAndroid drawerBackgroundColor="rgba(0,0,0,0.5)">
-   *   </DrawerLayoutAndroid>
-   * );
-   * ```
+   * @default `'white'`
    */
   drawerBackgroundColor?: ?ColorValue,
 
   /**
-   * Specifies the side of the screen from which the drawer will slide in.
+   * Side of the screen from which the drawer slides in.
+   *
+   * @default `'left'`
    */
   drawerPosition: ?('left' | 'right'),
 
   /**
-   * Specifies the width of the drawer, more precisely the width of the view that be pulled in
-   * from the edge of the window.
+   * Width of the drawer view.
    */
   drawerWidth?: ?number,
 
   /**
-   * Specifies the lock mode of the drawer. The drawer can be locked in 3 states:
-   * - unlocked (default), meaning that the drawer will respond (open/close) to touch gestures.
-   * - locked-closed, meaning that the drawer will stay closed and not respond to gestures.
-   * - locked-open, meaning that the drawer will stay opened and not respond to gestures.
-   * The drawer may still be opened and closed programmatically (`openDrawer`/`closeDrawer`).
+   * Lock mode of the drawer. `'unlocked'` responds to touch gestures, `'locked-closed'` stays closed, `'locked-open'` stays open.
+   *
+   * @default `'unlocked'`
    */
   drawerLockMode?: ?('unlocked' | 'locked-closed' | 'locked-open'),
 
   /**
-   * Function called whenever there is an interaction with the navigation view.
+   * Called when there is an interaction with the navigation view.
    */
   onDrawerSlide?: ?(event: DrawerSlideEvent) => unknown,
 
   /**
-   * Function called when the drawer state has changed. The drawer can be in 3 states:
-   * - Idle, meaning there is no interaction with the navigation view happening at the time
-   * - Dragging, meaning there is currently an interaction with the navigation view
-   * - Settling, meaning that there was an interaction with the navigation view, and the
-   * navigation view is now finishing its closing or opening animation
+   * Called when the drawer state changes. States: idle, dragging, settling.
    */
   onDrawerStateChanged?: ?(state: DrawerStates) => unknown,
 
   /**
-   * Function called whenever the navigation view has been opened.
+   * Called when the navigation view has been opened.
    */
   onDrawerOpen?: ?() => unknown,
 
   /**
-   * Function called whenever the navigation view has been closed.
+   * Called when the navigation view has been closed.
    */
   onDrawerClose?: ?() => unknown,
 
   /**
-   * The navigation view that will be rendered to the side of the screen and can be pulled in.
+   * The navigation view that will be rendered to the side of the screen.
    */
   renderNavigationView: () => React.MixedElement,
 
   /**
-   * Make the drawer take the entire screen and draw the background of the
-   * status bar to allow it to open over the status bar. It will only have an
-   * effect on API 21+.
+   * Makes the drawer take the entire screen and draws the background of the status bar to allow it to open over the status bar. Only has effect on API 21+.
    */
   statusBarBackgroundColor?: ?ColorValue,
 }>;

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -42,7 +42,13 @@ type BaseKeyboardEvent = {
 
 export type AndroidKeyboardEvent = Readonly<{
   ...BaseKeyboardEvent,
+  /**
+   * Always set to 0 on Android.
+   */
   duration: 0,
+  /**
+   * Always set to "keyboard" on Android.
+   */
   easing: 'keyboard',
 }>;
 
@@ -62,47 +68,8 @@ type KeyboardEventDefinitions = {
 };
 
 /**
- * `Keyboard` module to control keyboard events.
- *
- * ### Usage
- *
- * The Keyboard module allows you to listen for native events and react to them, as
- * well as make changes to the keyboard, like dismissing it.
- *
- *```
- * import React, { Component } from 'react';
- * import { Keyboard, TextInput } from 'react-native';
- *
- * class Example extends Component {
- *   componentWillMount () {
- *     this.keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', this._keyboardDidShow);
- *     this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', this._keyboardDidHide);
- *   }
- *
- *   componentWillUnmount () {
- *     this.keyboardDidShowListener.remove();
- *     this.keyboardDidHideListener.remove();
- *   }
- *
- *   _keyboardDidShow () {
- *     alert('Keyboard Shown');
- *   }
- *
- *   _keyboardDidHide () {
- *     alert('Keyboard Hidden');
- *   }
- *
- *   render() {
- *     return (
- *       <TextInput
- *         onSubmitEditing={Keyboard.dismiss}
- *       />
- *     );
- *   }
- * }
- *```
+ * Module to control keyboard events and make changes to the keyboard.
  */
-
 class KeyboardImpl {
   _currentlyShowing: ?KeyboardEvent;
 
@@ -123,28 +90,18 @@ class KeyboardImpl {
   }
 
   /**
-   * The `addListener` function connects a JavaScript function to an identified native
-   * keyboard notification event.
+   * Listen for native keyboard notification events.
    *
-   * This function then returns the reference to the listener.
-   *
-   * @param {string} eventName The `nativeEvent` is the string that identifies the event you're listening for.  This
-   *can be any of the following:
-   *
-   * - `keyboardWillShow`
-   * - `keyboardDidShow`
-   * - `keyboardWillHide`
-   * - `keyboardDidHide`
-   * - `keyboardWillChangeFrame`
-   * - `keyboardDidChangeFrame`
+   * Available events are: `keyboardWillShow`, `keyboardDidShow`,
+   * `keyboardWillHide`, `keyboardDidHide`, `keyboardWillChangeFrame`, and
+   * `keyboardDidChangeFrame`. Only `keyboardDidShow` and `keyboardDidHide`
+   * are available on Android.
    *
    * Android versions prior to API 30 rely on observing layout changes when
    * `android:windowSoftInputMode` is set to `adjustResize` or `adjustPan`.
    *
-   * `keyboardWillShow` as well as `keyboardWillHide` are not available on Android since there is
-   * no native corresponding event.
-   *
-   * @param {function} callback function to be called when the event fires.
+   * @param {string} eventName The native event name to listen for.
+   * @param {function} callback Function to be called when the event fires.
    */
   addListener<K extends keyof KeyboardEventDefinitions>(
     eventType: K,
@@ -180,15 +137,15 @@ class KeyboardImpl {
   }
 
   /**
-   * Return the metrics of the soft-keyboard if visible.
+   * Return the metrics of the soft keyboard if visible.
    */
   metrics(): ?KeyboardMetrics {
     return this._currentlyShowing?.endCoordinates;
   }
 
   /**
-   * Useful for syncing TextInput (or other keyboard accessory view) size of
-   * position changes with keyboard movements.
+   * Sync `TextInput` (or other keyboard accessory view) size or position
+   * changes with keyboard movements.
    */
   scheduleLayoutAnimation(event: KeyboardEvent): void {
     const {duration, easing} = event;
@@ -204,6 +161,12 @@ class KeyboardImpl {
   }
 }
 
+/**
+ * `Keyboard` module to control keyboard events and make changes to the
+ * keyboard, like dismissing it.
+ *
+ * @see https://reactnative.dev/docs/keyboard
+ */
 const Keyboard: KeyboardImpl = new KeyboardImpl();
 
 export default Keyboard;

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -36,19 +36,22 @@ export type KeyboardAvoidingViewProps = Readonly<{
   behavior?: ?('height' | 'position' | 'padding'),
 
   /**
-   * Style of the content container when `behavior` is 'position'.
+   * The style of the content container (View) when `behavior` is 'position'.
    */
   contentContainerStyle?: ?ViewStyleProp,
 
   /**
-   * Controls whether this `KeyboardAvoidingView` instance should take effect.
-   * This is useful when more than one is on the screen. Defaults to true.
+   * Whether the `KeyboardAvoidingView` is enabled.
+   *
+   * @default `true`
    */
   enabled?: ?boolean,
 
   /**
-   * Distance between the top of the user screen and the React Native view. This
-   * may be non-zero in some cases. Defaults to 0.
+   * Distance between the top of the user screen and the React Native view,
+   * may be non-zero in some use cases.
+   *
+   * @default `0`
    */
   keyboardVerticalOffset?: number,
 }>;
@@ -58,8 +61,10 @@ type KeyboardAvoidingViewState = {
 };
 
 /**
- * View that moves out of the way when the keyboard appears by automatically
- * adjusting its height, position, or bottom padding.
+ * Automatically adjusts its height, position, or bottom padding based on the
+ * keyboard height to remain visible while the virtual keyboard is displayed.
+ *
+ * @see https://reactnative.dev/docs/keyboardavoidingview
  */
 class KeyboardAvoidingView extends React.Component<
   KeyboardAvoidingViewProps,

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -44,28 +44,36 @@ type PressableBaseProps = Readonly<{
   cancelable?: ?boolean,
 
   /**
-   * Either children or a render prop that receives a boolean reflecting whether
+   * Either children or a function that receives a boolean reflecting whether
    * the component is currently pressed.
    */
   children?: React.Node | ((state: PressableStateCallbackType) => React.Node),
 
   /**
    * Duration to wait after hover in before calling `onHoverIn`.
+   *
+   * @platform macos windows
    */
   delayHoverIn?: ?number,
 
   /**
    * Duration to wait after hover out before calling `onHoverOut`.
+   *
+   * @platform macos windows
    */
   delayHoverOut?: ?number,
 
   /**
    * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
+   *
+   * @default `500`
    */
   delayLongPress?: ?number,
 
   /**
    * Whether the press behavior is disabled.
+   *
+   * @default `false`
    */
   disabled?: ?boolean,
 
@@ -77,6 +85,8 @@ type PressableBaseProps = Readonly<{
   /**
    * Additional distance outside of this view in which a touch is considered a
    * press before `onPressOut` is triggered.
+   *
+   * @default `{bottom: 30, left: 20, right: 20, top: 20}`
    */
   pressRetentionOffset?: ?RectOrSize,
 
@@ -86,36 +96,38 @@ type PressableBaseProps = Readonly<{
   onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
   /**
-   * Called when the hover is activated to provide visual feedback.
+   * Called when the hover is activated.
    */
   onHoverIn?: ?(event: MouseEvent) => unknown,
 
   /**
-   * Called when the hover is deactivated to undo visual feedback.
+   * Called when the hover is deactivated.
    */
   onHoverOut?: ?(event: MouseEvent) => unknown,
 
   /**
-   * Called when a long-tap gesture is detected.
+   * Called if the time after `onPressIn` lasts longer than `delayLongPress`.
    */
   onLongPress?: ?(event: GestureResponderEvent) => unknown,
 
   /**
-   * Called when a single tap gesture is detected.
+   * Called after `onPressOut`.
    */
   onPress?: ?(event: GestureResponderEvent) => unknown,
 
   /**
-   * Called when a touch is engaged before `onPress`.
+   * Called immediately when a touch is engaged, before `onPressOut` and
+   * `onPress`.
    */
   onPressIn?: ?(event: GestureResponderEvent) => unknown,
+
   /**
    * Called when the press location moves.
    */
   onPressMove?: ?(event: GestureResponderEvent) => unknown,
 
   /**
-   * Called when a touch is released before `onPress`.
+   * Called when a touch is released.
    */
   onPressOut?: ?(event: GestureResponderEvent) => unknown,
 
@@ -139,12 +151,17 @@ type PressableBaseProps = Readonly<{
   testID?: ?string,
 
   /**
-   * If true, doesn't play system sound on touch.
+   * If true, doesn't play Android system sound on press.
+   *
+   * @platform android
+   * @default `false`
    */
   android_disableSound?: ?boolean,
 
   /**
-   * Enables the Android ripple effect and configures its color.
+   * Enables the Android ripple effect and configures its properties.
+   *
+   * @platform android
    */
   android_ripple?: ?PressableAndroidRippleConfig,
 
@@ -154,7 +171,8 @@ type PressableBaseProps = Readonly<{
   testOnly_pressed?: ?boolean,
 
   /**
-   * Duration to wait after press down before calling `onPressIn`.
+   * Duration (in milliseconds) to wait after press down before calling
+   * `onPressIn`.
    */
   unstable_pressDelay?: ?number,
 }>;
@@ -169,8 +187,10 @@ export type PressableProps = Readonly<{
 }>;
 
 /**
- * Component used to build display components that should respond to whether the
- * component is currently pressed or not.
+ * A Core Component wrapper that can detect various stages of press
+ * interactions on any of its defined children.
+ *
+ * @see https://reactnative.dev/docs/pressable
  */
 function Pressable({
   ref: forwardedRef,

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js
@@ -20,10 +20,23 @@ import type {ViewProps} from '../View/ViewPropTypes';
 type DeterminateProgressBarAndroidStyleAttrProp = {
   styleAttr: 'Horizontal',
   indeterminate: false,
+  /**
+   * The progress value (between 0 and 1).
+   */
   progress: number,
 };
 
 type IndeterminateProgressBarAndroidStyleAttrProp = {
+  /**
+   * Style of the ProgressBar. One of:
+   *     Horizontal
+   *     Normal (default)
+   *     Small
+   *     Large
+   *     Inverse
+   *     SmallInverse
+   *     LargeInverse
+   */
   styleAttr:
     | 'Horizontal'
     | 'Normal'
@@ -32,6 +45,10 @@ type IndeterminateProgressBarAndroidStyleAttrProp = {
     | 'Inverse'
     | 'SmallInverse'
     | 'LargeInverse',
+  /**
+   * If the progress bar will show indeterminate progress.
+   * Note that this can only be false if styleAttr is Horizontal.
+   */
   indeterminate: true,
 };
 

--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -24,33 +24,53 @@ const Platform = require('../../Utilities/Platform').default;
 export type RefreshControlPropsIOS = Readonly<{
   /**
    * The color of the refresh indicator.
+   *
+   * @platform ios
    */
   tintColor?: ?ColorValue,
-  /**
-   * Title color.
-   */
-  titleColor?: ?ColorValue,
+
   /**
    * The title displayed under the refresh indicator.
+   *
+   * @platform ios
    */
   title?: ?string,
+
+  /**
+   * The color of the refresh indicator title.
+   *
+   * @platform ios
+   */
+  titleColor?: ?ColorValue,
 }>;
 
 export type RefreshControlPropsAndroid = Readonly<{
   /**
-   * Whether the pull to refresh functionality is enabled.
-   */
-  enabled?: ?boolean,
-  /**
    * The colors (at least one) that will be used to draw the refresh indicator.
+   *
+   * @platform android
    */
   colors?: ?ReadonlyArray<ColorValue>,
+
+  /**
+   * Whether the pull to refresh functionality is enabled.
+   *
+   * @default `true`
+   * @platform android
+   */
+  enabled?: ?boolean,
+
   /**
    * The background color of the refresh indicator.
+   *
+   * @platform android
    */
   progressBackgroundColor?: ?ColorValue,
+
   /**
    * Size of the refresh indicator.
+   *
+   * @platform android
    */
   size?: ?('default' | 'large'),
 }>;
@@ -67,7 +87,9 @@ type RefreshControlBaseProps = Readonly<{
   refreshing: boolean,
 
   /**
-   * Progress view top offset
+   * Progress view top offset.
+   *
+   * @default `0`
    */
   progressViewOffset?: ?number,
 }>;
@@ -81,49 +103,14 @@ export type RefreshControlProps = Readonly<{
 }>;
 
 /**
- * This component is used inside a ScrollView or ListView to add pull to refresh
- * functionality. When the ScrollView is at `scrollY: 0`, swiping down
- * triggers an `onRefresh` event.
+ * Used inside a `ScrollView` to add pull to refresh functionality. When the
+ * `ScrollView` is at `scrollY: 0`, swiping down triggers an `onRefresh` event.
  *
- * ### Usage example
+ * **Note:** `refreshing` is a controlled prop, this is why it needs to be set
+ * to `true` in the `onRefresh` function otherwise the refresh indicator will
+ * stop immediately.
  *
- * ``` js
- * class RefreshableList extends Component {
- *   constructor(props) {
- *     super(props);
- *     this.state = {
- *       refreshing: false,
- *     };
- *   }
- *
- *   _onRefresh() {
- *     this.setState({refreshing: true});
- *     fetchData().then(() => {
- *       this.setState({refreshing: false});
- *     });
- *   }
- *
- *   render() {
- *     return (
- *       <ListView
- *         refreshControl={
- *           <RefreshControl
- *             refreshing={this.state.refreshing}
- *             onRefresh={this._onRefresh.bind(this)}
- *           />
- *         }
- *         ...
- *       >
- *       ...
- *       </ListView>
- *     );
- *   }
- *   ...
- * }
- * ```
- *
- * __Note:__ `refreshing` is a controlled prop, this is why it needs to be set to true
- * in the `onRefresh` function otherwise the refresh indicator will stop immediately.
+ * @see https://reactnative.dev/docs/refreshcontrol
  */
 class RefreshControl extends React.Component<RefreshControlProps> {
   _nativeRef: ?React.ElementRef<

--- a/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -18,14 +18,11 @@ import * as React from 'react';
 export type SafeAreaViewInstance = HostInstance;
 
 /**
- * Renders nested content and automatically applies paddings reflect the portion
- * of the view that is not covered by navigation bars, tab bars, toolbars, and
- * other ancestor views.
+ * Renders content within the safe area boundaries of a device. Currently only applicable to iOS devices with iOS version 11 or later. Automatically applies padding to reflect the portion of the view not covered by navigation bars, tab bars, toolbars, and other ancestor views.
  *
- * Moreover, and most importantly, Safe Area's paddings reflect physical
- * limitation of the screen, such as rounded corners or camera notches (aka
- * sensor housing area on iPhone X).
- * @deprecated Use `react-native-safe-area-context` instead. This component will be removed in a future release.
+ * @see https://reactnative.dev/docs/safeareaview
+ * @deprecated Use `react-native-safe-area-context` instead.
+ * @platform ios
  */
 const SafeAreaView: component(
   ref?: React.RefSetter<SafeAreaViewInstance>,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -135,17 +135,48 @@ export interface ScrollViewScrollToOptions {
 
 // Public methods for ScrollView
 export interface ScrollViewImperativeMethods {
+  /**
+   * Returns a reference to the underlying scroll responder, which supports
+   * operations like `scrollTo`. All ScrollView-like components should
+   * implement this method so that they can be composed while providing access
+   * to the underlying scroll responder's methods.
+   */
   readonly getScrollResponder: () => ScrollResponderType;
   readonly getScrollableNode: () => ?number;
   readonly getInnerViewNode: () => ?number;
   readonly getInnerViewRef: () => InnerViewInstance | null;
+  /**
+   * Returns a reference to the underlying native scroll view, or null if the
+   * native instance is not mounted.
+   */
   readonly getNativeScrollRef: () => ScrollViewInstance | null;
+  /**
+   * Scrolls to a given x, y offset, either immediately or with a smooth animation.
+   * Syntax:
+   *
+   * scrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})
+   *
+   * Note: The weird argument signature is due to the fact that, for historical reasons,
+   * the function also accepts separate arguments as an alternative to the options object.
+   * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
+   */
   readonly scrollTo: (
     options?: ScrollViewScrollToOptions | number,
     deprecatedX?: number,
     deprecatedAnimated?: boolean,
   ) => void;
+  /**
+   * A helper function that scrolls to the end of the scrollview;
+   * If this is a vertical ScrollView, it scrolls to the bottom.
+   * If this is a horizontal ScrollView scrolls to the right.
+   *
+   * The options object has an animated prop, that enables the scrolling animation or not.
+   * The animated prop defaults to true
+   */
   readonly scrollToEnd: (options?: ?ScrollViewScrollToOptions) => void;
+  /**
+   * Displays the scroll indicators momentarily.
+   */
   readonly flashScrollIndicators: () => void;
   readonly scrollResponderZoomTo: (
     rect: {
@@ -177,33 +208,44 @@ export type ScrollViewPropsIOS = Readonly<{
   /**
    * Controls whether iOS should automatically adjust the content inset
    * for scroll views that are placed behind a navigation bar or
-   * tab bar/ toolbar. The default value is true.
+   * tab bar/toolbar.
+   *
+   * @default `true`
    * @platform ios
    */
   automaticallyAdjustContentInsets?: ?boolean,
+
   /**
    * Controls whether the ScrollView should automatically adjust its `contentInset`
-   * and `scrollViewInsets` when the Keyboard changes its size. The default value is false.
+   * and `scrollViewInsets` when the Keyboard changes its size.
+   *
+   * @default `false`
    * @platform ios
    */
   automaticallyAdjustKeyboardInsets?: ?boolean,
   /**
    * Controls whether iOS should automatically adjust the scroll indicator
-   * insets. The default value is true. Available on iOS 13 and later.
+   * insets. Available on iOS 13 and later.
+   *
+   * @default `true`
    * @platform ios
    */
   automaticallyAdjustsScrollIndicatorInsets?: ?boolean,
   /**
    * The amount by which the scroll view content is inset from the edges
-   * of the scroll view. Defaults to `{top: 0, left: 0, bottom: 0, right: 0}`.
+   * of the scroll view.
+   *
+   * @default `{top: 0, left: 0, bottom: 0, right: 0}`
    * @platform ios
    */
   contentInset?: ?EdgeInsetsProp,
   /**
    * When true, the scroll view bounces when it reaches the end of the
-   * content if the content is larger then the scroll view along the axis of
-   * the scroll direction. When false, it disables all bouncing even if
-   * the `alwaysBounce*` props are true. The default value is true.
+   * content if the content is larger than the scroll view along the axis of
+   * the scroll direction. When `false`, it disables all bouncing even if
+   * the `alwaysBounce*` props are `true`.
+   *
+   * @default `true`
    * @platform ios
    */
   bounces?: ?boolean,
@@ -223,23 +265,28 @@ export type ScrollViewPropsIOS = Readonly<{
   bouncesZoom?: ?boolean,
   /**
    * When true, the scroll view bounces horizontally when it reaches the end
-   * even if the content is smaller than the scroll view itself. The default
-   * value is true when `horizontal={true}` and false otherwise.
+   * even if the content is smaller than the scroll view itself.
+   *
+   * @default {@platform horizontal} `true`
    * @platform ios
    */
   alwaysBounceHorizontal?: ?boolean,
+
   /**
    * When true, the scroll view bounces vertically when it reaches the end
-   * even if the content is smaller than the scroll view itself. The default
-   * value is false when `horizontal={true}` and true otherwise.
+   * even if the content is smaller than the scroll view itself.
+   *
+   * @default {@platform horizontal} `false`
    * @platform ios
    */
   alwaysBounceVertical?: ?boolean,
+
   /**
    * When true, the scroll view automatically centers the content when the
    * content is smaller than the scroll view bounds; when the content is
-   * larger than the scroll view, this property has no effect. The default
-   * value is false.
+   * larger than the scroll view, this property has no effect.
+   *
+   * @default `false`
    * @platform ios
    */
   centerContent?: ?boolean,
@@ -255,48 +302,68 @@ export type ScrollViewPropsIOS = Readonly<{
   indicatorStyle?: ?('default' | 'black' | 'white'),
   /**
    * When true, the ScrollView will try to lock to only vertical or horizontal
-   * scrolling while dragging.  The default value is false.
+   * scrolling while dragging.
+   *
+   * @default `false`
    * @platform ios
    */
   directionalLockEnabled?: ?boolean,
+
   /**
-   * When false, once tracking starts, won't try to drag if the touch moves.
-   * The default value is true.
+   * When false, once tracking starts, the scroll view will not try to drag
+   * if the touch moves.
+   *
+   * @default `true`
    * @platform ios
    */
   canCancelContentTouches?: ?boolean,
+
   /**
-   * The maximum allowed zoom scale. The default value is 1.0.
+   * The maximum allowed zoom scale.
+   *
+   * @default `1.0`
    * @platform ios
    */
   maximumZoomScale?: ?number,
+
   /**
-   * The minimum allowed zoom scale. The default value is 1.0.
+   * The minimum allowed zoom scale.
+   *
+   * @default `1.0`
    * @platform ios
    */
   minimumZoomScale?: ?number,
+
   /**
    * When true, ScrollView allows use of pinch gestures to zoom in and out.
-   * The default value is true.
+   *
+   * @default `true`
    * @platform ios
    */
   pinchGestureEnabled?: ?boolean,
   /**
    * The amount by which the scroll view indicators are inset from the edges
    * of the scroll view. This should normally be set to the same value as
-   * the `contentInset`. Defaults to `{0, 0, 0, 0}`.
+   * the `contentInset`.
+   *
+   * @default `{top: 0, left: 0, bottom: 0, right: 0}`
    * @platform ios
    */
   scrollIndicatorInsets?: ?EdgeInsetsProp,
+
   /**
    * When true, the scroll view can be programmatically scrolled beyond its
-   * content size. The default value is false.
+   * content size.
+   *
+   * @default `false`
    * @platform ios
    */
   scrollToOverflowEnabled?: ?boolean,
+
   /**
    * When true, the scroll view scrolls to top when the status bar is tapped.
-   * The default value is true.
+   *
+   * @default `true`
    * @platform ios
    */
   scrollsToTop?: ?boolean,
@@ -307,18 +374,23 @@ export type ScrollViewPropsIOS = Readonly<{
   onScrollToTop?: (event: ScrollEvent) => void,
   /**
    * When true, shows a horizontal scroll indicator.
-   * The default value is true.
+   *
+   * @default `true`
    */
   showsHorizontalScrollIndicator?: ?boolean,
+
   /**
-   * The current scale of the scroll view content. The default value is 1.0.
+   * The current scale of the scroll view content.
+   *
+   * @default `1.0`
    * @platform ios
    */
   zoomScale?: ?number,
   /**
    * This property specifies how the safe area insets are used to modify the
-   * content area of the scroll view. The default value of this property is
-   * "never".
+   * content area of the scroll view.
+   *
+   * @default `'never'`
    * @platform ios
    */
   contentInsetAdjustmentBehavior?: ?(
@@ -331,8 +403,10 @@ export type ScrollViewPropsIOS = Readonly<{
 
 export type ScrollViewPropsAndroid = Readonly<{
   /**
-   * Enables nested scrolling for Android API level 21+.
-   * Nested scrolling is supported by default on iOS
+   * Enables nested scrolling for Android API level 21+. Nested scrolling is
+   * supported by default on iOS.
+   *
+   * @default `false`
    * @platform android
    */
   nestedScrollEnabled?: ?boolean,
@@ -367,8 +441,8 @@ export type ScrollViewPropsAndroid = Readonly<{
   overScrollMode?: ?('auto' | 'always' | 'never'),
   /**
    * Causes the scrollbars not to turn transparent when they are not in use.
-   * The default value is false.
    *
+   * @default `false`
    * @platform android
    */
   persistentScrollbar?: ?boolean,
@@ -390,8 +464,9 @@ export type ScrollViewPropsAndroid = Readonly<{
   /**
    * When false, the ScrollView will not automatically scroll to a focused child when
    * the child requests focus. This can be useful when you want to control the scroll
-   * position programmatically. The default value is true.
+   * position programmatically.
    *
+   * @default `true`
    * @platform android
    */
   scrollsChildToFocus?: ?boolean,
@@ -405,9 +480,11 @@ type StickyHeaderComponentType = component(
 type ScrollViewBaseProps = Readonly<{
   /**
    * These styles will be applied to the scroll view content container which
-   * wraps all of the child views. Example:
+   * wraps all of the child views.
    *
-   * ```
+   * Example:
+   *
+   * ```tsx
    * return (
    *   <ScrollView contentContainerStyle={styles.contentContainer}>
    *   </ScrollView>
@@ -423,14 +500,18 @@ type ScrollViewBaseProps = Readonly<{
   contentContainerStyle?: ?ViewStyleProp,
   /**
    * Used to manually set the starting scroll offset.
-   * The default value is `{x: 0, y: 0}`.
+   *
+   * @default `{x: 0, y: 0}`
    */
   contentOffset?: ?PointProp,
+
   /**
    * When true, the scroll view stops on the next index (in relation to scroll
    * position at release) regardless of how fast the gesture is. This can be
    * used for pagination when the page is less than the width of the
-   * horizontal ScrollView or the height of the vertical ScrollView. The default value is false.
+   * horizontal ScrollView or the height of the vertical ScrollView.
+   *
+   * @default `false`
    */
   disableIntervalMomentum?: ?boolean,
   /**
@@ -440,27 +521,31 @@ type ScrollViewBaseProps = Readonly<{
    * for `UIScrollViewDecelerationRateNormal` and
    * `UIScrollViewDecelerationRateFast` respectively.
    *
-   *   - `'normal'`: 0.998 on iOS, 0.985 on Android (the default)
+   *   - `'normal'`: 0.998 on iOS, 0.985 on Android
    *   - `'fast'`: 0.99 on iOS, 0.9 on Android
+   *
+   * @default `'normal'`
    */
   decelerationRate?: ?DecelerationRateType,
 
   /**
    * *Experimental, iOS Only*. The API is experimental and will change in future releases.
    *
-   * Controls how much distance is travelled after user stops scrolling.
-   * Value greater than 1 will increase the distance travelled.
-   * Value less than 1 will decrease the distance travelled.
+   * Controls how much distance is traveled after user stops scrolling.
+   * A value greater than 1 will increase the distance traveled.
+   * A value less than 1 will decrease the distance traveled.
    *
    * @deprecated
    *
-   * The default value is 1.
+   * @default `1`
    */
   experimental_endDraggingSensitivityMultiplier?: ?number,
 
   /**
    * When true, the scroll view's children are arranged horizontally in a row
-   * instead of vertically in a column. The default value is false.
+   * instead of vertically in a column.
+   *
+   * @default `false`
    */
   horizontal?: ?boolean,
   /**
@@ -473,14 +558,16 @@ type ScrollViewBaseProps = Readonly<{
    *
    * *Cross platform*
    *
-   *   - `'none'` (the default), drags do not dismiss the keyboard.
+   *   - `'none'`, drags do not dismiss the keyboard.
    *   - `'on-drag'`, the keyboard is dismissed when a drag begins.
    *
    * *iOS Only*
    *
    *   - `'interactive'`, the keyboard is dismissed interactively with the drag and moves in
    *     synchrony with the touch; dragging upwards cancels the dismissal.
-   *     On android this is not supported and it will have the same behavior as 'none'.
+   *     On Android this is not supported and it will have the same behavior as `'none'`.
+   *
+   * @default `'none'`
    */
   keyboardDismissMode?: ?// default
   // cross-platform
@@ -488,14 +575,16 @@ type ScrollViewBaseProps = Readonly<{
   /**
    * Determines when the keyboard should stay visible after a tap.
    *
-   *   - `'never'` (the default), tapping outside of the focused text input when the keyboard
-   *     is up dismisses the keyboard. When this happens, children won't receive the tap.
+   *   - `'never'`, tapping outside of the focused text input when the keyboard
+   *     is up dismisses the keyboard. When this happens, children will not receive the tap.
    *   - `'always'`, the keyboard will not dismiss automatically, and the scroll view will not
    *     catch taps, but children of the scroll view can catch taps.
    *   - `'handled'`, the keyboard will not dismiss automatically when the tap was handled by
-   *     a children, (or captured by an ancestor).
-   *   - `false`, deprecated, use 'never' instead
-   *   - `true`, deprecated, use 'always' instead
+   *     children, (or captured by an ancestor).
+   *   - `false`, deprecated, use `'never'` instead.
+   *   - `true`, deprecated, use `'always'` instead.
+   *
+   * @default `'never'`
    */
   keyboardShouldPersistTaps?: ?('always' | 'never' | 'handled' | true | false),
   /**
@@ -563,32 +652,42 @@ type ScrollViewBaseProps = Readonly<{
   onKeyboardWillHide?: (event: KeyboardEvent) => void,
   /**
    * When true, the scroll view stops on multiples of the scroll view's size
-   * when scrolling. This can be used for horizontal pagination. The default
-   * value is false.
+   * when scrolling. This can be used for horizontal pagination.
+   *
+   * @default `false`
    */
   pagingEnabled?: ?boolean,
+
   /**
    * When false, the view cannot be scrolled via touch interaction.
-   * The default value is true.
-   *
    * Note that the view can always be scrolled by calling `scrollTo`.
+   *
+   * @default `true`
    */
   scrollEnabled?: ?boolean,
+
   /**
    * Limits how often scroll events will be fired while scrolling, specified as
    * a time interval in ms. This may be useful when expensive work is performed
    * in response to scrolling. Values <= `16` will disable throttling,
    * regardless of the refresh rate of the device.
+   *
+   * @default `0`
    */
   scrollEventThrottle?: ?number,
+
   /**
    * When true, shows a vertical scroll indicator.
-   * The default value is true.
+   *
+   * @default `true`
    */
   showsVerticalScrollIndicator?: ?boolean,
+
   /**
-   * When true, Sticky header is hidden when scrolling down, and dock at the top
-   * when scrolling up
+   * When true, the sticky header is hidden when scrolling down, and docks
+   * at the top when scrolling up.
+   *
+   * @default `false`
    */
   stickyHeaderHiddenOnScroll?: ?boolean,
   /**
@@ -607,12 +706,14 @@ type ScrollViewBaseProps = Readonly<{
    */
   StickyHeaderComponent?: StickyHeaderComponentType,
   /**
-   * When `snapToInterval` is set, `snapToAlignment` will define the relationship
+   * When `snapToInterval` is set, `snapToAlignment` defines the relationship
    * of the snapping to the scroll view.
    *
-   *   - `'start'` (the default) will align the snap at the left (horizontal) or top (vertical)
-   *   - `'center'` will align the snap in the center
-   *   - `'end'` will align the snap at the right (horizontal) or bottom (vertical)
+   *   - `'start'`, aligns the snap at the left (horizontal) or top (vertical).
+   *   - `'center'`, aligns the snap in the center.
+   *   - `'end'`, aligns the snap at the right (horizontal) or bottom (vertical).
+   *
+   * @default `'start'`
    */
   snapToAlignment?: ?('start' | 'center' | 'end'),
   /**
@@ -635,25 +736,30 @@ type ScrollViewBaseProps = Readonly<{
   snapToOffsets?: ?ReadonlyArray<number>,
   /**
    * Use in conjunction with `snapToOffsets`. By default, the beginning
-   * of the list counts as a snap offset. Set `snapToStart` to false to disable
+   * of the list counts as a snap offset. Set `snapToStart` to `false` to disable
    * this behavior and allow the list to scroll freely between its start and
    * the first `snapToOffsets` offset.
-   * The default value is true.
+   *
+   * @default `true`
    */
   snapToStart?: ?boolean,
+
   /**
    * Use in conjunction with `snapToOffsets`. By default, the end
-   * of the list counts as a snap offset. Set `snapToEnd` to false to disable
+   * of the list counts as a snap offset. Set `snapToEnd` to `false` to disable
    * this behavior and allow the list to scroll freely between its end and
    * the last `snapToOffsets` offset.
-   * The default value is true.
+   *
+   * @default `true`
    */
   snapToEnd?: ?boolean,
+
   /**
    * Experimental: When true, offscreen child views (whose `overflow` value is
    * `hidden`) are removed from their native backing superview when offscreen.
-   * This can improve scrolling performance on long lists. The default value is
-   * true.
+   * This can improve scrolling performance on long lists.
+   *
+   * @default `true`
    */
   removeClippedSubviews?: ?boolean,
   /**
@@ -732,6 +838,8 @@ export type ScrollViewComponentStatics = Readonly<{
  * `FlatList` is also handy if you want to render separators between your items,
  * multiple columns, infinite scroll loading, or any number of other features it
  * supports out of the box.
+ *
+ * @see https://reactnative.dev/docs/scrollview
  */
 class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
   static Context: typeof ScrollViewContext = ScrollViewContext;

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -66,18 +66,21 @@ export type StatusBarPropsAndroid = Readonly<{
   /**
    * The background color of the status bar.
    *
-   * Please note that this prop has no effect on Android 15+
+   * @deprecated Has no effect on API level 35+ (Android 15+) due to
+   * edge-to-edge enforcement.
    *
    * @platform android
    */
   backgroundColor?: ?ColorValue,
+
   /**
-   * If the status bar is translucent.
-   * When translucent is set to true, the app will draw under the status bar.
-   * This is useful when using a semi transparent status bar color.
+   * If the status bar is translucent. When `true`, the app draws under the
+   * status bar. This is useful when using a semi-transparent status bar color.
    *
-   * Please note that this prop has no effect on Android 15+
+   * @deprecated Has no effect on API level 35+ (Android 15+) due to
+   * edge-to-edge enforcement.
    *
+   * @default `false`
    * @platform android
    */
   translucent?: ?boolean,
@@ -87,13 +90,16 @@ export type StatusBarPropsIOS = Readonly<{
   /**
    * If the network activity indicator should be visible.
    *
+   * @default `false`
    * @platform ios
    */
   networkActivityIndicatorVisible?: ?boolean,
+
   /**
-   * The transition effect when showing and hiding the status bar using the `hidden`
-   * prop. Defaults to 'fade'.
+   * The transition effect when showing and hiding the status bar using the
+   * `hidden` prop.
    *
+   * @default `'fade'`
    * @platform ios
    */
   showHideTransition?: ?('fade' | 'slide' | 'none'),
@@ -102,15 +108,23 @@ export type StatusBarPropsIOS = Readonly<{
 type StatusBarBaseProps = Readonly<{
   /**
    * If the status bar is hidden.
+   *
+   * @default `false`
    */
   hidden?: ?boolean,
+
   /**
    * If the transition between status bar property changes should be animated.
-   * Supported for backgroundColor, barStyle and hidden.
+   * Supported for `backgroundColor`, `barStyle`, and `hidden`.
+   *
+   * @default `false`
    */
   animated?: ?boolean,
+
   /**
    * Sets the color of the status bar text.
+   *
+   * @default `'default'`
    */
   barStyle?: ?('default' | 'auto' | 'light-content' | 'dark-content'),
 }>;
@@ -212,11 +226,12 @@ function createStackEntry(props: StatusBarProps): StackProps {
 }
 
 /**
- * Component to control the app status bar.
+ * Component to control the app's status bar. The status bar is the zone,
+ * typically at the top of the screen, that displays the current time, Wi-Fi and
+ * cellular network information, battery level and/or other status icons.
  *
- * It is possible to have multiple `StatusBar` components mounted at the same
- * time. The props will be merged in the order the `StatusBar` components were
- * mounted.
+ * Multiple `StatusBar` components can be mounted simultaneously; props merge in
+ * mount order.
  *
  * ### Imperative API
  *
@@ -228,7 +243,9 @@ function createStackEntry(props: StatusBarProps): StackProps {
  * before launching a third-party native UI component, and then call
  * `StatusBar.popStackEntry` when completed.
  *
- * ```
+ * Example:
+ *
+ * ```tsx
  * const openThirdPartyBugReporter = async () => {
  *   // The bug reporter has a dark background, so we push a new status bar style.
  *   const stackEntry = StatusBar.pushStackEntry({barStyle: 'light-content'});
@@ -252,6 +269,8 @@ function createStackEntry(props: StatusBarProps): StackProps {
  * ### Constants
  *
  * `currentHeight` (Android only) The height of the status bar.
+ *
+ * @see https://reactnative.dev/docs/statusbar
  */
 class StatusBar extends React.Component<StatusBarProps> {
   static _propsStack: Array<StackProps> = [];
@@ -329,10 +348,13 @@ class StatusBar extends React.Component<StatusBarProps> {
   }
 
   /**
-   * DEPRECATED - The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+   * DEPRECATED - The status bar network activity indicator is not supported in
+   * iOS 13 and later. This will be removed in a future release.
+   *
    * @param visible Show the indicator.
    *
-   * @deprecated
+   * @deprecated The status bar network activity indicator is not supported in
+   * iOS 13 and later.
    */
   static setNetworkActivityIndicatorVisible(visible: boolean) {
     if (Platform.OS !== 'ios') {

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -60,55 +60,54 @@ export type SwitchChangeEvent = NativeSyntheticEvent<SwitchChangeEventData>;
 
 type SwitchPropsBase = {
   /**
-    If true the user won't be able to toggle the switch.
-
-    @default false
+   * If true, the user won't be able to toggle the switch.
+   *
+   * @default `false`
    */
   disabled?: ?boolean,
 
   /**
-      The value of the switch. If true the switch will be turned on.
-
-      @default false
-     */
+   * The value of the switch. If true the switch will be turned on.
+   *
+   * @default `false`
+   */
   value?: ?boolean,
 
   /**
-      Color of the foreground switch grip. If this is set on iOS, the switch grip will lose its drop shadow.
-     */
+   * Color of the foreground switch grip. If set on iOS, the switch grip
+   * loses its drop shadow.
+   */
   thumbColor?: ?ColorValue,
 
   /**
-      Custom colors for the switch track.
-
-      _iOS_: When the switch value is false, the track shrinks into the border. If you want to change the
-      color of the background exposed by the shrunken track, use
-       [`ios_backgroundColor`](https://reactnative.dev/docs/switch#ios_backgroundColor).
-     */
+   * Custom colors for the switch track. On iOS, when the switch value is
+   * false, the track shrinks into the border.
+   */
   trackColor?: ?Readonly<{
     false?: ?ColorValue,
     true?: ?ColorValue,
   }>,
 
   /**
-      On iOS, custom color for the background. This background color can be
-      seen either when the switch value is false or when the switch is
-      disabled (and the switch is translucent).
-     */
+   * Custom color for the background. Can be seen when the switch value is
+   * false or when the switch is disabled (and the switch is translucent).
+   *
+   * @platform ios
+   */
   ios_backgroundColor?: ?ColorValue,
 
   /**
-      Invoked when the user tries to change the value of the switch. Receives
-      the change event as an argument. If you want to only receive the new
-      value, use `onValueChange` instead.
-     */
+   * Invoked when the user tries to change the value of the switch. Receives
+   * the change event as an argument. Use `onValueChange` to receive just
+   * the new value instead.
+   */
   onChange?: ?(event: SwitchChangeEvent) => Promise<void> | void,
 
   /**
-      Invoked when the user tries to change the value of the switch. Receives
-      the new value as an argument. If you want to instead receive an event,
-      use `onChange`.
-     */
+   * Invoked when the user tries to change the value of the switch. Receives
+   * the new value as an argument. Use `onChange` to receive the event
+   * instead.
+   */
   onValueChange?: ?(value: boolean) => Promise<void> | void,
 };
 
@@ -123,45 +122,49 @@ const returnsFalse = () => false;
 const returnsTrue = () => true;
 
 /**
-  Renders a boolean input.
-
-  This is a controlled component that requires an `onValueChange`
-  callback that updates the `value` prop in order for the component to
-  reflect user actions. If the `value` prop is not updated, the
-  component will continue to render the supplied `value` prop instead of
-  the expected result of any user actions.
-
-  ```SnackPlayer name=Switch
-  import React, { useState } from "react";
-  import { View, Switch, StyleSheet } from "react-native";
-
-  const App = () => {
-    const [isEnabled, setIsEnabled] = useState(false);
-    const toggleSwitch = () => setIsEnabled(previousState => !previousState);
-
-    return (
-      <View style={styles.container}>
-        <Switch
-          trackColor={{ false: "#767577", true: "#81b0ff" }}
-          thumbColor={isEnabled ? "#f5dd4b" : "#f4f3f4"}
-          ios_backgroundColor="#3e3e3e"
-          onValueChange={toggleSwitch}
-          value={isEnabled}
-        />
-      </View>
-    );
-  }
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      alignItems: "center",
-      justifyContent: "center"
-    }
-  });
-
-  export default App;
-  ```
+ * Renders a boolean input.
+ *
+ * This is a controlled component that requires an `onValueChange` callback
+ * that updates the `value` prop in order for the component to reflect user
+ * actions. If the `value` prop is not updated, the component will continue to
+ * render the supplied `value` prop instead of the expected result of any user
+ * actions.
+ *
+ * Example:
+ *
+ * ```tsx
+ * import React, {useState} from 'react';
+ * import {View, Switch, StyleSheet} from 'react-native';
+ *
+ * const App = () => {
+ *   const [isEnabled, setIsEnabled] = useState(false);
+ *   const toggleSwitch = () => setIsEnabled(previousState => !previousState);
+ *
+ *   return (
+ *     <View style={styles.container}>
+ *       <Switch
+ *         trackColor={{false: '#767577', true: '#81b0ff'}}
+ *         thumbColor={isEnabled ? '#f5dd4b' : '#f4f3f4'}
+ *         ios_backgroundColor="#3e3e3e"
+ *         onValueChange={toggleSwitch}
+ *         value={isEnabled}
+ *       />
+ *     </View>
+ *   );
+ * };
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     alignItems: 'center',
+ *     justifyContent: 'center',
+ *   },
+ * });
+ *
+ * export default App;
+ * ```
+ *
+ * @see https://reactnative.dev/docs/switch
  */
 const Switch: component(
   ref?: React.RefSetter<SwitchInstance>,

--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
@@ -18,76 +18,27 @@ import useWindowDimensions from '../../Utilities/useWindowDimensions';
 import RCTInputAccessoryViewNativeComponent from './RCTInputAccessoryViewNativeComponent';
 import * as React from 'react';
 
-/**
- * Note: iOS only
- *
- * A component which enables customization of the keyboard input accessory view.
- * The input accessory view is displayed above the keyboard whenever a TextInput
- * has focus. This component can be used to create custom toolbars.
- *
- * To use this component wrap your custom toolbar with the
- * InputAccessoryView component, and set a nativeID. Then, pass that nativeID
- * as the inputAccessoryViewID of whatever TextInput you desire. A simple
- * example:
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react';
- * import { AppRegistry, TextInput, InputAccessoryView, Button } from 'react-native';
- *
- * export default class UselessTextInput extends Component {
- *   constructor(props) {
- *     super(props);
- *     this.state = {text: 'Placeholder Text'};
- *   }
- *
- *   render() {
- *     const inputAccessoryViewID = "uniqueID";
- *     return (
- *       <View>
- *         <ScrollView keyboardDismissMode="interactive">
- *           <TextInput
- *             style={{
- *               padding: 10,
- *               paddingTop: 50,
- *             }}
- *             inputAccessoryViewID=inputAccessoryViewID
- *             onChangeText={text => this.setState({text})}
- *             value={this.state.text}
- *           />
- *         </ScrollView>
- *         <InputAccessoryView nativeID=inputAccessoryViewID>
- *           <Button
- *             onPress={() => this.setState({text: 'Placeholder Text'})}
- *             title="Reset Text"
- *           />
- *         </InputAccessoryView>
- *       </View>
- *     );
- *   }
- * }
- *
- * // skip this line if using Create React Native App
- * AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
- * ```
- *
- * This component can also be used to create sticky text inputs (text inputs
- * which are anchored to the top of the keyboard). To do this, wrap a
- * TextInput with the InputAccessoryView component, and don't set a nativeID.
- * For an example, look at InputAccessoryViewExample.js in RNTester.
- */
-
 /** @build-types emit-as-interface Expo compatibility */
 export type InputAccessoryViewProps = Readonly<{
   readonly children: React.Node,
   /**
-   * An ID which is used to associate this `InputAccessoryView` to
-   * specified TextInput(s).
+   * An ID used to associate this `InputAccessoryView` to specified `TextInput`(s).
    */
   nativeID?: ?string,
   style?: ?ViewStyleProp,
   backgroundColor?: ?ColorValue,
 }>;
 
+/**
+ * A component which enables customization of the keyboard input accessory view on iOS. The input accessory view is displayed above the keyboard whenever a `TextInput` has focus. This component can be used to create custom toolbars.
+ *
+ * To use this component, wrap your custom toolbar with `InputAccessoryView` and set a `nativeID`. Then, pass that `nativeID` as the `inputAccessoryViewID` of whatever `TextInput` you desire.
+ *
+ * This component can also be used to create sticky text inputs (text inputs which are anchored to the top of the keyboard). To do this, wrap a `TextInput` with `InputAccessoryView` and don't set a `nativeID`.
+ *
+ * @see https://reactnative.dev/docs/inputaccessoryview
+ * @platform ios
+ */
 const InputAccessoryView: React.ComponentType<InputAccessoryViewProps> = (
   props: InputAccessoryViewProps,
 ) => {

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -1069,9 +1069,18 @@ export type TextInputProps = Readonly<{
  * It isn't technically a class but this is the most elegant way to type it.
  */
 declare class _TextInputInstance extends ReactNativeElement {
+  /**
+   * Removes all text from the input.
+   */
   clear(): void;
+  /**
+   * Returns if the input is currently focused.
+   */
   isFocused(): boolean;
   getNativeRef(): ?ReactNativeElement;
+  /**
+   * Sets the start and end positions of text selection.
+   */
   setSelection(start: number, end: number): void;
 }
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -244,117 +244,6 @@ function useTextInputStateSynchronization({
   return {setLastNativeSelection, setLastNativeText};
 }
 
-/**
- * A foundational component for inputting text into the app via a
- * keyboard. Props provide configurability for several features, such as
- * auto-correction, auto-capitalization, placeholder text, and different keyboard
- * types, such as a numeric keypad.
- *
- * The simplest use case is to plop down a `TextInput` and subscribe to the
- * `onChangeText` events to read the user input. There are also other events,
- * such as `onSubmitEditing` and `onFocus` that can be subscribed to. A simple
- * example:
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react';
- * import { AppRegistry, TextInput } from 'react-native';
- *
- * export default class UselessTextInput extends Component {
- *   constructor(props) {
- *     super(props);
- *     this.state = { text: 'Useless Placeholder' };
- *   }
- *
- *   render() {
- *     return (
- *       <TextInput
- *         style={{height: 40, borderColor: 'gray', borderWidth: 1}}
- *         onChangeText={(text) => this.setState({text})}
- *         value={this.state.text}
- *       />
- *     );
- *   }
- * }
- *
- * // skip this line if using Create React Native App
- * AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
- * ```
- *
- * Two methods exposed via the native element are .focus() and .blur() that
- * will focus or blur the TextInput programmatically.
- *
- * Note that some props are only available with `multiline={true/false}`.
- * Additionally, border styles that apply to only one side of the element
- * (e.g., `borderBottomColor`, `borderLeftWidth`, etc.) will not be applied if
- * `multiline=false`. To achieve the same effect, you can wrap your `TextInput`
- * in a `View`:
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react';
- * import { AppRegistry, View, TextInput } from 'react-native';
- *
- * class UselessTextInput extends Component {
- *   render() {
- *     return (
- *       <TextInput
- *         {...this.props} // Inherit any props passed to it; e.g., multiline, numberOfLines below
- *         editable={true}
- *         maxLength={40}
- *       />
- *     );
- *   }
- * }
- *
- * export default class UselessTextInputMultiline extends Component {
- *   constructor(props) {
- *     super(props);
- *     this.state = {
- *       text: 'Useless Multiline Placeholder',
- *     };
- *   }
- *
- *   // If you type something in the text box that is a color, the background will change to that
- *   // color.
- *   render() {
- *     return (
- *      <View style={{
- *        backgroundColor: this.state.text,
- *        borderBottomColor: '#000000',
- *        borderBottomWidth: 1 }}
- *      >
- *        <UselessTextInput
- *          multiline={true}
- *          numberOfLines={4}
- *          onChangeText={(text) => this.setState({text})}
- *          value={this.state.text}
- *        />
- *      </View>
- *     );
- *   }
- * }
- *
- * // skip these lines if using Create React Native App
- * AppRegistry.registerComponent(
- *  'AwesomeProject',
- *  () => UselessTextInputMultiline
- * );
- * ```
- *
- * `TextInput` has by default a border at the bottom of its view. This border
- * has its padding set by the background image provided by the system, and it
- * cannot be changed. Solutions to avoid this is to either not set height
- * explicitly, case in which the system will take care of displaying the border
- * in the correct position, or to not display the border by setting
- * `underlineColorAndroid` to transparent.
- *
- * Note that on Android performing text selection in input can change
- * app's activity `windowSoftInputMode` param to `adjustResize`.
- * This may cause issues with components that have position: 'absolute'
- * while keyboard is active. To avoid this behavior either specify `windowSoftInputMode`
- * in AndroidManifest.xml ( https://developer.android.com/guide/topics/manifest/activity-element.html )
- * or control this param programmatically with native code.
- *
- */
 function InternalTextInput(props: TextInputProps): React.Node {
   const {
     'aria-busy': ariaBusy,
@@ -899,6 +788,121 @@ const autoCompleteWebToTextContentTypeMap = {
   username: 'username',
 } as const;
 
+/**
+ * A foundational component for inputting text into the app via a
+ * keyboard. Props provide configurability for several features, such as
+ * auto-correction, auto-capitalization, placeholder text, and different keyboard
+ * types, such as a numeric keypad.
+ *
+ * The simplest use case is to plop down a `TextInput` and subscribe to the
+ * `onChangeText` events to read the user input. There are also other events,
+ * such as `onSubmitEditing` and `onFocus` that can be subscribed to.
+ *
+ * Example:
+ *
+ * ```tsx
+ * import React, { Component } from 'react';
+ * import { AppRegistry, TextInput } from 'react-native';
+ *
+ * export default class UselessTextInput extends Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = { text: 'Useless Placeholder' };
+ *   }
+ *
+ *   render() {
+ *     return (
+ *       <TextInput
+ *         style={{height: 40, borderColor: 'gray', borderWidth: 1}}
+ *         onChangeText={(text) => this.setState({text})}
+ *         value={this.state.text}
+ *       />
+ *     );
+ *   }
+ * }
+ *
+ * // skip this line if using Create React Native App
+ * AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
+ * ```
+ *
+ * Two methods exposed via the native element are .focus() and .blur() that
+ * will focus or blur the TextInput programmatically.
+ *
+ * Note that some props are only available with `multiline={true/false}`.
+ * Additionally, border styles that apply to only one side of the element
+ * (e.g., `borderBottomColor`, `borderLeftWidth`, etc.) will not be applied if
+ * `multiline=false`. To achieve the same effect, you can wrap your `TextInput`
+ * in a `View`:
+ *
+ * Example:
+ *
+ * ```tsx
+ * import React, { Component } from 'react';
+ * import { AppRegistry, View, TextInput } from 'react-native';
+ *
+ * class UselessTextInput extends Component {
+ *   render() {
+ *     return (
+ *       <TextInput
+ *         {...this.props} // Inherit any props passed to it; e.g., multiline, numberOfLines below
+ *         editable={true}
+ *         maxLength={40}
+ *       />
+ *     );
+ *   }
+ * }
+ *
+ * export default class UselessTextInputMultiline extends Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = {
+ *       text: 'Useless Multiline Placeholder',
+ *     };
+ *   }
+ *
+ *   // If you type something in the text box that is a color, the background will change to that
+ *   // color.
+ *   render() {
+ *     return (
+ *      <View style={{
+ *        backgroundColor: this.state.text,
+ *        borderBottomColor: '#000000',
+ *        borderBottomWidth: 1 }}
+ *      >
+ *        <UselessTextInput
+ *          multiline={true}
+ *          numberOfLines={4}
+ *          onChangeText={(text) => this.setState({text})}
+ *          value={this.state.text}
+ *        />
+ *      </View>
+ *     );
+ *   }
+ * }
+ *
+ * // skip these lines if using Create React Native App
+ * AppRegistry.registerComponent(
+ *  'AwesomeProject',
+ *  () => UselessTextInputMultiline
+ * );
+ * ```
+ *
+ * `TextInput` has by default a border at the bottom of its view. This border
+ * has its padding set by the background image provided by the system, and it
+ * cannot be changed. Solutions to avoid this is to either not set height
+ * explicitly, case in which the system will take care of displaying the border
+ * in the correct position, or to not display the border by setting
+ * `underlineColorAndroid` to transparent.
+ *
+ * Note that on Android performing text selection in input can change
+ * app's activity `windowSoftInputMode` param to `adjustResize`.
+ * This may cause issues with components that have position: 'absolute'
+ * while keyboard is active. To avoid this behavior either specify `windowSoftInputMode`
+ * in AndroidManifest.xml ( https://developer.android.com/guide/topics/manifest/activity-element.html )
+ * or control this param programmatically with native code.
+ *
+ * @see https://reactnative.dev/docs/textinput
+ */
 const TextInput: component(
   ref?: React.RefSetter<TextInputInstance>,
   ...props: React.ElementConfig<typeof InternalTextInput>

--- a/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.android.js
+++ b/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.android.js
@@ -11,41 +11,43 @@
 import NativeToastAndroid from './NativeToastAndroid';
 
 /**
- * This exposes the native ToastAndroid module as a JS module. This has a function 'show'
- * which takes the following parameters:
+ * Displays Android toast messages.
  *
- * 1. String message: A string with the text to toast
- * 2. int duration: The duration of the toast. May be ToastAndroid.SHORT or ToastAndroid.LONG
- *
- * There is also a function `showWithGravity` to specify the layout gravity. May be
- * ToastAndroid.TOP, ToastAndroid.BOTTOM, ToastAndroid.CENTER.
- *
- * The 'showWithGravityAndOffset' function adds on the ability to specify offset
- * These offset values will translate to pixels.
- *
- * Basic usage:
- * ```javascript
- * ToastAndroid.show('A pikachu appeared nearby !', ToastAndroid.SHORT);
- * ToastAndroid.showWithGravity('All Your Base Are Belong To Us', ToastAndroid.SHORT, ToastAndroid.CENTER);
- * ToastAndroid.showWithGravityAndOffset('A wild toast appeared!', ToastAndroid.LONG, ToastAndroid.BOTTOM, 25, 50);
- * ```
+ * @see https://reactnative.dev/docs/toastandroid
+ * @platform android
  */
 
 const ToastAndroidConstants = NativeToastAndroid.getConstants();
 
 const ToastAndroid = {
-  // Toast duration constants
+  /** Toast duration constant for a short display time. */
   SHORT: ToastAndroidConstants.SHORT as number,
+
+  /** Toast duration constant for a long display time. */
   LONG: ToastAndroidConstants.LONG as number,
-  // Toast gravity constants
+
+  /** Toast gravity constant for top positioning. */
   TOP: ToastAndroidConstants.TOP as number,
+
+  /** Toast gravity constant for bottom positioning. */
   BOTTOM: ToastAndroidConstants.BOTTOM as number,
+
+  /** Toast gravity constant for center positioning. */
   CENTER: ToastAndroidConstants.CENTER as number,
 
+  /**
+   * Show a toast with the given message and duration (`ToastAndroid.SHORT` or
+   * `ToastAndroid.LONG`).
+   */
   show: function (message: string, duration: number): void {
     NativeToastAndroid.show(message, duration);
   },
 
+  /**
+   * Show a toast at a specified gravity position (`ToastAndroid.TOP`,
+   * `ToastAndroid.BOTTOM`, or `ToastAndroid.CENTER`). Only works on API 29
+   * and below.
+   */
   showWithGravity: function (
     message: string,
     duration: number,
@@ -54,6 +56,10 @@ const ToastAndroid = {
     NativeToastAndroid.showWithGravity(message, duration, gravity);
   },
 
+  /**
+   * Show a toast at a specified gravity position with additional pixel
+   * offsets. Only works on API 29 and below.
+   */
   showWithGravityAndOffset: function (
     message: string,
     duration: number,

--- a/packages/react-native/Libraries/Components/Touchable/Touchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/Touchable.js
@@ -49,91 +49,6 @@ const extractSingleTouch = (nativeEvent: {
 };
 
 /**
- * `Touchable`: Taps done right.
- *
- * You hook your `ResponderEventPlugin` events into `Touchable`. `Touchable`
- * will measure time/geometry and tells you when to give feedback to the user.
- *
- * ====================== Touchable Tutorial ===============================
- * The `Touchable` mixin helps you handle the "press" interaction. It analyzes
- * the geometry of elements, and observes when another responder (scroll view
- * etc) has stolen the touch lock. It notifies your component when it should
- * give feedback to the user. (bouncing/highlighting/unhighlighting).
- *
- * - When a touch was activated (typically you highlight)
- * - When a touch was deactivated (typically you unhighlight)
- * - When a touch was "pressed" - a touch ended while still within the geometry
- *   of the element, and no other element (like scroller) has "stolen" touch
- *   lock ("responder") (Typically you bounce the element).
- *
- * A good tap interaction isn't as simple as you might think. There should be a
- * slight delay before showing a highlight when starting a touch. If a
- * subsequent touch move exceeds the boundary of the element, it should
- * unhighlight, but if that same touch is brought back within the boundary, it
- * should rehighlight again. A touch can move in and out of that boundary
- * several times, each time toggling highlighting, but a "press" is only
- * triggered if that touch ends while within the element's boundary and no
- * scroller (or anything else) has stolen the lock on touches.
- *
- * To create a new type of component that handles interaction using the
- * `Touchable` mixin, do the following:
- *
- * - Initialize the `Touchable` state.
- *
- *   getInitialState: function() {
- *     return merge(this.touchableGetInitialState(), yourComponentState);
- *   }
- *
- * - Choose the rendered component who's touches should start the interactive
- *   sequence. On that rendered node, forward all `Touchable` responder
- *   handlers. You can choose any rendered node you like. Choose a node whose
- *   hit target you'd like to instigate the interaction sequence:
- *
- *   // In render function:
- *   return (
- *     <View
- *       onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
- *       onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
- *       onResponderGrant={this.touchableHandleResponderGrant}
- *       onResponderMove={this.touchableHandleResponderMove}
- *       onResponderRelease={this.touchableHandleResponderRelease}
- *       onResponderTerminate={this.touchableHandleResponderTerminate}>
- *       <View>
- *         Even though the hit detection/interactions are triggered by the
- *         wrapping (typically larger) node, we usually end up implementing
- *         custom logic that highlights this inner one.
- *       </View>
- *     </View>
- *   );
- *
- * - You may set up your own handlers for each of these events, so long as you
- *   also invoke the `touchable*` handlers inside of your custom handler.
- *
- * - Implement the handlers on your component class in order to provide
- *   feedback to the user. See documentation for each of these class methods
- *   that you should implement.
- *
- *   touchableHandlePress: function() {
- *      this.performBounceAnimation();  // or whatever you want to do.
- *   },
- *   touchableHandleActivePressIn: function() {
- *     this.beginHighlighting(...);  // Whatever you like to convey activation
- *   },
- *   touchableHandleActivePressOut: function() {
- *     this.endHighlighting(...);  // Whatever you like to convey deactivation
- *   },
- *
- * - There are more advanced methods you can implement (see documentation below):
- *   touchableGetHighlightDelayMS: function() {
- *     return 20;
- *   }
- *   // In practice, *always* use a predeclared constant (conserve memory).
- *   touchableGetPressRectOffset: function() {
- *     return {top: 20, left: 20, right: 20, bottom: 100};
- *   }
- */
-
-/**
  * Touchable states.
  */
 
@@ -964,6 +879,90 @@ const {
 TouchableMixinImpl.withoutDefaultFocusAndBlur =
   TouchableMixinWithoutDefaultFocusAndBlur;
 
+/**
+ * `Touchable`: Taps done right.
+ *
+ * You hook your `ResponderEventPlugin` events into `Touchable`. `Touchable`
+ * will measure time/geometry and tells you when to give feedback to the user.
+ *
+ * ====================== Touchable Tutorial ===============================
+ * The `Touchable` mixin helps you handle the "press" interaction. It analyzes
+ * the geometry of elements, and observes when another responder (scroll view
+ * etc) has stolen the touch lock. It notifies your component when it should
+ * give feedback to the user. (bouncing/highlighting/unhighlighting).
+ *
+ * - When a touch was activated (typically you highlight)
+ * - When a touch was deactivated (typically you unhighlight)
+ * - When a touch was "pressed" - a touch ended while still within the geometry
+ *   of the element, and no other element (like scroller) has "stolen" touch
+ *   lock ("responder") (Typically you bounce the element).
+ *
+ * A good tap interaction isn't as simple as you might think. There should be a
+ * slight delay before showing a highlight when starting a touch. If a
+ * subsequent touch move exceeds the boundary of the element, it should
+ * unhighlight, but if that same touch is brought back within the boundary, it
+ * should rehighlight again. A touch can move in and out of that boundary
+ * several times, each time toggling highlighting, but a "press" is only
+ * triggered if that touch ends while within the element's boundary and no
+ * scroller (or anything else) has stolen the lock on touches.
+ *
+ * To create a new type of component that handles interaction using the
+ * `Touchable` mixin, do the following:
+ *
+ * - Initialize the `Touchable` state.
+ *
+ *   getInitialState: function() {
+ *     return merge(this.touchableGetInitialState(), yourComponentState);
+ *   }
+ *
+ * - Choose the rendered component who's touches should start the interactive
+ *   sequence. On that rendered node, forward all `Touchable` responder
+ *   handlers. You can choose any rendered node you like. Choose a node whose
+ *   hit target you'd like to instigate the interaction sequence:
+ *
+ *   // In render function:
+ *   return (
+ *     <View
+ *       onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
+ *       onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
+ *       onResponderGrant={this.touchableHandleResponderGrant}
+ *       onResponderMove={this.touchableHandleResponderMove}
+ *       onResponderRelease={this.touchableHandleResponderRelease}
+ *       onResponderTerminate={this.touchableHandleResponderTerminate}>
+ *       <View>
+ *         Even though the hit detection/interactions are triggered by the
+ *         wrapping (typically larger) node, we usually end up implementing
+ *         custom logic that highlights this inner one.
+ *       </View>
+ *     </View>
+ *   );
+ *
+ * - You may set up your own handlers for each of these events, so long as you
+ *   also invoke the `touchable*` handlers inside of your custom handler.
+ *
+ * - Implement the handlers on your component class in order to provide
+ *   feedback to the user. See documentation for each of these class methods
+ *   that you should implement.
+ *
+ *   touchableHandlePress: function() {
+ *      this.performBounceAnimation();  // or whatever you want to do.
+ *   },
+ *   touchableHandleActivePressIn: function() {
+ *     this.beginHighlighting(...);  // Whatever you like to convey activation
+ *   },
+ *   touchableHandleActivePressOut: function() {
+ *     this.endHighlighting(...);  // Whatever you like to convey deactivation
+ *   },
+ *
+ * - There are more advanced methods you can implement (see documentation below):
+ *   touchableGetHighlightDelayMS: function() {
+ *     return 20;
+ *   }
+ *   // In practice, *always* use a predeclared constant (conserve memory).
+ *   touchableGetPressRectOffset: function() {
+ *     return {top: 20, left: 20, right: 20, bottom: 100};
+ *   }
+ */
 const TouchableImpl = {
   Mixin: TouchableMixinImpl,
   /**

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -43,25 +43,29 @@ type IOSProps = Readonly<{
 
 type TouchableHighlightBaseProps = Readonly<{
   /**
-   * Determines what the opacity of the wrapped view should be when touch is active.
+   * Opacity of the wrapped view when touch is active. Requires `underlayColor` to be set.
+   *
+   * @default `0.85`
    */
   activeOpacity?: ?number,
+
   /**
-   * The color of the underlay that will show through when the touch is active.
+   * Color of the underlay shown when touch is active.
    */
   underlayColor?: ?ColorValue,
-  /**
-   * @see https://reactnative.dev/docs/view#style
-   */
+
   style?: ?ViewStyleProp,
+
   /**
-   * Called immediately after the underlay is shown
+   * Called immediately after the underlay is shown.
    */
   onShowUnderlay?: ?() => void,
+
   /**
-   * Called immediately after the underlay is hidden
+   * Called immediately after the underlay is hidden.
    */
   onHideUnderlay?: ?() => void,
+
   testOnly_pressed?: ?boolean,
 
   hostRef?: React.RefSetter<TouchableHighlightInstance>,
@@ -85,102 +89,6 @@ type TouchableHighlightState = Readonly<{
   extraStyles: ?ExtraStyles,
 }>;
 
-/**
- * A wrapper for making views respond properly to touches.
- * On press down, the opacity of the wrapped view is decreased, which allows
- * the underlay color to show through, darkening or tinting the view.
- *
- * The underlay comes from wrapping the child in a new View, which can affect
- * layout, and sometimes cause unwanted visual artifacts if not used correctly,
- * for example if the backgroundColor of the wrapped view isn't explicitly set
- * to an opaque color.
- *
- * TouchableHighlight must have one child (not zero or more than one).
- * If you wish to have several child components, wrap them in a View.
- *
- * Example:
- *
- * ```
- * renderButton: function() {
- *   return (
- *     <TouchableHighlight onPress={this._onPressButton}>
- *       <Image
- *         style={styles.button}
- *         source={require('./myButton.png')}
- *       />
- *     </TouchableHighlight>
- *   );
- * },
- * ```
- *
- *
- * ### Example
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react'
- * import {
- *   AppRegistry,
- *   StyleSheet,
- *   TouchableHighlight,
- *   Text,
- *   View,
- * } from 'react-native'
- *
- * class App extends Component {
- *   constructor(props) {
- *     super(props)
- *     this.state = { count: 0 }
- *   }
- *
- *   onPress = () => {
- *     this.setState({
- *       count: this.state.count+1
- *     })
- *   }
- *
- *  render() {
- *     return (
- *       <View style={styles.container}>
- *         <TouchableHighlight
- *          style={styles.button}
- *          onPress={this.onPress}
- *         >
- *          <Text> Touch Here </Text>
- *         </TouchableHighlight>
- *         <View style={[styles.countContainer]}>
- *           <Text style={[styles.countText]}>
- *             { this.state.count !== 0 ? this.state.count: null}
- *           </Text>
- *         </View>
- *       </View>
- *     )
- *   }
- * }
- *
- * const styles = StyleSheet.create({
- *   container: {
- *     flex: 1,
- *     justifyContent: 'center',
- *     paddingHorizontal: 10
- *   },
- *   button: {
- *     alignItems: 'center',
- *     backgroundColor: '#DDDDDD',
- *     padding: 10
- *   },
- *   countContainer: {
- *     alignItems: 'center',
- *     padding: 10
- *   },
- *   countText: {
- *     color: '#FF00FF'
- *   }
- * })
- *
- * AppRegistry.registerComponent('App', () => App)
- * ```
- *
- */
 class TouchableHighlightImpl extends React.Component<
   TouchableHighlightProps,
   TouchableHighlightState,
@@ -424,6 +332,17 @@ class TouchableHighlightImpl extends React.Component<
   }
 }
 
+/**
+ * A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
+ *
+ * The underlay comes from wrapping the child in a new View, which can affect layout.
+ *
+ * Must have exactly one child (not zero or more than one). If you wish to have several child components, wrap them in a View.
+ *
+ * If you need more extensive and future-proof touch handling, use `Pressable`.
+ *
+ * @see https://reactnative.dev/docs/touchablehighlight
+ */
 const TouchableHighlight: component(
   ref?: React.RefSetter<TouchableHighlightInstance>,
   ...props: Readonly<Omit<TouchableHighlightProps, 'hostRef'>>

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -74,18 +74,11 @@ export type TouchableNativeFeedbackProps = Readonly<{
   ...TouchableWithoutFeedbackProps,
   ...TouchableNativeFeedbackTVProps,
   /**
-   * Determines the type of background drawable that's going to be used to display feedback.
-   * It takes an object with type property and extra data depending on the type.
-   * It's recommended to use one of the following static methods to generate that dictionary:
-   *      1) TouchableNativeFeedback.SelectableBackground() - will create object that represents android theme's
-   *         default background for selectable elements (?android:attr/selectableItemBackground)
-   *      2) TouchableNativeFeedback.SelectableBackgroundBorderless() - will create object that represent android
-   *         theme's default background for borderless selectable elements
-   *         (?android:attr/selectableItemBackgroundBorderless). Available on android API level 21+
-   *      3) TouchableNativeFeedback.Ripple(color, borderless) - will create object that represents ripple drawable
-   *         with specified color (as a string). If property borderless evaluates to true the ripple will render
-   *         outside of the view bounds (see native actionbar buttons as an example of that behavior). This background
-   *         type is available on Android API level 21+
+   * Determines the type of background drawable used to display touch feedback. Use one of the static methods to generate this value:
+   *
+   * - `TouchableNativeFeedback.SelectableBackground()` - Default background for selectable elements.
+   * - `TouchableNativeFeedback.SelectableBackgroundBorderless()` - Default background for borderless selectable elements. API 21+.
+   * - `TouchableNativeFeedback.Ripple(color, borderless)` - Ripple drawable with the specified color.
    */
   background?: ?(
     | Readonly<{
@@ -103,14 +96,9 @@ export type TouchableNativeFeedbackProps = Readonly<{
       }>
   ),
   /**
-   * Set to true to add the ripple effect to the foreground of the view, instead
-   * of the background. This is useful if one of your child views has a
-   * background of its own, or you're e.g. displaying images, and you don't want
-   * the ripple to be covered by them.
+   * If `true`, adds the ripple effect to the foreground of the view instead of the background. Useful if a child view has its own background, or you are displaying images.
    *
-   * Check TouchableNativeFeedback.canUseNativeForeground() first, as this is
-   * only available on Android 6.0 and above. If you try to use this on older
-   * versions, this will fallback to background.
+   * Check `TouchableNativeFeedback.canUseNativeForeground()` first, as this is only available on Android 6.0 and above. On older versions, this falls back to background.
    */
   useForeground?: ?boolean,
 }>;
@@ -120,14 +108,12 @@ type TouchableNativeFeedbackState = Readonly<{
 }>;
 
 /**
- * A wrapper for making views respond properly to touches (Android only).
- * On Android this component uses native state drawable to display touch feedback.
- * At the moment it only supports having a single View instance as a child node,
- * as it's implemented by replacing that View with another instance of RCTView node with some additional properties set.
+ * A wrapper for making views respond properly to touches (Android only). Uses native state drawable to display touch feedback.
  *
- * Background drawable of native feedback touchable can be customized with background property.
+ * Supports only a single View instance as a child. If you need more extensive and future-proof touch handling, use `Pressable`.
  *
- * @see https://reactnative.dev/docs/touchablenativefeedback#content
+ * @see https://reactnative.dev/docs/touchablenativefeedback
+ * @platform android
  */
 class TouchableNativeFeedback extends React.Component<
   TouchableNativeFeedbackProps,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -71,10 +71,12 @@ export type TouchableOpacityTVProps = Readonly<{
 
 type TouchableOpacityBaseProps = Readonly<{
   /**
-   * Determines what the opacity of the wrapped view should be when touch is active.
-   * Defaults to 0.2
+   * Opacity of the wrapped view when touch is active.
+   *
+   * @default `0.2`
    */
   activeOpacity?: ?number,
+
   style?: ?Animated.WithAnimatedValue<ViewStyleProp>,
 
   hostRef?: ?React.RefSetter<TouchableOpacityInstance>,
@@ -92,88 +94,13 @@ type TouchableOpacityState = Readonly<{
 }>;
 
 /**
- * A wrapper for making views respond properly to touches.
- * On press down, the opacity of the wrapped view is decreased, dimming it.
+ * A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
  *
- * Opacity is controlled by wrapping the children in an Animated.View, which is
- * added to the view hierarchy.  Be aware that this can affect layout.
+ * Opacity is controlled by wrapping the children in an `Animated.View`, which is added to the view hierarchy. Be aware that this can affect layout.
  *
- * Example:
+ * If you need more extensive and future-proof touch handling, use `Pressable`.
  *
- * ```
- * renderButton: function() {
- *   return (
- *     <TouchableOpacity onPress={this._onPressButton}>
- *       <Image
- *         style={styles.button}
- *         source={require('./myButton.png')}
- *       />
- *     </TouchableOpacity>
- *   );
- * },
- * ```
- * ### Example
- *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react'
- * import {
- *   AppRegistry,
- *   StyleSheet,
- *   TouchableOpacity,
- *   Text,
- *   View,
- * } from 'react-native'
- *
- * class App extends Component {
- *   state = { count: 0 }
- *
- *   onPress = () => {
- *     this.setState(state => ({
- *       count: state.count + 1
- *     }));
- *   };
- *
- *  render() {
- *    return (
- *      <View style={styles.container}>
- *        <TouchableOpacity
- *          style={styles.button}
- *          onPress={this.onPress}>
- *          <Text> Touch Here </Text>
- *        </TouchableOpacity>
- *        <View style={[styles.countContainer]}>
- *          <Text style={[styles.countText]}>
- *             { this.state.count !== 0 ? this.state.count: null}
- *           </Text>
- *         </View>
- *       </View>
- *     )
- *   }
- * }
- *
- * const styles = StyleSheet.create({
- *   container: {
- *     flex: 1,
- *     justifyContent: 'center',
- *     paddingHorizontal: 10
- *   },
- *   button: {
- *     alignItems: 'center',
- *     backgroundColor: '#DDDDDD',
- *     padding: 10
- *   },
- *   countContainer: {
- *     alignItems: 'center',
- *     padding: 10
- *   },
- *   countText: {
- *     color: '#FF00FF'
- *   }
- * })
- *
- * AppRegistry.registerComponent('App', () => App)
- * ```
- *
+ * @see https://reactnative.dev/docs/touchableopacity
  */
 class TouchableOpacity extends React.Component<
   TouchableOpacityProps,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -156,9 +156,9 @@ const PASSTHROUGH_PROPS = [
 ] as const;
 
 /**
- * Do not use unless you have a very good reason.
- * All the elements that respond to press should have a visual feedback when touched.
- * This is one of the primary reason a "web" app doesn't feel "native".
+ * Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
+ *
+ * Supports only one child. If you need more extensive and future-proof touch handling, use `Pressable`.
  *
  * @see https://reactnative.dev/docs/touchablewithoutfeedback
  */

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -19,9 +19,12 @@ import {use} from 'react';
 export type ViewInstance = HostInstance;
 
 /**
- * The most fundamental component for building a UI, View is a container that
+ * The most fundamental component for building a UI. `View` is a container that
  * supports layout with flexbox, style, some touch handling, and accessibility
- * controls.
+ * controls. `View` maps directly to the native view equivalent on whatever
+ * platform React Native is running on, whether that is a `UIView`, `<div>`,
+ * `android.view`, etc. `View` is designed to be nested inside other views and
+ * can have 0 to many children of any type.
  *
  * @see https://reactnative.dev/docs/view
  */

--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -145,12 +145,12 @@ export type AccessibilityActionName =
   /**
    * Generated when a VoiceOver user places focus on or inside the component and double taps with two fingers.
    * @platform ios
-   * */
+   */
   | 'magicTap'
   /**
    * Generated when a VoiceOver user places focus on or inside the component and performs a two finger scrub gesture (left, right, left).
    * @platform ios
-   * */
+   */
   | 'escape';
 
 // the info associated with an accessibility action
@@ -249,9 +249,15 @@ export type AccessibilityPropsAndroid = Readonly<{
   'aria-live'?: ?('polite' | 'assertive' | 'off'),
 
   /**
-   * Controls how view is important for accessibility which is if it
-   * fires accessibility events and if it is reported to accessibility services
-   * that query the screen. Works for Android only.
+   * Controls how view is important for accessibility which is if it fires accessibility events
+   * and if it is reported to accessibility services that query the screen.
+   * Works for Android only. See http://developer.android.com/reference/android/R.attr.html#importantForAccessibility for references.
+   *
+   * Possible values:
+   *      'auto' - The system determines whether the view is important for accessibility - default (recommended).
+   *      'yes' - The view is important for accessibility.
+   *      'no' - The view is not important for accessibility.
+   *      'no-hide-descendants' - The view is not important for accessibility, nor are any of its descendant views.
    *
    * @platform android
    *
@@ -288,6 +294,9 @@ export type AccessibilityPropsIOS = Readonly<{
   accessibilityViewIsModal?: ?boolean,
 
   /**
+   * A Boolean value that indicates whether or not to show the item in the large content viewer.
+   * Available on iOS 13.0+
+   *
    * @platform ios
    *
    * See https://reactnative.dev/docs/view#accessibilityshowslargecontentviewer
@@ -295,6 +304,8 @@ export type AccessibilityPropsIOS = Readonly<{
   accessibilityShowsLargeContentViewer?: ?boolean,
 
   /**
+   * When `accessibilityShowsLargeContentViewer` is set, this string will be used as title for the large content viewer.
+   *
    * @platform ios
    *
    * See https://reactnative.dev/docs/view#accessibilitylargecontenttitle

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -112,8 +112,18 @@ type PointerEventProps = Readonly<{
 }>;
 
 type FocusEventProps = Readonly<{
+  /**
+   * Callback that is called when the view is blurred.
+   *
+   * Note: This will only be called if the view is focusable.
+   */
   onBlur?: ?(event: BlurEvent) => void,
   onBlurCapture?: ?(event: BlurEvent) => void,
+  /**
+   * Callback that is called when the view is focused.
+   *
+   * Note: This will only be called if the view is focusable.
+   */
   onFocus?: ?(event: FocusEvent) => void,
   onFocusCapture?: ?(event: FocusEvent) => void,
 }>;
@@ -281,9 +291,17 @@ export type ViewPropsAndroid = Readonly<{
    * Whether this `View` should render itself (and all of its children) into a
    * single hardware texture on the GPU.
    *
-   * @platform android
+   * On Android, this is useful for animations and interactions that only
+   * modify opacity, rotation, translation and/or scale: in those cases, the
+   * view does not have to be redrawn and display lists do not need to be
+   * re-executed. The texture can be re-used and re-composited with different
+   * parameters. The downside is that this can use up limited video memory, so
+   * this prop should be set back to `false` at the end of the interaction/
+   * animation.
    *
-   * See https://reactnative.dev/docs/view#rendertohardwaretextureandroid
+   * @default `false`
+   *
+   * @platform android
    */
   renderToHardwareTextureAndroid?: ?boolean,
 
@@ -296,35 +314,40 @@ export type ViewPropsAndroid = Readonly<{
   hasTVPreferredFocus?: ?boolean,
 
   /**
-   * TV next focus down (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates down.
+   * The value is the `nativeID` of the target view.
    *
    * @platform android
    */
   nextFocusDown?: ?number,
 
   /**
-   * TV next focus forward (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates
+   * forward. The value is the `nativeID` of the target view.
    *
    * @platform android
    */
   nextFocusForward?: ?number,
 
   /**
-   * TV next focus left (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates left.
+   * The value is the `nativeID` of the target view.
    *
    * @platform android
    */
   nextFocusLeft?: ?number,
 
   /**
-   * TV next focus right (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates right.
+   * The value is the `nativeID` of the target view.
    *
    * @platform android
    */
   nextFocusRight?: ?number,
 
   /**
-   * TV next focus up (see documentation for the View component).
+   * Designates the next view to receive focus when the user navigates up.
+   * The value is the `nativeID` of the target view.
    *
    * @platform android
    */
@@ -371,6 +394,7 @@ export type TVViewPropsIOS = Readonly<{
    * *(Apple TV only)* May be set to true to force the Apple TV focus engine to move focus to this view.
    *
    * @platform ios
+   * @deprecated Use `focusable` instead
    */
   hasTVPreferredFocus?: boolean,
 
@@ -407,9 +431,18 @@ export type ViewPropsIOS = Readonly<{
   /**
    * Whether this `View` should be rendered as a bitmap before compositing.
    *
-   * @platform ios
+   * On iOS, this is useful for animations and interactions that do not
+   * modify this component's dimensions nor its children; for example, when
+   * translating the position of a static view, rasterization allows the
+   * renderer to skip re-rendering the view frame and re-use the cached
+   * bitmap.
    *
-   * See https://reactnative.dev/docs/view#shouldrasterizeios
+   * Rasterization incurs an offscreen drawing pass and the bitmap consumes
+   * memory. Test and measure when using this property.
+   *
+   * @default `false`
+   *
+   * @platform ios
    */
   shouldRasterizeIOS?: ?boolean,
 }>;
@@ -424,7 +457,7 @@ type ViewBaseProps = Readonly<{
    * optimization. Set this property to `false` to disable this optimization and
    * ensure that this `View` exists in the native view hierarchy.
    *
-   * See https://reactnative.dev/docs/view#collapsable
+   * @default `true`
    */
   collapsable?: ?boolean,
 
@@ -432,6 +465,8 @@ type ViewBaseProps = Readonly<{
    * Setting to false prevents direct children of the view from being removed
    * from the native view hierarchy, similar to the effect of setting
    * `collapsable={false}` on each child.
+   *
+   * @default `true`
    */
   collapsableChildren?: ?boolean,
 
@@ -463,10 +498,21 @@ type ViewBaseProps = Readonly<{
   nativeID?: ?string,
 
   /**
-   * Whether this `View` needs to rendered offscreen and composited with an
+   * Whether this `View` needs to be rendered offscreen and composited with an
    * alpha in order to preserve 100% correct colors and blending behavior.
+   * The default (`false`) falls back to drawing the component and its children
+   * with reduced alpha applied to the paint used to draw each element
+   * instead of rendering the full component offscreen and compositing it back
+   * with an alpha value. This default may be noticeable and undesired in the
+   * case where the `View` you are setting an opacity on has multiple
+   * overlapping elements (e.g. multiple overlapping `View`s, or text and a
+   * background).
    *
-   * See https://reactnative.dev/docs/view#needsoffscreenalphacompositing
+   * Rendering offscreen to preserve correct alpha behavior is extremely
+   * expensive and hard to debug for non-native developers, which is why it is
+   * not turned on by default.
+   *
+   * @default `false`
    */
   needsOffscreenAlphaCompositing?: ?boolean,
 
@@ -486,7 +532,12 @@ type ViewBaseProps = Readonly<{
   /**
    * Controls whether the `View` can be the target of touch events.
    *
-   * See https://reactnative.dev/docs/view#pointerevents
+   * - `'auto'`: The view can be the target of touch events.
+   * - `'none'`: The view is never the target of touch events.
+   * - `'box-none'`: The view is never the target of touch events but its
+   *   subviews can be.
+   * - `'box-only'`: The view can be the target of touch events but its
+   *   subviews cannot be.
    */
   pointerEvents?: ?('auto' | 'box-none' | 'box-only' | 'none'),
 

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -19,8 +19,22 @@ import Platform from '../Utilities/Platform';
 import RCTDeviceEventEmitter from './RCTDeviceEventEmitter';
 import invariant from 'invariant';
 
+/**
+ * The React Native implementation of the IOS RCTEventEmitter which is required when creating
+ * a module that communicates with IOS
+ */
 interface NativeModule {
+  /**
+   * Add the provided eventType as an active listener
+   * @param eventType name of the event for which we are registering listener
+   */
   addListener(eventType: string): void;
+  /**
+   * Remove a specified number of events.  There are no eventTypes in this case, as
+   * the native side doesn't remove the name, but only manages a counter of total
+   * listeners
+   * @param count number of listeners to remove (of any type)
+   */
   removeListeners(count: number): void;
 }
 
@@ -52,6 +66,10 @@ export default class NativeEventEmitter<
 {
   _nativeModule: ?NativeModule;
 
+  /**
+   * @param nativeModule the NativeModule implementation.  This is required on IOS and will throw
+   *      an invariant error if undefined.
+   */
   constructor(nativeModule?: ?NativeModule) {
     if (Platform.OS === 'ios') {
       invariant(
@@ -83,6 +101,14 @@ export default class NativeEventEmitter<
     }
   }
 
+  /**
+   * Add the specified listener, this call passes through to the NativeModule
+   * addListener
+   *
+   * @param eventType name of the event for which we are registering listener
+   * @param listener the listener function
+   * @param context context of the listener
+   */
   addListener<TEvent extends keyof TEventToArgsMap>(
     eventType: TEvent,
     listener: (...args: TEventToArgsMap[TEvent]) => unknown,
@@ -116,6 +142,9 @@ export default class NativeEventEmitter<
     RCTDeviceEventEmitter.emit(eventType, ...args);
   }
 
+  /**
+   * @param eventType  name of the event whose registered listeners to remove
+   */
   removeAllListeners<TEvent extends keyof TEventToArgsMap>(
     eventType?: ?TEvent,
   ): void {

--- a/packages/react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.js
@@ -11,8 +11,11 @@
 import RCTDeviceEventEmitter from './RCTDeviceEventEmitter';
 
 /**
+ * Receive events from native-code
  * Deprecated - subclass NativeEventEmitter to create granular event modules instead of
  * adding all event listeners directly to RCTNativeAppEventEmitter.
+ * @see https://github.com/facebook/react-native/blob/0.34-stable\Libraries\EventEmitter\RCTNativeAppEventEmitter.js
+ * @see https://reactnative.dev/docs/native-modules-ios#sending-events-to-javascript
  */
 const RCTNativeAppEventEmitter = RCTDeviceEventEmitter;
 export default RCTNativeAppEventEmitter;

--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -20,28 +20,34 @@ import * as React from 'react';
 export type {ImageBackgroundProps} from './ImageProps';
 
 /**
- * Very simple drop-in replacement for <Image> which supports nesting views.
+ * A common way to set a background image, similar to `background-image` in
+ * CSS. Accepts the same props as `Image` and allows adding children that
+ * layer on top of the background image. You must specify `width` and `height`
+ * style attributes.
  *
- * ```ReactNativeWebPlayer
- * import React, { Component } from 'react';
- * import { AppRegistry, View, ImageBackground, Text } from 'react-native';
+ * Example:
  *
- * class DisplayAnImageBackground extends Component {
- *   render() {
- *     return (
- *       <ImageBackground
- *         style={{width: 50, height: 50}}
- *         source={{uri: 'https://reactnative.dev/img/opengraph.png'}}
- *       >
- *         <Text>React</Text>
- *       </ImageBackground>
- *     );
- *   }
- * }
+ * ```tsx
+ * import React from 'react';
+ * import {ImageBackground, StyleSheet, Text} from 'react-native';
  *
- * // App registration and rendering
- * AppRegistry.registerComponent('DisplayAnImageBackground', () => DisplayAnImageBackground);
+ * const App = () => (
+ *   <ImageBackground
+ *     style={styles.background}
+ *     source={{uri: 'https://reactnative.dev/img/opengraph.png'}}>
+ *     <Text>React</Text>
+ *   </ImageBackground>
+ * );
+ *
+ * const styles = StyleSheet.create({
+ *   background: {
+ *     width: 200,
+ *     height: 200,
+ *   },
+ * });
  * ```
+ *
+ * @see https://reactnative.dev/docs/imagebackground
  */
 class ImageBackground extends React.Component<ImageBackgroundProps> {
   setNativeProps(props: {...}) {

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -63,64 +63,86 @@ export type ImagePropsIOS = Readonly<{
   /**
    * A static image to display while loading the image source.
    *
-   * See https://reactnative.dev/docs/image#defaultsource
+   * @platform ios
    */
   defaultSource?: ?ImageSource,
+
   /**
-   * Invoked when a partial load of the image is complete.
+   * Invoked when a partial load of the image is complete. Definition of what
+   * constitutes a "partial load" is loader specific though this is meant for
+   * progressive JPEG loads.
    *
-   * See https://reactnative.dev/docs/image#onpartialload
+   * @platform ios
    */
   onPartialLoad?: ?() => void,
+
   /**
-   * Invoked on download progress with `{nativeEvent: {loaded, total}}`.
+   * Invoked on download progress.
    *
-   * See https://reactnative.dev/docs/image#onprogress
+   * @platform ios
    */
   onProgress?: ?(event: ImageProgressEventIOS) => void,
 }>;
 
 export type ImagePropsAndroid = Readonly<{
   /**
-   * similarly to `source`, this property represents the resource used to render
-   * the loading indicator for the image, displayed until image is ready to be
-   * displayed, typically after when it got downloaded from network.
+   * Resource used to render a loading indicator for the image, displayed
+   * until the image is ready to be displayed.
+   *
+   * @platform android
    */
   loadingIndicatorSource?: ?(number | Readonly<ImageURISource>),
+
+  /**
+   * When `true`, enables progressive JPEG streaming.
+   *
+   * @default `false`
+   * @platform android
+   */
   progressiveRenderingEnabled?: ?boolean,
+
+  /**
+   * Duration of the fade-in animation in milliseconds.
+   *
+   * @default `300`
+   * @platform android
+   */
   fadeDuration?: ?number,
 
   /**
-   * The mechanism that should be used to resize the image when the image's dimensions
-   * differ from the image view's dimensions. Defaults to `auto`.
+   * The mechanism that should be used to resize the image when the image's
+   * dimensions differ from the image view's dimensions.
    *
    * - `auto`: Use heuristics to pick between `resize` and `scale`.
    *
-   * - `resize`: A software operation which changes the encoded image in memory before it
-   * gets decoded. This should be used instead of `scale` when the image is much larger
-   * than the view.
+   * - `resize`: A software operation which changes the encoded image in memory
+   *   before it gets decoded. This should be used instead of `scale` when the
+   *   image is much larger than the view.
    *
-   * - `scale`: The image gets drawn downscaled or upscaled. Compared to `resize`, `scale` is
-   * faster (usually hardware accelerated) and produces higher quality images. This
-   * should be used if the image is smaller than the view. It should also be used if the
-   * image is slightly bigger than the view.
+   * - `scale`: The image gets drawn downscaled or upscaled. Compared to
+   *   `resize`, `scale` is faster (usually hardware accelerated) and produces
+   *   higher quality images. This should be used if the image is smaller than
+   *   the view. It should also be used if the image is slightly bigger than
+   *   the view.
    *
-   * - `none`: No sampling is performed and the image is displayed in its full resolution. This
-   * should only be used in rare circumstances because it is considered unsafe as Android will
-   * throw a runtime exception when trying to render images that consume too much memory.
+   * - `none`: No sampling is performed and the image is displayed in its full
+   *   resolution. This should only be used in rare circumstances because it is
+   *   considered unsafe as Android throws a runtime exception when trying to
+   *   render images that consume too much memory.
    *
-   * More details about `resize` and `scale` can be found at http://frescolib.org/docs/resizing-rotating.html.
-   *
+   * @default `'auto'`
    * @platform android
    */
   resizeMethod?: ?('auto' | 'resize' | 'scale' | 'none'),
 
   /**
-   * When the `resizeMethod` is set to `resize`, the destination dimensions are
+   * When `resizeMethod` is set to `resize`, the destination dimensions are
    * multiplied by this value. The `scale` method is used to perform the
-   * remainder of the resize.
-   * This is used to produce higher quality images when resizing to small dimensions.
-   * Defaults to 1.0.
+   * remainder of the resize. This is used to produce higher quality images
+   * when resizing to small dimensions.
+   *
+   * @default `1.0`
+   * @platform android
    */
   resizeMultiplier?: ?number,
 }>;
@@ -128,138 +150,120 @@ export type ImagePropsAndroid = Readonly<{
 /** @build-types emit-as-interface Expo compatibility */
 export type ImagePropsBase = Readonly<{
   ...Omit<ViewProps, 'style'>,
+
   /**
-   * When true, indicates the image is an accessibility element.
-   *
-   * See https://reactnative.dev/docs/image#accessible
+   * When `true`, indicates the image is an accessibility element.
    */
   accessible?: ?boolean,
 
   /**
-   * Internal prop to set an "Analytics Tag" that can will be set on the Image
+   * Internal prop to set an "Analytics Tag" that can will be set on the Image.
    */
   internal_analyticTag?: ?string,
 
   /**
    * The text that's read by the screen reader when the user interacts with
    * the image.
-   *
-   * See https://reactnative.dev/docs/image#accessibilitylabel
    */
   accessibilityLabel?: ?Stringish,
 
   /**
-   * Alias for accessibilityLabel
-   * See https://reactnative.dev/docs/image#accessibilitylabel
+   * Alias for `accessibilityLabel`.
    */
   'aria-label'?: ?Stringish,
 
   /**
-   * Represents the nativeID of the associated label. When the assistive technology focuses on the component with this props.
+   * Represents the `nativeID` of the associated label. When the assistive
+   * technology focuses on the component with this prop.
    *
    * @platform android
    */
   'aria-labelledby'?: ?string,
+
   /**
-   * The text that's read by the screen reader when the user interacts with
-   * the image.
-   *
-   * See https://reactnative.dev/docs/image#alt
+   * Alternative text description of the image, read by the screen reader
+   * when the user interacts with it. Automatically marks the element as
+   * accessible.
    */
   alt?: ?Stringish,
 
   /**
-   * blurRadius: the blur radius of the blur filter added to the image
-   *
-   * See https://reactnative.dev/docs/image#blurradius
+   * The blur radius of the blur filter added to the image. On iOS, needs to
+   * be more than 5.
    */
   blurRadius?: ?number,
 
   /**
-   * See https://reactnative.dev/docs/image#capinsets
+   * When the image is resized, the corners of the size specified by
+   * `capInsets` stay a fixed size, but the center content and borders of
+   * the image are stretched. This is useful for creating resizable rounded
+   * buttons, shadows, and other resizable assets.
+   *
+   * @platform ios
    */
   capInsets?: ?EdgeInsetsProp,
 
   /**
-   * Adds the CORS related header to the request.
-   * Similar to crossorigin from HTML.
+   * CORS mode for fetching the image resource. When unset, the image
+   * request is made without the CORS header.
    *
-   * See https://reactnative.dev/docs/image#crossorigin
+   * @default `'anonymous'`
    */
   crossOrigin?: ?('anonymous' | 'use-credentials'),
 
   /**
    * Height of the image component.
-   *
-   * See https://reactnative.dev/docs/image#height
    */
   height?: number,
 
   /**
    * Width of the image component.
-   *
-   * See https://reactnative.dev/docs/image#width
    */
   width?: number,
 
   /**
-   * Invoked on load error with `{nativeEvent: {error}}`.
-   *
-   * See https://reactnative.dev/docs/image#onerror
+   * Invoked on load error.
    */
   onError?: ?(event: ImageErrorEvent) => void,
 
   /**
-   * onLayout function
-   *
-   * Invoked on mount and layout changes with
-   *
-   * {nativeEvent: { layout: {x, y, width, height} }}.
-   *
-   * See https://reactnative.dev/docs/image#onlayout
+   * Invoked on mount and on layout changes.
    */
-
   onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
   /**
    * Invoked when load completes successfully.
-   *
-   * See https://reactnative.dev/docs/image#onload
    */
   onLoad?: ?(event: ImageLoadEvent) => void,
 
   /**
    * Invoked when load either succeeds or fails.
-   *
-   * See https://reactnative.dev/docs/image#onloadend
    */
   onLoadEnd?: ?() => void,
 
   /**
    * Invoked on load start.
-   *
-   * See https://reactnative.dev/docs/image#onloadstart
    */
   onLoadStart?: ?() => void,
 
   /**
    * The image source (either a remote URL or a local file resource).
    *
-   * This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments.
-   * The native side will then choose the best uri to display based on the measured size of the image container.
-   * A cache property can be added to control how networked request interacts with the local cache.
+   * This prop can also contain several remote URLs, specified together with
+   * their width and height and potentially with scale/other URI arguments.
+   * The native side then chooses the best URI to display based on the
+   * measured size of the image container. A `cache` property can be added to
+   * control how networked request interacts with the local cache.
    *
-   * The currently supported formats are png, jpg, jpeg, bmp, gif, webp (Android only), psd (iOS only).
-   *
-   * See https://reactnative.dev/docs/image#source
+   * The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`,
+   * `webp` (Android only), and `psd` (iOS only).
    */
   source?: ?ImageSource,
 
   /**
-   * A string indicating which referrer to use when fetching the resource.
-   * Similar to referrerpolicy from HTML.
+   * Which referrer to use when fetching the image resource.
    *
-   * See https://reactnative.dev/docs/image#referrerpolicy
+   * @default `'strict-origin-when-cross-origin'`
    */
   referrerPolicy?: ?(
     | 'no-referrer'
@@ -276,59 +280,50 @@ export type ImagePropsBase = Readonly<{
    * Determines how to resize the image when the frame doesn't match the raw
    * image dimensions.
    *
-   * 'cover': Scale the image uniformly (maintain the image's aspect ratio)
-   * so that both dimensions (width and height) of the image will be equal
-   * to or larger than the corresponding dimension of the view (minus padding).
+   * - `cover`: Scale the image uniformly (maintain the image's aspect ratio)
+   *   so that both dimensions (width and height) of the image are equal to
+   *   or larger than the corresponding dimension of the view (minus padding).
    *
-   * 'contain': Scale the image uniformly (maintain the image's aspect ratio)
-   * so that both dimensions (width and height) of the image will be equal to
-   * or less than the corresponding dimension of the view (minus padding).
+   * - `contain`: Scale the image uniformly (maintain the image's aspect
+   *   ratio) so that both dimensions (width and height) of the image are
+   *   equal to or less than the corresponding dimension of the view (minus
+   *   padding).
    *
-   * 'stretch': Scale width and height independently, This may change the
-   * aspect ratio of the src.
+   * - `stretch`: Scale width and height independently. This may change the
+   *   aspect ratio of the source.
    *
-   * 'repeat': Repeat the image to cover the frame of the view.
-   * The image will keep it's size and aspect ratio. (iOS only)
+   * - `repeat`: Repeat the image to cover the frame of the view. The image
+   *   keeps its size and aspect ratio (iOS only).
    *
-   * 'center': Scale the image down so that it is completely visible,
-   * if bigger than the area of the view.
-   * The image will not be scaled up.
+   * - `center`: Scale the image down so that it is completely visible, if
+   *   bigger than the area of the view. The image is not scaled up.
    *
-   * 'none': Do not resize the image. The image will be displayed at its intrinsic size.
+   * - `none`: Do not resize the image. The image is displayed at its
+   *   intrinsic size.
    *
-   * See https://reactnative.dev/docs/image#resizemode
+   * @default `'cover'`
    */
   resizeMode?: ?ImageResizeMode,
 
-  /**
-   * A unique identifier for this element to be used in UI Automation
-   * testing scripts.
-   *
-   * See https://reactnative.dev/docs/image#testid
-   */
   testID?: ?string,
 
   /**
-   * Changes the color of all the non-transparent pixels to the tintColor.
-   *
-   * See https://reactnative.dev/docs/image#tintcolor
+   * Changes the color of all non-transparent pixels to the `tintColor`.
    */
   tintColor?: ColorValue,
 
   /**
-   * A string representing the resource identifier for the image. Similar to
-   * src from HTML.
-   *
-   * See https://reactnative.dev/docs/image#src
+   * A remote URL string for the image resource. Takes precedence over
+   * `source`.
    */
   src?: ?string,
 
   /**
-   * Similar to srcset from HTML.
-   *
-   * See https://reactnative.dev/docs/image#srcset
+   * Comma-separated list of candidate image sources with pixel density
+   * descriptors.
    */
   srcSet?: ?string,
+
   children?: empty,
 }>;
 
@@ -338,7 +333,7 @@ export type ImageProps = Readonly<{
   ...ImagePropsBase,
 
   /**
-   * See https://reactnative.dev/docs/image#style
+   * Style applied to the `Image` component.
    */
   style?: ?ImageStyleProp,
 }>;
@@ -349,23 +344,19 @@ export type ImageBackgroundProps = Readonly<{
   children?: React.Node,
 
   /**
-   * Style applied to the outer View component
-   *
-   * See https://reactnative.dev/docs/imagebackground#style
+   * Style applied to the outer `View` wrapper. Accepts `ViewStyle` props
+   * rather than `ImageStyle` props.
    */
   style?: ?ViewStyleProp,
 
   /**
-   * Style applied to the inner Image component
-   *
-   * See https://reactnative.dev/docs/imagebackground#imagestyle
+   * Style applied to the inner `Image` component.
    */
   imageStyle?: ?ImageStyleProp,
 
   /**
-   * Allows to set a reference to the inner Image component
-   *
-   * See https://reactnative.dev/docs/imagebackground#imageref
+   * A ref setter assigned the element node of the inner `Image` component
+   * when mounted.
    */
   imageRef?: React.RefSetter<React.ElementRef<ImageType>>,
 }>;

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -25,101 +25,6 @@ const previousCentroidYOfTouchesChangedAfter =
 const currentCentroidX = TouchHistoryMath.currentCentroidX;
 const currentCentroidY = TouchHistoryMath.currentCentroidY;
 
-/**
- * `PanResponder` reconciles several touches into a single gesture. It makes
- * single-touch gestures resilient to extra touches, and can be used to
- * recognize simple multi-touch gestures.
- *
- * It provides a predictable wrapper of the responder handlers provided by the
- * [gesture responder system](docs/gesture-responder-system.html).
- * For each handler, it provides a new `gestureState` object alongside the
- * native event object:
- *
- * ```
- * onPanResponderMove: (event, gestureState) => {}
- * ```
- *
- * A native event is a synthetic touch event with the following form:
- *
- *  - `nativeEvent`
- *      + `changedTouches` - Array of all touch events that have changed since the last event
- *      + `identifier` - The ID of the touch
- *      + `locationX` - The X position of the touch, relative to the element
- *      + `locationY` - The Y position of the touch, relative to the element
- *      + `pageX` - The X position of the touch, relative to the root element
- *      + `pageY` - The Y position of the touch, relative to the root element
- *      + `target` - The node id of the element receiving the touch event
- *      + `timestamp` - A time identifier for the touch, useful for velocity calculation
- *      + `touches` - Array of all current touches on the screen
- *
- * A `gestureState` object has the following:
- *
- *  - `stateID` - ID of the gestureState- persisted as long as there at least
- *     one touch on screen
- *  - `moveX` - the latest screen coordinates of the recently-moved touch
- *  - `moveY` - the latest screen coordinates of the recently-moved touch
- *  - `x0` - the screen coordinates of the responder grant
- *  - `y0` - the screen coordinates of the responder grant
- *  - `dx` - accumulated distance of the gesture since the touch started
- *  - `dy` - accumulated distance of the gesture since the touch started
- *  - `vx` - current velocity of the gesture
- *  - `vy` - current velocity of the gesture
- *  - `numberActiveTouches` - Number of touches currently on screen
- *
- * ### Basic Usage
- *
- * ```
- *   componentWillMount: function() {
- *     this._panResponder = PanResponder.create({
- *       // Ask to be the responder:
- *       onStartShouldSetPanResponder: (evt, gestureState) => true,
- *       onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
- *       onMoveShouldSetPanResponder: (evt, gestureState) => true,
- *       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
- *
- *       onPanResponderGrant: (evt, gestureState) => {
- *         // The gesture has started. Show visual feedback so the user knows
- *         // what is happening!
- *
- *         // gestureState.d{x,y} will be set to zero now
- *       },
- *       onPanResponderMove: (evt, gestureState) => {
- *         // The most recent move distance is gestureState.move{X,Y}
- *
- *         // The accumulated gesture distance since becoming responder is
- *         // gestureState.d{x,y}
- *       },
- *       onPanResponderTerminationRequest: (evt, gestureState) => true,
- *       onPanResponderRelease: (evt, gestureState) => {
- *         // The user has released all touches while this view is the
- *         // responder. This typically means a gesture has succeeded
- *       },
- *       onPanResponderTerminate: (evt, gestureState) => {
- *         // Another component has become the responder, so this gesture
- *         // should be cancelled
- *       },
- *       onShouldBlockNativeResponder: (evt, gestureState) => {
- *         // Returns whether this component should block native components from becoming the JS
- *         // responder. Returns true by default. Is currently only supported on android.
- *         return true;
- *       },
- *     });
- *   },
- *
- *   render: function() {
- *     return (
- *       <View {...this._panResponder.panHandlers} />
- *     );
- *   },
- *
- * ```
- *
- * ### Working Example
- *
- * To see it in action, try the
- * [PanResponder example in RNTester](https://github.com/facebook/react-native/blob/HEAD/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js)
- */
-
 export type PanResponderGestureState = {
   /**
    * ID of the gestureState - persisted as long as there at least one touch on screen
@@ -225,9 +130,106 @@ export type PanResponderCallbacks = Readonly<{
   onShouldBlockNativeResponder?: ?ActiveCallback,
 }>;
 
+/**
+ * Reconciles several touches into a single gesture. Makes single-touch
+ * gestures resilient to extra touches and can recognize basic multi-touch
+ * gestures.
+ *
+ * It provides a predictable wrapper of the responder handlers provided by the
+ * [gesture responder system](docs/gesture-responder-system.html).
+ * For each handler, it provides a new `gestureState` object alongside the
+ * native event object:
+ *
+ * ```
+ * onPanResponderMove: (event, gestureState) => {}
+ * ```
+ *
+ * A native event is a synthetic touch event with the following form:
+ *
+ *  - `nativeEvent`
+ *      + `changedTouches` - Array of all touch events that have changed since the last event
+ *      + `identifier` - The ID of the touch
+ *      + `locationX` - The X position of the touch, relative to the element
+ *      + `locationY` - The Y position of the touch, relative to the element
+ *      + `pageX` - The X position of the touch, relative to the root element
+ *      + `pageY` - The Y position of the touch, relative to the root element
+ *      + `target` - The node id of the element receiving the touch event
+ *      + `timestamp` - A time identifier for the touch, useful for velocity calculation
+ *      + `touches` - Array of all current touches on the screen
+ *
+ * A `gestureState` object has the following:
+ *
+ *  - `stateID` - ID of the gestureState- persisted as long as there at least
+ *     one touch on screen
+ *  - `moveX` - the latest screen coordinates of the recently-moved touch
+ *  - `moveY` - the latest screen coordinates of the recently-moved touch
+ *  - `x0` - the screen coordinates of the responder grant
+ *  - `y0` - the screen coordinates of the responder grant
+ *  - `dx` - accumulated distance of the gesture since the touch started
+ *  - `dy` - accumulated distance of the gesture since the touch started
+ *  - `vx` - current velocity of the gesture
+ *  - `vy` - current velocity of the gesture
+ *  - `numberActiveTouches` - Number of touches currently on screen
+ *
+ * ### Basic Usage
+ *
+ * Example:
+ *
+ * ```tsx
+ *   componentWillMount: function() {
+ *     this._panResponder = PanResponder.create({
+ *       // Ask to be the responder:
+ *       onStartShouldSetPanResponder: (evt, gestureState) => true,
+ *       onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
+ *       onMoveShouldSetPanResponder: (evt, gestureState) => true,
+ *       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
+ *
+ *       onPanResponderGrant: (evt, gestureState) => {
+ *         // The gesture has started. Show visual feedback so the user knows
+ *         // what is happening!
+ *
+ *         // gestureState.d{x,y} will be set to zero now
+ *       },
+ *       onPanResponderMove: (evt, gestureState) => {
+ *         // The most recent move distance is gestureState.move{X,Y}
+ *
+ *         // The accumulated gesture distance since becoming responder is
+ *         // gestureState.d{x,y}
+ *       },
+ *       onPanResponderTerminationRequest: (evt, gestureState) => true,
+ *       onPanResponderRelease: (evt, gestureState) => {
+ *         // The user has released all touches while this view is the
+ *         // responder. This typically means a gesture has succeeded
+ *       },
+ *       onPanResponderTerminate: (evt, gestureState) => {
+ *         // Another component has become the responder, so this gesture
+ *         // should be cancelled
+ *       },
+ *       onShouldBlockNativeResponder: (evt, gestureState) => {
+ *         // Returns whether this component should block native components from becoming the JS
+ *         // responder. Returns true by default. Is currently only supported on android.
+ *         return true;
+ *       },
+ *     });
+ *   },
+ *
+ *   render: function() {
+ *     return (
+ *       <View {...this._panResponder.panHandlers} />
+ *     );
+ *   },
+ *
+ * ```
+ *
+ * ### Working Example
+ *
+ * To see it in action, try the
+ * [PanResponder example in RNTester](https://github.com/facebook/react-native/blob/HEAD/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js)
+ *
+ * @see https://reactnative.dev/docs/panresponder
+ */
 const PanResponder = {
   /**
-   *
    * A graphical explanation of the touch data flow:
    *
    * +----------------------------+             +--------------------------------+
@@ -366,11 +368,14 @@ const PanResponder = {
   },
 
   /**
+   * Create a `PanResponder` instance with a config of gesture callback
+   * handlers.
+   *
    * @param {object} config Enhanced versions of all of the responder callbacks
    * that provide not only the typical `ResponderSyntheticEvent`, but also the
    * `PanResponder` gesture state.  Simply replace the word `Responder` with
    * `PanResponder` in each of the typical `onResponder*` callbacks. For
-   * example, the `config` object would look like:
+   * example, the `config` object looks like:
    *
    *  - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
    *  - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -159,18 +159,19 @@ const Presets = {
 };
 
 /**
- * Automatically animates views to their new positions when the
- * next layout happens.
- *
- * A common way to use this API is to call it before calling `setState`.
+ * Automatically animates views to their new positions when the next layout
+ * happens. Call before updating state to animate the transition.
  *
  * Note that in order to get this to work on **Android** you need to set the following flags via `UIManager`:
  *
  *     UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
+ *
+ * @see https://reactnative.dev/docs/layoutanimation
  */
 const LayoutAnimation = {
   /**
-   * Schedules an animation to happen on the next layout.
+   * Schedule an animation for the next layout. Config includes duration,
+   * create/update/delete sub-configs.
    *
    * @param config Specifies animation properties:
    *
@@ -183,10 +184,16 @@ const LayoutAnimation = {
    * @param onError Called on error. Only supported on iOS.
    */
   configureNext,
+
   /**
-   * Helper for creating a config for `configureNext`.
+   * Helper that creates a config object for `configureNext`.
    */
   create: createLayoutAnimation,
+
+  /**
+   * Enum of animation types (spring, linear, easeInEaseOut, easeIn, easeOut,
+   * keyboard).
+   */
   Types: Object.freeze({
     spring: 'spring',
     linear: 'linear',
@@ -195,15 +202,24 @@ const LayoutAnimation = {
     easeOut: 'easeOut',
     keyboard: 'keyboard',
   }) as LayoutAnimationTypes,
+
+  /**
+   * Enum of layout properties to animate (opacity, scaleX, scaleY, scaleXY).
+   */
   Properties: Object.freeze({
     opacity: 'opacity',
     scaleX: 'scaleX',
     scaleY: 'scaleY',
     scaleXY: 'scaleXY',
   }) as LayoutAnimationProperties,
+
   checkConfig(...args: Array<unknown>) {
     console.error('LayoutAnimation.checkConfig(...) has been disabled.');
   },
+
+  /**
+   * Predefined configs (easeInEaseOut, linear, spring).
+   */
   Presets,
   easeInEaseOut: configureNext.bind(null, Presets.easeInEaseOut) as (
     onAnimationDidEnd?: OnAnimationDidEndCallback,

--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -27,10 +27,7 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   }
 
   /**
-   * Add a handler to Linking changes by listening to the `url` event type
-   * and providing the handler
-   *
-   * See https://reactnative.dev/docs/linking#addeventlistener
+   * Listen for incoming URL changes.
    */
   addEventListener<K extends keyof LinkingEventDefinitions>(
     eventType: K,
@@ -40,9 +37,14 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   }
 
   /**
-   * Try to open the given `url` with any of the installed apps.
+   * Open the given URL with any installed app that can handle it. This
+   * includes URLs such as locations (e.g. "geo:37.484847,-122.148386"),
+   * contacts, or any other URL that can be opened with installed apps.
    *
-   * See https://reactnative.dev/docs/linking#openurl
+   * This method will fail if the system doesn't know how to open the
+   * specified URL. If you're passing in a non-http(s) URL, it's best to
+   * check `canOpenURL` first. For web URLs, the protocol ("http://",
+   * "https://") must be set accordingly.
    */
   openURL(url: string): Promise<void> {
     this._validateURL(url);
@@ -54,9 +56,10 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   }
 
   /**
-   * Determine whether or not an installed app can handle a given URL.
-   *
-   * See https://reactnative.dev/docs/linking#canopenurl
+   * Check whether an installed app can handle a given URL. For web URLs,
+   * the protocol ("http://", "https://") must be set accordingly. As of
+   * iOS 9, your app needs to provide the `LSApplicationQueriesSchemes`
+   * key inside Info.plist.
    */
   canOpenURL(url: string): Promise<boolean> {
     this._validateURL(url);
@@ -68,9 +71,8 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   }
 
   /**
-   * Open app settings.
-   *
-   * See https://reactnative.dev/docs/linking#opensettings
+   * Open the device Settings app and display the app’s custom settings, if
+   * it has any.
    */
   openSettings(): Promise<void> {
     if (Platform.OS === 'android') {
@@ -81,10 +83,9 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   }
 
   /**
-   * If the app launch was triggered by an app link,
-   * it will give the link url, otherwise it will give `null`
-   *
-   * See https://reactnative.dev/docs/linking#getinitialurl
+   * Get the URL that launched the app, or `null` if it was not launched from
+   * a link. To support deep linking on Android, see
+   * https://developer.android.com/training/app-indexing/deep-linking.html#handling-intents.
    */
   getInitialURL(): Promise<?string> {
     return Platform.OS === 'android'
@@ -92,12 +93,12 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
       : nullthrows(NativeLinkingManager).getInitialURL();
   }
 
-  /*
-   * Launch an Android intent with extras (optional)
+  /**
+   * Launch an Android intent with optional extras. Useful for deep-linking
+   * to settings pages, opening an SMS app with a message draft in place,
+   * and more. See https://developer.android.com/reference/kotlin/android/content/Intent.
    *
    * @platform android
-   *
-   * See https://reactnative.dev/docs/linking#sendintent
    */
   sendIntent(
     action: string,
@@ -126,9 +127,9 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
 const Linking: LinkingImpl = new LinkingImpl();
 
 /**
- * `Linking` gives you a general interface to interact with both incoming
- * and outgoing app links.
+ * General interface to interact with both incoming and outgoing app links,
+ * including deep links and universal links.
  *
- * See https://reactnative.dev/docs/linking
+ * @see https://reactnative.dev/docs/linking
  */
 export default Linking;

--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -169,6 +169,7 @@ export type SectionListProps<ItemT, SectionT = DefaultSectionT> = {
  * - By default, the list looks for a `key` prop on each item and uses that for the React key.
  *   Alternatively, you can provide a custom `keyExtractor` prop.
  *
+ * @see https://reactnative.dev/docs/sectionlist
  */
 export default class SectionList<
   ItemT = any,
@@ -222,6 +223,9 @@ export default class SectionList<
     }
   }
 
+  /**
+   * Provides a handle to the underlying scroll node.
+   */
   getScrollableNode(): any {
     const listRef = this._wrapperListRef && this._wrapperListRef.getListRef();
     if (listRef) {

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -46,6 +46,9 @@ function convertLegacyComponentStack(componentStack: Stack): Stack {
 
 export type {LogData, ExtendedExceptionData, IgnorePattern};
 
+/**
+ * LogBox displays logs in the app.
+ */
 let LogBox;
 
 interface ILogBox {
@@ -60,9 +63,6 @@ interface ILogBox {
   addException(error: ExtendedExceptionData): void;
 }
 
-/**
- * LogBox displays logs in the app.
- */
 if (__DEV__) {
   const LogBoxData = require('./Data/LogBoxData');
   const {

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -47,12 +47,6 @@ const ModalEventEmitter =
       )
     : null;
 
-/**
- * The Modal component is a simple way to present content above an enclosing view.
- *
- * See https://reactnative.dev/docs/modal
- */
-
 // In order to route onDismiss callbacks, we need to uniquely identifier each
 // <Modal> on screen. There can be different ones, either nested or as siblings.
 // We cannot pass the onDismiss callback to native as the view will be
@@ -66,42 +60,50 @@ type OrientationChangeEvent = Readonly<{
 /** @build-types emit-as-interface Uniwind compatibility */
 export type ModalBaseProps = {
   /**
-   * @deprecated Use animationType instead
+   * @deprecated Use `animationType` instead.
    */
   animated?: boolean,
+
   /**
-   * The `animationType` prop controls how the modal animates.
+   * Controls how the modal animates. `'slide'` slides in from the bottom,
+   * `'fade'` fades into view, `'none'` appears without animation.
    *
-   * - `slide` slides in from the bottom
-   * - `fade` fades into view
-   * - `none` appears without an animation
+   * @default `'none'`
    */
   animationType?: ?('none' | 'slide' | 'fade'),
+
   /**
-   * The `transparent` prop determines whether your modal will fill the entire view.
-   * Setting this to `true` will render the modal over a transparent background.
+   * Whether the modal fills the entire view. Setting to `true` renders the
+   * modal over a transparent background.
+   *
+   * @default `false`
    */
   transparent?: ?boolean,
+
   /**
-   * The `visible` prop determines whether your modal is visible.
+   * Whether the modal is visible.
+   *
+   * @default `true`
    */
   visible?: ?boolean,
+
   /**
-   * The `onRequestClose` callback is called when the user taps the hardware back button on Android, dismisses the sheet using a gesture on iOS (when `allowSwipeDismissal` is set to true) or the menu button on Apple TV.
-   *
-   * This is required on iOS and Android.
+   * Called when the user taps the hardware back button on Android, the menu
+   * button on Apple TV, or the modal is dismissed via drag gesture on iOS
+   * (when `allowSwipeDismissal` is `true`). Required on Android and TV.
    */
   // onRequestClose?: (event: NativeSyntheticEvent<any>) => void;
   onRequestClose?: ?DirectEventHandler<null>,
+
   /**
-   * The `onShow` prop allows passing a function that will be called once the modal has been shown.
+   * Called once the modal has been shown.
    */
   // onShow?: (event: NativeSyntheticEvent<any>) => void;
   onShow?: ?DirectEventHandler<null>,
 
   /**
-   * The `backdropColor` props sets the background color of the modal's container.
-   * Defaults to `white` if not provided and transparent is `false`. Ignored if `transparent` is `true`.
+   * The backdrop color of the modal's container. Defaults to `white` if
+   * `transparent` is `false`. Ignored if `transparent` is `true`.
    */
   backdropColor?: ColorValue,
 
@@ -113,7 +115,11 @@ export type ModalBaseProps = {
 
 export type ModalPropsIOS = {
   /**
-   * The `presentationStyle` determines the style of modal to show
+   * Controls how the modal appears.
+   *
+   * @default `'fullScreen'` if `transparent` is `false`, `'overFullScreen'` if `transparent` is `true`.
+   *
+   * @platform ios
    */
   presentationStyle?: ?(
     | 'fullScreen'
@@ -123,8 +129,13 @@ export type ModalPropsIOS = {
   ),
 
   /**
-   * The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations.
-   * On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
+   * Array of orientations the modal can be rotated to. On iOS, the modal is
+   * still restricted by what is specified in your app's Info.plist
+   * `UISupportedInterfaceOrientations` field.
+   *
+   * @default `['portrait']`
+   *
+   * @platform ios
    */
   supportedOrientations?: ?ReadonlyArray<
     | 'portrait'
@@ -135,14 +146,19 @@ export type ModalPropsIOS = {
   >,
 
   /**
-   * The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
+   * Called once the modal has been dismissed.
+   *
+   * @platform ios
    */
   // onDismiss?: (() => void) | undefined;
   onDismiss?: ?() => void,
 
   /**
-   * The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed.
-   * The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
+   * Called when the orientation changes while the modal is displayed. The
+   * orientation provided is only `'portrait'` or `'landscape'`. This callback
+   * is also called on initial render, regardless of the current orientation.
+   *
+   * @platform ios
    */
   // onOrientationChange?:
   //   | ((event: NativeSyntheticEvent<any>) => void)
@@ -150,25 +166,42 @@ export type ModalPropsIOS = {
   onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
 
   /**
-   * Controls whether the modal can be dismissed by swiping down on iOS.
-   * This requires you to implement the `onRequestClose` prop to handle the dismissal.
+   * Controls whether the modal can be dismissed by swiping down. Requires
+   * `onRequestClose` to be set.
+   *
+   * @default `false`
+   *
+   * @platform ios
    */
   allowSwipeDismissal?: ?boolean,
 };
 
 export type ModalPropsAndroid = {
   /**
-   *  Controls whether to force hardware acceleration for the underlying window.
+   * Controls whether to force hardware acceleration for the underlying window.
+   *
+   * @default `false`
+   *
+   * @platform android
    */
   hardwareAccelerated?: ?boolean,
 
   /**
-   *  Determines whether your modal should go under the system statusbar.
+   * Whether the modal should go under the system statusbar.
+   *
+   * @default `false`
+   *
+   * @platform android
    */
   statusBarTranslucent?: ?boolean,
 
   /**
-   *  Determines whether your modal should go under the system navigationbar.
+   * Whether the modal should go under the system navigation bar.
+   * `statusBarTranslucent` also needs to be `true`.
+   *
+   * @default `false`
+   *
+   * @platform android
    */
   navigationBarTranslucent?: ?boolean,
 };
@@ -218,6 +251,11 @@ type ModalState = {
   isRendered: boolean,
 };
 
+/**
+ * A basic way to present content above an enclosing view.
+ *
+ * @see https://reactnative.dev/docs/modal
+ */
 class Modal extends React.Component<ModalProps, ModalState> {
   static defaultProps: {hardwareAccelerated: boolean, visible: boolean} = {
     visible: true,

--- a/packages/react-native/Libraries/Performance/Systrace.js
+++ b/packages/react-native/Libraries/Performance/Systrace.js
@@ -8,6 +8,14 @@
  * @format
  */
 
+/**
+ * `Systrace` provides performance tracing for React Native applications.
+ * Methods in this module allow marking synchronous and asynchronous events
+ * that are visualized in supported system tracing tools.
+ *
+ * @see https://reactnative.dev/docs/systrace
+ */
+
 import typeof * as SystraceModule from './Systrace';
 
 const TRACE_TAG_REACT = 1 << 13; // eslint-disable-line no-bitwise

--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -129,13 +129,15 @@ const PERMISSIONS = Object.freeze({
   ACCESS_LOCAL_NETWORK: 'android.permission.ACCESS_LOCAL_NETWORK',
 }) as PermissionsType;
 
-/**
- * `PermissionsAndroid` provides access to Android M's new permissions model.
- *
- * See https://reactnative.dev/docs/permissionsandroid
- */
 class PermissionsAndroidImpl {
+  /**
+   * A list of specified "dangerous" permissions that require prompting the user.
+   */
   PERMISSIONS: PermissionsType = PERMISSIONS;
+
+  /**
+   * Possible results of a permission request.
+   */
   RESULTS: Readonly<{
     DENIED: 'denied',
     GRANTED: 'granted',
@@ -170,10 +172,8 @@ class PermissionsAndroidImpl {
   }
 
   /**
-   * Returns a promise resolving to a boolean value as to whether the specified
-   * permissions has been granted
-   *
-   * See https://reactnative.dev/docs/permissionsandroid#check
+   * Check whether the specified permission has been granted. Returns a
+   * `Promise` resolving to a boolean.
    */
   check(permission: Permission): Promise<boolean> {
     if (Platform.OS !== 'android') {
@@ -224,10 +224,13 @@ class PermissionsAndroidImpl {
   }
 
   /**
-   * Prompts the user to enable a permission and returns a promise resolving to a
-   * string value indicating whether the user allowed or denied the request
+   * Prompt the user to enable a permission. Returns a `Promise` resolving to a
+   * `PermissionStatus` string indicating whether the user allowed or denied the
+   * request.
    *
-   * See https://reactnative.dev/docs/permissionsandroid#request
+   * If the optional `rationale` argument is provided, this function first
+   * checks with the OS whether it is necessary to show an explanatory dialog
+   * before presenting the system permission prompt.
    */
   async request(
     permission: Permission,
@@ -275,11 +278,9 @@ class PermissionsAndroidImpl {
   }
 
   /**
-   * Prompts the user to enable multiple permissions in the same dialog and
-   * returns an object with the permissions as keys and strings as values
-   * indicating whether the user allowed or denied the request
-   *
-   * See https://reactnative.dev/docs/permissionsandroid#requestmultiple
+   * Prompt the user to enable multiple permissions in a single dialog. Returns
+   * a `Promise` resolving to an object mapping each requested permission to its
+   * `PermissionStatus`.
    */
   requestMultiple(
     permissions: Array<Permission>,
@@ -300,6 +301,15 @@ class PermissionsAndroidImpl {
   }
 }
 
+/**
+ * Provides access to Android M's (API 23+) permissions model. Handles prompts
+ * for "dangerous" permissions that require explicit user approval. On devices
+ * before SDK 23, permissions are automatically granted if listed in the
+ * manifest.
+ *
+ * @see https://reactnative.dev/docs/permissionsandroid
+ * @platform android
+ */
 const PermissionsAndroidInstance: PermissionsAndroidImpl =
   new PermissionsAndroidImpl();
 export default PermissionsAndroidInstance;

--- a/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -185,6 +185,10 @@ class PushNotificationIOS {
   _remoteNotificationCompleteCallbackCalled: boolean;
   _threadID: string;
 
+  /**
+   * iOS fetch results that best describe the result of a finished remote notification handler.
+   * For a list of possible values, see `PushNotificationIOS.FetchResult`.
+   */
   static FetchResult: FetchResult = {
     NewData: 'UIBackgroundFetchResultNewData',
     NoData: 'UIBackgroundFetchResultNoData',

--- a/packages/react-native/Libraries/ReactNative/AppRegistry.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.js
@@ -9,11 +9,6 @@
  */
 
 import registerCallableModule from '../Core/registerCallableModule';
-/**
- * `AppRegistry` is the JavaScript entry point to running all React Native apps.
- *
- * See https://reactnative.dev/docs/appregistry
- */
 import * as AppRegistry from './AppRegistryImpl';
 
 // Register LogBox as a default surface
@@ -31,4 +26,19 @@ global.RN$AppRegistry = AppRegistry;
 
 registerCallableModule('AppRegistry', AppRegistry);
 
+/**
+ * `AppRegistry` is the JS entry point to running all React Native apps. Root
+ * components register themselves with `AppRegistry.registerComponent`, then
+ * the native system can load the bundle for the app and run it when ready by
+ * invoking `AppRegistry.runApplication`.
+ *
+ * To stop an application when a view should be destroyed, call
+ * `AppRegistry.unmountApplicationComponentAtRootTag` with the tag that was
+ * passed into `runApplication`. These should always be used as a pair.
+ *
+ * `AppRegistry` should be required early in the require sequence to make sure
+ * the JS execution environment is set up before other modules are required.
+ *
+ * @see https://reactnative.dev/docs/appregistry
+ */
 export {AppRegistry};

--- a/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
@@ -41,16 +41,28 @@ let componentProviderInstrumentationHook: ComponentProviderInstrumentationHook =
 let wrapperComponentProvider: ?WrapperComponentProvider;
 let rootViewStyleProvider: ?RootViewStyleProvider;
 
+/**
+ * Sets a provider for a wrapper component that will wrap the root component
+ * of every registered app.
+ */
 export function setWrapperComponentProvider(
   provider: WrapperComponentProvider,
 ) {
   wrapperComponentProvider = provider;
 }
 
+/**
+ * Sets a provider for styles to be applied to the root view of every
+ * registered app.
+ */
 export function setRootViewStyleProvider(provider: RootViewStyleProvider) {
   rootViewStyleProvider = provider;
 }
 
+/**
+ * Registers multiple apps with a single call by providing an array of app
+ * configurations.
+ */
 export function registerConfig(config: Array<AppConfig>): void {
   config.forEach(appConfig => {
     if (appConfig.run) {
@@ -72,7 +84,9 @@ export function registerConfig(config: Array<AppConfig>): void {
 }
 
 /**
- * Registers an app's root component.
+ * Registers a root component for the given app key. Once registered, the
+ * native system can run the app by calling `runApplication` with the same
+ * key.
  *
  * See https://reactnative.dev/docs/appregistry#registercomponent
  */
@@ -105,11 +119,17 @@ export function registerComponent(
   return appKey;
 }
 
+/**
+ * Registers a custom run function for the given app key.
+ */
 export function registerRunnable(appKey: string, run: Runnable): string {
   runnables[appKey] = run;
   return appKey;
 }
 
+/**
+ * Registers a component as a navigable section.
+ */
 export function registerSection(
   appKey: string,
   component: ComponentProvider,
@@ -117,24 +137,39 @@ export function registerSection(
   registerComponent(appKey, component, true);
 }
 
+/**
+ * Returns the app keys for all registered runnables.
+ */
 export function getAppKeys(): ReadonlyArray<string> {
   return Object.keys(runnables);
 }
 
+/**
+ * Returns the keys for all registered sections.
+ */
 export function getSectionKeys(): ReadonlyArray<string> {
   return Object.keys(sections);
 }
 
+/**
+ * Returns a copy of the registered sections map.
+ */
 export function getSections(): Runnables {
   return {
     ...sections,
   };
 }
 
+/**
+ * Returns the runnable registered for the given app key.
+ */
 export function getRunnable(appKey: string): ?Runnable {
   return runnables[appKey];
 }
 
+/**
+ * Returns the full registry of section keys and runnables.
+ */
 export function getRegistry(): Registry {
   return {
     sections: getSectionKeys(),
@@ -142,6 +177,10 @@ export function getRegistry(): Registry {
   };
 }
 
+/**
+ * Sets a hook that is called when a component provider is instrumented
+ * during registration.
+ */
 export function setComponentProviderInstrumentationHook(
   hook: ComponentProviderInstrumentationHook,
 ) {
@@ -149,7 +188,9 @@ export function setComponentProviderInstrumentationHook(
 }
 
 /**
- * Loads the JavaScript bundle and runs the app.
+ * Loads the JavaScript bundle and runs the app registered under the given
+ * key. This is called by the native system when it is ready to display the
+ * app.
  *
  * See https://reactnative.dev/docs/appregistry#runapplication
  */
@@ -176,7 +217,7 @@ export function runApplication(
 }
 
 /**
- * Update initial props for a surface that's already rendered
+ * Updates the initial props for a surface that has already been rendered.
  */
 export function setSurfaceProps(
   appKey: string,
@@ -203,7 +244,8 @@ export function setSurfaceProps(
 }
 
 /**
- * Stops an application when a view should be destroyed.
+ * Stops an application when a view should be destroyed. Should always be
+ * called as a counterpart to `runApplication`.
  *
  * See https://reactnative.dev/docs/appregistry#unmountapplicationcomponentatroottag
  */
@@ -214,7 +256,8 @@ export function unmountApplicationComponentAtRootTag(rootTag: RootTag): void {
 }
 
 /**
- * Register a headless task. A headless task is a bit of code that runs without a UI.
+ * Registers a headless task. A headless task is a bit of code that runs
+ * without a UI, e.g. for background sync or push notifications.
  *
  * See https://reactnative.dev/docs/appregistry#registerheadlesstask
  */
@@ -229,7 +272,9 @@ export function registerHeadlessTask(
 }
 
 /**
- * Register a cancellable headless task. A headless task is a bit of code that runs without a UI.
+ * Registers a cancellable headless task. A headless task is a bit of code
+ * that runs without a UI. Unlike `registerHeadlessTask`, this variant
+ * accepts a cancel provider that can be used to abort the task.
  *
  * See https://reactnative.dev/docs/appregistry#registercancellableheadlesstask
  */
@@ -248,7 +293,8 @@ export function registerCancellableHeadlessTask(
 }
 
 /**
- * Only called from native code. Starts a headless task.
+ * Starts a headless task. Called from native code when a registered headless
+ * task should begin execution.
  *
  * See https://reactnative.dev/docs/appregistry#startheadlesstask
  */
@@ -294,7 +340,8 @@ export function startHeadlessTask(
 }
 
 /**
- * Only called from native code. Cancels a headless task.
+ * Cancels a headless task. Called from native code when a previously started
+ * headless task should be aborted.
  *
  * See https://reactnative.dev/docs/appregistry#cancelheadlesstask
  */

--- a/packages/react-native/Libraries/ReactNative/I18nManager.js
+++ b/packages/react-native/Libraries/ReactNative/I18nManager.js
@@ -27,11 +27,20 @@ function getI18nManagerConstants(): I18nManagerConstants {
   };
 }
 
+/**
+ * Utilities for managing Right-to-Left (RTL) layout support.
+ *
+ * @see https://reactnative.dev/docs/i18nmanager
+ */
 export default {
   getConstants: (): I18nManagerConstants => {
     return i18nConstants;
   },
 
+  /**
+   * Allows the app to opt in to RTL layout behavior. Should be called early
+   * in app startup. Takes effect on the next app reload.
+   */
   allowRTL: (shouldAllow: boolean) => {
     if (!NativeI18nManager) {
       return;
@@ -40,6 +49,10 @@ export default {
     NativeI18nManager.allowRTL(shouldAllow);
   },
 
+  /**
+   * Forces the app into RTL layout mode, regardless of the device locale.
+   * Takes effect on the next app reload.
+   */
   forceRTL: (shouldForce: boolean) => {
     if (!NativeI18nManager) {
       return;
@@ -48,6 +61,10 @@ export default {
     NativeI18nManager.forceRTL(shouldForce);
   },
 
+  /**
+   * Controls whether `left`/`right` style properties are automatically swapped
+   * in RTL layouts. When enabled, `left` becomes `right` and vice versa.
+   */
   swapLeftAndRightInRTL: (flipStyles: boolean) => {
     if (!NativeI18nManager) {
       return;
@@ -56,7 +73,10 @@ export default {
     NativeI18nManager.swapLeftAndRightInRTL(flipStyles);
   },
 
+  /** Whether the current layout direction is Right-to-Left. */
   isRTL: i18nConstants.isRTL as I18nManagerConstants['isRTL'],
+
+  /** Whether left and right style properties are swapped in RTL mode. */
   doLeftAndRightSwapInRTL:
     i18nConstants.doLeftAndRightSwapInRTL as I18nManagerConstants['doLeftAndRightSwapInRTL'],
 };

--- a/packages/react-native/Libraries/ReactNative/UIManager.js
+++ b/packages/react-native/Libraries/ReactNative/UIManager.js
@@ -26,6 +26,25 @@ const UIManagerImpl: UIManagerJSInterface =
 // $FlowFixMe[cannot-spread-interface]
 const UIManager: UIManagerJSInterface = {
   ...UIManagerImpl,
+  /**
+   * Determines the location on screen, width, and height of the given view and
+   * returns the values via an async callback. If successful, the callback will
+   * be called with the following arguments:
+   *
+   *  - x
+   *  - y
+   *  - width
+   *  - height
+   *  - pageX
+   *  - pageY
+   *
+   * Note that these measurements are not available until after the rendering
+   * has been completed in native. If you need the measurements as soon as
+   * possible, consider using the [`onLayout`
+   * prop](docs/view.html#onlayout) instead.
+   *
+   * @deprecated Use `ref.measure` instead.
+   */
   measure(
     reactTag: number,
     callback: (
@@ -54,6 +73,23 @@ const UIManager: UIManagerJSInterface = {
     }
   },
 
+  /**
+   * Determines the location of the given view in the window and returns the
+   * values via an async callback. If the React root view is embedded in
+   * another native view, this will give you the absolute coordinates. If
+   * successful, the callback will be called with the following
+   * arguments:
+   *
+   *  - x
+   *  - y
+   *  - width
+   *  - height
+   *
+   * Note that these measurements are not available until after the rendering
+   * has been completed in native.
+   *
+   * @deprecated Use `ref.measureInWindow` instead.
+   */
   measureInWindow(
     reactTag: number,
     callback: (
@@ -80,6 +116,16 @@ const UIManager: UIManagerJSInterface = {
     }
   },
 
+  /**
+   * Like [`measure()`](#measure), but measures the view relative an ancestor,
+   * specified as `relativeToNativeNode`. This means that the returned x, y
+   * are relative to the origin x, y of the ancestor view.
+   *
+   * As always, to obtain a native node handle for a component, you can use
+   * `React.findNodeHandle(component)`.
+   *
+   * @deprecated Use `ref.measureLayout` instead.
+   */
   measureLayout(
     reactTag: number,
     ancestorReactTag: number,
@@ -154,6 +200,13 @@ const UIManager: UIManagerJSInterface = {
     }
   },
 
+  /**
+   * Used to call a native view method from JavaScript
+   *
+   * reactTag - Id of react view.
+   * commandID - Id of the native method that should be called.
+   * commandArgs - Args of the native method that we can pass from JS to native.
+   */
   dispatchViewManagerCommand(
     reactTag: number,
     commandName: number | string,

--- a/packages/react-native/Libraries/Settings/Settings.ios.js
+++ b/packages/react-native/Libraries/Settings/Settings.ios.js
@@ -18,15 +18,29 @@ const subscriptions: Array<{
   ...
 }> = [];
 
+/**
+ * Wrapper around `NSUserDefaults`, a persistent key-value store available on
+ * iOS.
+ *
+ * @see https://reactnative.dev/docs/settings
+ * @platform ios
+ */
 const Settings = {
   _settings: (NativeSettingsManager &&
     NativeSettingsManager.getConstants().settings) as any,
 
+  /**
+   * Get the current value for the given key.
+   */
   get(key: string): unknown {
     // $FlowFixMe[object-this-reference]
     return this._settings[key];
   },
 
+  /**
+   * Set one or more values by merging the provided object into the current
+   * settings.
+   */
   set(settings: Object) {
     // $FlowFixMe[object-this-reference]
     // $FlowFixMe[unsafe-object-assign]
@@ -34,6 +48,11 @@ const Settings = {
     NativeSettingsManager.setValues(settings);
   },
 
+  /**
+   * Subscribe to changes for the specified keys. The callback is invoked
+   * whenever a watched key's value changes. Returns a `watchId` that can be
+   * passed to `clearWatch` to unsubscribe.
+   */
   watchKeys(keys: string | Array<string>, callback: Function): number {
     if (typeof keys === 'string') {
       keys = [keys];
@@ -49,6 +68,9 @@ const Settings = {
     return sid;
   },
 
+  /**
+   * Unsubscribe a watcher previously registered with `watchKeys`.
+   */
   clearWatch(watchId: number) {
     if (watchId < subscriptions.length) {
       subscriptions[watchId] = {keys: [], callback: null};

--- a/packages/react-native/Libraries/Share/Share.js
+++ b/packages/react-native/Libraries/Share/Share.js
@@ -41,42 +41,38 @@ export type ShareAction = {
   activityType?: string | null,
 };
 
+/**
+ * Opens a dialog to share text content.
+ *
+ * @see https://reactnative.dev/docs/share
+ */
 class Share {
   /**
-   * Open a dialog to share text content.
+   * Open a share dialog to share text content.
    *
-   * In iOS, Returns a Promise which will be invoked an object containing `action`, `activityType`.
-   * If the user dismissed the dialog, the Promise will still be resolved with action being `Share.dismissedAction`
-   * and all the other keys being undefined.
+   * On iOS, returns a Promise which resolves to an object containing `action`
+   * and `activityType`. If the user dismissed the dialog, the Promise will
+   * still resolve with action being `Share.dismissedAction` and all the other
+   * keys being undefined.
    *
-   * In Android, Returns a Promise which always resolves with action being `Share.sharedAction`.
+   * On Android, returns a Promise which always resolves with action being
+   * `Share.sharedAction`.
    *
-   * ### Content
+   * **Content:**
    *
-   * #### iOS
+   * - `message` - A message to share.
+   * - `url` (iOS) - A URL to share.
+   * - `title` (Android) - Title of the message.
    *
-   *  - `url` - a URL to share
-   *  - `message` - a message to share
+   * At least one of `url` or `message` is required.
    *
-   * At least one of `URL` or `message` is required.
+   * **Options:**
    *
-   * #### Android
-   *
-   * - `title` - title of the message (optional)
-   * - `message` - a message to share (often will include a URL).
-   *
-   * ### Options
-   *
-   * #### iOS
-   *
-   *  - `subject` - a subject to share via email
-   *  - `excludedActivityTypes`
-   *  - `tintColor`
-   *
-   * #### Android
-   *
-   *  - `dialogTitle`
-   *
+   * - `dialogTitle` (Android) - Title of the share dialog.
+   * - `excludedActivityTypes` (iOS) - Activity types to exclude.
+   * - `subject` (iOS) - A subject to share via email.
+   * - `tintColor` (iOS) - Tint color for the share dialog.
+   * - `anchor` (iOS) - The anchor point for the popover (iPad).
    */
   static share(
     content: ShareContent,
@@ -173,7 +169,8 @@ class Share {
   static sharedAction: 'sharedAction' = 'sharedAction';
 
   /**
-   * The dialog has been dismissed.
+   * The dialog was dismissed.
+   *
    * @platform ios
    */
   static dismissedAction: 'dismissedAction' = 'dismissedAction';

--- a/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.js.flow
+++ b/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.js.flow
@@ -11,6 +11,12 @@
 import type {ProcessedColorValue} from './processColor';
 import type {NativeColorValue} from './StyleSheet';
 
+/**
+ * Select native platform color
+ * The color must match the string that exists on the native platform
+ *
+ * @see https://reactnative.dev/docs/platformcolor#example
+ */
 declare export function PlatformColor(
   ...names: Array<string>
 ): NativeColorValue;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -41,7 +41,7 @@ export type {
  * most useful when using DynamicColorIOS which can be a string or a dynamic
  * color object.
  *
- * type props = {backgroundColor: ColorValue};
+ * `type Props = {backgroundColor: ColorValue};`
  */
 export type ColorValue = ____ColorValue_Internal;
 
@@ -186,4 +186,44 @@ export type ImageStyle = ____ImageStyle_Internal;
  */
 export type DangerouslyImpreciseStyle = ____DangerouslyImpreciseStyle_Internal;
 
+/**
+ * A styling abstraction for React Native, inspired by CSS stylesheets.
+ *
+ * Use `StyleSheet.create()` to define a group of named styles in one place,
+ * separate from your render logic. The styles are plain objects, so the call
+ * is effectively an identity function — its main benefit is static type
+ * checking of each style against the valid native style properties for a
+ * `View`, `Text`, or `Image`. Naming styles and moving them out of the render
+ * tree also keeps components easier to read.
+ *
+ * Example:
+ *
+ * ```tsx
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     padding: 24,
+ *   },
+ *   title: {
+ *     fontSize: 20,
+ *     fontWeight: '600',
+ *   },
+ * });
+ *
+ * function Screen() {
+ *   return (
+ *     <View style={styles.container}>
+ *       <Text style={styles.title}>Hello</Text>
+ *     </View>
+ *   );
+ * }
+ * ```
+ *
+ * The module also provides helpers for combining styles — `compose` (merge
+ * two styles, with the second overriding the first) and `flatten` (collapse
+ * an array of styles into a single object) — plus the constants `absoluteFill`,
+ * `absoluteFillObject`, and `hairlineWidth` for common layout patterns.
+ *
+ * @see https://reactnative.dev/docs/stylesheet
+ */
 export default StyleSheet;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js
@@ -103,9 +103,10 @@ export default {
   },
 
   /**
-   * A very common pattern is to create overlays with position absolute and zero positioning,
-   * so `absoluteFill` can be used for convenience and to reduce duplication of these repeated
-   * styles.
+   * A very common pattern is to create overlays with position absolute and
+   * zero positioning (`top`, `right`, `bottom`, `left` all set to `0`), so
+   * `absoluteFill` can be used for convenience and to reduce duplication of
+   * these repeated styles.
    */
   absoluteFill,
 
@@ -176,7 +177,8 @@ export default {
   },
 
   /**
-   * An identity function for creating style sheets.
+   * Creates a StyleSheet style reference from the given object. The values in
+   * the object are frozen in development to prevent mutation.
    */
   // $FlowFixMe[unsupported-variance-annotation]
   create<out S extends ____Styles_Internal>(obj: S): Readonly<S> {

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -845,6 +845,10 @@ export type ____ViewStyle_InternalBase = Readonly<{
   backfaceVisibility?: 'visible' | 'hidden',
   backgroundColor?: ____ColorValue_Internal,
   borderColor?: ____ColorValue_Internal,
+  /**
+   * On iOS 13+, it is possible to change the corner curve of borders.
+   * @platform ios
+   */
   borderCurve?: 'circular' | 'continuous',
   borderBottomColor?: ____ColorValue_Internal,
   borderEndColor?: ____ColorValue_Internal,
@@ -881,7 +885,18 @@ export type ____ViewStyle_InternalBase = Readonly<{
   outlineOffset?: number,
   outlineStyle?: 'solid' | 'dotted' | 'dashed',
   outlineWidth?: number,
+  /**
+   * Sets the elevation of a view, using Android's underlying
+   * [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation).
+   * This adds a drop shadow to the item and affects z-order for overlapping views.
+   * Only supported on Android 5.0+, has no effect on earlier versions.
+   *
+   * @platform android
+   */
   elevation?: number,
+  /**
+   * Controls whether the View can be the target of touch events.
+   */
   pointerEvents?: 'auto' | 'none' | 'box-none' | 'box-only',
   cursor?: CursorValue,
   boxShadow?: ReadonlyArray<BoxShadowValue> | string,
@@ -1001,6 +1016,11 @@ type ____TextStyle_InternalBase = Readonly<{
   fontFamily?: string,
   fontSize?: number,
   fontStyle?: 'normal' | 'italic',
+  /**
+   * Specifies font weight. The values 'normal' and 'bold' are supported
+   * for most fonts. Not all fonts have a variant for each of the numeric
+   * values, in that case the closest one is chosen.
+   */
   fontWeight?: ____FontWeight_Internal,
   fontVariant?: ____FontVariantArray_Internal | string,
   textShadowOffset?: Readonly<{

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -36,7 +36,11 @@ export type TextInstance = HostInstance;
 export type {TextProps} from './TextProps';
 
 /**
- * Text is the fundamental component for displaying text.
+ * A React component for displaying text. `Text` supports nesting, styling,
+ * and touch handling.
+ *
+ * `Text` uses text layout instead of flexbox — elements inside wrap at end of
+ * line rather than being positioned as rectangles.
  *
  * @see https://reactnative.dev/docs/text
  */

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -40,14 +40,19 @@ type TextPointerEventProps = Readonly<{
 
 export type TextPropsIOS = {
   /**
-   * Specifies whether font should be scaled down automatically to fit given style constraints.
+   * Whether fonts should be scaled down to fit style constraints.
    *
-   * See https://reactnative.dev/docs/text#adjustsfontsizetofit
+   * @default `false`
+   * @platform ios
    */
   adjustsFontSizeToFit?: ?boolean,
 
   /**
-   * The Dynamic Type scale ramp to apply to this element on iOS.
+   * The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/textstyle)
+   * ramp to apply.
+   *
+   * @default `'body'`
+   * @platform ios
    */
   dynamicTypeRamp?: ?(
     | 'caption2'
@@ -67,14 +72,16 @@ export type TextPropsIOS = {
    * When `true`, no visual change is made when text is pressed down. By
    * default, a gray oval highlights the text on press down.
    *
-   * See https://reactnative.dev/docs/text#supperhighlighting
+   * @default `false`
+   * @platform ios
    */
   suppressHighlighting?: ?boolean,
 
   /**
-   * Set line break strategy on iOS.
+   * Line break strategy on iOS.
    *
-   * See https://reactnative.dev/docs/text.html#linebreakstrategyios
+   * @default `'none'`
+   * @platform ios
    */
   lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
 };
@@ -83,40 +90,40 @@ export type TextPropsAndroid = {
   /**
    * Specifies the disabled state of the text view for testing purposes.
    *
-   * See https://reactnative.dev/docs/text#disabled
+   * @platform android
    */
   disabled?: ?boolean,
 
   /**
-   * The highlight color of the text.
+   * Highlight color of the text when selected.
    *
-   * See https://reactnative.dev/docs/text#selectioncolor
+   * @platform android
    */
   selectionColor?: ?ColorValue,
 
   /**
-   * Determines the types of data converted to clickable URLs in the text element.
-   * By default no data types are detected.
+   * Types of data converted to clickable URLs in the text element.
+   *
+   * @default `'none'`
+   * @platform android
    */
   dataDetectorType?: ?('phoneNumber' | 'link' | 'email' | 'none' | 'all'),
 
   /**
-   * Set text break strategy on Android API Level 23+
-   * default is `highQuality`.
+   * Text break strategy on Android.
    *
-   * See https://reactnative.dev/docs/text#textbreakstrategy
+   * @default `'highQuality'`
+   * @platform android
    */
   textBreakStrategy?: ?('balanced' | 'highQuality' | 'simple'),
 
-  /**
-   * iOS Only
-   */
   adjustsFontSizeToFit?: ?boolean,
 
   /**
-   * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
+   * Smallest possible font scale when `adjustsFontSizeToFit` is enabled
+   * (values 0.01-1.0).
    *
-   * See https://reactnative.dev/docs/text#minimumfontscale
+   * @platform ios
    */
   minimumFontScale?: ?number,
 };
@@ -126,110 +133,68 @@ type TextBaseProps = Readonly<{
 
   /**
    * Controls whether the `Text` can be the target of touch events.
-   *
-   * See https://reactnative.dev/docs/view#pointerevents
    */
   pointerEvents?: ?('auto' | 'box-none' | 'box-only' | 'none'),
 
   /**
    * Whether fonts should scale to respect Text Size accessibility settings.
-   * The default is `true`.
    *
-   * See https://reactnative.dev/docs/text#allowfontscaling
+   * @default `true`
    */
   allowFontScaling?: ?boolean,
 
   /**
-   * Set hyphenation strategy on Android.
+   * Sets automatic hyphenation frequency.
    *
+   * @default `'none'`
+   * @platform android
    */
   android_hyphenationFrequency?: ?('normal' | 'none' | 'full'),
+
   children?: ?React.Node,
 
   /**
-   * When `numberOfLines` is set, this prop defines how text will be
-   * truncated.
+   * How text is truncated when `numberOfLines` is set. On Android with
+   * `numberOfLines` greater than 1, only `'tail'` works correctly.
    *
-   * This can be one of the following values:
-   *
-   * - `head` - The line is displayed so that the end fits in the container and the missing text
-   * at the beginning of the line is indicated by an ellipsis glyph. e.g., "...wxyz"
-   * - `middle` - The line is displayed so that the beginning and end fit in the container and the
-   * missing text in the middle is indicated by an ellipsis glyph. "ab...yz"
-   * - `tail` - The line is displayed so that the beginning fits in the container and the
-   * missing text at the end of the line is indicated by an ellipsis glyph. e.g., "abcd..."
-   * - `clip` - Lines are not drawn past the edge of the text container.
-   *
-   * The default is `tail`.
-   *
-   * `numberOfLines` must be set in conjunction with this prop.
-   *
-   * > `clip` is working only for iOS
-   *
-   * See https://reactnative.dev/docs/text#ellipsizemode
+   * @default `'tail'`
    */
   ellipsizeMode?: ?('clip' | 'head' | 'middle' | 'tail'),
 
-  /**
-   * Used to reference react managed views from native code.
-   *
-   * See https://reactnative.dev/docs/text#nativeid
-   */
   id?: string,
 
   /**
-   * Specifies largest possible scale a font can reach when `allowFontScaling` is enabled.
-   * Possible values:
-   * `null/undefined` (default): inherit from the parent node or the global default (0)
-   * `0`: no max, ignore parent/global default
-   * `>= 1`: sets the maxFontSizeMultiplier of this node to this value
+   * Largest possible font scale when `allowFontScaling` is enabled.
+   * `null`/`undefined` inherits from the parent node or the global default (0).
+   * `0` means no max (ignores parent/global default). `>= 1` sets the
+   * `maxFontSizeMultiplier` of this node to this value.
    */
   maxFontSizeMultiplier?: ?number,
 
-  /**
-   * Used to locate this view from native code.
-   *
-   * See https://reactnative.dev/docs/text#nativeid
-   */
   nativeID?: ?string,
 
   /**
-   * Used to truncate the text with an ellipsis after computing the text
-   * layout, including line wrapping, such that the total number of lines
-   * does not exceed this number.
+   * Truncate text with an ellipsis after this many lines. `0` means no
+   * restriction.
    *
-   * This prop is commonly used with `ellipsizeMode`.
-   *
-   * See https://reactnative.dev/docs/text#numberoflines
+   * @default `0`
    */
   numberOfLines?: ?number,
 
-  /**
-   * Invoked on mount and layout changes.
-   *
-   * {nativeEvent: { layout: {x, y, width, height}}}.
-   *
-   * See https://reactnative.dev/docs/text#onlayout
-   */
   onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
-  /**
-   * This function is called on long press.
-   * e.g., `onLongPress={this.increaseSize}>`
-   *
-   * See https://reactnative.dev/docs/text#onlongpress
-   */
+  /** Called on long press. */
   onLongPress?: ?(event: GestureResponderEvent) => unknown,
 
-  /**
-   * This function is called on press.
-   * Text intrinsically supports press handling with a default highlight state (which can be disabled with suppressHighlighting).
-   *
-   * See https://reactnative.dev/docs/text#onpress
-   */
+  /** Called on press, triggered after `onPressOut`. */
   onPress?: ?(event: GestureResponderEvent) => unknown,
+
+  /** Called immediately when a touch is engaged. */
   onPressIn?: ?(event: GestureResponderEvent) => unknown,
+
+  /** Called when a touch is released. */
   onPressOut?: ?(event: GestureResponderEvent) => unknown,
+
   onResponderGrant?: ?(event: GestureResponderEvent) => void,
   onResponderMove?: ?(event: GestureResponderEvent) => void,
   onResponderRelease?: ?(event: GestureResponderEvent) => void,
@@ -237,13 +202,13 @@ type TextBaseProps = Readonly<{
   onResponderTerminationRequest?: ?() => boolean,
   onStartShouldSetResponder?: ?() => boolean,
   onMoveShouldSetResponder?: ?() => boolean,
+
+  /** Invoked on text layout change. */
   onTextLayout?: ?(event: TextLayoutEvent) => unknown,
 
   /**
    * Defines how far your touch may move off of the button, before
    * deactivating the button.
-   *
-   * See https://reactnative.dev/docs/text#pressretentionoffset
    */
   pressRetentionOffset?: ?PressRetentionOffset,
 
@@ -253,22 +218,14 @@ type TextBaseProps = Readonly<{
   role?: ?Role,
 
   /**
-   * Lets the user select text.
+   * Lets the user select text for native copy and paste.
    *
-   * See https://reactnative.dev/docs/text#selectable
+   * @default `false`
    */
   selectable?: ?boolean,
 
-  /**
-   * @see https://reactnative.dev/docs/text#style
-   */
   style?: ?TextStyleProp,
 
-  /**
-   * Used to locate this view in end-to-end tests.
-   *
-   * See https://reactnative.dev/docs/text#testid
-   */
   testID?: ?string,
 }>;
 

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -76,6 +76,9 @@ export type LayoutChangeEvent = NativeSyntheticEvent<
   }>,
 >;
 
+/**
+ * @deprecated Use `TextLayoutEvent` instead.
+ */
 type TextLayoutEventData = Readonly<{
   lines: Array<TextLayoutLine>,
 }>;

--- a/packages/react-native/Libraries/Utilities/BackHandler.android.js
+++ b/packages/react-native/Libraries/Utilities/BackHandler.android.js
@@ -37,30 +37,13 @@ RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function (nativeEvent) {
 });
 
 /**
- * Detect hardware button presses for back navigation.
+ * Detects hardware button presses for back navigation and lets you register
+ * event listeners for the system's back action. Event subscriptions are called
+ * in reverse order (i.e. last registered subscription first). If one
+ * subscription returns `true`, earlier subscriptions are not called.
  *
- * Android: Detect hardware back button presses, and programmatically invoke the default back button
- * functionality to exit the app if there are no listeners or if none of the listeners return true.
- *
- * iOS: Not applicable.
- *
- * The event subscriptions are called in reverse order (i.e. last registered subscription first),
- * and if one subscription returns true then subscriptions registered earlier will not be called.
- *
- * Example:
- *
- * ```javascript
- * BackHandler.addEventListener('hardwareBackPress', function() {
- *  // this.onMainScreen and this.goBack are just examples, you need to use your own implementation here
- *  // Typically you would use the navigator here to go to the last state.
- *
- *  if (!this.onMainScreen()) {
- *    this.goBack();
- *    return true;
- *  }
- *  return false;
- * });
- * ```
+ * @see https://reactnative.dev/docs/backhandler
+ * @platform android
  */
 type TBackHandler = {
   readonly exitApp: () => void,
@@ -70,6 +53,9 @@ type TBackHandler = {
   ) => {remove: () => void, ...},
 };
 const BackHandler: TBackHandler = {
+  /**
+   * Programmatically exit the app.
+   */
   exitApp: function (): void {
     if (!NativeDeviceEventManager) {
       return;
@@ -79,9 +65,8 @@ const BackHandler: TBackHandler = {
   },
 
   /**
-   * Adds an event handler. Supported events:
-   *
-   * - `hardwareBackPress`: Fires when the Android hardware back button is pressed.
+   * Listen for the `hardwareBackPress` event. The handler should return `true`
+   * to prevent the event from bubbling to earlier registered listeners.
    */
   addEventListener: function (
     eventName: BackPressEventName,

--- a/packages/react-native/Libraries/Utilities/BackHandler.js.flow
+++ b/packages/react-native/Libraries/Utilities/BackHandler.js.flow
@@ -12,6 +12,11 @@
 
 export type BackPressEventName = 'backPress' | 'hardwareBackPress';
 
+/**
+ * Event dispatched when the hardware back button is pressed.
+ * The `timeStamp` property reflects the native timestamp captured
+ * when the back press was emitted.
+ */
 export interface HardwareBackPressEvent {
   readonly type: string;
   readonly timeStamp: number;
@@ -25,6 +30,17 @@ type TBackHandler = {
   ): {remove: () => void, ...},
 };
 
+/**
+ * Detect hardware back button presses, and programmatically invoke the
+ * default back button functionality to exit the app if there are no
+ * listeners or if none of the listeners return true.
+ * The event subscriptions are called in reverse order
+ * (i.e. last registered subscription first), and if one subscription
+ * returns true then subscriptions registered earlier
+ * will not be called.
+ *
+ * @see https://reactnative.dev/docs/backhandler
+ */
 declare const BackHandler: TBackHandler;
 
 declare export default typeof BackHandler;

--- a/packages/react-native/Libraries/Utilities/DevSettings.js
+++ b/packages/react-native/Libraries/Utilities/DevSettings.js
@@ -15,7 +15,11 @@ import NativeDevSettings from '../NativeModules/specs/NativeDevSettings';
 import Platform from '../Utilities/Platform';
 
 /**
- * The DevSettings module exposes methods for customizing settings for developers in development.
+ * The `DevSettings` module exposes methods for customizing settings for
+ * developers in development mode. This module is a no-op in production
+ * builds.
+ *
+ * @see https://reactnative.dev/docs/devsettings
  */
 let DevSettings: {
   /**
@@ -31,6 +35,9 @@ let DevSettings: {
    * @param reason
    */
   reload(reason?: string): void,
+  /**
+   * Notify the native side that a Fast Refresh has occurred.
+   */
   onFastRefresh(): void,
 } = {
   addMenuItem(title: string, handler: () => unknown): void {},

--- a/packages/react-native/Libraries/Utilities/Dimensions.js
+++ b/packages/react-native/Libraries/Utilities/Dimensions.js
@@ -30,18 +30,23 @@ const eventEmitter = new EventEmitter<{
 let dimensionsInitialized = false;
 let dimensions: DimensionsPayload;
 
+/**
+ * Provides the application window's width and height. Prefer
+ * `useWindowDimensions` in React components.
+ *
+ * @see https://reactnative.dev/docs/dimensions
+ */
 class Dimensions {
   /**
+   * Returns the current dimensions for `'window'` or `'screen'`. On Android,
+   * `'window'` dimensions exclude the status bar and navigation bar.
+   *
    * NOTE: `useWindowDimensions` is the preferred API for React components.
    *
-   * Initial dimensions are set before `runApplication` is called so they should
-   * be available before any other require's are run, but may be updated later.
-   *
-   * Note: Although dimensions are available immediately, they may change (e.g
-   * due to device rotation) so any rendering logic or styles that depend on
-   * these constants should try to call this function on every render, rather
-   * than caching the value (for example, using inline styles rather than
-   * setting a value in a `StyleSheet`).
+   * Although dimensions are available immediately, they may change (e.g. due to
+   * device rotation) so any rendering logic or styles that depend on these
+   * constants should try to call this function on every render, rather than
+   * caching the value.
    *
    * Example: `const {height, width} = Dimensions.get('window');`
    *
@@ -98,10 +103,11 @@ class Dimensions {
   /**
    * Add an event handler. Supported events:
    *
-   * - `change`: Fires when a property within the `Dimensions` object changes. The argument
-   *   to the event handler is an object with `window` and `screen` properties whose values
-   *   are the same as the return values of `Dimensions.get('window')` and
-   *   `Dimensions.get('screen')`, respectively.
+   * - `change`: Fires when a property within the `Dimensions` object changes,
+   *   such as on device rotation or foldable device state changes. The argument
+   *   to the event handler is a `DimensionsPayload` object with `window` and
+   *   `screen` properties whose values are the same as the return values of
+   *   `Dimensions.get('window')` and `Dimensions.get('screen')`, respectively.
    */
   static addEventListener(
     type: 'change',

--- a/packages/react-native/Libraries/Utilities/PixelRatio.js
+++ b/packages/react-native/Libraries/Utilities/PixelRatio.js
@@ -13,7 +13,7 @@
 const Dimensions = require('./Dimensions').default;
 
 /**
- * PixelRatio class gives access to the device pixel density.
+ * Provides access to the device's pixel density and font scale.
  *
  * ## Fetching a correctly sized image
  *
@@ -21,7 +21,9 @@ const Dimensions = require('./Dimensions').default;
  * device. A good rule of thumb is to multiply the size of the image you display
  * by the pixel ratio.
  *
- * ```
+ * Example:
+ *
+ * ```tsx
  * var image = getImage({
  *   width: PixelRatio.getPixelSizeForLayoutSize(200),
  *   height: PixelRatio.getPixelSizeForLayoutSize(100),
@@ -55,6 +57,7 @@ const Dimensions = require('./Dimensions').default;
  * rounding is done relative to the root rather than the parent, again to avoid
  * accumulating rounding errors.
  *
+ * @see https://reactnative.dev/docs/pixelratio
  */
 class PixelRatio {
   /**

--- a/packages/react-native/Libraries/Utilities/Platform.js.flow
+++ b/packages/react-native/Libraries/Utilities/Platform.js.flow
@@ -10,4 +10,8 @@
 
 import type {PlatformType} from './PlatformTypes';
 
+/**
+ * Provides information about the platform the app is running on and utility
+ * methods for platform-specific logic.
+ */
 declare export default PlatformType;

--- a/packages/react-native/Libraries/Utilities/PlatformTypes.js
+++ b/packages/react-native/Libraries/Utilities/PlatformTypes.js
@@ -29,9 +29,24 @@ export type PlatformSelectSpec<T> =
 
 type IOSPlatform = {
   __constants: null,
+
+  /** The platform identifier. Always `'ios'` on iOS. */
   OS: 'ios',
+
+  /**
+   * The OS version string (e.g. `'26.0'`).
+   *
+   * @platform ios
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get Version(): string,
+
+  /**
+   * An object of platform-specific constants, including `reactNativeVersion`,
+   * `osVersion`, `interfaceIdiom`, and more.
+   *
+   * @platform ios
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get constants(): {
     forceTouchAvailable: boolean,
@@ -48,26 +63,69 @@ type IOSPlatform = {
     systemName: string,
     isMacCatalyst?: boolean,
   },
+
+  /**
+   * Whether the app is running on an iPad.
+   *
+   * @platform ios
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get isPad(): boolean,
+
+  /**
+   * Whether the app is running on a TV device.
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean,
+
+  /**
+   * Whether the app is running on Apple Vision Pro.
+   *
+   * @platform ios
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get isVision(): boolean,
+
+  /**
+   * Whether the app is running in a test environment.
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean,
+
   // $FlowFixMe[unsafe-getters-setters]
   get isDisableAnimations(): boolean,
+
   // $FlowFixMe[unsafe-getters-setters]
   get isMacCatalyst(): boolean,
+
+  /**
+   * Returns the most fitting value for the current platform from the given
+   * spec object. The spec can include keys for specific platform names
+   * (`'ios'`, `'android'`, etc.) and a `default` fallback.
+   */
   select: <T>(spec: PlatformSelectSpec<T>) => T,
 };
 
 type AndroidPlatform = {
   __constants: null,
+
+  /** The platform identifier. Always `'android'` on Android. */
   OS: 'android',
+
+  /**
+   * The Android API level (e.g. `34`).
+   *
+   * @platform android
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get Version(): number,
+
+  /**
+   * An object of platform-specific constants, including `reactNativeVersion`,
+   * `Version`, `Release`, `Model`, and more.
+   *
+   * @platform android
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get constants(): {
     isTesting: boolean,
@@ -88,14 +146,33 @@ type AndroidPlatform = {
     Brand: string,
     Manufacturer: string,
   },
+
+  /**
+   * Whether the app is running on a TV device.
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean,
+
+  /**
+   * Whether the app is running on Apple Vision Pro. Always `false` on Android.
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get isVision(): boolean,
+
+  /**
+   * Whether the app is running in a test environment.
+   */
   // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean,
+
   // $FlowFixMe[unsafe-getters-setters]
   get isDisableAnimations(): boolean,
+
+  /**
+   * Returns the most fitting value for the current platform from the given
+   * spec object. The spec can include keys for specific platform names
+   * (`'ios'`, `'android'`, etc.) and a `default` fallback.
+   */
   select: <T>(spec: PlatformSelectSpec<T>) => T,
 };
 

--- a/packages/react-native/Libraries/Utilities/useColorScheme.js
+++ b/packages/react-native/Libraries/Utilities/useColorScheme.js
@@ -21,12 +21,14 @@ const subscribe = (onStoreChange: () => void) => {
 };
 
 /**
- * Returns the active color scheme (`'light'` or `'dark'`). Automatically
- * re-renders the component when the color scheme changes.
+ * React hook that provides and subscribes to color scheme updates from the
+ * `Appearance` module. Returns `'light'`, `'dark'`, or `null`.
  *
  * Notes:
  * - `null` will only be returned if the native Appearance module is unavailable
  *   (out of tree platforms).
+ *
+ * @see https://reactnative.dev/docs/usecolorscheme
  */
 export default function useColorScheme(): ColorSchemeName | null {
   return useSyncExternalStore(subscribe, getColorScheme);

--- a/packages/react-native/Libraries/Utilities/useWindowDimensions.js
+++ b/packages/react-native/Libraries/Utilities/useWindowDimensions.js
@@ -15,6 +15,12 @@ import {
 } from './NativeDeviceInfo';
 import {useEffect, useState} from 'react';
 
+/**
+ * React hook that provides the application window's width, height, scale, and
+ * font scale. Automatically updates when screen size or font scale changes.
+ *
+ * @see https://reactnative.dev/docs/usewindowdimensions
+ */
 export default function useWindowDimensions():
   | DisplayMetrics
   | DisplayMetricsAndroid {

--- a/packages/react-native/Libraries/Vibration/Vibration.js
+++ b/packages/react-native/Libraries/Vibration/Vibration.js
@@ -12,12 +12,6 @@ import NativeVibration from './NativeVibration';
 
 const Platform = require('../Utilities/Platform').default;
 
-/**
- * Vibration API
- *
- * See https://reactnative.dev/docs/vibration
- */
-
 let _vibrating: boolean = false;
 let _id: number = 0; // _id is necessary to prevent race condition.
 const _default_vibration_length = 400;
@@ -64,11 +58,21 @@ function vibrateScheduler(
   );
 }
 
+/**
+ * Vibrates the device. On Android, requires the `android.permission.VIBRATE`
+ * permission. On iOS, vibration duration is fixed at approximately 400ms
+ * (implemented via `AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)`).
+ *
+ * @see https://reactnative.dev/docs/vibration
+ */
 const Vibration = {
   /**
-   * Trigger a vibration with specified `pattern`.
+   * Trigger a vibration with the specified `pattern`.
    *
-   * See https://reactnative.dev/docs/vibration#vibrate
+   * The pattern can be a number (duration in ms) or an array of numbers. When
+   * an array is provided on Android, odd indices represent vibration duration
+   * and even indices represent separation time. On iOS, the duration value is
+   * ignored and each vibration lasts approximately 400ms.
    */
   vibrate: function (
     pattern?: number | Array<number> = _default_vibration_length,
@@ -95,10 +99,9 @@ const Vibration = {
       }
     }
   },
+
   /**
-   * Stop vibration
-   *
-   * See https://reactnative.dev/docs/vibration#cancel
+   * Stop vibrating after `vibrate()` was called with repetition enabled.
    */
   cancel: function () {
     if (Platform.OS === 'ios') {


### PR DESCRIPTION
Summary:
**Context**

Strict TypeScript API readiness: High quality inline docs should reach users via TypeScript in their IDEs.

**This diff**

I asked Claude to crawl reactnative.dev and insert JSDoc comments into our core components, based on some manual-pass starting points.

This is also a quality pass on all modules touched, standardising JSDoc use, and in some cases merging/removing redundant information (preferring the docs we’ve maintained more carefully on the website).

**Manual edits**

- `StyleSheet`

Commit 2 of 2 (APIs).

Replaces https://github.com/react/react-native/pull/57380.

Changelog:
[General][Added] - Strict TypeScript API: Component and API doc comment coverage has been significantly improved

Differential Revision: D110195868
