### PR TITLE
fix(podspec): remove duplicate scrollview subspec in React-FabricComponents

### DIFF
--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -101,17 +101,6 @@ Pod::Spec.new do |s|
       sss.header_dir           = "react/renderer/components/safeareaview"
     end
 
-    ss.subspec "scrollview" do |sss|
-      sss.source_files         = podspec_sources(["react/renderer/components/scrollview/*.{m,mm,cpp,h}",
-                                  "react/renderer/components/scrollview/platform/cxx/**/*.{m,mm,cpp,h}",
-                                  "react/renderer/components/scrollview/platform/ios/**/*.{m,mm,cpp,h}"],
-                                  ["react/renderer/components/scrollview/*.h",
-                                  "react/renderer/components/scrollview/platform/cxx/**/*.h",
-                                  "react/renderer/components/scrollview/platform/ios/**/*.h"])
-      sss.exclude_files        = "react/renderer/components/scrollview/tests"
-      sss.header_dir           = "react/renderer/components/scrollview"
-    end
-
     ss.subspec "text" do |sss|
       sss.source_files         = podspec_sources(["react/renderer/components/text/*.{m,mm,cpp,h}",
                                   "react/renderer/components/text/platform/cxx/**/*.{m,mm,cpp,h}"],


### PR DESCRIPTION
## Summary

Upstream version of our react-native-macos fix (microsoft/react-native-macos#2969).

The `scrollview` subspec is declared in both `React-Fabric.podspec` (recursive
`scrollview/**/*` glob) and `React-FabricComponents.podspec` (`scrollview/*` +
`platform/cxx` + `platform/ios`). The globs overlap, so after `pod install` the
same sources (`ScrollViewShadowNode.cpp`, `BaseScrollViewProps.cpp`,
`ScrollEvent.cpp`, etc.) land in both the `React-Fabric` and
`React-FabricComponents` Pods targets, and consumers that link both (e.g. via
`-all_load`) hit duplicate symbol errors.

`React-Fabric.podspec`'s recursive glob already covers everything
FabricComponents listed, so this removes the duplicate subspec.

Note on SPM: the SPM manifest (`Package.swift`) handles scrollview differently —
it's assigned solely to the `React-Fabric` target, with no FabricComponents
scrollview target. This is an existing divergence between the CocoaPods and SPM
setups; this PR only touches CocoaPods, so SPM is unaffected.

## Changelog:

[IOS] [FIXED] - emove duplicate scrollview subspec in React-FabricComponents

## Test Plan

CI should pass.
