### PR TITLE
Persist Change Bundle Location host setting

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
@@ -54,6 +54,7 @@ public open class PackagerConnectionSettings(private val appContext: Context) {
       } else {
         _cachedOrOverrideHost = host
       }
+      preferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply()
     }
 
   public open fun resetDebugServerHost() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
@@ -21,7 +21,7 @@ public open class PackagerConnectionSettings(private val appContext: Context) {
   public val packageName: String = appContext.packageName
 
   init {
-    resetDebugServerHost()
+    _cachedOrOverrideHost = null
   }
 
   public open var debugServerHost: String
@@ -50,14 +50,16 @@ public open class PackagerConnectionSettings(private val appContext: Context) {
     }
     set(host) {
       if (host.isEmpty()) {
+        preferences.edit().remove(PREFS_DEBUG_SERVER_HOST_KEY).apply()
         _cachedOrOverrideHost = null
       } else {
+        preferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply()
         _cachedOrOverrideHost = host
       }
-      preferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply()
     }
 
   public open fun resetDebugServerHost() {
+    preferences.edit().remove(PREFS_DEBUG_SERVER_HOST_KEY).apply()
     _cachedOrOverrideHost = null
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Persist `Change Bundle Location` updates to the same `debug_http_host` preference used by the Android Dev Settings screen.

Previously, `Change Bundle Location` only updated the in-memory `PackagerConnectionSettings` host override. After killing and restarting the app process, the host was read again from `SharedPreferences`, so the change was lost.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Persist Change Bundle Location debug server host changes

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Verified with RNTester `debugOptimized` on Android:

1. Installed and launched RNTester on a physical Android device.
2. Opened the React Native Dev Menu.
3. Changed the bundle location using `Change Bundle Location`.
4. Killed and restarted the app process.
5. Confirmed the updated host is still used after restart.