### PR TITLE
Fix Fantom REPL crash from metro default import

### DIFF
--- a/private/react-native-fantom/repl/replMetro.js
+++ b/private/react-native-fantom/repl/replMetro.js
@@ -11,7 +11,7 @@
 import type {Server as HttpServer} from 'http';
 import type {Server as HttpsServer} from 'https';
 
-import Metro from 'metro';
+import * as Metro from 'metro';
 import {mergeConfig} from 'metro-config';
 import {Server as NetServer} from 'net';
 import path from 'path';


### PR DESCRIPTION
Summary:
The Fantom REPL (`yarn fantom-cli`) crashed on startup with `TypeError: Cannot read properties of undefined (reading 'loadConfig')`. `metro` is a CommonJS module that only provides named exports, so the default import `import Metro from 'metro'` resolves to `undefined` under the Babel interop used to run the REPL, and any access such as `Metro.loadConfig` throws.

Switch to a namespace import (`import * as Metro from 'metro'`), matching how metro is already imported in the Fantom global setup.

Changelog: [Internal]

Differential Revision: D110754395


