### PR TITLE
Deprecate DrawerLayoutAndroid

### DIFF
--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -35,8 +35,12 @@ const DRAWER_STATES = ['Idle', 'Dragging', 'Settling'] as const;
 /**
  * React component that wraps the platform `DrawerLayout` (Android only). The Drawer (typically used for navigation) is rendered with `renderNavigationView` and direct children are the main view. The navigation view is initially not visible on the screen, but can be pulled in from the side of the window specified by the `drawerPosition` prop and its width can be set by the `drawerWidth` prop.
  *
- * @see https://reactnative.dev/docs/drawerlayoutandroid
+ * DrawerLayoutAndroid is deprecated and will be removed in a future release.
+ * Use `react-native-drawer-layout` instead.
+ *
+ * @see https://reactnavigation.org/docs/drawer-layout/
  * @platform android
+ * @deprecated
  */
 class DrawerLayoutAndroid
   extends React.Component<DrawerLayoutAndroidProps, DrawerLayoutAndroidState>

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.d.ts
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.d.ts
@@ -21,7 +21,10 @@ export interface DrawerSlideEvent
   extends NativeSyntheticEvent<NativeTouchEvent> {}
 
 /**
- * @see DrawerLayoutAndroid.android.js
+ * DrawerLayoutAndroid is deprecated and will be removed in a future release.
+ * Use `react-native-drawer-layout` instead.
+ * @see https://reactnavigation.org/docs/drawer-layout/
+ * @deprecated
  */
 export interface DrawerLayoutAndroidProps extends ViewProps {
   /**
@@ -123,6 +126,12 @@ interface DrawerPosition {
 declare class DrawerLayoutAndroidComponent extends React.Component<DrawerLayoutAndroidProps> {}
 declare const DrawerLayoutAndroidBase: Constructor<HostInstance> &
   typeof DrawerLayoutAndroidComponent;
+/**
+ * DrawerLayoutAndroid is deprecated and will be removed in a future release.
+ * Use `react-native-drawer-layout` instead.
+ * @see https://reactnavigation.org/docs/drawer-layout/
+ * @deprecated
+ */
 export class DrawerLayoutAndroid extends DrawerLayoutAndroidBase {
   /**
    * drawer's positions.

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
@@ -27,6 +27,12 @@ export type DrawerSlideEvent = NativeSyntheticEvent<
   }>,
 >;
 
+/**
+ * DrawerLayoutAndroid is deprecated and will be removed in a future release.
+ * Use `react-native-drawer-layout` instead.
+ * @see https://reactnavigation.org/docs/drawer-layout/
+ * @deprecated
+ */
 export type DrawerLayoutAndroidProps = Readonly<{
   ...ViewProps,
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -39,6 +39,12 @@ module.exports = {
     return require('./Libraries/Components/Button').default;
   },
   get DrawerLayoutAndroid() {
+    warnOnce(
+      'drawer-layout-android-deprecated',
+      'DrawerLayoutAndroid is deprecated and will be removed in a future release. ' +
+        "Use 'react-native-drawer-layout' instead. " +
+        'See https://reactnavigation.org/docs/drawer-layout/',
+    );
     return require('./Libraries/Components/DrawerAndroid/DrawerLayoutAndroid')
       .default;
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Deprecates `DrawerLayoutAndroid` as part of the effort to keep core lean. It is Android only, and `react-native-drawer-layout` is a better, cross-platform alternative.

This adds a `@deprecated` JSDoc tag to the component and its props (Flow and TypeScript) and a one-time runtime warning when the component is imported, pointing users to `react-native-drawer-layout`. No behavior changes.

## Changelog:

[ANDROID] [DEPRECATED] - Deprecate `DrawerLayoutAndroid`, use `react-native-drawer-layout` instead

## Test Plan:

- `@deprecated` shows a strikethrough on `DrawerLayoutAndroid` in editors.
- Importing/rendering `DrawerLayoutAndroid` logs the deprecation warning once, pointing to `react-native-drawer-layout`.
