### PR TITLE
Deprecate InputAccessoryView

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.d.ts
@@ -17,9 +17,16 @@ import {ViewStyle} from '../../StyleSheet/StyleSheetTypes';
  *
  * To use this component wrap your custom toolbar with the InputAccessoryView component, and set a nativeID. Then, pass
  * that nativeID as the inputAccessoryViewID of whatever TextInput you desire.
+ *
+ * InputAccessoryView is deprecated and will be removed in a future release.
+ * @deprecated
  */
 export class InputAccessoryView extends React.Component<InputAccessoryViewProps> {}
 
+/**
+ * InputAccessoryView is deprecated and will be removed in a future release.
+ * @deprecated
+ */
 export interface InputAccessoryViewProps {
   backgroundColor?: ColorValue | undefined;
 

--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
@@ -18,6 +18,10 @@ import useWindowDimensions from '../../Utilities/useWindowDimensions';
 import RCTInputAccessoryViewNativeComponent from './RCTInputAccessoryViewNativeComponent';
 import * as React from 'react';
 
+/**
+ * InputAccessoryView is deprecated and will be removed in a future release.
+ * @deprecated
+ */
 /** @build-types emit-as-interface Expo compatibility */
 export type InputAccessoryViewProps = Readonly<{
   readonly children: React.Node,
@@ -36,8 +40,10 @@ export type InputAccessoryViewProps = Readonly<{
  *
  * This component can also be used to create sticky text inputs (text inputs which are anchored to the top of the keyboard). To do this, wrap a `TextInput` with `InputAccessoryView` and don't set a `nativeID`.
  *
- * @see https://reactnative.dev/docs/inputaccessoryview
+ * InputAccessoryView is deprecated and will be removed in a future release.
+ *
  * @platform ios
+ * @deprecated
  */
 const InputAccessoryView: React.ComponentType<InputAccessoryViewProps> = (
   props: InputAccessoryViewProps,

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -55,6 +55,10 @@ module.exports = {
     return require('./Libraries/Image/ImageBackground').default;
   },
   get InputAccessoryView() {
+    warnOnce(
+      'input-accessory-view-deprecated',
+      'InputAccessoryView is deprecated and will be removed in a future release.',
+    );
     return require('./Libraries/Components/TextInput/InputAccessoryView')
       .default;
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Deprecates `InputAccessoryView` as part of the effort to keep core lean. It is iOS only, and `react-native-keyboard-controller` [`KeyboardStickyView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-sticky-view) is a better, cross-platform alternative.

This adds a `@deprecated` JSDoc tag to the component and its props (Flow and TypeScript) and a one-time runtime warning when the component is imported. No behavior changes.

## Changelog:

[ANDROID] [DEPRECATED] - Deprecate `InputAccessoryView`

## Test Plan:

- `@deprecated` shows a strikethrough on `InputAccessoryView` in editors.
- Importing/rendering `InputAccessoryView` logs the deprecation warning once.
