### PR TITLE
Colocate deprecated native component specs with their components

### DIFF
--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicatorViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicatorViewNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/ActivityIndicatorViewNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/ActivityIndicatorViewNativeComponent';
+export * from '../../../src/private/components/activityindicator/specs/ActivityIndicatorViewNativeComponent';
+export {default} from '../../../src/private/components/activityindicator/specs/ActivityIndicatorViewNativeComponent';

--- a/packages/react-native/Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/AndroidDrawerLayoutNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/AndroidDrawerLayoutNativeComponent';
+export * from '../../../src/private/components/drawerlayoutandroid/specs/AndroidDrawerLayoutNativeComponent';
+export {default} from '../../../src/private/components/drawerlayoutandroid/specs/AndroidDrawerLayoutNativeComponent';

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/ProgressBarAndroidNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/ProgressBarAndroidNativeComponent';
+export * from '../../../src/private/components/progressbarandroid/specs/ProgressBarAndroidNativeComponent';
+export {default} from '../../../src/private/components/progressbarandroid/specs/ProgressBarAndroidNativeComponent';

--- a/packages/react-native/Libraries/Components/RefreshControl/AndroidSwipeRefreshLayoutNativeComponent.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/AndroidSwipeRefreshLayoutNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/AndroidSwipeRefreshLayoutNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/AndroidSwipeRefreshLayoutNativeComponent';
+export * from '../../../src/private/components/refreshcontrol/specs/AndroidSwipeRefreshLayoutNativeComponent';
+export {default} from '../../../src/private/components/refreshcontrol/specs/AndroidSwipeRefreshLayoutNativeComponent';

--- a/packages/react-native/Libraries/Components/RefreshControl/PullToRefreshViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/PullToRefreshViewNativeComponent.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent';
-import PullToRefreshViewNativeComponent from '../../../src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent';
+export * from '../../../src/private/components/refreshcontrol/specs/PullToRefreshViewNativeComponent';
+import PullToRefreshViewNativeComponent from '../../../src/private/components/refreshcontrol/specs/PullToRefreshViewNativeComponent';
 
 export default PullToRefreshViewNativeComponent;

--- a/packages/react-native/Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/RCTSafeAreaViewNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/RCTSafeAreaViewNativeComponent';
+export * from '../../../src/private/components/safeareaview/specs/RCTSafeAreaViewNativeComponent';
+export {default} from '../../../src/private/components/safeareaview/specs/RCTSafeAreaViewNativeComponent';

--- a/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollContentViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollContentViewNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/AndroidHorizontalScrollContentViewNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/AndroidHorizontalScrollContentViewNativeComponent';
+export * from '../../../src/private/components/scrollview/specs/AndroidHorizontalScrollContentViewNativeComponent';
+export {default} from '../../../src/private/components/scrollview/specs/AndroidHorizontalScrollContentViewNativeComponent';

--- a/packages/react-native/Libraries/Components/Switch/AndroidSwitchNativeComponent.js
+++ b/packages/react-native/Libraries/Components/Switch/AndroidSwitchNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/AndroidSwitchNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/AndroidSwitchNativeComponent';
+export * from '../../../src/private/components/switch/specs/AndroidSwitchNativeComponent';
+export {default} from '../../../src/private/components/switch/specs/AndroidSwitchNativeComponent';

--- a/packages/react-native/Libraries/Components/Switch/SwitchNativeComponent.js
+++ b/packages/react-native/Libraries/Components/Switch/SwitchNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/SwitchNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/SwitchNativeComponent';
+export * from '../../../src/private/components/switch/specs/SwitchNativeComponent';
+export {default} from '../../../src/private/components/switch/specs/SwitchNativeComponent';

--- a/packages/react-native/Libraries/Components/TextInput/RCTInputAccessoryViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTInputAccessoryViewNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/RCTInputAccessoryViewNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/RCTInputAccessoryViewNativeComponent';
+export * from '../../../src/private/components/inputaccessoryview/specs/RCTInputAccessoryViewNativeComponent';
+export {default} from '../../../src/private/components/inputaccessoryview/specs/RCTInputAccessoryViewNativeComponent';

