### PR TITLE
Forward host:didInitializeRuntime: callback to user delegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -212,6 +212,13 @@ using namespace facebook::react;
   }
 }
 
+- (void)host:(RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime
+{
+  if ([_delegate respondsToSelector:@selector(host:didInitializeRuntime:)]) {
+    [_delegate host:host didInitializeRuntime:runtime];
+  }
+}
+
 - (NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup
 {
 #if RN_DISABLE_OSS_PLUGIN_HEADER


### PR DESCRIPTION
## Summary:

`RCTReactNativeFactory` acts as `RCTHost`'s delegate but did not implement `host:didInitializeRuntime:`, causing the optional callback to never reach the user's `RCTReactNativeFactoryDelegate`.

Add the missing forwarding method following the same pattern as `hostDidStart:` so the runtime reference is properly delivered to the user delegate.

Fixes #57349.

## Changelog:

[IOS] [FIXED] - Forward `host:didInitializeRuntime:` callback to user delegate in `RCTReactNativeFactory`

## Test Plan:

1. Implement `host:didInitializeRuntime:` in a custom `RCTReactNativeFactoryDelegate` subclass (e.g. RNTester's `AppDelegate`)
2. Build and launch the app
3. Verify the callback is invoked and the `jsi::Runtime` reference is received
4. Confirm `hostDidStart:` continues to work as before