### PR TITLE
Add missing LogBox method declarations to LogBox.d.ts (#57472)

### DIFF
--- a/packages/react-native/Libraries/LogBox/LogBox.d.ts
+++ b/packages/react-native/Libraries/LogBox/LogBox.d.ts
@@ -22,6 +22,17 @@ export interface LogBoxStatic {
 
   install(): void;
   uninstall(): void;
+
+  /**
+   * Whether LogBox is currently installed.
+   */
+  isInstalled(): boolean;
+
+  /**
+   * Clear all logs and dismiss the LogBox surface. Invoked by the Fast Refresh
+   * pipeline on each applied update.
+   */
+  clearAllLogs(): void;
 }
 
 export const LogBox: LogBoxStatic;


### PR DESCRIPTION
Summary:

`LogBox.d.ts` declared only `ignoreLogs`, `ignoreAllLogs`, `install`, and `uninstall`, but the runtime `LogBox` object also exposes `isInstalled()` and `clearAllLogs()`. Add these two signatures so TypeScript consumers can call them without casting.

Changelog:
[General][Added] - Add `isInstalled()` and `clearAllLogs()` to the `LogBox` TypeScript declarations

Reviewed By: christophpurrer

Differential Revision: D110930249


