### PR TITLE
fix(ios): perf issues w/ image masks

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -31,7 +31,6 @@ using namespace facebook::react;
     _props = defaultProps;
 
     _imageView = [RCTUIImageViewAnimated new];
-    _imageView.clipsToBounds = YES;
     _imageView.contentMode = RCTContentModeFromImageResizeMode(defaultProps->resizeMode);
     _imageView.layer.minificationFilter = kCAFilterTrilinear;
     _imageView.layer.magnificationFilter = kCAFilterTrilinear;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -995,6 +995,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   }
 
   const auto borderMetrics = _props->resolveBorderMetrics(_layoutMetrics);
+  BOOL const borderRadiiCircular = areBorderRadiiCircular(borderMetrics.borderRadii);
 
   // Stage 1. Shadow Path
   BOOL const layerHasShadow = layer.shadowOpacity > 0 && CGColorGetAlpha(layer.shadowColor) > 0;
@@ -1044,7 +1045,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   const bool useCoreAnimationBorderRendering =
       borderMetrics.borderColors.isUniform() && borderMetrics.borderWidths.isUniform() &&
       borderMetrics.borderStyles.isUniform() && borderMetrics.borderStyles.left == BorderStyle::Solid &&
-      areBorderRadiiCircular(borderMetrics.borderRadii) &&
+      borderRadiiCircular &&
       (
           // iOS draws borders in front of the content whereas CSS draws them behind
           // the content. For this reason, only use iOS border drawing when clipping
@@ -1126,7 +1127,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _outlineLayer.frame = CGRectInset(
         layer.bounds, -_props->outlineOffset - _props->outlineWidth, -_props->outlineOffset - _props->outlineWidth);
 
-    if (areBorderRadiiCircular(borderMetrics.borderRadii) && borderMetrics.borderRadii.topLeft.horizontal == 0) {
+    if (borderRadiiCircular && borderMetrics.borderRadii.topLeft.horizontal == 0) {
       UIColor *outlineColor = RCTUIColorFromSharedColor(_props->outlineColor);
       _outlineLayer.borderWidth = _props->outlineWidth;
       _outlineLayer.borderColor = outlineColor.CGColor;
@@ -1302,7 +1303,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   if (self.currentContainerView.clipsToBounds) {
     BOOL clipToPaddingBox = ReactNativeFeatureFlags::enableIOSViewClipToPaddingBox();
     if (!clipToPaddingBox) {
-      if (areBorderRadiiCircular(borderMetrics.borderRadii)) {
+      if (borderRadiiCircular) {
         self.currentContainerView.layer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
       } else {
         CALayer *maskLayer =
@@ -1312,20 +1313,26 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
         self.currentContainerView.layer.mask = maskLayer;
       }
 
-      for (UIView *subview in self.currentContainerView.subviews) {
-        if ([subview isKindOfClass:[UIImageView class]]) {
-          RCTCornerInsets cornerInsets = RCTGetCornerInsets(
-              RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
-              RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths));
+      if (!borderRadiiCircular &&
+          (borderMetrics.borderColors.left || borderMetrics.borderColors.right || borderMetrics.borderColors.top ||
+           borderMetrics.borderColors.bottom)) {
+        for (UIView *subview in self.currentContainerView.subviews) {
+          if ([subview isKindOfClass:[UIImageView class]]) {
+            RCTCornerInsets cornerInsets = RCTGetCornerInsets(
+                RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
+                RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths));
 
-          // If the subview is an image view, we have to apply the mask directly to the image view's layer,
-          // otherwise the image might overflow with the border radius.
-          subview.layer.mask = [self createMaskLayer:subview.bounds cornerInsets:cornerInsets];
+            // If the subview is an image view, we have to apply the mask directly to the image view's layer,
+            // otherwise the image might overflow with the border radius.
+            // Applying a mask is rendering wise expensive so we only apply it when needed, which is only
+            // for none uniform border radii (that are actually visible by color).
+            subview.layer.mask = [self createMaskLayer:subview.bounds cornerInsets:cornerInsets];
+          }
         }
       }
     } else if (
         !borderMetrics.borderWidths.isUniform() || borderMetrics.borderWidths.left != 0 ||
-        !areBorderRadiiCircular(borderMetrics.borderRadii)) {
+        !borderRadiiCircular) {
       CALayer *maskLayer = [self createMaskLayer:RCTCGRectFromRect(_layoutMetrics.getPaddingFrame())
                                     cornerInsets:RCTGetCornerInsets(
                                                      RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -1051,6 +1051,13 @@ const styles = StyleSheet.create({
   flex: {
     flex: 1,
   },
+  imageWithUniformButNoneCircularBorderRadius: {
+    width: 200,
+    height: 100,
+    borderRadius: '50%',
+    borderWidth: 4,
+    borderColor: 'blue',
+  },
   imageWithBorderRadius: {
     borderRadius: 5,
   },
@@ -1420,6 +1427,10 @@ exports.examples = [
     render: function (): React.Node {
       return (
         <View style={styles.horizontal} testID="border-radius-example">
+          <Image
+            style={styles.imageWithUniformButNoneCircularBorderRadius}
+            source={fullImage}
+          />
           <Image
             style={[styles.base, styles.imageWithBorderRadius]}
             source={fullImage}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Two years ago, in this PR:

- https://github.com/react/react-native/pull/45973 

a fix for this issue was introduced:

- https://github.com/facebook/react-native/issues/45958

This fix can cause performance issues as we are applying a mask which is rendering wise a heavy operation, often causing the rendering phase to do multiple offscreen draw passes.
We noticed this to a considerable, measure-able effect in the discord app.

This specific case for `UIImageViews`:

https://github.com/react/react-native/blob/4aef2b0126c22ab386c970a84d61a9ef2c4b3ddd/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm#L1316-L1323

is really only needed when:

- We actually draw a visible border (ie it has a color)
- the border is not uniform and not circular 

The reason we need this handling is for content to not draw over the border like this:

<img width="422" height="110" alt="Screenshot 2026-07-01 at 15 08 45" src="https://github.com/user-attachments/assets/cc482e9f-10b6-4d9b-b372-b20c17451ba9" />


However, when the user just wants to add a border radius (e.g. `borderRadius: 10`), applying a mask is not needed. The image will be correctly "cut out" by the parent `RCTViewComponentView` applying the `cornerRadius`, which is much better performance wise.

Hence my fix here is to simply disable this special handling when its not needed.

### The performance gain

<details>
<summary>
Code for `RNTesterPlayground.js`
</summary>

```jsx
import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
import type {ImageSource, ListRenderItemInfo} from 'react-native';

import RNTesterText from '../../components/RNTesterText';
import * as React from 'react';
import {FlatList, Image, StyleSheet, View} from 'react-native';

type AvatarItem = Readonly<{
  id: string,
  source: ImageSource,
}>;

const IMAGE_COUNT = 10_000;
const NUM_COLUMNS = 12;
const IMAGE_SOURCES: ReadonlyArray<ImageSource> = [
  require('../../assets/bunny.png'),
  require('../../assets/hawk.png'),
  require('../../assets/rubber-ducky.png'),
  require('../../assets/flowers.png'),
];

function createAvatarItem(index: number): AvatarItem {
  const id = `rn-tester-${index}`;
  const source = IMAGE_SOURCES[index % IMAGE_SOURCES.length];

  return {
    id,
    source,
  };
}

function createAvatarItems(): ReadonlyArray<AvatarItem> {
  const avatars: Array<AvatarItem> = [];

  for (let index = 0; index < IMAGE_COUNT; index++) {
    const avatar = createAvatarItem(index);
    avatars.push(avatar);
  }

  return avatars;
}

const AVATARS = createAvatarItems();

function renderAvatarItem({item}: ListRenderItemInfo<AvatarItem>): React.Node {
  return (
    <View style={styles.imageCell}>
      <Image source={item.source} style={styles.image} />
    </View>
  );
}

function Playground() {
  return (
    <View style={styles.container}>
      <RNTesterText>
        Local image grid for measuring Image clipping performance.
      </RNTesterText>
      <FlatList
        contentContainerStyle={styles.listContent}
        data={AVATARS}
        initialNumToRender={NUM_COLUMNS * 4}
        keyExtractor={item => item.id}
        maxToRenderPerBatch={NUM_COLUMNS * 4}
        numColumns={NUM_COLUMNS}
        renderItem={renderAvatarItem}
        style={styles.list}
        windowSize={5}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    padding: 10,
  },
  image: {
    height: '100%',
    width: '100%',
    borderRadius: 4,
    backgroundColor: '#eee',
  },
  imageCell: {
    aspectRatio: 1,
    backgroundColor: '#eee',
    flex: 1,
    margin: 2,
  },
  list: {
    flex: 1,
  },
  listContent: {
    paddingTop: 10,
  },
});

export default {
  title: 'Playground',
  name: 'playground',
  description: 'Test out new features and ideas.',
  render: (): React.Node => <Playground />,
} as RNTesterModuleExample;

```

</details>

I created an example case where we render a list of images that have `borderRadius: 4` and scrolled it for a bit and performance profiled it using the xcode instruments:

<img width="3238" height="1325" alt="Screenshot 2026-07-01 at 15 21 24" src="https://github.com/user-attachments/assets/281921ab-1c0f-4e6b-8372-9d032a0131cb" />


Here are the differences when it comes to render & offscreen passes, as well as CPU and GPU usage:

metric | before | after fix | delta
-- | -- | -- | --
hitches | 52 | 7 | -86.5%
hitch time total | 600ms | 88ms | -85.4%
hitches > 16.67ms | 14 | 0 | eliminated
render rows | 970 | 1221 | +25.9%¹
render rows/sec | 69.7/s | 81.0/s | +16.2%
avg render duration | 11.77ms | 6.31ms | -46.4%
p95 render duration | 13.79ms | 11.21ms | -18.7%
render rows > 8.33ms | 966 | 384 | -60.2%
render rows > 16.67ms | 5 | 0 | eliminated
total render work | 11.41s | 7.71s | -32.5%
total offscreen passes | 253,442 | 1,221 | -99.5%
avg offscreen/render | 261.3 | 1.0 | -99.6%
render rows with >100 offscreen passes | 966 | 0 | eliminated
avg GPU duration | 10.17ms | 1.22ms | -88.0%
GPU rows > 8.33ms | 763 | 0 | eliminated
total GPU work | 8.18s | 1.48s | -81.9%
avg update commit | 0.73ms | 0.52ms | -28.7%
p95 update commit | 2.49ms | 1.54ms | -38.2%
avg CPU | 65.8% | 58.5% | -7.3pp
weighted avg FPS | 53.5 | 60.0 | +6.5 FPS²
avg GPU/device utilization | 51.8% | 15.7% | -36.1pp

> 1. We are able to render more in the same 15s time frame
> 2. The profiling tool only records up to 60 fps it seems

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Performance: don't unnecessarily apply masks to `UIImageView`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

In RNTester, where i added two new example cases for image borders, you can verify that the border radii examples are still working as expected:


<img width="603" height="1311" alt="Screenshot 2026-07-01 at 15 38 00" src="https://github.com/user-attachments/assets/0615d5be-c34f-47d4-a967-8f645c28b5ad" />
