### PR TITLE
Remove ReactNativeElement from Fantom tests (nullthrows/HostInstance/HTMLElement)

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -13,13 +13,13 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
 import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
+import * as React from 'react';
 import {createRef} from 'react';
 import {Animated, Easing, View, useAnimatedValue} from 'react-native';
 import {allowStyleProp} from 'react-native/Libraries/Animated/NativeAnimatedAllowlist';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 // Deferred start outputs the initial value on the first animation frame and
 // re-anchors timing on the second. This delays animation progress by one
@@ -54,7 +54,7 @@ test('moving box by 100 points', () => {
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   expect(viewElement.getBoundingClientRect().x).toBe(0);
 
@@ -119,7 +119,7 @@ test('native-driven interpolation honors custom easing', () => {
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   Fantom.runTask(() => {
     Animated.timing(_progress, {
@@ -179,7 +179,7 @@ test('native-driven interpolation preserves easing overshoot under clamp', () =>
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   Fantom.runTask(() => {
     Animated.timing(_progress, {
@@ -231,7 +231,7 @@ function startTimingAnimationAndGetTranslateXAfterFirstFrame(): number {
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   Fantom.runTask(() => {
     Animated.timing(_translateX, {
@@ -326,11 +326,8 @@ test('animation driven by onScroll event', () => {
     root.render(<PressableWithNativeDriver />);
   });
 
-  const scrollViewelement = ensureInstance(
-    scrollViewRef.current,
-    ReactNativeElement,
-  );
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const scrollViewelement = nullthrows(scrollViewRef.current);
+  const viewElement = nullthrows(viewRef.current);
 
   Fantom.scrollTo(scrollViewelement, {
     x: 0,
@@ -397,10 +394,7 @@ test('animation driven by onScroll event when animated view is unmounted', () =>
     root.render(<PressableWithNativeDriver mountAnimatedView={false} />);
   });
 
-  const scrollViewelement = ensureInstance(
-    scrollViewRef.current,
-    ReactNativeElement,
-  );
+  const scrollViewelement = nullthrows(scrollViewRef.current);
 
   Fantom.scrollTo(scrollViewelement, {
     x: 0,
@@ -438,7 +432,7 @@ test('animated opacity', () => {
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   expect(viewElement.getBoundingClientRect().x).toBe(0);
 
@@ -492,7 +486,7 @@ test('moving box by 50 points with offset 10', () => {
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   expect(viewElement.getBoundingClientRect().x).toBe(0);
 
@@ -592,11 +586,8 @@ describe('Value.flattenOffset', () => {
       _onScroll.addListener(fn);
     });
 
-    const scrollViewelement = ensureInstance(
-      scrollViewRef.current,
-      ReactNativeElement,
-    );
-    const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+    const scrollViewelement = nullthrows(scrollViewRef.current);
+    const viewElement = nullthrows(viewRef.current);
 
     Fantom.scrollTo(scrollViewelement, {
       x: 0,
@@ -676,11 +667,8 @@ describe('Value.extractOffset', () => {
       _onScroll.addListener(fn);
     });
 
-    const scrollViewelement = ensureInstance(
-      scrollViewRef.current,
-      ReactNativeElement,
-    );
-    const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+    const scrollViewelement = nullthrows(scrollViewRef.current);
+    const viewElement = nullthrows(viewRef.current);
 
     Fantom.scrollTo(scrollViewelement, {
       x: 0,
@@ -751,7 +739,7 @@ test('animate layout props', () => {
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   Fantom.runTask(() => {
     _heightAnimation = Animated.timing(_animatedHeight, {
@@ -819,7 +807,7 @@ test('AnimatedValue.interpolate', () => {
     root.render(<MyApp outputRangeX={1} />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   expect(_valueX?.__getValue()).toBe(0.5);
   expect(_interpolatedValueX?.__getValue()).toBe(50);
@@ -891,7 +879,7 @@ test('Animated.sequence', () => {
     root.render(<MyApp />);
   });
 
-  const element = ensureInstance(elementRef.current, ReactNativeElement);
+  const element = nullthrows(elementRef.current);
 
   expect(element.getBoundingClientRect().y).toBe(0);
 

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedBackend-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedBackend-itest.js
@@ -13,13 +13,12 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {Component, createRef, memo, useEffect, useMemo, useState} from 'react';
 import {Animated, View, useAnimatedValue} from 'react-native';
 import {allowStyleProp} from 'react-native/Libraries/Animated/NativeAnimatedAllowlist';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 // marginLeft (and the other margin props) are only on the native animated
 // allowlist when the shared backend is enabled. This test deliberately does NOT
@@ -108,7 +107,7 @@ test('animated opacity', () => {
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   expect(viewElement.getBoundingClientRect().x).toBe(0);
 
@@ -414,7 +413,7 @@ test('animate non-layout props and rerender', () => {
     root.render(<MyApp />);
   });
 
-  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+  const viewElement = nullthrows(viewRef.current);
 
   Fantom.runTask(() => {
     _opacityAnimation = Animated.timing(_animatedOpacity, {

--- a/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-itest.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-itest.js
@@ -10,12 +10,13 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import ensureInstance from '../../../../src/private/__tests__/utilities/ensureInstance';
+import type {HostInstance} from 'react-native';
+
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {ActivityIndicator} from 'react-native';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<ActivityIndicator>', () => {
   it('sets displayName', () => {
@@ -167,28 +168,26 @@ describe('<ActivityIndicator>', () => {
   });
 
   describe('ref', () => {
-    it('provides a valid ReactNativeElement instance', () => {
-      const elementRef =
-        createRef<React.ElementRef<typeof ActivityIndicator>>();
+    it('provides a valid HTMLElement instance', () => {
+      const elementRef = createRef<HostInstance>();
       const root = Fantom.createRoot();
 
       Fantom.runTask(() => {
         root.render(<ActivityIndicator ref={elementRef} />);
       });
 
-      expect(elementRef.current).toBeInstanceOf(ReactNativeElement);
+      expect(elementRef.current).toBeInstanceOf(HTMLElement);
     });
 
     it('has the correct tag name', () => {
-      const elementRef =
-        createRef<React.ElementRef<typeof ActivityIndicator>>();
+      const elementRef = createRef<HostInstance>();
       const root = Fantom.createRoot();
 
       Fantom.runTask(() => {
         root.render(<ActivityIndicator ref={elementRef} />);
       });
 
-      const element = ensureInstance(elementRef.current, ReactNativeElement);
+      const element = nullthrows(elementRef.current);
       expect(element.tagName).toBe('RN:AndroidProgressBar');
     });
   });

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-itest.js
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-itest.js
@@ -11,16 +11,16 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type {AccessibilityProps, HostInstance} from 'react-native';
+import type {HostInstance} from 'react-native';
+import type {AccessibilityProps} from 'react-native';
 
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {Pressable} from 'react-native';
 import {PlatformColor, Text} from 'react-native';
 import accessibilityPropsSuite from 'react-native/src/private/__tests__/utilities/accessibilityPropsSuite';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<Pressable>', () => {
   describe('props', () => {
@@ -94,7 +94,7 @@ describe('<Pressable>', () => {
           );
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onPressCallback).toHaveBeenCalledTimes(1);
@@ -118,7 +118,7 @@ describe('<Pressable>', () => {
           );
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         Fantom.dispatchNativeEvent(element, 'change', {value: true});
 
         expect(onPressCallback).toHaveBeenCalledTimes(0);
@@ -263,7 +263,7 @@ describe('<Pressable>', () => {
             </Pressable>,
           );
         });
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
 
         expect(element.childNodes.length).toBe(1);
 
@@ -302,7 +302,7 @@ describe('<Pressable>', () => {
           root.render(<Pressable ref={elementRef} />);
         });
 
-        expect(elementRef.current).toBeInstanceOf(ReactNativeElement);
+        expect(elementRef.current).toBeInstanceOf(HTMLElement);
       });
 
       it('uses the "RN:View" tag name', () => {
@@ -314,7 +314,7 @@ describe('<Pressable>', () => {
           root.render(<Pressable ref={elementRef} />);
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         // Pressable is implemented with a <View> under the hood
         expect(element.tagName).toBe('RN:View');
       });

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -17,8 +17,6 @@ import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {ScrollView, Text, View} from 'react-native';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<ScrollView>', () => {
   describe('rendering', () => {
@@ -93,7 +91,7 @@ describe('<ScrollView>', () => {
         root.render(<ScrollView innerViewRef={ref} />);
       });
 
-      expect(ref.mock.lastCall[0]).toBeInstanceOf(ReactNativeElement);
+      expect(ref.mock.lastCall[0]).toBeInstanceOf(HTMLElement);
 
       Fantom.runTask(() => {
         root.render(<></>);
@@ -111,14 +109,14 @@ describe('<ScrollView>', () => {
         root.render(<ScrollView innerViewRef={refA} />);
       });
 
-      expect(refA.mock.lastCall[0]).toBeInstanceOf(ReactNativeElement);
+      expect(refA.mock.lastCall[0]).toBeInstanceOf(HTMLElement);
 
       Fantom.runTask(() => {
         root.render(<ScrollView innerViewRef={refB} />);
       });
 
       expect(refA.mock.lastCall[0]).toBe(null);
-      expect(refB.mock.lastCall[0]).toBeInstanceOf(ReactNativeElement);
+      expect(refB.mock.lastCall[0]).toBeInstanceOf(HTMLElement);
     });
   });
 
@@ -131,10 +129,7 @@ describe('<ScrollView>', () => {
         root.render(<ScrollView ref={ref} />);
       });
 
-      const innerView = ensureInstance(
-        nullthrows(ref.current).getInnerViewRef(),
-        ReactNativeElement,
-      );
+      const innerView = nullthrows(nullthrows(ref.current).getInnerViewRef());
       expect(innerView.tagName).toBe('RN:View');
     });
   });

--- a/packages/react-native/Libraries/Components/Switch/__tests__/Switch-itest.js
+++ b/packages/react-native/Libraries/Components/Switch/__tests__/Switch-itest.js
@@ -9,14 +9,14 @@
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
 import type {HostInstance} from 'react-native';
 
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {Switch} from 'react-native';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<ExampleComponent>', () => {
   describe('props', () => {
@@ -38,8 +38,8 @@ describe('<ExampleComponent>', () => {
           root.render(<Switch ref={elementRef} />);
         });
 
-        expect(elementRef.current).toBeInstanceOf(ReactNativeElement);
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        expect(elementRef.current).toBeInstanceOf(HTMLElement);
+        const element = nullthrows(elementRef.current);
         expect(element.tagName).toBe('RN:Switch');
       });
     });

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-itest.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-itest.js
@@ -11,15 +11,15 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type {AccessibilityProps, HostInstance} from 'react-native';
+import type {HostInstance} from 'react-native';
+import type {AccessibilityProps} from 'react-native';
 
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {Text, TouchableHighlight, View} from 'react-native';
 import accessibilityPropsSuite from 'react-native/src/private/__tests__/utilities/accessibilityPropsSuite';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<TouchableHighlight>', () => {
   describe('props', () => {
@@ -214,7 +214,7 @@ describe('<TouchableHighlight>', () => {
           );
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onPressCallback).toHaveBeenCalledTimes(1);
@@ -240,7 +240,7 @@ describe('<TouchableHighlight>', () => {
           );
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onShowUnderlayCallback).toHaveBeenCalledTimes(1);
@@ -265,7 +265,7 @@ describe('<TouchableHighlight>', () => {
           );
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onPressCallback).toHaveBeenCalledTimes(0);
@@ -370,7 +370,7 @@ describe('<TouchableHighlight>', () => {
           <rn-view accessibilityState="{disabled:true,selected:false,checked:None,busy:false,expanded:null}" />,
         );
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onPressCallback).toHaveBeenCalledTimes(0);
@@ -455,7 +455,7 @@ describe('<TouchableHighlight>', () => {
           );
         });
 
-        expect(elementRef.current).toBeInstanceOf(ReactNativeElement);
+        expect(elementRef.current).toBeInstanceOf(HTMLElement);
       });
 
       it('uses the "RN:View" tag name', () => {
@@ -471,7 +471,7 @@ describe('<TouchableHighlight>', () => {
           );
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         expect(element.tagName).toBe('RN:View');
       });
     });

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableOpacity-itest.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableOpacity-itest.js
@@ -14,11 +14,10 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {HostInstance} from 'react-native';
 
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {Text, TouchableOpacity} from 'react-native';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<TouchableOpacity>', () => {
   it('sets displayName', () => {
@@ -116,7 +115,7 @@ describe('<TouchableOpacity>', () => {
           );
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onPressCallback).toHaveBeenCalledTimes(1);
@@ -140,7 +139,7 @@ describe('<TouchableOpacity>', () => {
           );
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onPressCallback).toHaveBeenCalledTimes(0);
@@ -189,9 +188,8 @@ describe('<TouchableOpacity>', () => {
           );
         });
 
-        const element = ensureInstance(
+        const element = nullthrows(
           root.document.documentElement.firstElementChild,
-          ReactNativeElement,
         );
         expect(element.childNodes.length).toBe(1);
 
@@ -215,7 +213,7 @@ describe('<TouchableOpacity>', () => {
           root.render(<TouchableOpacity ref={elementRef} />);
         });
 
-        expect(elementRef.current).toBeInstanceOf(ReactNativeElement);
+        expect(elementRef.current).toBeInstanceOf(HTMLElement);
       });
 
       it('uses the "RN:View" tag name', () => {
@@ -227,7 +225,7 @@ describe('<TouchableOpacity>', () => {
           root.render(<TouchableOpacity ref={elementRef} />);
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         expect(element.tagName).toBe('RN:View');
       });
     });

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableWithoutFeedback-itest.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableWithoutFeedback-itest.js
@@ -13,11 +13,10 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {AccessibilityProps} from 'react-native';
 
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {Text, TouchableWithoutFeedback, View} from 'react-native';
 import accessibilityPropsSuite from 'react-native/src/private/__tests__/utilities/accessibilityPropsSuite';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<TouchableWithoutFeedback>', () => {
   describe('props', () => {
@@ -142,10 +141,7 @@ describe('<TouchableWithoutFeedback>', () => {
         });
 
         expect(
-          ensureInstance(
-            root.document.documentElement.firstElementChild,
-            ReactNativeElement,
-          ).tagName,
+          nullthrows(root.document.documentElement.firstElementChild).tagName,
         ).toBe('RN:Paragraph');
 
         Fantom.runTask(() => {
@@ -159,10 +155,7 @@ describe('<TouchableWithoutFeedback>', () => {
         });
 
         expect(
-          ensureInstance(
-            root.document.documentElement.firstElementChild,
-            ReactNativeElement,
-          ).tagName,
+          nullthrows(root.document.documentElement.firstElementChild).tagName,
         ).toBe('RN:View');
       });
     });

--- a/packages/react-native/Libraries/Components/View/__tests__/View-flexBasisFitContent-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-flexBasisFitContent-itest.js
@@ -13,12 +13,11 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {ScrollView, StyleSheet, View} from 'react-native';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 const VIEWPORT_WIDTH = 402;
 const VIEWPORT_HEIGHT = 760;
@@ -53,12 +52,9 @@ test('auto-height wrapper around a feed ScrollView stays bounded by the viewport
     );
   });
 
-  const wrapper = ensureInstance(wrapperRef.current, ReactNativeElement);
-  const scrollView = ensureInstance(scrollViewRef.current, ReactNativeElement);
-  const feedContent = ensureInstance(
-    feedContentRef.current,
-    ReactNativeElement,
-  );
+  const wrapper = nullthrows(wrapperRef.current);
+  const scrollView = nullthrows(scrollViewRef.current);
+  const feedContent = nullthrows(feedContentRef.current);
 
   const wrapperRect = wrapper.getBoundingClientRect();
   const scrollViewRect = scrollView.getBoundingClientRect();

--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -14,12 +14,11 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {View} from 'react-native';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<View>', () => {
   it('has displayName', () => {
@@ -222,10 +221,7 @@ describe('<View>', () => {
               );
             });
 
-            const viewElement = ensureInstance(
-              viewRef.current,
-              ReactNativeElement,
-            );
+            const viewElement = nullthrows(viewRef.current);
 
             const viewBounds = viewElement.getBoundingClientRect();
             expect(viewBounds.x).toBe(expectedBounds.x);
@@ -1119,7 +1115,7 @@ describe('<View>', () => {
         root.render(<View ref={elementRef} />);
       });
 
-      expect(elementRef.current).toBeInstanceOf(ReactNativeElement);
+      expect(elementRef.current).toBeInstanceOf(HTMLElement);
     });
 
     it('uses the "RN:View" tag name', () => {
@@ -1131,7 +1127,7 @@ describe('<View>', () => {
         root.render(<View ref={elementRef} />);
       });
 
-      const element = ensureInstance(elementRef.current, ReactNativeElement);
+      const element = nullthrows(elementRef.current);
       expect(element.tagName).toBe('RN:View');
     });
   });

--- a/packages/react-native/Libraries/Image/__tests__/Image-itest.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-itest.js
@@ -13,15 +13,14 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {AccessibilityProps, HostInstance} from 'react-native';
 
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {Image} from 'react-native';
 import * as ImageInjection from 'react-native/Libraries/Image/ImageInjection';
 import accessibilityPropsSuite from 'react-native/src/private/__tests__/utilities/accessibilityPropsSuite';
 import {testIDPropSuite} from 'react-native/src/private/__tests__/utilities/commonPropsSuite';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
 import NativeFantom from 'react-native/src/private/testing/fantom/specs/NativeFantom';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 const LOGO_SOURCE = {uri: 'https://reactnative.dev/img/tiny_logo.png'};
 
@@ -214,7 +213,7 @@ describe('<Image>', () => {
 
           expect(onPropCallback).toHaveBeenCalledTimes(0);
 
-          const image = ensureInstance(ref.current, ReactNativeElement);
+          const image = nullthrows(ref.current);
           Fantom.dispatchNativeEvent(image, onProp, {});
 
           expect(onPropCallback).toHaveBeenCalledTimes(1);
@@ -640,7 +639,7 @@ describe('<Image>', () => {
           root.render(<Image ref={elementRef} />);
         });
 
-        expect(elementRef.current).toBeInstanceOf(ReactNativeElement);
+        expect(elementRef.current).toBeInstanceOf(HTMLElement);
       });
 
       it('uses the "RN:Image" tag name', () => {
@@ -652,7 +651,7 @@ describe('<Image>', () => {
           root.render(<Image ref={elementRef} />);
         });
 
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        const element = nullthrows(elementRef.current);
         expect(element.tagName).toBe('RN:Image');
       });
     });

--- a/packages/react-native/Libraries/Image/__tests__/ImageBackground-itest.js
+++ b/packages/react-native/Libraries/Image/__tests__/ImageBackground-itest.js
@@ -13,11 +13,10 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {HostInstance} from 'react-native';
 
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {ImageBackground} from 'react-native';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<ImageBackground>', () => {
   describe('props', () => {
@@ -147,7 +146,7 @@ describe('<ImageBackground>', () => {
         root.render(<ImageBackground imageRef={elementRef} />);
       });
 
-      const image = ensureInstance(elementRef.current, ReactNativeElement);
+      const image = nullthrows(elementRef.current);
       expect(image.tagName).toBe('RN:Image');
     });
   });

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
@@ -9,14 +9,14 @@
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
 import type {HostInstance} from 'react-native';
 
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {Modal} from 'react-native';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 const DEFAULT_MODAL_CHILD_VIEW = (
   <rn-view backgroundColor="rgba(255, 255, 255, 1)" flex="1" left="0" top="0" />
@@ -315,8 +315,8 @@ describe('<Modal>', () => {
           root.render(<Modal ref={elementRef} />);
         });
 
-        expect(elementRef.current).toBeInstanceOf(ReactNativeElement);
-        const element = ensureInstance(elementRef.current, ReactNativeElement);
+        expect(elementRef.current).toBeInstanceOf(HTMLElement);
+        const element = nullthrows(elementRef.current);
         expect(element.tagName).toBe('RN:ModalHostView');
       });
     });

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-itest.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-itest.js
@@ -16,11 +16,10 @@ import type {HostInstance} from 'react-native';
 
 import usePressability from '../usePressability';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {View} from 'react-native';
-import ensureInstance from 'react-native/src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 function PressabilityTestView({
   config,
@@ -52,7 +51,7 @@ describe('Pressability', () => {
           );
         });
 
-        const element = ensureInstance(ref.current, ReactNativeElement);
+        const element = nullthrows(ref.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onPress).toHaveBeenCalledTimes(1);
@@ -73,7 +72,7 @@ describe('Pressability', () => {
           );
         });
 
-        const element = ensureInstance(ref.current, ReactNativeElement);
+        const element = nullthrows(ref.current);
         Fantom.dispatchNativeEvent(element, 'click');
 
         expect(onPress).toHaveBeenCalledTimes(0);
@@ -94,7 +93,7 @@ describe('Pressability', () => {
           );
         });
 
-        const element = ensureInstance(ref.current, ReactNativeElement);
+        const element = nullthrows(ref.current);
         Fantom.dispatchNativeEvent(element, 'click');
         expect(onPress).toHaveBeenCalledTimes(0);
 
@@ -187,7 +186,7 @@ describe('Pressability', () => {
           );
         });
 
-        const element = ensureInstance(ref.current, ReactNativeElement);
+        const element = nullthrows(ref.current);
         Fantom.dispatchNativeEvent(element, 'click');
         expect(onPressFirst).toHaveBeenCalledTimes(1);
         expect(onPressSecond).toHaveBeenCalledTimes(0);
@@ -232,7 +231,7 @@ describe('Pressability', () => {
           root.render(<TestApp showPressable={true} />);
         });
 
-        const element = ensureInstance(ref.current, ReactNativeElement);
+        const element = nullthrows(ref.current);
         Fantom.dispatchNativeEvent(element, 'click');
         expect(onPress).toHaveBeenCalledTimes(1);
 

--- a/packages/react-native/Libraries/ReactNative/__tests__/StaleEventHandlersFromInterruptedRender-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/StaleEventHandlersFromInterruptedRender-itest.js
@@ -12,17 +12,12 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef, startTransition, useDeferredValue, useState} from 'react';
 import {View} from 'react-native';
 import {NativeEventCategory} from 'react-native/src/private/testing/fantom/specs/NativeFantom';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
-
-function ensureReactNativeElement(value: unknown): ReactNativeElement {
-  return ensureInstance(value, ReactNativeElement);
-}
 
 describe('stale event handlers from interrupted render', () => {
   // This test demonstrates a bug where canonical.currentProps (which stores
@@ -79,7 +74,7 @@ describe('stale event handlers from interrupted render', () => {
     }) {
       if (shouldDispatchDuringRender && deferredLabel === label) {
         shouldDispatchDuringRender = false;
-        const element = ensureReactNativeElement(viewRef.current);
+        const element = nullthrows(viewRef.current);
         Fantom.dispatchNativeEvent(
           element,
           'onPointerUp',

--- a/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
@@ -13,13 +13,12 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {ScrollView, View} from 'react-native';
 import NativeFantomTestSpecificMethods from 'react-native/src/private/testing/fantom/specs/NativeFantomTestSpecificMethods';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 NativeFantomTestSpecificMethods.registerForcedCloneCommitHook();
 
@@ -37,10 +36,7 @@ describe('ScrollViewShadowNode', () => {
       );
     });
 
-    const scrollViewElement = ensureInstance(
-      scrollViewRef.current,
-      ReactNativeElement,
-    );
+    const scrollViewElement = nullthrows(scrollViewRef.current);
 
     // Scrolling triggers a state update to store the scroll position
     // - the state update gets committed

--- a/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-itest.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-itest.js
@@ -12,8 +12,6 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from '../../../src/private/types/HostInstance';
 
-import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from '../../../src/private/webapis/dom/nodes/ReactNativeElement';
 import View from '../../Components/View/View';
 import useMergeRefs from '../useMergeRefs';
 import * as Fantom from '@react-native/fantom';
@@ -29,7 +27,7 @@ function id(instance: HostInstance | null): string | null {
   if (instance == null) {
     return null;
   }
-  return ensureInstance(instance, ReactNativeElement).id;
+  return instance.id;
 }
 
 test('accepts a ref callback', () => {

--- a/packages/react-native/Libraries/Utilities/__tests__/useRefEffect-itest.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useRefEffect-itest.js
@@ -12,8 +12,6 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from '../../../src/private/types/HostInstance';
 
-import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
-import ReactNativeElement from '../../../src/private/webapis/dom/nodes/ReactNativeElement';
 import View from '../../Components/View/View';
 import useRefEffect from '../useRefEffect';
 import * as Fantom from '@react-native/fantom';
@@ -39,7 +37,7 @@ function keyOf(instance: ?HostInstance): ?string {
   if (instance == null) {
     return null;
   }
-  return ensureInstance(instance, ReactNativeElement).id;
+  return instance.id;
 }
 
 function effectEntry(name: string, key: ?string): RegistryEntry {

--- a/packages/react-native/src/private/__tests__/utilities/ShadowNodeReferenceCounter.js
+++ b/packages/react-native/src/private/__tests__/utilities/ShadowNodeReferenceCounter.js
@@ -8,12 +8,12 @@
  * @format
  */
 
-import ReactNativeElement from '../../webapis/dom/nodes/ReadOnlyNode';
-import ensureInstance from './ensureInstance';
+import type {HostInstance} from 'react-native';
+
 import * as Fantom from '@react-native/fantom';
 
 export function createShadowNodeReferenceCounter(
-  element: ReactNativeElement,
+  element: HostInstance,
 ): () => number {
   const getReferenceCount = Fantom.createShadowNodeReferenceCounter(element);
   // Create the reference counting function in a helper instead of creating a
@@ -34,7 +34,7 @@ function createExpirationChecker(
 
 export function createShadowNodeReferenceCountingRef(): [
   () => number,
-  React.RefSetter<unknown>,
+  React.RefSetter<HostInstance>,
 ] {
   let getReferenceCount: ?() => number;
 
@@ -45,15 +45,14 @@ export function createShadowNodeReferenceCountingRef(): [
     return getReferenceCount();
   }
 
-  function ref(instance: unknown | null) {
+  function ref(instance: HostInstance | null) {
     if (instance == null) {
       return;
     }
-    const element = ensureInstance(instance, ReactNativeElement);
     if (getReferenceCount != null) {
       throw new Error('ShadowNode reference counter was already initialized.');
     }
-    getReferenceCount = createShadowNodeReferenceCounter(element);
+    getReferenceCount = createShadowNodeReferenceCounter(instance);
   }
 
   return [getShadowNodeReferenceCount, ref];

--- a/packages/react-native/src/private/__tests__/utilities/ShadowNodeRevisionGetter.js
+++ b/packages/react-native/src/private/__tests__/utilities/ShadowNodeRevisionGetter.js
@@ -8,13 +8,11 @@
  * @format
  */
 
-import ReactNativeElement from '../../webapis/dom/nodes/ReadOnlyNode';
-import ensureInstance from './ensureInstance';
+import type {HostInstance} from 'react-native';
+
 import * as Fantom from '@react-native/fantom';
 
-function createShadowNodeRevisionGetter(
-  element: ReactNativeElement,
-): () => ?number {
+function createShadowNodeRevisionGetter(element: HostInstance): () => ?number {
   const getRevision = Fantom.createShadowNodeRevisionGetter(element);
   return () => {
     return getRevision();
@@ -23,7 +21,7 @@ function createShadowNodeRevisionGetter(
 
 export function createShadowNodeReferenceGetterRef(): [
   () => ?number,
-  React.RefSetter<unknown>,
+  React.RefSetter<HostInstance>,
 ] {
   let getRevision: ?() => ?number;
 
@@ -34,15 +32,14 @@ export function createShadowNodeReferenceGetterRef(): [
     return getRevision();
   }
 
-  function ref(instance: unknown | null) {
+  function ref(instance: HostInstance | null) {
     if (instance == null) {
       return;
     }
-    const element = ensureInstance(instance, ReactNativeElement);
     if (getRevision != null) {
       throw new Error('ShadowNode revision getter was already initialized.');
     }
-    getRevision = createShadowNodeRevisionGetter(element);
+    getRevision = createShadowNodeRevisionGetter(instance);
   }
 
   return [getShadowNodeReferenceCount, ref];

--- a/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
+++ b/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
@@ -12,10 +12,9 @@
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {Node} from '../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from 'react-native';
 
 import {getNodeFromPublicInstance} from '../../../../../Libraries/ReactPrivate/ReactNativePrivateInterface';
-import ReactNativeElement from '../../../webapis/dom/nodes/ReactNativeElement';
-import ensureInstance from '../ensureInstance';
 import isUnreachable from '../isUnreachable';
 import {
   createShadowNodeReferenceCounter,
@@ -47,14 +46,14 @@ test('shadow node expires when root is destroyed', () => {
 test('element is not retained by `createShadowNodeReferenceCounter`', () => {
   const root = Fantom.createRoot();
 
-  let elementWeakRef: ?WeakRef<ReactNativeElement>;
+  let elementWeakRef: ?WeakRef<HostInstance>;
   let getReferenceCount: ?() => number;
 
-  function ref(instance: React.ElementRef<typeof View> | null) {
+  function ref(instance: HostInstance | null) {
     if (instance == null) {
       return;
     }
-    const element = ensureInstance(instance, ReactNativeElement);
+    const element = nullthrows(instance);
     elementWeakRef = new WeakRef(element);
     getReferenceCount = createShadowNodeReferenceCounter(element);
   }
@@ -81,14 +80,14 @@ test('element is not retained by `createShadowNodeReferenceCounter`', () => {
 test('shadow node expires when JavaScript element is reachable', () => {
   const root = Fantom.createRoot();
 
-  let element: ?ReactNativeElement;
+  let element: ?HostInstance;
   let getReferenceCount: ?() => number;
 
-  function ref(instance: React.ElementRef<typeof View> | null) {
+  function ref(instance: HostInstance | null) {
     if (instance == null) {
       return;
     }
-    element = ensureInstance(instance, ReactNativeElement);
+    element = nullthrows(instance);
     getReferenceCount = createShadowNodeReferenceCounter(element);
   }
 
@@ -119,11 +118,11 @@ test('shadow node is retained when JavaScript node is reachable', () => {
   let node: ?Node;
   let getReferenceCount: ?() => number;
 
-  function ref(instance: React.ElementRef<typeof View> | null) {
+  function ref(instance: HostInstance | null) {
     if (instance == null) {
       return;
     }
-    const element = ensureInstance(instance, ReactNativeElement);
+    const element = nullthrows(instance);
     node = getNodeFromPublicInstance(element);
     getReferenceCount = createShadowNodeReferenceCounter(element);
   }

--- a/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-itest.js
+++ b/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-itest.js
@@ -12,12 +12,11 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {Rect} from '../VirtualView';
 import type {NativeModeChangeEvent} from '../VirtualViewNativeComponent';
+import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import isUnreachable from '../../../__tests__/utilities/isUnreachable';
 import {createShadowNodeReferenceCountingRef} from '../../../__tests__/utilities/ShadowNodeReferenceCounter';
 import {getNodeFromPublicInstance} from '../../../../../Libraries/ReactPrivate/ReactNativePrivateInterface';
-import ReactNativeElement from '../../../webapis/dom/nodes/ReactNativeElement';
 import VirtualView, {_logs, VirtualViewMode} from '../VirtualView';
 import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
@@ -234,7 +233,7 @@ describe('memory management', () => {
     const root = Fantom.createRoot();
 
     let weakRef: ?WeakRef<interface {}>;
-    const callbackRef = (instance: React.ElementRef<typeof Text> | null) => {
+    const callbackRef = (instance: HostInstance | null) => {
       if (instance !== null) {
         weakRef = new WeakRef(getNodeAsObjectFromPublicInstance(instance));
       }
@@ -320,7 +319,7 @@ describe('memory management', () => {
  * Helper to reduce duplication of the mock event payload.
  */
 export function dispatchModeChangeEvent(
-  instance: unknown,
+  instance: ?HostInstance,
   mode: VirtualViewMode,
 ): void {
   const targetRect = {
@@ -363,16 +362,12 @@ export function dispatchModeChangeEvent(
     }
   }
 
-  Fantom.dispatchNativeEvent(
-    ensureInstance(instance, ReactNativeElement),
-    'onModeChange',
-    {
-      mode: mode as number,
-      targetRect,
-      // $FlowFixMe[incompatible-type] - https://fburl.com/workplace/t8a3yvuo
-      thresholdRect,
-    } as NativeModeChangeEvent,
-  );
+  Fantom.dispatchNativeEvent(nullthrows(instance), 'onModeChange', {
+    mode: mode as number,
+    targetRect,
+    // $FlowFixMe[incompatible-type] - https://fburl.com/workplace/t8a3yvuo
+    thresholdRect,
+  } as NativeModeChangeEvent);
 }
 
 /**
@@ -398,10 +393,10 @@ function createWeakRefCallback<
 /**
  * Gets the shadow node via `instance.__internalInstanceHandle.stateNode.node`.
  */
-function getNodeAsObjectFromPublicInstance(instance: unknown): interface {} {
-  const node = getNodeFromPublicInstance(
-    ensureInstance(instance, ReactNativeElement),
-  );
+function getNodeAsObjectFromPublicInstance(
+  instance: HostInstance,
+): interface {} {
+  const node = getNodeFromPublicInstance(instance);
   if (node == null || typeof node !== 'object') {
     throw new Error('Expected node to be an object, got: ' + typeof node);
   }

--- a/packages/react-native/src/private/renderer/branching/__tests__/ShadowTreeBranching-itest.js
+++ b/packages/react-native/src/private/renderer/branching/__tests__/ShadowTreeBranching-itest.js
@@ -13,12 +13,11 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {View} from 'react-native';
 import NativeFantomTestSpecificMethods from 'react-native/src/private/testing/fantom/specs/NativeFantomTestSpecificMethods';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('ShadowTreeBranching', () => {
   function LayoutEffectObserver({onCommit}: {onCommit: () => void}) {
@@ -177,10 +176,7 @@ describe('ShadowTreeBranching', () => {
 
               // The React revision is not merged yet but the new dimensions
               // should be visible from JS
-              const viewNode = ensureInstance(
-                viewRef.current,
-                ReactNativeElement,
-              );
+              const viewNode = nullthrows(viewRef.current);
               const rect = viewNode.getBoundingClientRect();
               dimensions = [rect.width, rect.height];
             }}

--- a/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
+++ b/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
@@ -13,12 +13,11 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {useLayoutEffect} from 'react';
 import {ScrollView, Text} from 'react-native';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('UIConsistency', () => {
   it('should provide consistent data from the tree within the same synchronous function', () => {
@@ -36,10 +35,7 @@ describe('UIConsistency', () => {
       );
     });
 
-    const scrollViewNode = ensureInstance(
-      scrollViewRef.current,
-      ReactNativeElement,
-    );
+    const scrollViewNode = nullthrows(scrollViewRef.current);
 
     Fantom.runTask(() => {
       expect(scrollViewNode.scrollTop).toBe(0);
@@ -78,10 +74,7 @@ describe('UIConsistency', () => {
       );
     });
 
-    const scrollViewNode = ensureInstance(
-      scrollViewRef.current,
-      ReactNativeElement,
-    );
+    const scrollViewNode = nullthrows(scrollViewRef.current);
 
     Fantom.runTask(() => {
       // We never accessed the tree before the state update
@@ -127,10 +120,7 @@ describe('UIConsistency', () => {
       );
     });
 
-    const scrollViewNode = ensureInstance(
-      scrollViewRef.current,
-      ReactNativeElement,
-    );
+    const scrollViewNode = nullthrows(scrollViewRef.current);
 
     Fantom.runTask(() => {
       root.render(

--- a/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
+++ b/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
@@ -13,11 +13,10 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 
-import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {View} from 'react-native';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('ViewFlattening', () => {
   /**
@@ -474,7 +473,7 @@ describe('reconciliation of setNativeProps and React commit', () => {
       <rn-view nativeID={'first native id'} testID={'first test id'} />,
     );
 
-    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+    const element = nullthrows(nodeRef.current);
 
     Fantom.runTask(() => {
       // Calling `setNativeProps` forces bug https://github.com/facebook/react-native/issues/47476 to manifest.
@@ -534,7 +533,7 @@ describe('reconciliation of setNativeProps and React commit', () => {
         .toJSX(),
     ).toEqual(<rn-view nativeID={'first native id'} />);
 
-    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+    const element = nullthrows(nodeRef.current);
 
     Fantom.runTask(() => {
       element.setNativeProps({nativeID: 'second native id'});

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -32,7 +32,7 @@ describe('ReactNativeDocument', () => {
       root.render(<View ref={nodeRef} />);
     });
 
-    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+    const element = nullthrows(nodeRef.current);
     const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
 
     expect(document.isConnected).toBe(true);
@@ -58,7 +58,7 @@ describe('ReactNativeDocument', () => {
       root.render(<View ref={nodeRef} />);
     });
 
-    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+    const element = nullthrows(nodeRef.current);
     const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
 
     expect(document.childNodes.length).toBe(1);
@@ -77,7 +77,7 @@ describe('ReactNativeDocument', () => {
       root.render(<View ref={nodeRef} />);
     });
 
-    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+    const element = nullthrows(nodeRef.current);
     const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
 
     expect(document.childElementCount).toBe(1);
@@ -95,7 +95,7 @@ describe('ReactNativeDocument', () => {
       root.render(<View ref={nodeRef} />);
     });
 
-    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+    const element = nullthrows(nodeRef.current);
     const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
 
     expect(document.nodeName).toBe('#document');
@@ -117,7 +117,7 @@ describe('ReactNativeDocument', () => {
       root.render(<View ref={nodeRef} />);
     });
 
-    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+    const element = nullthrows(nodeRef.current);
     const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
 
     const {x, y, width, height} =
@@ -141,7 +141,7 @@ describe('ReactNativeDocument', () => {
       root.render(<View ref={nodeRef} />);
     });
 
-    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+    const element = nullthrows(nodeRef.current);
     const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
     const documentElement = document.documentElement;
 
@@ -193,13 +193,11 @@ describe('ReactNativeDocument', () => {
     Fantom.runTask(() => {
       maybeWeakDocument = new WeakRef(
         ensureInstance(
-          ensureInstance(nodeRef.current, ReactNativeElement).ownerDocument,
+          nullthrows(nodeRef.current).ownerDocument,
           ReactNativeDocument,
         ),
       );
-      maybeWeakNode = new WeakRef(
-        ensureInstance(nodeRef.current, ReactNativeElement),
-      );
+      maybeWeakNode = new WeakRef(nullthrows(nodeRef.current));
     });
 
     const weakDocument = nullthrows(maybeWeakDocument);

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-traversal-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-traversal-benchmark-itest.js
@@ -14,9 +14,8 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {HostInstance} from 'react-native';
 import type {FnOptions} from 'tinybench';
 
-import ensureInstance from '../../../../__tests__/utilities/ensureInstance';
-import ReactNativeElement from '../ReactNativeElement';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {View} from 'react-native';
 
@@ -41,7 +40,7 @@ const commonOptions: FnOptions = {
       );
     });
 
-    node = ensureInstance(viewRef.current, ReactNativeElement);
+    node = nullthrows(viewRef.current);
   },
   afterAll: () => {
     Fantom.runTask(() => root.destroy());

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-benchmark-itest.js
@@ -14,8 +14,8 @@ import type {Root} from '@react-native/fantom';
 import type {HostInstance} from 'react-native';
 import type IntersectionObserverType from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserver';
 
-import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import ScrollView from 'react-native/Libraries/Components/ScrollView/ScrollView';
@@ -109,7 +109,7 @@ Fantom.unstable_benchmark
         Fantom.runTask(() => {
           root.render(<View ref={rootRef} />);
         });
-        rootNode = ensureInstance(rootRef.current, ReactNativeElement);
+        rootNode = nullthrows(rootRef.current);
       },
       afterEach: () => {
         expect(mockCallback).not.toHaveBeenCalled();
@@ -131,7 +131,7 @@ Fantom.unstable_benchmark
           root.render(<View style={{width: 100, height: 10}} ref={nodeRef} />);
           observer = new IntersectionObserver(mockCallback);
         });
-        node = ensureInstance(nodeRef.current, ReactNativeElement);
+        node = nullthrows(nodeRef.current);
       },
       afterEach: () => {
         expect(mockCallback).toHaveBeenCalledTimes(1);
@@ -160,8 +160,8 @@ Fantom.unstable_benchmark
             </View>,
           );
         });
-        node = ensureInstance(nodeRef.current, ReactNativeElement);
-        rootNode = ensureInstance(rootRef.current, ReactNativeElement);
+        node = nullthrows(nodeRef.current);
+        rootNode = nullthrows(rootRef.current);
         Fantom.runTask(() => {
           observer = new IntersectionObserver(mockCallback, {root: rootNode});
         });
@@ -193,8 +193,8 @@ Fantom.unstable_benchmark
             </View>,
           );
         });
-        node = ensureInstance(nodeRef.current, ReactNativeElement);
-        rootNode = ensureInstance(rootRef.current, ReactNativeElement);
+        node = nullthrows(nodeRef.current);
+        rootNode = nullthrows(rootRef.current);
         Fantom.runTask(() => {
           observer = new IntersectionObserver(mockCallback, {
             root: rootNode,
@@ -229,10 +229,7 @@ Fantom.unstable_benchmark
             </ScrollView>,
           );
         });
-        scrollViewNode = ensureInstance(
-          scrollViewRef.current,
-          ReactNativeElement,
-        );
+        scrollViewNode = nullthrows(scrollViewRef.current);
       },
       afterEach: () => {
         cleanup(root, observer);
@@ -256,10 +253,7 @@ Fantom.unstable_benchmark
             </ScrollView>,
           );
         });
-        scrollViewNode = ensureInstance(
-          scrollViewRef.current,
-          ReactNativeElement,
-        );
+        scrollViewNode = nullthrows(scrollViewRef.current);
       },
       afterEach: () => {
         cleanup(root);
@@ -285,11 +279,8 @@ Fantom.unstable_benchmark
             </ScrollView>,
           );
         });
-        scrollViewNode = ensureInstance(
-          scrollViewRef.current,
-          ReactNativeElement,
-        );
-        node = ensureInstance(nodeRef.current, ReactNativeElement);
+        scrollViewNode = nullthrows(scrollViewRef.current);
+        node = nullthrows(nodeRef.current);
         Fantom.runTask(() => {
           observer = new IntersectionObserver(mockCallback, {});
           observer.observe(node);
@@ -325,11 +316,8 @@ Fantom.unstable_benchmark
             </ScrollView>,
           );
         });
-        scrollViewNode = ensureInstance(
-          scrollViewRef.current,
-          ReactNativeElement,
-        );
-        node = ensureInstance(nodeRef.current, ReactNativeElement);
+        scrollViewNode = nullthrows(scrollViewRef.current);
+        node = nullthrows(nodeRef.current);
         Fantom.runTask(() => {
           observer = new IntersectionObserver(mockCallback, {
             root: scrollViewNode,
@@ -367,11 +355,8 @@ Fantom.unstable_benchmark
             </ScrollView>,
           );
         });
-        scrollViewNode = ensureInstance(
-          scrollViewRef.current,
-          ReactNativeElement,
-        );
-        node = ensureInstance(nodeRef.current, ReactNativeElement);
+        scrollViewNode = nullthrows(scrollViewRef.current);
+        node = nullthrows(nodeRef.current);
         Fantom.runTask(() => {
           observer = new IntersectionObserver(mockCallback, {threshold: 1});
           observer.observe(node);
@@ -415,11 +400,8 @@ Fantom.unstable_benchmark
             </ScrollView>,
           );
         });
-        scrollViewNode = ensureInstance(
-          scrollViewRef.current,
-          ReactNativeElement,
-        );
-        node = ensureInstance(nodeRef.current, ReactNativeElement);
+        scrollViewNode = nullthrows(scrollViewRef.current);
+        node = nullthrows(nodeRef.current);
         Fantom.runTask(() => {
           observer = new IntersectionObserver(mockCallback, {
             threshold: 1,

--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -14,13 +14,13 @@ import type {HostInstance} from 'react-native';
 
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {createRef} from 'react';
 import {View} from 'react-native';
 import setUpIntersectionObserver from 'react-native/src/private/setup/setUpIntersectionObserver';
 import setUpMutationObserver from 'react-native/src/private/setup/setUpMutationObserver';
 import EventTarget from 'react-native/src/private/webapis/dom/events/EventTarget';
-import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 import DOMException from 'react-native/src/private/webapis/errors/DOMException';
 import IntersectionObserver from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserver';
 import IntersectionObserverEntry from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry';
@@ -396,7 +396,7 @@ describe('structuredClone', () => {
             self.disconnect();
           });
 
-          observer.observe(ensureInstance(ref.current, ReactNativeElement));
+          observer.observe(nullthrows(ref.current));
         });
 
         const entry = ensureInstance(entries[0], IntersectionObserverEntry);
@@ -424,7 +424,7 @@ describe('structuredClone', () => {
             records.push(...e);
           });
 
-          observer.observe(ensureInstance(ref.current, ReactNativeElement), {
+          observer.observe(nullthrows(ref.current), {
             childList: true,
           });
         });


### PR DESCRIPTION
Summary:
Removes the `ensureInstance(ref.current, ReactNativeElement)` pattern from Fantom tests. Host refs are typed as `HostInstance` and read with `nullthrows(ref.current)`; component-specific instance types (e.g. `React.ElementRef<typeof TextInput>`, `React.ElementRef<typeof ScrollView>`) are kept only where a test actually uses a component's imperative API (`focus`/`blur`/`clear`, `getInnerViewRef`, etc.). This drops the `ReactNativeElement`/`ensureInstance` imports from tests that only needed a non-null host instance.

Where a test genuinely needs a runtime type check, `instanceof ReactNativeElement` / `toBeInstanceOf(ReactNativeElement)` is replaced with the standard `instanceof HTMLElement` (a global), since React Native elements are instances of `HTMLElement` at runtime.

This also covers the internal `-itest.fb.js` tests and the shared ShadowNode test utilities (`ShadowNodeReferenceCounter`/`ShadowNodeRevisionGetter`), which now type their refs as `HostInstance`.

Known follow-up: the RN Flow global type definitions still need to be fixed. At the type level `HTMLElement` does not match `HostInstance` yet, even though the runtime values do. Because of this, `HTMLElement` cannot be used where a narrowed value flows into RN-internal APIs typed as `HostInstance`/`ReadOnlyNode` (e.g. `VirtualView`, which instead types its helper params as `HostInstance` directly and passes them through without a narrowing check). Aligning the `HTMLElement` global definition with `HostInstance` would let those remaining spots use `HTMLElement` too.

This is a test-only change with no runtime or user-facing impact.

Changelog:
[Internal]

Differential Revision: D110888634


