### PR TITLE
Deprecate ImageBackground

### DIFF
--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -47,7 +47,11 @@ export type {ImageBackgroundProps} from './ImageProps';
  * });
  * ```
  *
+ * ImageBackground is deprecated and will be removed in a future release.
+ * Use a `View` with an absolutely positioned `Image` instead.
+ *
  * @see https://reactnative.dev/docs/imagebackground
+ * @deprecated
  */
 class ImageBackground extends React.Component<ImageBackgroundProps> {
   setNativeProps(props: {...}) {

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -338,7 +338,13 @@ export type ImageProps = Readonly<{
   style?: ?ImageStyleProp,
 }>;
 
-/** @build-types emit-as-interface Uniwind compatibility */
+/**
+ * ImageBackground is deprecated and will be removed in a future release.
+ * Use a `View` with an absolutely positioned `Image` instead.
+ * @see https://reactnative.dev/docs/imagebackground
+ * @deprecated
+ * @build-types emit-as-interface Uniwind compatibility
+ */
 export type ImageBackgroundProps = Readonly<{
   ...ImageProps,
   children?: React.Node,

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -62,7 +62,18 @@ module.exports = {
   get Image() {
     return require('./Libraries/Image/Image').default;
   },
+  /**
+   * @deprecated ImageBackground is deprecated and will be removed in a future release.
+   * Use a View with an absolutely positioned Image instead.
+   * See https://reactnative.dev/docs/imagebackground
+   */
   get ImageBackground() {
+    warnOnce(
+      'image-background-deprecated',
+      'ImageBackground is deprecated and will be removed in a future release. ' +
+        'Use a View with an absolutely positioned Image instead. ' +
+        'See https://reactnative.dev/docs/imagebackground',
+    );
     return require('./Libraries/Image/ImageBackground').default;
   },
   get InputAccessoryView() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Deprecates `ImageBackground` as part of the effort to keep core lean. It is a thin wrapper around a `View` and an `Image`, and can easily be replaced by composing a `View` with an absolutely positioned `Image` and layering children on top:

```tsx
import type { ReactNode, Ref } from "react";
import {
  Image,
  StyleSheet,
  View,
  type ImageProps,
  type ViewProps,
} from "react-native";

type ImageBackgroundProps = Omit<ImageProps, "style"> & {
  children?: ReactNode;
  ref?: Ref<View>;
  style?: ViewProps["style"];
};

export const ImageBackground = ({
  children,
  importantForAccessibility,
  ref,
  style,
  ...props
}: ImageBackgroundProps) => {
  const { height, width } = StyleSheet.flatten(style);

  return (
    <View
      ref={ref}
      accessibilityIgnoresInvertColors={true}
      importantForAccessibility={importantForAccessibility}
      style={style}
    >
      <Image
        {...props}
        importantForAccessibility={importantForAccessibility}
        style={[StyleSheet.absoluteFill, { height, width }]}
      />
      {children}
    </View>
  );
};
```

## Changelog:

[GENERAL] [DEPRECATED] - Deprecate `ImageBackground`, use a `View` with an absolutely positioned `Image` instead

## Test Plan:

- `deprecated` shows a strikethrough on `ImageBackground` in editors.
- Importing/rendering `ImageBackground` logs the deprecation warning once.