### PR TITLE
Remove duplicate React-jserrorhandler dependency in runtimescheduler podspec

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -49,7 +49,6 @@ Pod::Spec.new do |s|
   s.dependency "React-timing"
   s.dependency "React-jserrorhandler"
   s.dependency "React-jsi"
-  s.dependency "React-jserrorhandler"
   s.dependency "React-performancetimeline"
   s.dependency "React-rendererconsistency"
   add_dependency(s, "React-debug")


### PR DESCRIPTION
Summary:
Removes duplicate `React-jserrorhandler` dependency declaration from the React-runtimescheduler.podspec file. The dependency was listed twice (lines 50 and 52), now consolidated to a single entry.

Changelog: [Internal]

Differential Revision: D110778944


