### PR TITLE
Skip memcpy when source vector is empty in MapBufferBuilder::build

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -183,11 +183,19 @@ MapBuffer MapBufferBuilder::build() {
 
   std::vector<uint8_t> buffer(bufferSize);
   memcpy(buffer.data(), &header_, headerSize);
-  memcpy(buffer.data() + headerSize, buckets_.data(), bucketSize);
-  memcpy(
-      buffer.data() + headerSize + bucketSize,
-      dynamicData_.data(),
-      dynamicData_.size());
+  // buckets_.data() / dynamicData_.data() return nullptr when the vector is
+  // empty; passing nullptr to memcpy is UB even with size 0 (glibc marks the
+  // src argument nonnull) and trips UBSan halt-on-error on empty / scalar-only
+  // MapBuffers.
+  if (!buckets_.empty()) {
+    memcpy(buffer.data() + headerSize, buckets_.data(), bucketSize);
+  }
+  if (!dynamicData_.empty()) {
+    memcpy(
+        buffer.data() + headerSize + bucketSize,
+        dynamicData_.data(),
+        dynamicData_.size());
+  }
 
   return MapBuffer(std::move(buffer));
 }


### PR DESCRIPTION
Summary:
`buckets_.data()` and `dynamicData_.data()` return `nullptr` when the vector is empty, and glibc marks `memcpy`'s src argument as `nonnull`. Passing `nullptr` is UB even with a size of 0, which trips UBSan halt-on-error on any MapBuffer that has no buckets (`EMPTY()`) or no dynamic-data entries (scalar-only maps). Guard both memcpys with an empty check.

Changelog:
[General][Fixed] - Avoid `memcpy(_, nullptr, 0)` UB in `MapBufferBuilder::build` for empty / scalar-only MapBuffers

Reviewed By: cortinico

Differential Revision: D110316404


