### PR TITLE
Repro: outlineColor crashes on Android (New Architecture) [#57190]

### DIFF
--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -14,12 +14,25 @@ import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
 
+// Repro for #57190: on Android + New Architecture, setting `outlineColor`
+// crashes with:
+//   java.lang.ClassCastException: java.lang.Double cannot be cast to
+//   java.lang.Integer
+//     at com.facebook.react.uimanager.BaseViewManagerDelegate.setProperty
+//
+// Root cause: `BaseViewManagerDelegate` casts the outline color prop straight
+// to Int (`value as Int?`) while every other color prop (backgroundColor,
+// shadowColor) uses `ColorPropConverter.getColor(...)`. Under Fabric, color
+// props are always delivered as `Double`, so the cast throws on mount.
+//
+// Rendering the View below is enough to crash the app on Android.
 function Playground() {
   return (
     <View style={styles.container}>
       <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
+        #57190: the outlined box below crashes on Android (New Architecture)
       </RNTesterText>
+      <View style={styles.outlined} />
     </View>
   );
 }
@@ -27,6 +40,14 @@ function Playground() {
 const styles = StyleSheet.create({
   container: {
     padding: 10,
+    gap: 10,
+  },
+  outlined: {
+    width: 100,
+    height: 100,
+    outlineColor: '#007AFF',
+    outlineWidth: 2,
+    outlineStyle: 'solid',
   },
 });
 


### PR DESCRIPTION
## Summary

Reproduction for #57190.

On **Android + New Architecture**, setting `outlineColor` on any view crashes on mount:

```
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Integer
    at com.facebook.react.uimanager.BaseViewManagerDelegate.setProperty(BaseViewManagerDelegate.kt:107)
```

Root cause: in `BaseViewManagerDelegate.kt`, the outline color prop is cast directly to `Int`:

```kotlin
ViewProps.OUTLINE_COLOR -> mViewManager.setOutlineColor(view, value as Int?)
```

while the sibling color props go through `ColorPropConverter.getColor(...)`:

```kotlin
ViewProps.BACKGROUND_COLOR -> setBackgroundColor(view, ColorPropConverter.getColor(value, view.context, 0))
ViewProps.SHADOW_COLOR     -> setShadowColor(view, ColorPropConverter.getColor(value, view.context, 0))
```

Under Fabric, color props are delivered as `java.lang.Double`, so `value as Int?` throws. Likely introduced in #46934; reproduces on 0.85+.

This PR edits `RNTesterPlayground.js` to reproduce the crash, per the contributing guidelines.

## Changelog:

[INTERNAL] [CHANGED] - Repro for outlineColor ClassCastException in RNTesterPlayground

## Test Plan

1. Build RNTester for Android with the New Architecture enabled.
2. Open the **Playground** example.
3. The app crashes on mount with `java.lang.Double cannot be cast to java.lang.Integer` from `BaseViewManagerDelegate.setProperty`.

Not reproducible on iOS, and not on the legacy architecture when the packed ARGB color fits in a signed 32-bit int.
