### PR TITLE
Fix visibility of NativeMap/Array internal symbols

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/PerformanceCounter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/PerformanceCounter.kt
@@ -6,6 +6,7 @@
  */
 
 package com.facebook.react.bridge
+
 public interface PerformanceCounter {
   public fun profileNextBatch()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.kt
@@ -108,7 +108,7 @@ public open class ReadableNativeArray protected constructor() : NativeArray(), R
     return arrayList
   }
 
-  private companion object {
+  internal companion object {
     @get:JvmStatic
     @get:JvmName("getJNIPassCounter")
     var jniPassCounter: Int = 0

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.kt
@@ -215,7 +215,7 @@ public open class ReadableNativeMap protected constructor() : NativeMap(), Reada
     return hashMap
   }
 
-  private companion object {
+  internal companion object {
     @get:JvmStatic
     @get:JvmName("getJNIPassCounter")
     var jniPassCounter: Int = 0


### PR DESCRIPTION
Summary:
`getJNIPassCounter` was visible to Java but not to internal Kotlin targets.

Changelog: [internal]

Differential Revision: D110877445


