### PR TITLE
Restore eslint path match for assets-registry (fix CI)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
       files: [
         './packages/react-native/Libraries/**/*.{js,flow}',
         './packages/react-native/src/**/*.{js,flow}',
+        './packages/assets-registry/registry.js',
       ],
       parser: 'hermes-eslint',
       rules: {

--- a/packages/react-native/src/asset-registry.js
+++ b/packages/react-native/src/asset-registry.js
@@ -22,7 +22,7 @@
 
 const {AssetRegistry} = require('./private/assets/AssetRegistry');
 
-/* eslint-disable @react-native/monorepo/no-commonjs-exports */
+// eslint-disable-next-line @react-native/monorepo/no-commonjs-exports
 module.exports = {
   registerAsset: AssetRegistry.registerAsset,
   getAssetByID: AssetRegistry.getAssetByID,


### PR DESCRIPTION
Summary:
D110053924 removed the ESLint config match for `packages/assets-registry/` a little early — the files still exist and an unused suppression warning causes a failure when run with `--max-warnings 0`.

Revert this to restore stable `test_js` jobs on `main`.

{F1992042843}

Changelog: [Internal]

Differential Revision: D110786490


