### PR TITLE
Remove what's remaining from InteractionManager

### DIFF
--- a/.github/workflow-scripts/addDescriptiveLabels.js
+++ b/.github/workflow-scripts/addDescriptiveLabels.js
@@ -109,7 +109,6 @@ const apis = [
   'ImageEditor',
   'ImagePickerIOS',
   'ImageStore',
-  'InteractionManager',
   'Keyboard',
   'LayoutAnimation',
   'Linking',

--- a/packages/react-native-babel-preset/src/configs/lazy-imports.js
+++ b/packages/react-native-babel-preset/src/configs/lazy-imports.js
@@ -62,7 +62,6 @@ module.exports = new Set([
   'Easing',
   'ReactNative',
   'I18nManager',
-  'InteractionManager',
   'Keyboard',
   'LayoutAnimation',
   'Linking',

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -27,7 +27,6 @@
 import typeof * as ReactNativePublicAPI from './index.js.flow';
 
 const warnOnce = require('./Libraries/Utilities/warnOnce').default;
-const invariant = require('invariant');
 
 module.exports = {
   // #region Components
@@ -386,21 +385,3 @@ module.exports = {
   },
   // #endregion
 } as ReactNativePublicAPI;
-
-if (__DEV__) {
-  /* $FlowFixMe[prop-missing] This is intentional: Flow will error when
-   * attempting to access InteractionManager. */
-  /* $FlowFixMe[invalid-export] This is intentional: Flow will error when
-   * attempting to access InteractionManager. */
-  Object.defineProperty(module.exports, 'InteractionManager', {
-    configurable: true,
-    get() {
-      invariant(
-        false,
-        'InteractionManager has been removed from react-native core. ' +
-          'Please refactor long tasks into smaller ones, and use ' +
-          "'requestIdleCallback' instead.",
-      );
-    },
-  });
-}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Completes the removal of `InteractionManager`. #57026 removed the public API and left a `__DEV__` invariant stub; this removes that stub (mirroring #57025) along with the now-dead entries in the Babel lazy-imports config and the issue-labeling script. Use `requestIdleCallback` instead.

See https://github.com/react/react-native/issues/57384

## Changelog:

[GENERAL] [REMOVED] - Remove the `InteractionManager` `__DEV__` stub

## Test Plan:

- `yarn flow` and `tsc` pass.
