### PR TITLE
Run AnimationBackend commit hook on ReactRevisionMerge commits (#57410)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.cpp
@@ -24,7 +24,8 @@ RootShadowNode::Unshared AnimationBackendCommitHook::shadowTreeWillCommit(
     const RootShadowNode::Unshared& newRootShadowNode,
     const ShadowTreeCommitOptions& commitOptions) noexcept {
   if (commitOptions.source != ShadowTreeCommitSource::React &&
-      commitOptions.source != ShadowTreeCommitSource::AnimationEndSync) {
+      commitOptions.source != ShadowTreeCommitSource::AnimationEndSync &&
+      commitOptions.source != ShadowTreeCommitSource::ReactRevisionMerge) {
     return newRootShadowNode;
   }
 


### PR DESCRIPTION
Summary:

`AnimationBackendCommitHook` reconciles animated props during React commits to prevent React from overwriting animation-driven prop updates. Commits with source `ReactRevisionMerge` were being excluded, which currently was not a problem, because this source is only used with fabricCommitBranching which is currently disabled.

Changelog:
[General][Fixed] - Add `ReactRevisionMerge` source to the AnimationBackendCommitHook

Reviewed By: rubennorte

Differential Revision: D110459778


