### PR TITLE
Fix skipped post-publish jobs in release mode

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -201,7 +201,15 @@ jobs:
   post_publish:
     runs-on: ubuntu-latest
     needs: [determine_mode, publish_react_native]
-    if: needs.determine_mode.outputs.mode == 'release'
+    # Use always() so this job still runs in release mode even though some
+    # upstream jobs (e.g. build_android) are skipped and would otherwise
+    # poison the implicit success() gate. The explicit result checks below
+    # handle the real gating: only run for a successful release publish.
+    if: |
+      always() &&
+      needs.determine_mode.result == 'success' &&
+      needs.publish_react_native.result == 'success' &&
+      needs.determine_mode.outputs.mode == 'release'
     env:
       REACT_NATIVE_BOT_GITHUB_TOKEN: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
     steps:
@@ -256,19 +264,38 @@ jobs:
   # ─── Release-only: changelog, podfile bump, draft release ────────
   generate_changelog:
     needs: [determine_mode, publish_react_native]
-    if: needs.determine_mode.outputs.mode == 'release'
+    # always() + explicit result checks: run for a successful release publish
+    # even when skipped upstream jobs would trip the implicit success() gate.
+    if: |
+      always() &&
+      needs.determine_mode.result == 'success' &&
+      needs.publish_react_native.result == 'success' &&
+      needs.determine_mode.outputs.mode == 'release'
     uses: ./.github/workflows/generate-changelog.yml
     secrets: inherit
 
   bump_podfile_lock:
     needs: [determine_mode, publish_react_native]
-    if: needs.determine_mode.outputs.mode == 'release'
+    # always() + explicit result checks: run for a successful release publish
+    # even when skipped upstream jobs would trip the implicit success() gate.
+    if: |
+      always() &&
+      needs.determine_mode.result == 'success' &&
+      needs.publish_react_native.result == 'success' &&
+      needs.determine_mode.outputs.mode == 'release'
     uses: ./.github/workflows/bump-podfile-lock.yml
     secrets: inherit
 
   create_draft_release:
     needs: [determine_mode, generate_changelog, set_hermes_version]
-    if: needs.determine_mode.outputs.mode == 'release'
+    # always() + explicit result checks: run for a successful release even when
+    # skipped upstream jobs would trip the implicit success() gate.
+    if: |
+      always() &&
+      needs.determine_mode.result == 'success' &&
+      needs.generate_changelog.result == 'success' &&
+      needs.set_hermes_version.result == 'success' &&
+      needs.determine_mode.outputs.mode == 'release'
     uses: ./.github/workflows/create-draft-release.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

During the 0.87.0-rc.0 release, the npm packages published successfully (`publish_react_native` ✓) but every release-only downstream job was **skipped**: `post_publish`, `generate_changelog`, `bump_podfile_lock`, and `create_draft_release`. As a result the community template was not published, rn-diff-purge was not triggered, npm/Maven verification did not run, the changelog was not generated, `Podfile.lock` was not bumped, and no draft GitHub release was created.

### Root cause

These four jobs gate on a bare condition:

```yaml
if: needs.determine_mode.outputs.mode == 'release'
```

Because that expression contains no status-check function, GitHub Actions implicitly ANDs a `success()` gate. `success()` evaluates to false when there is a **skipped job in the dependency graph**. In release mode, `build_android` (a dependency of `publish_react_native`) is always skipped, which poisons the implicit `success()` for these downstream jobs — so they skip even after a fully successful publish.

`publish_react_native` already works around exactly this with `always()` + explicit `.result == 'success'` checks (see its existing `if:` and comment). This PR applies the same, proven pattern to the four downstream jobs.

### Fix

Replace each bare `if:` with `always()` plus explicit result checks so the jobs run whenever the release publish actually succeeds, and only in release mode:

```yaml
if: |
  always() &&
  needs.determine_mode.result == 'success' &&
  needs.publish_react_native.result == 'success' &&
  needs.determine_mode.outputs.mode == 'release'
```

(`create_draft_release` checks `generate_changelog` and `set_hermes_version` instead, matching its `needs`.)

## Changelog:
[Internal] -

### Notes

- This bug is structural — it affects **every** release, not just rc.0, since `build_android` is always skipped in release mode.
- A companion PR backports this fix to `0.87-stable`.

## Test plan

- `if` expressions unchanged in intent: run only for a successful release publish, skip for nightly/bumped-packages.
- YAML validated locally.
- Verify on the next release that `post_publish`, `generate_changelog`, `bump_podfile_lock`, and `create_draft_release` all run after `publish_react_native` succeeds.