### PR TITLE
fix(ios): perf issues border masks

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -31,7 +31,6 @@ using namespace facebook::react;
     _props = defaultProps;
 
     _imageView = [RCTUIImageViewAnimated new];
-    _imageView.clipsToBounds = YES;
     _imageView.contentMode = RCTContentModeFromImageResizeMode(defaultProps->resizeMode);
     _imageView.layer.minificationFilter = kCAFilterTrilinear;
     _imageView.layer.magnificationFilter = kCAFilterTrilinear;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -11,6 +11,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <QuartzCore/QuartzCore.h>
 #import <objc/runtime.h>
+#import <optional>
 #import <ranges>
 
 #import <RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.h>
@@ -19,6 +20,7 @@
 #import <React/RCTBorderDrawing.h>
 #import <React/RCTBoxShadow.h>
 #import <React/RCTConversions.h>
+#import <React/RCTLayerCornerConfiguration.h>
 #import <React/RCTLinearGradient.h>
 #import <React/RCTLocalizedString.h>
 #import <React/RCTRadialGradient.h>
@@ -855,110 +857,6 @@ static RCTBorderColors RCTCreateRCTBorderColorsFromBorderColors(BorderColors bor
       .right = RCTUIColorFromSharedColor(borderColors.right)};
 }
 
