### PR TITLE
Add Fantom tests for scheduler yielding with idle callbacks

### DIFF
--- a/packages/react-native/src/private/webapis/idlecallbacks/__tests__/requestIdleCallback-itest.js
+++ b/packages/react-native/src/private/webapis/idlecallbacks/__tests__/requestIdleCallback-itest.js
@@ -119,4 +119,54 @@ describe('requestIdleCallback', () => {
       requestIdleCallback(idleCallback);
     });
   });
+
+  it('should not yield while executing a low priority task even when scheduling an idle callback', () => {
+    const {
+      unstable_scheduleCallback,
+      unstable_LowPriority,
+      unstable_shouldYield,
+    } = global.nativeRuntimeScheduler;
+
+    let shouldYieldBeforeSchedulingIdleCallback;
+    let shouldYieldAfterSchedulingIdleCallback;
+
+    Fantom.runTask(() => {
+      unstable_scheduleCallback(unstable_LowPriority, () => {
+        shouldYieldBeforeSchedulingIdleCallback = unstable_shouldYield();
+
+        // Scheduling an idle callback (a lower priority task) must not turn
+        // the currently executing low priority task into something that should
+        // yield, as no higher priority work is pending.
+        requestIdleCallback(() => {});
+
+        shouldYieldAfterSchedulingIdleCallback = unstable_shouldYield();
+      });
+    });
+
+    expect(shouldYieldBeforeSchedulingIdleCallback).toBe(false);
+    expect(shouldYieldAfterSchedulingIdleCallback).toBe(false);
+  });
+
+  it('should execute a low priority task scheduled after an idle callback before the idle callback', () => {
+    const {unstable_scheduleCallback, unstable_LowPriority} =
+      global.nativeRuntimeScheduler;
+
+    const executionOrder: Array<string> = [];
+
+    Fantom.runTask(() => {
+      unstable_scheduleCallback(unstable_LowPriority, () => {
+        // Even though the idle callback is scheduled first, the low priority
+        // task scheduled after it has a higher priority, so it must run first.
+        requestIdleCallback(() => {
+          executionOrder.push('idleCallback');
+        });
+
+        unstable_scheduleCallback(unstable_LowPriority, () => {
+          executionOrder.push('lowPriorityTask');
+        });
+      });
+    });
+
+    expect(executionOrder).toEqual(['lowPriorityTask', 'idleCallback']);
+  });
 });


### PR DESCRIPTION
Summary:
Extend the `requestIdleCallback` integration test suite with two cases that cover how idle callbacks interact with low priority tasks running through the scheduler:

- `shouldYield` stays `false` while a low priority task is executing, even when an idle callback is scheduled in the middle of its execution (an idle callback is lower priority, so no yielding is warranted).
- A low priority task scheduled after an idle callback executes before the idle callback, since the low priority task has a higher priority.

Changelog: [Internal]

Differential Revision: D110753031


