### PR TITLE
Fix iOS TextInput Dynamic Type audit support

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) id<RCTBackedTextInputDelegate> textInputDelegate;
 @property (nonatomic, readonly) CGSize contentSize;
 @property (nonatomic, strong, nullable) NSDictionary<NSAttributedStringKey, id> *defaultTextAttributes;
+@property (nonatomic, assign) BOOL adjustsFontForContentSizeCategory;
 @property (nonatomic, assign) BOOL contextMenuHidden;
 @property (nonatomic, assign, getter=isEditable) BOOL editable;
 @property (nonatomic, assign) BOOL caretHidden;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -42,6 +42,11 @@ using namespace facebook::react;
 
 static NSSet<NSNumber *> *returnKeyTypesSet;
 
+static BOOL RCTAdjustsFontForContentSizeCategoryFromTextAttributes(const TextAttributes &textAttributes)
+{
+  return textAttributes.allowFontScaling.value_or(true);
+}
+
 @implementation RCTTextInputComponentView {
   TextInputShadowNode::ConcreteState::Shared _state;
   UIView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
@@ -92,6 +97,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
     _backedTextInputView = defaultProps->multiline ? [RCTUITextView new] : [RCTUITextField new];
     _backedTextInputView.textInputDelegate = self;
+    _backedTextInputView.adjustsFontForContentSizeCategory =
+        RCTAdjustsFontForContentSizeCategoryFromTextAttributes(defaultProps->textAttributes);
     _ignoreNextTextInputCall = NO;
     _comingFromJS = NO;
     _didMoveToWindow = NO;
@@ -145,6 +152,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     const auto &newTextInputProps = static_cast<const TextInputProps &>(*_props);
     _backedTextInputView.defaultTextAttributes =
         RCTNSTextAttributesFromTextAttributes(newTextInputProps.getEffectiveTextAttributes(RCTFontSizeMultiplier()));
+    _backedTextInputView.adjustsFontForContentSizeCategory =
+        RCTAdjustsFontForContentSizeCategoryFromTextAttributes(newTextInputProps.textAttributes);
   }
 }
 
@@ -298,6 +307,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     defaultAttributes[RCTAttributedStringEventEmitterKey] =
         _backedTextInputView.defaultTextAttributes[RCTAttributedStringEventEmitterKey];
     _backedTextInputView.defaultTextAttributes = defaultAttributes;
+    _backedTextInputView.adjustsFontForContentSizeCategory =
+        RCTAdjustsFontForContentSizeCategoryFromTextAttributes(newTextInputProps.textAttributes);
   }
 
   if (newTextInputProps.selectionColor != oldTextInputProps.selectionColor) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -30,6 +30,7 @@ void RCTCopyBackedTextInput(
   toTextInput.textInputDelegate = fromTextInput.textInputDelegate;
   toTextInput.placeholderColor = fromTextInput.placeholderColor;
   toTextInput.defaultTextAttributes = fromTextInput.defaultTextAttributes;
+  toTextInput.adjustsFontForContentSizeCategory = fromTextInput.adjustsFontForContentSizeCategory;
   toTextInput.autocapitalizationType = fromTextInput.autocapitalizationType;
   toTextInput.autocorrectionType = fromTextInput.autocorrectionType;
   toTextInput.contextMenuHidden = fromTextInput.contextMenuHidden;

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -762,7 +762,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
           />
           <ExampleTextInput
             style={{marginTop: 10}}
-            placeholder="allowFontScaling = false"
+            placeholder="allowFontScaling = true"
             allowFontScaling={true}
           />
         </View>


### PR DESCRIPTION
## Summary
- Enables UIKit Dynamic Type adjustment reporting for iOS TextInput backing controls when font scaling is enabled.
- Preserves that setting when TextInput swaps between single-line and multiline backing views.
- Fixes the RNTester iOS allowFontScaling example placeholder so the scaling-enabled input is labeled correctly.

Fixes #51612.

## Changelog
[IOS] [FIXED] - Report Dynamic Type support for TextInput when font scaling is enabled

## Test Plan
- `PATH="$NVM_BIN:$PATH" yarn flow-check`
- `PATH="$NVM_BIN:$PATH" yarn test-typescript`
- `node_modules/.bin/prettier --check packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js`
- `PATH="$NVM_BIN:$PATH" NODE_BINARY="$NVM_BIN/node" xcodebuild -workspace packages/rn-tester/RNTesterPods.xcworkspace -scheme RNTester -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' build`
- `git diff --check`

Not run in this terminal session: manual Accessibility Inspector audit for RNTester TextInput > allowFontScaling attribute.
