### PR TITLE
feat: Replace EventEmitter with EventTarget in Dimensions

### DIFF
--- a/packages/react-native/Libraries/Utilities/Dimensions.d.ts
+++ b/packages/react-native/Libraries/Utilities/Dimensions.d.ts
@@ -71,6 +71,7 @@ export interface Dimensions {
       window: ScaledSize;
       screen: ScaledSize;
     }) => void,
+    options?: {once?: true | undefined; signal?: AbortSignal | undefined},
   ): EmitterSubscription;
 }
 

--- a/packages/react-native/Libraries/Utilities/Dimensions.js
+++ b/packages/react-native/Libraries/Utilities/Dimensions.js
@@ -8,10 +8,13 @@
  * @format
  */
 
+import type {EventSubscription} from '../vendor/emitter/EventEmitter';
+
+import Event from '../../src/private/webapis/dom/events/Event';
+import EventTarget, {
+  type AddEventListenerOptions,
+} from '../../src/private/webapis/dom/events/EventTarget';
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
-import EventEmitter, {
-  type EventSubscription,
-} from '../vendor/emitter/EventEmitter';
 import NativeDeviceInfo, {
   type DimensionsPayload,
   type DisplayMetrics,
@@ -24,9 +27,7 @@ export type {DimensionsPayload, DisplayMetrics, DisplayMetricsAndroid};
 /** @deprecated Use DisplayMetrics */
 export type ScaledSize = DisplayMetrics;
 
-const eventEmitter = new EventEmitter<{
-  change: [DimensionsPayload],
-}>();
+const eventTarget = new EventTarget();
 let dimensionsInitialized = false;
 let dimensions: DimensionsPayload;
 
@@ -94,7 +95,7 @@ class Dimensions {
     dimensions = {window, screen};
     if (dimensionsInitialized) {
       // Don't fire 'change' the first time the dimensions are set.
-      eventEmitter.emit('change', dimensions);
+      eventTarget.dispatchEvent(new Event('change'));
     } else {
       dimensionsInitialized = true;
     }
@@ -112,13 +113,16 @@ class Dimensions {
   static addEventListener(
     type: 'change',
     handler: Function,
+    options?: Pick<AddEventListenerOptions, 'once' | 'signal'>,
   ): EventSubscription {
     invariant(
       type === 'change',
       'Trying to subscribe to unknown event: "%s"',
       type,
     );
-    return eventEmitter.addListener(type, handler);
+    const onChange = () => handler(dimensions);
+    eventTarget.addEventListener(type, onChange, options);
+    return {remove: () => eventTarget.removeEventListener(type, onChange)};
   }
 }
 

--- a/packages/react-native/Libraries/Utilities/__tests__/Dimensions-itest.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/Dimensions-itest.js
@@ -13,15 +13,18 @@ import Dimensions from '../Dimensions';
 import Platform from '../Platform';
 
 describe('Dimensions', () => {
+  const dimensions = {
+    width: 400,
+    height: 800,
+    scale: 2,
+    densityDpi: 2,
+    fontScale: 3,
+  };
+
   it('should set window dimensions', () => {
+    const newDimensions = {...dimensions};
     Dimensions.set({
-      windowPhysicalPixels: {
-        width: 400,
-        height: 800,
-        scale: 2,
-        densityDpi: 2,
-        fontScale: 3,
-      },
+      windowPhysicalPixels: newDimensions,
     });
 
     expect(Dimensions.get('window').width).toEqual(200);
@@ -33,16 +36,10 @@ describe('Dimensions', () => {
   it('should set screen dimensions on Android', () => {
     // $FlowFixMe[incompatible-type] - `Platform.OS` needs to be read-only.
     Platform.OS = 'android';
-    const dimensions = {
-      width: 400,
-      height: 800,
-      scale: 2,
-      densityDpi: 2,
-      fontScale: 3,
-    };
+    const newDimensions = {...dimensions};
     Dimensions.set({
-      windowPhysicalPixels: dimensions,
-      screenPhysicalPixels: dimensions,
+      windowPhysicalPixels: newDimensions,
+      screenPhysicalPixels: newDimensions,
     });
 
     expect(Dimensions.get('screen').width).toEqual(200);
@@ -54,17 +51,65 @@ describe('Dimensions', () => {
   it('should set screen dimensions on iOS', () => {
     // $FlowFixMe[incompatible-type] - `Platform.OS` needs to be read-only.
     Platform.OS = 'ios';
-    const dimensions = {
-      width: 400,
-      height: 800,
-      scale: 2,
-      densityDpi: 2,
-      fontScale: 3,
-    };
     Dimensions.set({
       windowPhysicalPixels: dimensions,
     });
 
     expect(Dimensions.get('screen')).toEqual(Dimensions.get('window'));
+  });
+
+  it('should call a listener on each dimension change', () => {
+    const listener = jest.fn();
+    const newDimensions1 = {...dimensions, width: 10};
+    const newDimensions2 = {...dimensions, width: 30};
+    const sub = Dimensions.addEventListener('change', listener);
+
+    Dimensions.set({windowPhysicalPixels: newDimensions1});
+    Dimensions.set({windowPhysicalPixels: newDimensions2});
+
+    expect(listener).toBeCalledTimes(2);
+    expect(listener).toHaveBeenNthCalledWith(1, {
+      screen: {fontScale: 3, height: 400, scale: 2, width: 5},
+      window: {fontScale: 3, height: 400, scale: 2, width: 5},
+    });
+    expect(listener).toHaveBeenNthCalledWith(2, {
+      screen: {fontScale: 3, height: 400, scale: 2, width: 15},
+      window: {fontScale: 3, height: 400, scale: 2, width: 15},
+    });
+    sub.remove();
+  });
+
+  it('should call a listener once', () => {
+    const listener = jest.fn();
+    const newDimensions1 = {...dimensions, fontScale: 1};
+    const newDimensions2 = {...dimensions, fontScale: 2};
+    Dimensions.addEventListener('change', listener, {once: true});
+
+    Dimensions.set({windowPhysicalPixels: newDimensions1});
+    Dimensions.set({windowPhysicalPixels: newDimensions2});
+
+    expect(listener).toBeCalledTimes(1);
+    expect(listener).toBeCalledWith({
+      screen: {fontScale: 1, height: 400, scale: 2, width: 200},
+      window: {fontScale: 1, height: 400, scale: 2, width: 200},
+    });
+  });
+
+  it('should remove a listener on a signal abort', () => {
+    const listener = jest.fn();
+    const newDimensions1 = {...dimensions, fontScale: 1};
+    const newDimensions2 = {...dimensions, fontScale: 2};
+    const c = new AbortController();
+    Dimensions.addEventListener('change', listener, {signal: c.signal});
+
+    Dimensions.set({windowPhysicalPixels: newDimensions2});
+    c.abort(); // remove listener
+    Dimensions.set({windowPhysicalPixels: newDimensions1});
+
+    expect(listener).toBeCalledTimes(1);
+    expect(listener).toBeCalledWith({
+      screen: {fontScale: 2, height: 400, scale: 2, width: 200},
+      window: {fontScale: 2, height: 400, scale: 2, width: 200},
+    });
   });
 });

--- a/packages/react-native/__typetests__/index.tsx
+++ b/packages/react-native/__typetests__/index.tsx
@@ -164,6 +164,13 @@ function testDimensions() {
     dimensionsListener,
   );
   subscription.remove();
+
+  Dimensions.addEventListener('change', dimensionsListener, {
+    once: true,
+  });
+  Dimensions.addEventListener('change', dimensionsListener, {
+    signal: AbortSignal.timeout(5000),
+  });
 }
 
 function TextUseWindowDimensions() {


### PR DESCRIPTION
## Summary:

**Motivation:** Make `addEventListener(...)` method - event target like 

So, `Dimensions.addEventListener` now accept 3rd argument with options `{ once?: boolean, signal?: AbortSignal }`

```tsx
// 1. `once: true` - the listener would be automatically removed when invoked
Dimensions.addEventListener('change', listener, {once: true});

// 2. `signal?: AbortSignal` the listener will be removed when the `abort()` method
const controller = new AbortController();
Dimensions.addEventListener('change', listener, {signal: controller.signal});
```

## Changelog:

[GENERAL] [CHANGED] - Replace `EventEmitter` with `EventTarget` in `Dimensions`

## Test Plan:

```bash
yarn fantom packages/react-native/Libraries/Utilities/__tests__/Dimensions-itest.js --watch
```
