### PR TITLE
Update remaining facebook/react-native references to react/react-native in .github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
 ✋ To keep the backlog clean and actionable, issues will be
 🚫 closed if they do not follow one of the issue templates:
-👉 https://github.com/facebook/react-native/issues/new/choose
+👉 https://github.com/react/react-native/issues/new/choose
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,11 +16,11 @@ body:
         * If you're found a problem with our **documentation**, [report it here](https://github.com/facebook/react-native-website/issues/).
         * If you're having an issue with **Metro** (the bundler), [report it here](https://github.com/facebook/metro/issues/).
         * If you're using an external library, report the issue to the **library first**.
-        * Please [search for similar issues](https://github.com/facebook/react-native/issues) in our issue tracker.
+        * Please [search for similar issues](https://github.com/react/react-native/issues) in our issue tracker.
 
         Make sure that your issue:
         * Have a **valid reproducer** (See [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug)).
-        * Is tested against the [**latest stable**](https://github.com/facebook/react-native/releases/) of React Native.
+        * Is tested against the [**latest stable**](https://github.com/react/react-native/releases/) of React Native.
 
         🚨 IMPORTANT: Due to the extreme number of bugs we receive, issues **without a reproducer** or for an [**unsupported versions**](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) of React Native **will be closed**.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/debugger_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/debugger_bug_report.yml
@@ -16,9 +16,9 @@ body:
         * If you've found a problem with our **documentation**, [report it here](https://github.com/facebook/react-native-website/issues/).
         * If you're having an issue with **Metro** (the bundler), [report it here](https://github.com/facebook/metro/issues/).
         * If you're using an external library, report the issue to the **library first**.
-        * Please [search for similar issues](https://github.com/facebook/react-native/issues) in our issue tracker.
+        * Please [search for similar issues](https://github.com/react/react-native/issues) in our issue tracker.
 
-        Make sure that your issue is tested against the [**latest stable**](https://github.com/facebook/react-native/releases/) of React Native.
+        Make sure that your issue is tested against the [**latest stable**](https://github.com/react/react-native/releases/) of React Native.
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
@@ -12,12 +12,12 @@ body:
         Thank you for taking the time to report an issue for [the New Architecture of React Native](https://reactnative.dev/docs/the-new-architecture/landing-page),
         your contribution will help make the framework better for everyone.
 
-        If you're **NOT** using the New Architecture, please use this [other bug type](https://github.com/facebook/react-native/issues/new?template=bug_report.yml).
+        If you're **NOT** using the New Architecture, please use this [other bug type](https://github.com/react/react-native/issues/new?template=bug_report.yml).
         Do not attempt to open a bug in this category if you're not using the New Architecture as your bug will be closed.
 
         Make sure that your issue:
         * Have a **valid reproducer** (See [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug)).
-        * Is tested against the [**latest stable**](https://github.com/facebook/react-native/releases/) of React Native.
+        * Is tested against the [**latest stable**](https://github.com/react/react-native/releases/) of React Native.
 
         🚨 IMPORTANT: Due to the extreme number of bugs we receive, issues **without a reproducer** or for an [**unsupported versions**](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) of React Native **will be closed**.
   - type: textarea

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -20,4 +20,4 @@ To help you upgrade to this version, you can use the [upgrade helper](https://re
 
 ---
 
-See changes from this release in the [changelog PR](https://github.com/facebook/react-native/labels/%F0%9F%93%9D%20Changelog)
+See changes from this release in the [changelog PR](https://github.com/react/react-native/labels/%F0%9F%93%9D%20Changelog)

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -15,7 +15,7 @@ The React Native website is hosted on a [separate repository](https://github.com
 
 ## 🐛 I found a bug in React Native.
 
-If you want to report a reproducible bug or regression in the React Native library, you can [create a new issue](https://github.com/facebook/react-native/issues/new?labels=Type%3A+Bug+Report&template=bug_report.md). It's a good idea to look through [open issues](https://github.com/facebook/react-native/issues) before doing so, as someone else may have reported a similar issue.
+If you want to report a reproducible bug or regression in the React Native library, you can [create a new issue](https://github.com/react/react-native/issues/new?labels=Type%3A+Bug+Report&template=bug_report.md). It's a good idea to look through [open issues](https://github.com/react/react-native/issues) before doing so, as someone else may have reported a similar issue.
 
 
 ## 🚀 I want to discuss the future of React Native.

--- a/.github/workflow-scripts/__tests__/createDraftRelease-test.js
+++ b/.github/workflow-scripts/__tests__/createDraftRelease-test.js
@@ -38,7 +38,7 @@ describe('Create Draft Release', () => {
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://github.com/facebook/react-native/releases/tag/v0.77.1',
+        'https://github.com/react/react-native/releases/tag/v0.77.1',
       );
     });
   });
@@ -49,39 +49,39 @@ describe('Create Draft Release', () => {
 
 ## v0.77.2
 
-- [PR #1234](https://github.com/facebook/react-native/pull/1234) - Some change
-- [PR #5678](https://github.com/facebook/react-native/pull/5678) - Some other change
+- [PR #1234](https://github.com/react/react-native/pull/1234) - Some change
+- [PR #5678](https://github.com/react/react-native/pull/5678) - Some other change
 
 
 ## v0.77.1
 ### Breaking Changes
-- [PR #9012](https://github.com/facebook/react-native/pull/9012) - Some other change
+- [PR #9012](https://github.com/react/react-native/pull/9012) - Some other change
 
 #### Android
-- [PR #3456](https://github.com/facebook/react-native/pull/3456) - Some other change
-- [PR #3457](https://github.com/facebook/react-native/pull/3457) - Some other change
+- [PR #3456](https://github.com/react/react-native/pull/3456) - Some other change
+- [PR #3457](https://github.com/react/react-native/pull/3457) - Some other change
 
 #### iOS
-- [PR #3436](https://github.com/facebook/react-native/pull/3436) - Some other change
-- [PR #3437](https://github.com/facebook/react-native/pull/3437) - Some other change
+- [PR #3436](https://github.com/react/react-native/pull/3436) - Some other change
+- [PR #3437](https://github.com/react/react-native/pull/3437) - Some other change
 
 ### Fixed
-- [PR #9012](https://github.com/facebook/react-native/pull/9012) - Some other change
+- [PR #9012](https://github.com/react/react-native/pull/9012) - Some other change
 
 #### Android
-- [PR #3456](https://github.com/facebook/react-native/pull/3456) - Some other change
+- [PR #3456](https://github.com/react/react-native/pull/3456) - Some other change
 
 #### iOS
-- [PR #3437](https://github.com/facebook/react-native/pull/3437) - Some other change
+- [PR #3437](https://github.com/react/react-native/pull/3437) - Some other change
 
 
 ## v0.77.0
 
-- [PR #3456](https://github.com/facebook/react-native/pull/3456) - Some other change
+- [PR #3456](https://github.com/react/react-native/pull/3456) - Some other change
 
 ## v0.76.0
 
-- [PR #7890](https://github.com/facebook/react-native/pull/7890) - Some other change`;
+- [PR #7890](https://github.com/react/react-native/pull/7890) - Some other change`;
 
       jest.spyOn(fs, 'readFileSync').mockImplementationOnce(func => {
         return mockedReturnValue;
@@ -89,24 +89,24 @@ describe('Create Draft Release', () => {
       const changelog = _extractChangelog('0.77.1');
       expect(changelog).toEqual(`## v0.77.1
 ### Breaking Changes
-- [PR #9012](https://github.com/facebook/react-native/pull/9012) - Some other change
+- [PR #9012](https://github.com/react/react-native/pull/9012) - Some other change
 
 #### Android
-- [PR #3456](https://github.com/facebook/react-native/pull/3456) - Some other change
-- [PR #3457](https://github.com/facebook/react-native/pull/3457) - Some other change
+- [PR #3456](https://github.com/react/react-native/pull/3456) - Some other change
+- [PR #3457](https://github.com/react/react-native/pull/3457) - Some other change
 
 #### iOS
-- [PR #3436](https://github.com/facebook/react-native/pull/3436) - Some other change
-- [PR #3437](https://github.com/facebook/react-native/pull/3437) - Some other change
+- [PR #3436](https://github.com/react/react-native/pull/3436) - Some other change
+- [PR #3437](https://github.com/react/react-native/pull/3437) - Some other change
 
 ### Fixed
-- [PR #9012](https://github.com/facebook/react-native/pull/9012) - Some other change
+- [PR #9012](https://github.com/react/react-native/pull/9012) - Some other change
 
 #### Android
-- [PR #3456](https://github.com/facebook/react-native/pull/3456) - Some other change
+- [PR #3456](https://github.com/react/react-native/pull/3456) - Some other change
 
 #### iOS
-- [PR #3437](https://github.com/facebook/react-native/pull/3437) - Some other change`);
+- [PR #3437](https://github.com/react/react-native/pull/3437) - Some other change`);
     });
 
     it('does not extract changelog for rc.0', async () => {
@@ -129,15 +129,15 @@ describe('Create Draft Release', () => {
       });
       const changelog = `## v${version}
 ### Breaking Changes
-- [PR #9012](https://github.com/facebook/react-native/pull/9012) - Some other change
+- [PR #9012](https://github.com/react/react-native/pull/9012) - Some other change
 
 #### Android
-- [PR #3456](https://github.com/facebook/react-native/pull/3456) - Some other change
-- [PR #3457](https://github.com/facebook/react-native/pull/3457) - Some other change
+- [PR #3456](https://github.com/react/react-native/pull/3456) - Some other change
+- [PR #3457](https://github.com/react/react-native/pull/3457) - Some other change
 
 #### iOS
-- [PR #3436](https://github.com/facebook/react-native/pull/3436) - Some other change
-- [PR #3437](https://github.com/facebook/react-native/pull/3437) - Some other change`;
+- [PR #3436](https://github.com/react/react-native/pull/3436) - Some other change
+- [PR #3437](https://github.com/react/react-native/pull/3437) - Some other change`;
       const body = _computeBody(changelog, version);
 
       expect(body).toEqual(`${changelog}
@@ -166,7 +166,7 @@ To help you upgrade to this version, you can use the [Upgrade Helper](https://re
 
 ---
 
-View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/react-native/blob/main/CHANGELOG.md).`);
+View the whole changelog in the [CHANGELOG.md file](https://github.com/react/react-native/blob/main/CHANGELOG.md).`);
     });
 
     it('computes body for release when hermes versions are passed', async () => {
@@ -174,15 +174,15 @@ View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/
       const hermesVersion = '0.15.0';
       const changelog = `## v${version}
 ### Breaking Changes
-- [PR #9012](https://github.com/facebook/react-native/pull/9012) - Some other change
+- [PR #9012](https://github.com/react/react-native/pull/9012) - Some other change
 
 #### Android
-- [PR #3456](https://github.com/facebook/react-native/pull/3456) - Some other change
-- [PR #3457](https://github.com/facebook/react-native/pull/3457) - Some other change
+- [PR #3456](https://github.com/react/react-native/pull/3456) - Some other change
+- [PR #3457](https://github.com/react/react-native/pull/3457) - Some other change
 
 #### iOS
-- [PR #3436](https://github.com/facebook/react-native/pull/3436) - Some other change
-- [PR #3437](https://github.com/facebook/react-native/pull/3437) - Some other change`;
+- [PR #3436](https://github.com/react/react-native/pull/3436) - Some other change
+- [PR #3437](https://github.com/react/react-native/pull/3437) - Some other change`;
       const body = _computeBody(changelog, version, hermesVersion);
 
       expect(body).toEqual(`${changelog}
@@ -211,14 +211,14 @@ To help you upgrade to this version, you can use the [Upgrade Helper](https://re
 
 ---
 
-View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/react-native/blob/main/CHANGELOG.md).`);
+View the whole changelog in the [CHANGELOG.md file](https://github.com/react/react-native/blob/main/CHANGELOG.md).`);
     });
   });
 
   describe('#_createDraftReleaseOnGitHub', () => {
     it('creates a draft release on GitHub', async () => {
       const version = '0.77.1';
-      const url = 'https://api.github.com/repos/facebook/react-native/releases';
+      const url = 'https://api.github.com/repos/react/react-native/releases';
       const token = 'token';
       const headers = {
         Accept: 'Accept: application/vnd.github+json',
@@ -243,7 +243,7 @@ View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/
             Promise.resolve({
               id: 1,
               html_url:
-                'https://github.com/facebook/react-native/releases/tag/v0.77.1',
+                'https://github.com/react/react-native/releases/tag/v0.77.1',
             }),
         }),
       );
@@ -255,7 +255,7 @@ View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        `https://api.github.com/repos/facebook/react-native/releases`,
+        `https://api.github.com/repos/react/react-native/releases`,
         {
           method: 'POST',
           headers: headers,
@@ -265,13 +265,13 @@ View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/
       expect(response).toEqual({
         id: 1,
         html_url:
-          'https://github.com/facebook/react-native/releases/tag/v0.77.1',
+          'https://github.com/react/react-native/releases/tag/v0.77.1',
       });
     });
 
     it('creates a draft release for prerelease on GitHub', async () => {
       const version = '0.77.0-rc.2';
-      const url = 'https://api.github.com/repos/facebook/react-native/releases';
+      const url = 'https://api.github.com/repos/react/react-native/releases';
       const token = 'token';
       const headers = {
         Accept: 'Accept: application/vnd.github+json',
@@ -296,7 +296,7 @@ View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/
             Promise.resolve({
               id: 1,
               html_url:
-                'https://github.com/facebook/react-native/releases/tag/v0.77.1',
+                'https://github.com/react/react-native/releases/tag/v0.77.1',
             }),
         }),
       );
@@ -308,7 +308,7 @@ View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        `https://api.github.com/repos/facebook/react-native/releases`,
+        `https://api.github.com/repos/react/react-native/releases`,
         {
           method: 'POST',
           headers: headers,
@@ -318,13 +318,13 @@ View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/
       expect(response).toEqual({
         id: 1,
         html_url:
-          'https://github.com/facebook/react-native/releases/tag/v0.77.1',
+          'https://github.com/react/react-native/releases/tag/v0.77.1',
       });
     });
 
     it('throws if the post failes', async () => {
       const version = '0.77.0-rc.2';
-      const url = 'https://api.github.com/repos/facebook/react-native/releases';
+      const url = 'https://api.github.com/repos/react/react-native/releases';
       const token = 'token';
       const headers = {
         Accept: 'Accept: application/vnd.github+json',
@@ -352,7 +352,7 @@ View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/
       ).rejects.toThrowError();
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        `https://api.github.com/repos/facebook/react-native/releases`,
+        `https://api.github.com/repos/react/react-native/releases`,
         {
           method: 'POST',
           headers: headers,

--- a/.github/workflow-scripts/__tests__/generateChangelog-test.js
+++ b/.github/workflow-scripts/__tests__/generateChangelog-test.js
@@ -191,7 +191,7 @@ N/A`;
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.github.com/repos/facebook/react-native/pulls',
+        'https://api.github.com/repos/react/react-native/pulls',
         {
           method: 'POST',
           headers: headers,
@@ -203,7 +203,7 @@ N/A`;
       const currentVersion = '0.79.0-rc5';
       const token = 'token';
       const expectedPrURL =
-        'https://github.com/facebook/react-native/pulls/1234';
+        'https://github.com/react/react-native/pulls/1234';
 
       const returnedObject = {
         status: 201,
@@ -238,7 +238,7 @@ N/A`;
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.github.com/repos/facebook/react-native/pulls',
+        'https://api.github.com/repos/react/react-native/pulls',
         {
           method: 'POST',
           headers: headers,

--- a/.github/workflow-scripts/actOnLabel.js
+++ b/.github/workflow-scripts/actOnLabel.js
@@ -84,7 +84,7 @@ module.exports = async (github, context, labelWithContext) => {
     case 'Needs: Issue Template':
       await addComment(
         `> [!WARNING]\n` +
-          `> **Missing issue template**: It looks like your issue may be missing some necessary information. GitHub provides an example template whenever a [new issue is created](https://github.com/facebook/react-native/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A&projects=&template=bug_report.yml). Could you go back and make sure to fill out the template? You may edit this issue, or close it and open a new one.`,
+          `> **Missing issue template**: It looks like your issue may be missing some necessary information. GitHub provides an example template whenever a [new issue is created](https://github.com/react/react-native/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A&projects=&template=bug_report.yml). Could you go back and make sure to fill out the template? You may edit this issue, or close it and open a new one.`,
       );
       await requestAuthorFeedback();
       return;
@@ -105,7 +105,7 @@ module.exports = async (github, context, labelWithContext) => {
     case 'Needs: Repro':
       await addComment(
         `> [!WARNING]\n` +
-          `> **Missing reproducer**: We could not detect a reproducible example in your issue report. Reproducers are **mandatory** and we can accept only one of those as a valid reproducer: <br/><ul><li>For majority of bugs: send us a Pull Request with the [RNTesterPlayground.js](https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js) edited to reproduce your bug.</li><li>If your bug is UI related: a [Snack](https://snack.expo.dev)</li><li> If your bug is build/upgrade related: a project using our [Reproducer Template](https://github.com/react-native-community/reproducer-react-native/generate)</li></ul><br/>You can read more about about it on our website: [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug).`,
+          `> **Missing reproducer**: We could not detect a reproducible example in your issue report. Reproducers are **mandatory** and we can accept only one of those as a valid reproducer: <br/><ul><li>For majority of bugs: send us a Pull Request with the [RNTesterPlayground.js](https://github.com/react/react-native/blob/main/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js) edited to reproduce your bug.</li><li>If your bug is UI related: a [Snack](https://snack.expo.dev)</li><li> If your bug is build/upgrade related: a project using our [Reproducer Template](https://github.com/react-native-community/reproducer-react-native/generate)</li></ul><br/>You can read more about about it on our website: [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug).`,
       );
       await requestAuthorFeedback();
       return;

--- a/.github/workflow-scripts/analyze_scripts.sh
+++ b/.github/workflow-scripts/analyze_scripts.sh
@@ -21,6 +21,6 @@ if [ -x "$(command -v shellcheck)" ]; then
     -exec sh -c 'shellcheck "$1"' -- {} \;
 
 else
-  echo 'shellcheck is not installed. See https://github.com/facebook/react-native/wiki/Development-Dependencies#shellcheck for instructions.'
+  echo 'shellcheck is not installed. See https://github.com/react/react-native/wiki/Development-Dependencies#shellcheck for instructions.'
   exit 1
 fi

--- a/.github/workflow-scripts/createDraftRelease.js
+++ b/.github/workflow-scripts/createDraftRelease.js
@@ -23,8 +23,8 @@ function _extractChangelog(version) {
     // for RC.0 and for the release of a new stable minor, the changelog is too long
     // to be added in a release. The release body is usually something shorter.
     // See for example the release for 0.76.0 or 0.77.0:
-    // 0.76: https://github.com/facebook/react-native/releases/tag/v0.76.0
-    // 0.77: https://github.com/facebook/react-native/releases/tag/v0.77.0
+    // 0.76: https://github.com/react/react-native/releases/tag/v0.76.0
+    // 0.77: https://github.com/react/react-native/releases/tag/v0.77.0
     return '';
   }
   const changelog = String(fs.readFileSync('CHANGELOG.md', 'utf8')).split('\n');
@@ -85,11 +85,11 @@ To help you upgrade to this version, you can use the [Upgrade Helper](https://re
 
 ---
 
-View the whole changelog in the [CHANGELOG.md file](https://github.com/facebook/react-native/blob/main/CHANGELOG.md).`;
+View the whole changelog in the [CHANGELOG.md file](https://github.com/react/react-native/blob/main/CHANGELOG.md).`;
 }
 
 async function _verifyTagExists(version) {
-  const url = `https://github.com/facebook/react-native/releases/tag/v${version}`;
+  const url = `https://github.com/react/react-native/releases/tag/v${version}`;
 
   const response = await fetch(url);
   if (response.status === 404) {
@@ -98,7 +98,7 @@ async function _verifyTagExists(version) {
 }
 
 async function _createDraftReleaseOnGitHub(version, body, latest, token) {
-  const url = 'https://api.github.com/repos/facebook/react-native/releases';
+  const url = 'https://api.github.com/repos/react/react-native/releases';
   const method = 'POST';
   const headers = _headers(token);
   const fetchBody = JSON.stringify({

--- a/.github/workflow-scripts/generateChangelog.js
+++ b/.github/workflow-scripts/generateChangelog.js
@@ -59,7 +59,7 @@ function _pushCommit(version) {
 
 async function _createPR(version, token) {
   log('Creating changelog pr');
-  const url = 'https://api.github.com/repos/facebook/react-native/pulls';
+  const url = 'https://api.github.com/repos/react/react-native/pulls';
   const body = `
 ## Summary
 Add Changelog for ${version}


### PR DESCRIPTION
## Summary

The repo's canonical home is now `react/react-native` (GitHub redirects `facebook/react-native` → `react/react-native`). #57167 migrated the workflow fork-prevention guards (`github.repository == 'react/react-native'`) but only touched the workflow `if:` guards — it left **64 stale `facebook/react-native` references** scattered across the rest of `.github`:

- **Release/changelog automation** that calls the GitHub API at the old path (`createDraftRelease.js`, `generateChangelog.js`) — functionally important.
- Bot comment links (`actOnLabel.js`).
- Issue templates, `SUPPORT.md`, `RELEASE_TEMPLATE.md`, and the shellcheck wiki link.
- The corresponding `__tests__` assertions.

This PR updates all remaining RN-repo references to `react/react-native`, and **deliberately preserves the 5 `facebook/react-native-website` references** (a separate repo — the docs site).

## Test plan

- `grep -rn "facebook/react-native" .github/ | grep -v "react-native-website"` returns nothing; the 5 `-website` refs remain untouched.
- `yarn jest .github/workflow-scripts/__tests__/createDraftRelease-test.js .github/workflow-scripts/__tests__/generateChangelog-test.js` → 20/20 pass.

## Note

This cleanup fixes the release/changelog automation and reference consistency. It does not by itself restart the nightly schedule — that also requires the scheduled workflow to be re-enabled in the Actions tab (GitHub disables schedules on a repo transfer/rename).

Changelog: [Internal]