### PR TITLE
Add type-test for View imperative handle methods

### DIFF
--- a/packages/react-native/__typetests__/component-refs.tsx
+++ b/packages/react-native/__typetests__/component-refs.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {View} from 'react-native';
+
+// A ref to a host component resolves to its imperative handle, which exposes
+// the native measurement and mutation methods. `React.ComponentRef<typeof View>`
+// is the pattern that resolves to that handle under both the legacy and the
+// strict public types; the `View` component type itself is not the handle.
+type ViewHandle = React.ComponentRef<typeof View>;
+
+export function ViewImperativeHandle() {
+  const viewRef = React.useRef<ViewHandle>(null);
+  const targetRef = React.useRef<ViewHandle>(null);
+
+  const measure = () => {
+    const view = viewRef.current;
+    const target = targetRef.current;
+    if (view == null || target == null) {
+      return;
+    }
+
+    view.measure(
+      (
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        pageX: number,
+        pageY: number,
+      ) => {},
+    );
+
+    view.measureInWindow(
+      (x: number, y: number, width: number, height: number) => {},
+    );
+
+    view.measureLayout(
+      target,
+      (left: number, top: number, width: number, height: number) => {},
+      () => {},
+    );
+
+    view.setNativeProps({});
+  };
+
+  return (
+    <View ref={viewRef}>
+      <View ref={targetRef} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary:

Calling imperative handle methods on a `View` ref works through `React.ComponentRef<typeof View>`, but the public type-tests only covered `measure`, `measureInWindow`, and `setNativeProps`, leaving `measureLayout` with no type-level regression guard. This adds a focused type-test that pins the full handle contract against both the legacy and the generated strict public types.

Root cause of the gap: a ref to a host component resolves to its imperative handle (`ReactNativeElement` under the strict types), not to the `View` component type. The component type is a function and does not carry the native methods, so the type that must be exercised is `React.ComponentRef<typeof View>`. Without a test asserting `measureLayout` on that type, a change to the handle surface could drop the method from the public types without failing CI.

Fix: add `packages/react-native/__typetests__/view-ref.tsx` asserting `measure`, `measureInWindow`, `measureLayout`, and `setNativeProps` on `React.ComponentRef<typeof View>`. The file lives in the shared `__typetests__` directory, so it is type-checked against both `types/` (legacy) and `types_generated/` (strict, via `react-native-strict-api`).

## On `ViewInstance` (per @huntie's note on #54104)

Checked how the new `ViewInstance` / per-component `*Instance` types affect this test. Findings from the repo:

- `ViewInstance` is exported today on `main` (`packages/react-native/Libraries/Components/View/View.js`: `export type ViewInstance = HostInstance`, re-exported from `index.js.flow`) and is present in `0.87-stable` but not in `0.86-stable`, so it ships in 0.87 as noted.
- It is part of the Strict TypeScript API only (introduced in #56953, aligned in #56951, per react-native-community/discussions-and-proposals#1003). The legacy hand-written `types/` still model `View` as `class View extends ViewBase` and do not export `ViewInstance`.
- `ViewInstance` resolves to `HostInstance` / `ReactNativeElement`, the same handle `React.ComponentRef<typeof View>` resolves to, so it covers all four methods this test pins. `React.ComponentRef<typeof View>` is not superseded for this purpose and is still used in `__typetests__/index.tsx`.

Because this test is checked against both the legacy and strict variants, it stays on `React.ComponentRef<typeof View>`: that is the spelling valid under both, whereas `ViewInstance` would not resolve under the legacy variant. Once the strict API is the default, a strict-only follow-up could assert the same contract through `useRef<ViewInstance>` directly.

## Changelog:

[INTERNAL] [ADDED] - Add type-test for View imperative handle methods

## Test Plan:

Both type-check suites pass with the new file, and the file lints clean.

```
$ yarn test-typescript
$ tsc -p packages/react-native/types/tsconfig.json
(exit 0)

$ yarn test-generated-typescript
$ tsc -p packages/react-native/types_generated/tsconfig.test.json
(exit 0)

$ eslint --max-warnings 0 packages/react-native/__typetests__/view-ref.tsx
(exit 0)
```

Confirmed the test guards the contract: adding a call to a non-existent method on the ref (`view.nonExistentMethod123()`) fails both suites with `TS2339: Property 'nonExistentMethod123' does not exist on type 'ReactNativeElement'` (strict) and `... on type 'View'` (legacy). Removing that line restores a clean pass.

This does not change the behavior reported in #54104 that `useRef<View>().measure()` errors under the strict types; per @huntie that is addressed for app code in 0.87 via `useRef<ViewInstance>`. This PR guards the existing supported pattern and closes the `measureLayout` coverage gap.

Refs #54104
