### PR TITLE
Fix debugOptimized DevSettingsActivity manifest

### DIFF
--- a/packages/react-native/ReactAndroid/src/debugOptimized/AndroidManifest.xml
+++ b/packages/react-native/ReactAndroid/src/debugOptimized/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <!--
+    debugOptimized keeps JS debugging and DevSupport enabled while using
+    optimized native code. Keep this manifest in sync with the debug
+    DevSupport manifest so debug-only DevSupport components remain available.
+   -->
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+  <!--
+    On Android 17 (SDK 37) devices, apps that declare this must hold ACCESS_LOCAL_NETWORK
+    to reach the dev server over the local network. Loopback via `adb reverse` is exempt.
+   -->
+  <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK"/>
+
+  <application>
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"
+              android:exported="false" />
+  </application>
+
+</manifest>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes #57396.

`debugOptimized` builds still expose the React Native Dev Menu `Settings` item, but `DevSettingsActivity` was only declared in the `debug` manifest. This caused `Settings` to crash in `debugOptimized` with `ActivityNotFoundException`.

This adds a `debugOptimized` manifest matching the existing debug dev-support manifest, so `DevSettingsActivity` is declared for that build type.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Fix Dev Menu Settings crash in debugOptimized builds

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Verified with RNTester debugOptimized:

``` sh
yarn install --frozen-lockfile
yarn start
./gradlew :packages:rn-tester:android:app:installDebugOptimized -PreactNativeArchitectures=arm64-v8a
```
then shake and tap `Settings`, confirm that Debug Settings opens instead of crashing.