--- a/packages/react-native/Libraries/Components/UnimplementedViews/UnimplementedNativeViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/UnimplementedViews/UnimplementedNativeViewNativeComponent.js
@@ -8,5 +8,5 @@
  * @format
  */
 
-export * from '../../../src/private/specs_DEPRECATED/components/UnimplementedNativeViewNativeComponent';
-export {default} from '../../../src/private/specs_DEPRECATED/components/UnimplementedNativeViewNativeComponent';
+export * from '../../../src/private/components/unimplementedview/specs/UnimplementedNativeViewNativeComponent';
+export {default} from '../../../src/private/components/unimplementedview/specs/UnimplementedNativeViewNativeComponent';

--- a/packages/react-native/Libraries/Debugging/DebuggingOverlay.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlay.js
@@ -11,11 +11,11 @@
 import type {
   ElementRectangle,
   TraceUpdate,
-} from '../../src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent';
+} from '../../src/private/components/debuggingoverlay/specs/DebuggingOverlayNativeComponent';
 
 import DebuggingOverlayNativeComponent, {
   Commands,
-} from '../../src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent';
+} from '../../src/private/components/debuggingoverlay/specs/DebuggingOverlayNativeComponent';
 import View from '../Components/View/View';
 import UIManager from '../ReactNative/UIManager';
 import StyleSheet from '../StyleSheet/StyleSheet';

--- a/packages/react-native/Libraries/Debugging/DebuggingOverlayNativeComponent.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlayNativeComponent.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export * from '../../src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent';
-import DebuggingOverlayNativeComponent from '../../src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent';
+export * from '../../src/private/components/debuggingoverlay/specs/DebuggingOverlayNativeComponent';
+import DebuggingOverlayNativeComponent from '../../src/private/components/debuggingoverlay/specs/DebuggingOverlayNativeComponent';
 
 export default DebuggingOverlayNativeComponent;

--- a/packages/react-native/Libraries/Modal/RCTModalHostViewNativeComponent.js
+++ b/packages/react-native/Libraries/Modal/RCTModalHostViewNativeComponent.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export * from '../../src/private/specs_DEPRECATED/components/RCTModalHostViewNativeComponent';
-import RCTModalHostViewNativeComponent from '../../src/private/specs_DEPRECATED/components/RCTModalHostViewNativeComponent';
+export * from '../../src/private/components/modal/specs/RCTModalHostViewNativeComponent';
+import RCTModalHostViewNativeComponent from '../../src/private/components/modal/specs/RCTModalHostViewNativeComponent';
 
 export default RCTModalHostViewNativeComponent;

--- a/packages/react-native/src/private/components/activityindicator/specs/ActivityIndicatorViewNativeComponent.js
+++ b/packages/react-native/src/private/components/activityindicator/specs/ActivityIndicatorViewNativeComponent.js
@@ -8,12 +8,12 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
-import type {WithDefault} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ColorValue} from '../../../../../Libraries/StyleSheet/StyleSheet';
+import type {WithDefault} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 
 type RCTActivityIndicatorViewNativeProps = Readonly<{
   ...ViewProps,

--- a/packages/react-native/src/private/components/debuggingoverlay/specs/DebuggingOverlayNativeComponent.js
+++ b/packages/react-native/src/private/components/debuggingoverlay/specs/DebuggingOverlayNativeComponent.js
@@ -8,12 +8,12 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ProcessedColorValue} from '../../../../Libraries/StyleSheet/processColor';
-import type {HostComponent} from '../../types/HostComponent';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ProcessedColorValue} from '../../../../../Libraries/StyleSheet/processColor';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeCommands from '../../../../../Libraries/Utilities/codegenNativeCommands';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
 type DebuggingOverlayNativeProps = Readonly<{

--- a/packages/react-native/src/private/components/drawerlayoutandroid/specs/AndroidDrawerLayoutNativeComponent.js
+++ b/packages/react-native/src/private/components/drawerlayoutandroid/specs/AndroidDrawerLayoutNativeComponent.js
@@ -8,18 +8,18 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ColorValue} from '../../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   DirectEventHandler,
   Float,
   Int32,
   WithDefault,
-} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeCommands from '../../../../../Libraries/Utilities/codegenNativeCommands';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
 type DrawerStateEvent = Readonly<{

--- a/packages/react-native/src/private/components/inputaccessoryview/specs/RCTInputAccessoryViewNativeComponent.js
+++ b/packages/react-native/src/private/components/inputaccessoryview/specs/RCTInputAccessoryViewNativeComponent.js
@@ -8,11 +8,11 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
-import type {HostComponent} from '../../types/HostComponent';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ColorValue} from '../../../../../Libraries/StyleSheet/StyleSheet';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 
 type InputAccessoryNativeProps = Readonly<{
   ...ViewProps,

--- a/packages/react-native/src/private/components/modal/specs/RCTModalHostViewNativeComponent.js
+++ b/packages/react-native/src/private/components/modal/specs/RCTModalHostViewNativeComponent.js
@@ -8,15 +8,15 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
 import type {
   DirectEventHandler,
   Int32,
   WithDefault,
-} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 
 type OrientationChangeEvent = Readonly<{
   orientation: 'portrait' | 'landscape',

--- a/packages/react-native/src/private/components/progressbarandroid/specs/ProgressBarAndroidNativeComponent.js
+++ b/packages/react-native/src/private/components/progressbarandroid/specs/ProgressBarAndroidNativeComponent.js
@@ -8,15 +8,15 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ColorValue} from '../../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   Double,
   WithDefault,
-} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 
 type AndroidProgressBarNativeProps = Readonly<{
   ...ViewProps,

--- a/packages/react-native/src/private/components/refreshcontrol/specs/AndroidSwipeRefreshLayoutNativeComponent.js
+++ b/packages/react-native/src/private/components/refreshcontrol/specs/AndroidSwipeRefreshLayoutNativeComponent.js
@@ -8,17 +8,17 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ColorValue} from '../../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   DirectEventHandler,
   Float,
   WithDefault,
-} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeCommands from '../../../../../Libraries/Utilities/codegenNativeCommands';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
 type AndroidSwipeRefreshLayoutNativeProps = Readonly<{

--- a/packages/react-native/src/private/components/refreshcontrol/specs/PullToRefreshViewNativeComponent.js
+++ b/packages/react-native/src/private/components/refreshcontrol/specs/PullToRefreshViewNativeComponent.js
@@ -8,17 +8,17 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ColorValue} from '../../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   DirectEventHandler,
   Float,
   WithDefault,
-} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeCommands from '../../../../../Libraries/Utilities/codegenNativeCommands';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
 type PullToRefreshNativeProps = Readonly<{

--- a/packages/react-native/src/private/components/safeareaview/SafeAreaView_INTERNAL_DO_NOT_USE.js
+++ b/packages/react-native/src/private/components/safeareaview/SafeAreaView_INTERNAL_DO_NOT_USE.js
@@ -19,10 +19,10 @@ const exported: component(
   ref?: React.RefSetter<React.ElementRef<typeof View>>,
   ...ViewProps
 ) = Platform.select({
-  ios: require('../../../../src/private/specs_DEPRECATED/components/RCTSafeAreaViewNativeComponent')
+  ios: require('../../../../src/private/components/safeareaview/specs/RCTSafeAreaViewNativeComponent')
     .default,
   android: UIManager.hasViewManagerConfig('RCTSafeAreaView')
-    ? require('../../../../src/private/specs_DEPRECATED/components/RCTSafeAreaViewNativeComponent')
+    ? require('../../../../src/private/components/safeareaview/specs/RCTSafeAreaViewNativeComponent')
         .default
     : View,
   default: View,

--- a/packages/react-native/src/private/components/safeareaview/specs/RCTSafeAreaViewNativeComponent.js
+++ b/packages/react-native/src/private/components/safeareaview/specs/RCTSafeAreaViewNativeComponent.js
@@ -8,10 +8,10 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../types/HostComponent';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 
 type RCTSafeAreaViewNativeProps = Readonly<{
   ...ViewProps,

--- a/packages/react-native/src/private/components/scrollview/HScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/scrollview/HScrollViewNativeComponents.js
@@ -16,7 +16,7 @@ import AndroidHorizontalScrollViewNativeComponent from '../../../../Libraries/Co
 import ScrollContentViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';
 import ScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponent';
 import Platform from '../../../../Libraries/Utilities/Platform';
-import AndroidHorizontalScrollContentViewNativeComponent from '../../specs_DEPRECATED/components/AndroidHorizontalScrollContentViewNativeComponent';
+import AndroidHorizontalScrollContentViewNativeComponent from '../../components/scrollview/specs/AndroidHorizontalScrollContentViewNativeComponent';
 
 export const HScrollViewNativeComponent: HostComponent<ScrollViewNativeProps> =
   Platform.OS === 'android'

--- a/packages/react-native/src/private/components/scrollview/specs/AndroidHorizontalScrollContentViewNativeComponent.js
+++ b/packages/react-native/src/private/components/scrollview/specs/AndroidHorizontalScrollContentViewNativeComponent.js
@@ -8,10 +8,10 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../types/HostComponent';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 
 type AndroidHorizontalScrollContentViewNativeProps = Readonly<{
   ...ViewProps,

--- a/packages/react-native/src/private/components/switch/specs/AndroidSwitchNativeComponent.js
+++ b/packages/react-native/src/private/components/switch/specs/AndroidSwitchNativeComponent.js
@@ -8,17 +8,17 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ColorValue} from '../../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   BubblingEventHandler,
   Int32,
   WithDefault,
-} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeCommands from '../../../../../Libraries/Utilities/codegenNativeCommands';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
 type AndroidSwitchChangeEvent = Readonly<{

--- a/packages/react-native/src/private/components/switch/specs/SwitchNativeComponent.js
+++ b/packages/react-native/src/private/components/switch/specs/SwitchNativeComponent.js
@@ -8,17 +8,17 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {ColorValue} from '../../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   BubblingEventHandler,
   Int32,
   WithDefault,
-} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeCommands from '../../../../../Libraries/Utilities/codegenNativeCommands';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
 type NativeSwitchChangeEvent = Readonly<{

--- a/packages/react-native/src/private/components/unimplementedview/specs/UnimplementedNativeViewNativeComponent.js
+++ b/packages/react-native/src/private/components/unimplementedview/specs/UnimplementedNativeViewNativeComponent.js
@@ -8,11 +8,11 @@
  * @format
  */
 
-import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {WithDefault} from '../../../../Libraries/Types/CodegenTypes';
-import type {HostComponent} from '../../types/HostComponent';
+import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {WithDefault} from '../../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../../types/HostComponent';
 
-import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
+import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 
 type UnimplementedNativeViewNativeProps = Readonly<{
   ...ViewProps,


### PR DESCRIPTION
Summary:
Moves the native component specs out of the legacy `specs_DEPRECATED/components` directory and into a `specs/` folder colocated with the component they belong to, under `src/private/components/<component-name>/specs/`. The directory name for each component is its public name, lowercased and without spaces (e.g. `DrawerLayoutAndroid` -> `drawerlayoutandroid`, `RefreshControl` -> `refreshcontrol`).

This continues the effort described in the `specs_DEPRECATED` README of gradually moving specs out of that directory until it can be removed. Specs shared by the same public component are grouped together (e.g. `AndroidSwitchNativeComponent` and `SwitchNativeComponent` under `switch/specs`, `AndroidSwipeRefreshLayoutNativeComponent` and `PullToRefreshViewNativeComponent` under `refreshcontrol/specs`).

Relative imports inside each moved spec were updated for the new depth, and every consumer (the re-export shims under `Libraries` plus the colocated `scrollview` and `safeareaview` consumers) now points at the new location. Public import paths are unchanged because the `Libraries` re-export shims are preserved. Codegen still discovers the specs since it scans the whole `src` directory.

Changelog: [Internal]

Differential Revision: D110472967