-static CALayerCornerCurve CornerCurveFromBorderCurve(BorderCurve borderCurve)
-{
-  // The constants are available only starting from iOS 13
-  // CALayerCornerCurve is a typealias on NSString *
-  switch (borderCurve) {
-    case BorderCurve::Continuous:
-      return @"continuous"; // kCACornerCurveContinuous;
-    case BorderCurve::Circular:
-      return @"circular"; // kCACornerCurveCircular;
-  }
-}
-
-struct RCTLayerCornerConfiguration {
-  CGFloat cornerRadius{0};
-  CACornerMask maskedCorners{0};
-  BorderCurve cornerCurve{BorderCurve::Circular};
-  bool hasRoundedCorner{false};
-};
-
-static bool RCTUpdateLayerCornerConfiguration(
-    const CornerRadii &cornerRadii,
-    BorderCurve cornerCurve,
-    CACornerMask cornerMask,
-    RCTLayerCornerConfiguration &cornerConfiguration)
-{
-  if (cornerRadii.horizontal != cornerRadii.vertical) {
-    return false;
-  }
-
-  if (cornerRadii.horizontal == 0) {
-    return true;
-  }
-
-  CGFloat cornerRadius = (CGFloat)cornerRadii.horizontal;
-  if (cornerConfiguration.hasRoundedCorner) {
-    if (cornerConfiguration.cornerRadius != cornerRadius) {
-      return false;
-    }
-
-    if (cornerConfiguration.cornerCurve != cornerCurve) {
-      return false;
-    }
-  } else {
-    cornerConfiguration.cornerRadius = cornerRadius;
-    cornerConfiguration.cornerCurve = cornerCurve;
-    cornerConfiguration.hasRoundedCorner = true;
-  }
-
-  cornerConfiguration.maskedCorners |= cornerMask;
-  return true;
-}
-
-static bool RCTGetLayerCornerConfiguration(
-    const BorderMetrics &borderMetrics,
-    RCTLayerCornerConfiguration &cornerConfiguration)
-{
-  cornerConfiguration = RCTLayerCornerConfiguration{};
-
-  bool topLeftIsRepresentable = RCTUpdateLayerCornerConfiguration(
-      borderMetrics.borderRadii.topLeft,
-      borderMetrics.borderCurves.topLeft,
-      kCALayerMinXMinYCorner,
-      cornerConfiguration);
-  if (!topLeftIsRepresentable) {
-    return false;
-  }
-
-  bool topRightIsRepresentable = RCTUpdateLayerCornerConfiguration(
-      borderMetrics.borderRadii.topRight,
-      borderMetrics.borderCurves.topRight,
-      kCALayerMaxXMinYCorner,
-      cornerConfiguration);
-  if (!topRightIsRepresentable) {
-    return false;
-  }
-
-  bool bottomLeftIsRepresentable = RCTUpdateLayerCornerConfiguration(
-      borderMetrics.borderRadii.bottomLeft,
-      borderMetrics.borderCurves.bottomLeft,
-      kCALayerMinXMaxYCorner,
-      cornerConfiguration);
-  if (!bottomLeftIsRepresentable) {
-    return false;
-  }
-
-  bool bottomRightIsRepresentable = RCTUpdateLayerCornerConfiguration(
-      borderMetrics.borderRadii.bottomRight,
-      borderMetrics.borderCurves.bottomRight,
-      kCALayerMaxXMaxYCorner,
-      cornerConfiguration);
-  if (!bottomRightIsRepresentable) {
-    return false;
-  }
-
-  if (!cornerConfiguration.hasRoundedCorner) {
-    cornerConfiguration.maskedCorners = kCALayerMinXMinYCorner
-                                        | kCALayerMaxXMinYCorner
-                                        | kCALayerMinXMaxYCorner
-                                        | kCALayerMaxXMaxYCorner;
-  }
-
-  return true;
-}
-
 static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 {
   switch (borderStyle) {
@@ -1134,8 +1032,9 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   }
 #endif
 
-  RCTLayerCornerConfiguration layerCornerConfiguration;
-  const bool layerCornersAreRepresentable = RCTGetLayerCornerConfiguration(borderMetrics, layerCornerConfiguration);
+  const std::optional<RCTLayerCornerConfiguration> layerCornerConfiguration =
+      RCTGetLayerCornerConfiguration(borderMetrics);
+  const bool layerCornersAreRepresentable = layerCornerConfiguration.has_value();
 
   const bool useCoreAnimationBorderRendering =
       borderMetrics.borderColors.isUniform() && borderMetrics.borderWidths.isUniform() &&
@@ -1181,9 +1080,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     layer.borderWidth = (CGFloat)borderMetrics.borderWidths.left;
     UIColor *borderColor = RCTUIColorFromSharedColor(borderMetrics.borderColors.left);
     layer.borderColor = borderColor.CGColor;
-    layer.cornerRadius = layerCornerConfiguration.cornerRadius;
-    layer.maskedCorners = layerCornerConfiguration.maskedCorners;
-    layer.cornerCurve = CornerCurveFromBorderCurve(layerCornerConfiguration.cornerCurve);
+    RCTApplyLayerCornerConfiguration(layer, *layerCornerConfiguration);
   } else {
     if (!_borderLayer) {
       CALayer *borderLayer = [CALayer new];
@@ -1223,7 +1120,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _outlineLayer.frame = CGRectInset(
         layer.bounds, -_props->outlineOffset - _props->outlineWidth, -_props->outlineOffset - _props->outlineWidth);
 
-    if (layerCornersAreRepresentable && layerCornerConfiguration.cornerRadius == 0) {
+    if (layerCornersAreRepresentable && layerCornerConfiguration->cornerRadius == 0) {
       UIColor *outlineColor = RCTUIColorFromSharedColor(_props->outlineColor);
       _outlineLayer.borderWidth = _props->outlineWidth;
       _outlineLayer.borderColor = outlineColor.CGColor;
@@ -1401,9 +1298,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     BOOL clipToPaddingBox = ReactNativeFeatureFlags::enableIOSViewClipToPaddingBox();
     if (!clipToPaddingBox) {
       if (layerCornersAreRepresentable) {
-        currentContainerView.layer.cornerRadius = layerCornerConfiguration.cornerRadius;
-        currentContainerView.layer.maskedCorners = layerCornerConfiguration.maskedCorners;
-        currentContainerView.layer.cornerCurve = CornerCurveFromBorderCurve(layerCornerConfiguration.cornerCurve);
+        RCTApplyLayerCornerConfiguration(currentContainerView.layer, *layerCornerConfiguration);
       } else {
         CALayer *maskLayer =
             [self createMaskLayer:self.bounds
@@ -1439,9 +1334,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
                                                      RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths))];
       currentContainerView.layer.mask = maskLayer;
     } else {
-      currentContainerView.layer.cornerRadius = layerCornerConfiguration.cornerRadius;
-      currentContainerView.layer.maskedCorners = layerCornerConfiguration.maskedCorners;
-      currentContainerView.layer.cornerCurve = CornerCurveFromBorderCurve(layerCornerConfiguration.cornerCurve);
+      RCTApplyLayerCornerConfiguration(currentContainerView.layer, *layerCornerConfiguration);
     }
   }
 }
@@ -1453,13 +1346,9 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   // Bounds is needed here to account for scaling transforms properly and ensure
   // we do not scale twice
   layer.frame = CGRectMake(0, 0, self.layer.bounds.size.width, self.layer.bounds.size.height);
-  RCTLayerCornerConfiguration cornerConfiguration;
-  const bool cornersAreRepresentable = RCTGetLayerCornerConfiguration(borderMetrics, cornerConfiguration);
-  if (cornersAreRepresentable) {
+  if (const auto cornerConfiguration = RCTGetLayerCornerConfiguration(borderMetrics)) {
     layer.mask = nil;
-    layer.cornerRadius = cornerConfiguration.cornerRadius;
-    layer.maskedCorners = cornerConfiguration.maskedCorners;
-    layer.cornerCurve = CornerCurveFromBorderCurve(cornerConfiguration.cornerCurve);
+    RCTApplyLayerCornerConfiguration(layer, *cornerConfiguration);
   } else {
     CAShapeLayer *maskLayer = [self
         createMaskLayer:self.bounds

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -995,6 +995,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   }
 
   const auto borderMetrics = _props->resolveBorderMetrics(_layoutMetrics);
+  BOOL const borderRadiiCircular = areBorderRadiiCircular(borderMetrics.borderRadii);
 
   // Stage 1. Shadow Path
   BOOL const layerHasShadow = layer.shadowOpacity > 0 && CGColorGetAlpha(layer.shadowColor) > 0;
@@ -1044,7 +1045,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   const bool useCoreAnimationBorderRendering =
       borderMetrics.borderColors.isUniform() && borderMetrics.borderWidths.isUniform() &&
       borderMetrics.borderStyles.isUniform() && borderMetrics.borderStyles.left == BorderStyle::Solid &&
-      areBorderRadiiCircular(borderMetrics.borderRadii) &&
+      borderRadiiCircular &&
       (
           // iOS draws borders in front of the content whereas CSS draws them behind
           // the content. For this reason, only use iOS border drawing when clipping
@@ -1126,7 +1127,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _outlineLayer.frame = CGRectInset(
         layer.bounds, -_props->outlineOffset - _props->outlineWidth, -_props->outlineOffset - _props->outlineWidth);
 
-    if (areBorderRadiiCircular(borderMetrics.borderRadii) && borderMetrics.borderRadii.topLeft.horizontal == 0) {
+    if (borderRadiiCircular && borderMetrics.borderRadii.topLeft.horizontal == 0) {
       UIColor *outlineColor = RCTUIColorFromSharedColor(_props->outlineColor);
       _outlineLayer.borderWidth = _props->outlineWidth;
       _outlineLayer.borderColor = outlineColor.CGColor;
@@ -1302,7 +1303,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   if (self.currentContainerView.clipsToBounds) {
     BOOL clipToPaddingBox = ReactNativeFeatureFlags::enableIOSViewClipToPaddingBox();
     if (!clipToPaddingBox) {
-      if (areBorderRadiiCircular(borderMetrics.borderRadii)) {
+      if (borderRadiiCircular) {
         self.currentContainerView.layer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
       } else {
         CALayer *maskLayer =
@@ -1312,20 +1313,26 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
         self.currentContainerView.layer.mask = maskLayer;
       }
 
-      for (UIView *subview in self.currentContainerView.subviews) {
-        if ([subview isKindOfClass:[UIImageView class]]) {
-          RCTCornerInsets cornerInsets = RCTGetCornerInsets(
-              RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
-              RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths));
+      if (!borderRadiiCircular &&
+          (borderMetrics.borderColors.left || borderMetrics.borderColors.right || borderMetrics.borderColors.top ||
+           borderMetrics.borderColors.bottom)) {
+        for (UIView *subview in self.currentContainerView.subviews) {
+          if ([subview isKindOfClass:[UIImageView class]]) {
+            RCTCornerInsets cornerInsets = RCTGetCornerInsets(
+                RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
+                RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths));
 
-          // If the subview is an image view, we have to apply the mask directly to the image view's layer,
-          // otherwise the image might overflow with the border radius.
-          subview.layer.mask = [self createMaskLayer:subview.bounds cornerInsets:cornerInsets];
+            // If the subview is an image view, we have to apply the mask directly to the image view's layer,
+            // otherwise the image might overflow with the border radius.
+            // Applying a mask is rendering wise expensive so we only apply it when needed, which is only
+            // for none uniform border radii (that are actually visible by color).
+            subview.layer.mask = [self createMaskLayer:subview.bounds cornerInsets:cornerInsets];
+          }
         }
       }
     } else if (
         !borderMetrics.borderWidths.isUniform() || borderMetrics.borderWidths.left != 0 ||
-        !areBorderRadiiCircular(borderMetrics.borderRadii)) {
+        !borderRadiiCircular) {
       CALayer *maskLayer = [self createMaskLayer:RCTCGRectFromRect(_layoutMetrics.getPaddingFrame())
                                     cornerInsets:RCTGetCornerInsets(
                                                      RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -867,6 +867,98 @@ static CALayerCornerCurve CornerCurveFromBorderCurve(BorderCurve borderCurve)
   }
 }
 
+struct RCTLayerCornerConfiguration {
+  CGFloat cornerRadius{0};
+  CACornerMask maskedCorners{0};
+  BorderCurve cornerCurve{BorderCurve::Circular};
+  bool hasRoundedCorner{false};
+};
+
+static bool RCTUpdateLayerCornerConfiguration(
+    const CornerRadii &cornerRadii,
+    BorderCurve cornerCurve,
+    CACornerMask cornerMask,
+    RCTLayerCornerConfiguration &cornerConfiguration)
+{
+  if (cornerRadii.horizontal != cornerRadii.vertical) {
+    return false;
+  }
+
+  if (cornerRadii.horizontal == 0) {
+    return true;
+  }
+
+  CGFloat cornerRadius = (CGFloat)cornerRadii.horizontal;
+  if (cornerConfiguration.hasRoundedCorner) {
+    if (cornerConfiguration.cornerRadius != cornerRadius) {
+      return false;
+    }
+
+    if (cornerConfiguration.cornerCurve != cornerCurve) {
+      return false;
+    }
+  } else {
+    cornerConfiguration.cornerRadius = cornerRadius;
+    cornerConfiguration.cornerCurve = cornerCurve;
+    cornerConfiguration.hasRoundedCorner = true;
+  }
+
+  cornerConfiguration.maskedCorners |= cornerMask;
+  return true;
+}
+
+static bool RCTGetLayerCornerConfiguration(
+    const BorderMetrics &borderMetrics,
+    RCTLayerCornerConfiguration &cornerConfiguration)
+{
+  cornerConfiguration = RCTLayerCornerConfiguration{};
+
+  bool topLeftIsRepresentable = RCTUpdateLayerCornerConfiguration(
+      borderMetrics.borderRadii.topLeft,
+      borderMetrics.borderCurves.topLeft,
+      kCALayerMinXMinYCorner,
+      cornerConfiguration);
+  if (!topLeftIsRepresentable) {
+    return false;
+  }
+
+  bool topRightIsRepresentable = RCTUpdateLayerCornerConfiguration(
+      borderMetrics.borderRadii.topRight,
+      borderMetrics.borderCurves.topRight,
+      kCALayerMaxXMinYCorner,
+      cornerConfiguration);
+  if (!topRightIsRepresentable) {
+    return false;
+  }
+
+  bool bottomLeftIsRepresentable = RCTUpdateLayerCornerConfiguration(
+      borderMetrics.borderRadii.bottomLeft,
+      borderMetrics.borderCurves.bottomLeft,
+      kCALayerMinXMaxYCorner,
+      cornerConfiguration);
+  if (!bottomLeftIsRepresentable) {
+    return false;
+  }
+
+  bool bottomRightIsRepresentable = RCTUpdateLayerCornerConfiguration(
+      borderMetrics.borderRadii.bottomRight,
+      borderMetrics.borderCurves.bottomRight,
+      kCALayerMaxXMaxYCorner,
+      cornerConfiguration);
+  if (!bottomRightIsRepresentable) {
+    return false;
+  }
+
+  if (!cornerConfiguration.hasRoundedCorner) {
+    cornerConfiguration.maskedCorners = kCALayerMinXMinYCorner
+                                        | kCALayerMaxXMinYCorner
+                                        | kCALayerMinXMaxYCorner
+                                        | kCALayerMaxXMaxYCorner;
+  }
+
+  return true;
+}
+
 static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 {
   switch (borderStyle) {
@@ -995,7 +1087,6 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   }
 
   const auto borderMetrics = _props->resolveBorderMetrics(_layoutMetrics);
-  BOOL const borderRadiiCircular = areBorderRadiiCircular(borderMetrics.borderRadii);
 
   // Stage 1. Shadow Path
   BOOL const layerHasShadow = layer.shadowOpacity > 0 && CGColorGetAlpha(layer.shadowColor) > 0;
@@ -1042,10 +1133,14 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     [self setHoverStyle:hoverStyle];
   }
 #endif
+
+  RCTLayerCornerConfiguration layerCornerConfiguration;
+  const bool layerCornersAreRepresentable = RCTGetLayerCornerConfiguration(borderMetrics, layerCornerConfiguration);
+
   const bool useCoreAnimationBorderRendering =
       borderMetrics.borderColors.isUniform() && borderMetrics.borderWidths.isUniform() &&
       borderMetrics.borderStyles.isUniform() && borderMetrics.borderStyles.left == BorderStyle::Solid &&
-      borderRadiiCircular &&
+      layerCornersAreRepresentable &&
       (
           // iOS draws borders in front of the content whereas CSS draws them behind
           // the content. For this reason, only use iOS border drawing when clipping
@@ -1086,8 +1181,9 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     layer.borderWidth = (CGFloat)borderMetrics.borderWidths.left;
     UIColor *borderColor = RCTUIColorFromSharedColor(borderMetrics.borderColors.left);
     layer.borderColor = borderColor.CGColor;
-    layer.cornerRadius = (CGFloat)borderMetrics.borderRadii.topLeft.horizontal;
-    layer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
+    layer.cornerRadius = layerCornerConfiguration.cornerRadius;
+    layer.maskedCorners = layerCornerConfiguration.maskedCorners;
+    layer.cornerCurve = CornerCurveFromBorderCurve(layerCornerConfiguration.cornerCurve);
   } else {
     if (!_borderLayer) {
       CALayer *borderLayer = [CALayer new];
@@ -1127,7 +1223,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _outlineLayer.frame = CGRectInset(
         layer.bounds, -_props->outlineOffset - _props->outlineWidth, -_props->outlineOffset - _props->outlineWidth);
 
-    if (borderRadiiCircular && borderMetrics.borderRadii.topLeft.horizontal == 0) {
+    if (layerCornersAreRepresentable && layerCornerConfiguration.cornerRadius == 0) {
       UIColor *outlineColor = RCTUIColorFromSharedColor(_props->outlineColor);
       _outlineLayer.borderWidth = _props->outlineWidth;
       _outlineLayer.borderColor = outlineColor.CGColor;
@@ -1299,24 +1395,28 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   }
 
   // clipping
-  self.currentContainerView.layer.mask = nil;
-  if (self.currentContainerView.clipsToBounds) {
+  UIView *currentContainerView = self.currentContainerView;
+  currentContainerView.layer.mask = nil;
+  if (currentContainerView.clipsToBounds) {
     BOOL clipToPaddingBox = ReactNativeFeatureFlags::enableIOSViewClipToPaddingBox();
     if (!clipToPaddingBox) {
-      if (borderRadiiCircular) {
-        self.currentContainerView.layer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
+      if (layerCornersAreRepresentable) {
+        currentContainerView.layer.cornerRadius = layerCornerConfiguration.cornerRadius;
+        currentContainerView.layer.maskedCorners = layerCornerConfiguration.maskedCorners;
+        currentContainerView.layer.cornerCurve = CornerCurveFromBorderCurve(layerCornerConfiguration.cornerCurve);
       } else {
         CALayer *maskLayer =
             [self createMaskLayer:self.bounds
                      cornerInsets:RCTGetCornerInsets(
                                       RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero)];
-        self.currentContainerView.layer.mask = maskLayer;
+        currentContainerView.layer.cornerRadius = 0;
+        currentContainerView.layer.mask = maskLayer;
       }
 
-      if (!borderRadiiCircular &&
+      if (!layerCornersAreRepresentable &&
           (borderMetrics.borderColors.left || borderMetrics.borderColors.right || borderMetrics.borderColors.top ||
            borderMetrics.borderColors.bottom)) {
-        for (UIView *subview in self.currentContainerView.subviews) {
+        for (UIView *subview in currentContainerView.subviews) {
           if ([subview isKindOfClass:[UIImageView class]]) {
             RCTCornerInsets cornerInsets = RCTGetCornerInsets(
                 RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
@@ -1332,14 +1432,16 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
       }
     } else if (
         !borderMetrics.borderWidths.isUniform() || borderMetrics.borderWidths.left != 0 ||
-        !borderRadiiCircular) {
+        !layerCornersAreRepresentable) {
       CALayer *maskLayer = [self createMaskLayer:RCTCGRectFromRect(_layoutMetrics.getPaddingFrame())
                                     cornerInsets:RCTGetCornerInsets(
                                                      RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
                                                      RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths))];
-      self.currentContainerView.layer.mask = maskLayer;
+      currentContainerView.layer.mask = maskLayer;
     } else {
-      self.currentContainerView.layer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
+      currentContainerView.layer.cornerRadius = layerCornerConfiguration.cornerRadius;
+      currentContainerView.layer.maskedCorners = layerCornerConfiguration.maskedCorners;
+      currentContainerView.layer.cornerCurve = CornerCurveFromBorderCurve(layerCornerConfiguration.cornerCurve);
     }
   }
 }
@@ -1351,10 +1453,13 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   // Bounds is needed here to account for scaling transforms properly and ensure
   // we do not scale twice
   layer.frame = CGRectMake(0, 0, self.layer.bounds.size.width, self.layer.bounds.size.height);
-  if (areBorderRadiiCircular(borderMetrics.borderRadii)) {
+  RCTLayerCornerConfiguration cornerConfiguration;
+  const bool cornersAreRepresentable = RCTGetLayerCornerConfiguration(borderMetrics, cornerConfiguration);
+  if (cornersAreRepresentable) {
     layer.mask = nil;
-    layer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
-    layer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
+    layer.cornerRadius = cornerConfiguration.cornerRadius;
+    layer.maskedCorners = cornerConfiguration.maskedCorners;
+    layer.cornerCurve = CornerCurveFromBorderCurve(cornerConfiguration.cornerCurve);
   } else {
     CAShapeLayer *maskLayer = [self
         createMaskLayer:self.bounds
@@ -1721,6 +1826,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   // corner
   destinationView.layer.cornerRadius = sourceView.layer.cornerRadius;
   sourceView.layer.cornerRadius = 0;
+  destinationView.layer.maskedCorners = sourceView.layer.maskedCorners;
   destinationView.layer.cornerCurve = sourceView.layer.cornerCurve;
 
   // custom layers

--- a/packages/react-native/React/Fabric/Utils/RCTLayerCornerConfiguration.h
+++ b/packages/react-native/React/Fabric/Utils/RCTLayerCornerConfiguration.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <optional>
+
+#import <QuartzCore/QuartzCore.h>
+#import <react/renderer/components/view/primitives.h>
+
+/*
+ * Describes how a view's border radii can be rendered through CoreAnimation's
+ * `cornerRadius` / `maskedCorners` fast path instead of a `CAShapeLayer` mask.
+ */
+struct RCTLayerCornerConfiguration {
+  CGFloat cornerRadius{0};
+  CACornerMask maskedCorners{0};
+  facebook::react::BorderCurve cornerCurve{facebook::react::BorderCurve::Circular};
+  bool hasRoundedCorner{false};
+};
+
+/*
+ * Returns a corner configuration when `borderMetrics` can be represented with a
+ * single `cornerRadius` + `maskedCorners`, i.e. every rounded corner shares the
+ * same circular radius and curve. Returns `std::nullopt` when the radii require
+ * a mask layer instead (an elliptical corner, or differing radii/curves between
+ * rounded corners).
+ */
+std::optional<RCTLayerCornerConfiguration> RCTGetLayerCornerConfiguration(
+    const facebook::react::BorderMetrics &borderMetrics);
+
+/*
+ * Applies a corner configuration to a layer's `cornerRadius`, `maskedCorners`
+ * and `cornerCurve`.
+ */
+void RCTApplyLayerCornerConfiguration(CALayer *layer, const RCTLayerCornerConfiguration &cornerConfiguration);

--- a/packages/react-native/React/Fabric/Utils/RCTLayerCornerConfiguration.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTLayerCornerConfiguration.mm
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTLayerCornerConfiguration.h"
+
+using namespace facebook::react;
+
+static CALayerCornerCurve CornerCurveFromBorderCurve(BorderCurve borderCurve)
+{
+  switch (borderCurve) {
+    case BorderCurve::Continuous:
+      return kCACornerCurveContinuous;
+    case BorderCurve::Circular:
+      return kCACornerCurveCircular;
+  }
+}
+
+static bool RCTUpdateLayerCornerConfiguration(
+    const CornerRadii &cornerRadii,
+    BorderCurve cornerCurve,
+    CACornerMask cornerMask,
+    RCTLayerCornerConfiguration &cornerConfiguration)
+{
+  if (cornerRadii.horizontal != cornerRadii.vertical) {
+    return false;
+  }
+
+  if (cornerRadii.horizontal == 0) {
+    return true;
+  }
+
+  CGFloat cornerRadius = (CGFloat)cornerRadii.horizontal;
+  if (cornerConfiguration.hasRoundedCorner) {
+    if (cornerConfiguration.cornerRadius != cornerRadius) {
+      return false;
+    }
+
+    if (cornerConfiguration.cornerCurve != cornerCurve) {
+      return false;
+    }
+  } else {
+    cornerConfiguration.cornerRadius = cornerRadius;
+    cornerConfiguration.cornerCurve = cornerCurve;
+    cornerConfiguration.hasRoundedCorner = true;
+  }
+
+  cornerConfiguration.maskedCorners |= cornerMask;
+  return true;
+}
+
+std::optional<RCTLayerCornerConfiguration> RCTGetLayerCornerConfiguration(const BorderMetrics &borderMetrics)
+{
+  RCTLayerCornerConfiguration cornerConfiguration;
+
+  const struct {
+    const CornerRadii &radii;
+    BorderCurve curve;
+    CACornerMask mask;
+  } corners[] = {
+      {borderMetrics.borderRadii.topLeft, borderMetrics.borderCurves.topLeft, kCALayerMinXMinYCorner},
+      {borderMetrics.borderRadii.topRight, borderMetrics.borderCurves.topRight, kCALayerMaxXMinYCorner},
+      {borderMetrics.borderRadii.bottomLeft, borderMetrics.borderCurves.bottomLeft, kCALayerMinXMaxYCorner},
+      {borderMetrics.borderRadii.bottomRight, borderMetrics.borderCurves.bottomRight, kCALayerMaxXMaxYCorner},
+  };
+
+  for (const auto &corner : corners) {
+    bool isRepresentable =
+        RCTUpdateLayerCornerConfiguration(corner.radii, corner.curve, corner.mask, cornerConfiguration);
+    if (!isRepresentable) {
+      return std::nullopt;
+    }
+  }
+
+  if (!cornerConfiguration.hasRoundedCorner) {
+    cornerConfiguration.maskedCorners =
+        kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner | kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
+  }
+
+  return cornerConfiguration;
+}
+
+void RCTApplyLayerCornerConfiguration(CALayer *layer, const RCTLayerCornerConfiguration &cornerConfiguration)
+{
+  layer.cornerRadius = cornerConfiguration.cornerRadius;
+  layer.maskedCorners = cornerConfiguration.maskedCorners;
+  layer.cornerCurve = CornerCurveFromBorderCurve(cornerConfiguration.cornerCurve);
+}

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -1051,6 +1051,13 @@ const styles = StyleSheet.create({
   flex: {
     flex: 1,
   },
+  imageWithUniformButNoneCircularBorderRadius: {
+    width: 200,
+    height: 100,
+    borderRadius: '50%',
+    borderWidth: 4,
+    borderColor: 'blue',
+  },
   imageWithBorderRadius: {
     borderRadius: 5,
   },
@@ -1420,6 +1427,10 @@ exports.examples = [
     render: function (): React.Node {
       return (
         <View style={styles.horizontal} testID="border-radius-example">
+          <Image
+            style={styles.imageWithUniformButNoneCircularBorderRadius}
+            source={fullImage}
+          />
           <Image
             style={[styles.base, styles.imageWithBorderRadius]}
             source={fullImage}

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -3189,6 +3189,13 @@ struct RCTFontProperties {
   public UIFontWeight weight;
 }
 
+struct RCTLayerCornerConfiguration {
+  public CACornerMask maskedCorners;
+  public CGFloat cornerRadius;
+  public bool hasRoundedCorner;
+  public facebook::react::BorderCurve cornerCurve;
+}
+
 struct RCTLayoutContext {
   public CGPoint absolutePosition;
   public __unsafe_unretained NSHashTable<NSString*>* _Nonnull other;

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -3177,6 +3177,13 @@ struct RCTFontProperties {
   public UIFontWeight weight;
 }
 
+struct RCTLayerCornerConfiguration {
+  public CACornerMask maskedCorners;
+  public CGFloat cornerRadius;
+  public bool hasRoundedCorner;
+  public facebook::react::BorderCurve cornerCurve;
+}
+
 struct RCTLayoutContext {
   public CGPoint absolutePosition;
   public __unsafe_unretained NSHashTable<NSString*>* _Nonnull other;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -3189,6 +3189,13 @@ struct RCTFontProperties {
   public UIFontWeight weight;
 }
 
+struct RCTLayerCornerConfiguration {
+  public CACornerMask maskedCorners;
+  public CGFloat cornerRadius;
+  public bool hasRoundedCorner;
+  public facebook::react::BorderCurve cornerCurve;
+}
+
 struct RCTLayoutContext {
   public CGPoint absolutePosition;
   public __unsafe_unretained NSHashTable<NSString*>* _Nonnull other;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

> [!NOTE]
> Follow up fix to:
> - https://github.com/react/react-native/pull/57399
> ^ This PR can either merged first, or closed, and we merge only this PR?

In discord we noticed performance regression when switching to the new arch in a few of our iOS surfaces, which after profiling turned out to be related to how borders are handled on the new architecture. 

Before, on the old arch, none uniform border would be drawn as UIImages and would be drawn as background layer, where on new arch we start to use masks for none uniform borders. Using masks has the draw back of iOS needing to do offscreen render passes, which are expensive in the rendering pipeline, leading to hitches / frame drops.

In #57399 I addressed the issue by making sure to not masks UIImages explicitly if borders are uniform & circular. In this PR I extend the fix to also work for border radii that are only applied to few edges, but are otherwise uniform & circular.

I created this synthetic benchmark example, where we render many images with only bottom border radii, which highlights the perf issue. See before, after the fix:

<details>
<summary>
Code for `RNTesterPlayground.js`
</summary>

```jsx
/**
 * Copyright (c) Meta Platforms, Inc. and affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 *
 * @flow strict-local
 * @format
 */

import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
import type {ImageSource, ListRenderItemInfo} from 'react-native';

import RNTesterText from '../../components/RNTesterText';
import * as React from 'react';
import {FlatList, Image, StyleSheet, View} from 'react-native';

type AvatarItem = Readonly<{
  id: string,
  source: ImageSource,
}>;

const IMAGE_COUNT = 10_000;
const NUM_COLUMNS = 10;
const IMAGE_SOURCES: ReadonlyArray<ImageSource> = [
  require('../../assets/bunny.png'),
  require('../../assets/hawk.png'),
  require('../../assets/rubber-ducky.png'),
  require('../../assets/flowers.png'),
];

function createAvatarItem(index: number): AvatarItem {
  const id = `rn-tester-${index}`;
  const source = IMAGE_SOURCES[index % IMAGE_SOURCES.length];

  return {
    id,
    source,
  };
}

function createAvatarItems(): ReadonlyArray<AvatarItem> {
  const avatars: Array<AvatarItem> = [];

  for (let index = 0; index < IMAGE_COUNT; index++) {
    const avatar = createAvatarItem(index);
    avatars.push(avatar);
  }

  return avatars;
}

const AVATARS = createAvatarItems();

function renderAvatarItem({item}: ListRenderItemInfo<AvatarItem>): React.Node {
  return (
    <View style={styles.imageCell}>
      <Image source={item.source} style={styles.image} />
    </View>
  );
}

function Playground() {
  return (
    <View style={styles.container}>
      <RNTesterText>
        Local image grid for measuring Image clipping performance.
      </RNTesterText>
      <FlatList
        contentContainerStyle={styles.listContent}
        data={AVATARS}
        initialNumToRender={NUM_COLUMNS * 4}
        keyExtractor={item => item.id}
        maxToRenderPerBatch={NUM_COLUMNS * 4}
        numColumns={NUM_COLUMNS}
        renderItem={renderAvatarItem}
        style={styles.list}
        windowSize={5}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    padding: 10,
  },
  image: {
    height: '100%',
    width: '100%',
    backgroundColor: 'red',
    // borderRadius: 4,
    borderBottomRightRadius: 14,
    borderBottomLeftRadius: 14,
  },
  imageCell: {
    aspectRatio: 1,
    backgroundColor: '#eee',
    flex: 1,
    margin: 2,
  },
  list: {
    flex: 1,
  },
  listContent: {
    paddingTop: 10,
  },
});

export default {
  title: 'Playground',
  name: 'playground',
  description: 'Test out new features and ideas.',
  render: (): React.Node => <Playground />,
} as RNTesterModuleExample;

```
</details>

| Before | ✨ After ✨ |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/134ebb6d-a98e-4719-826e-7a639fc49b77" /> | <video src="https://github.com/user-attachments/assets/19a0dc52-feb6-4d76-9a6a-a87b725e2a6b" /> |
| <ul><li>Visible hitches</li><li>Not at 120hz or 60fps even</li></ul> | <li>Almost no hitches</li><li>Profiler confirms maintaining 60 FPS</li> |

Investigating the issue with the xcode performance profiling tools we can see that with the mask approach we have over >300 offscreen passes which cause very long frames on the render server, averaging around ~20ms:

> Left before, right after: only 1 offscreen pass & no hitches

<img width="3014" height="1324" alt="Screenshot 2026-07-02 at 12 55 23" src="https://github.com/user-attachments/assets/e11a1332-1bd0-4e6c-b55d-b0373ce50883" />

Performance comparison in numbers:

metric | not optimized | optimized | delta
-- | -- | -- | --
hitches | 326 | 0 | -100%
steady FPS | 36.2 | 60.0 | +65.7%
steady GPU util | 77.2% | 15.1% | -80.4%
avg render duration | 21.39ms | 4.40ms | -79.4%
p95 render duration | 22.72ms | 7.77ms | -65.8%
max render duration | 58.00ms | 15.57ms | -73.2%
renders > 8.33ms | 348 | 44 | much lower
renders > 16.67ms | 348 | 0 | -100%
avg offscreen passes/render | 361.9 | 1.0 | -99.7%
offscreen passes/sec | 12,050 | 91 | -99.2%
avg update duration | 0.496ms | 0.352ms | -29.1%
p95 update duration | 1.93ms | 1.18ms | -39.1%

This fix is also more generic, so addressing any view extending `RCTViewComponentView` and using not-all-edges border radii.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Performance: improve performance for border radii in `RCTViewComponentView` that are uniform but don't cover all edges

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Added more examples in RNTester for image border radii and made sure they don't regress
- Performance profiles with the provided RNTester playground snippet above
