### PR TITLE
Guard deferred Fabric surface start against concurrent unregister (#57404)

### DIFF
--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -105,6 +105,12 @@ using namespace facebook::react;
     [self->_surfacePresenter.mountingManager attachSurfaceToView:self.view
                                                        surfaceId:self->_surfaceHandler->getSurfaceId()];
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
+      // This runs two async hops later; a concurrent instance teardown/reload may have unregistered
+      // the surface since the check in -start. Without this re-check SurfaceHandler::start()
+      // dereferences a now-null uiManager.
+      if (self->_surfaceHandler->getStatus() != SurfaceHandler::Status::Registered) {
+        return;
+      }
       self->_surfaceHandler->start();
       [self _propagateStageChange];
 


### PR DESCRIPTION
Summary:

`-[RCTFabricSurface start]` defers `SurfaceHandler::start()` across two async hops after its synchronous `Registered` check. If a concurrent `RCTInstance` teardown unregisters the surface in that window, the deferred `start()` dereferences a now-null `link_.uiManager` — debug aborts on the `react_native_assert`, release null-derefs. It is a TOCTOU: `-[RCTInstance invalidate]` tears down asynchronously on the JS thread with no completion signal, so an app-layer barrier cannot order against it — the start path itself must tolerate a concurrently-unregistered surface.

Fix: re-check `getStatus() == Registered` inside the deferred block before calling `start()`. Behavior-preserving on the success path; only the already-broken unregistered case changes from crash to a cancelled start.

Scope: iOS only. A companion cross-platform guard in `SurfaceHandler::start()` (return + `LOG(ERROR)` instead of the dev-fatal/release-compiled-out assert) would close the residual window between the re-check and `start()` atomically; left out to keep this iOS-only — happy to add if reviewers prefer. Flagging for code-owner review since this is core surface-start code.

Repro: an in-process React host teardown + rebuild that unregisters a surface while its deferred start is still queued.

Changelog: [iOS][Fixed] - Cancel a deferred Fabric surface start when the surface was unregistered by a concurrent instance teardown, instead of dereferencing a null UIManager

Differential Revision: D109477868


