### PR TITLE
fix: decimal values in transformOrigin string parser

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js
@@ -113,5 +113,10 @@ describe('processTransformOrigin', () => {
         processTransformOrigin('top 30% center');
       }).toThrow('Could not parse transform-origin: top 30% center');
     });
+    it('should handle decimal percentage and pixel values', () => {
+      expect(processTransformOrigin('50.5% 30.2%')).toEqual(['50.5%', '30.2%', 0]);
+      expect(processTransformOrigin('12.5px 7.5px')).toEqual([12.5, 7.5, 0]);
+      expect(processTransformOrigin('.5% .5px')).toEqual(['.5%', 0.5, 0]);
+    });
   });
 });

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js
@@ -114,7 +114,11 @@ describe('processTransformOrigin', () => {
       }).toThrow('Could not parse transform-origin: top 30% center');
     });
     it('should handle decimal percentage and pixel values', () => {
-      expect(processTransformOrigin('50.5% 30.2%')).toEqual(['50.5%', '30.2%', 0]);
+      expect(processTransformOrigin('50.5% 30.2%')).toEqual([
+        '50.5%',
+        '30.2%',
+        0,
+      ]);
       expect(processTransformOrigin('12.5px 7.5px')).toEqual([12.5, 7.5, 0]);
       expect(processTransformOrigin('.5% .5px')).toEqual(['.5%', 0.5, 0]);
     });

--- a/packages/react-native/Libraries/StyleSheet/processTransformOrigin.js
+++ b/packages/react-native/Libraries/StyleSheet/processTransformOrigin.js
@@ -11,7 +11,8 @@
 import invariant from 'invariant';
 
 // Pre-compiled regex pattern for performance - avoids regex compilation on each call
-const TRANSFORM_ORIGIN_REGEX = /(top|bottom|left|right|center|\d*\.?\d+(?:%|px)|0)/gi;
+const TRANSFORM_ORIGIN_REGEX =
+  /(top|bottom|left|right|center|\d*\.?\d+(?:%|px)|0)/gi;
 
 const INDEX_X = 0;
 const INDEX_Y = 1;

--- a/packages/react-native/Libraries/StyleSheet/processTransformOrigin.js
+++ b/packages/react-native/Libraries/StyleSheet/processTransformOrigin.js
@@ -11,7 +11,7 @@
 import invariant from 'invariant';
 
 // Pre-compiled regex pattern for performance - avoids regex compilation on each call
-const TRANSFORM_ORIGIN_REGEX = /(top|bottom|left|right|center|\d+(?:%|px)|0)/gi;
+const TRANSFORM_ORIGIN_REGEX = /(top|bottom|left|right|center|\d*\.?\d+(?:%|px)|0)/gi;
 
 const INDEX_X = 0;
 const INDEX_Y = 1;

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformOriginTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformOriginTest.cpp
@@ -425,4 +425,34 @@ TEST(CSSTransformOrigin, percentage_percentage) {
   EXPECT_EQ(origin.z, CSSLength{});
 }
 
+TEST(CSSTransformOrigin, decimal_length_length) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("12.5px 7.5px");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.x));
+  EXPECT_EQ(std::get<CSSLength>(origin.x).value, 12.5f);
+  EXPECT_EQ(std::get<CSSLength>(origin.x).unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.y));
+  EXPECT_EQ(std::get<CSSLength>(origin.y).value, 7.5f);
+  EXPECT_EQ(std::get<CSSLength>(origin.y).unit, CSSLengthUnit::Px);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, decimal_percentage_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("50.5% 30.2%");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 50.5f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 30.2f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
 } // namespace facebook::react


### PR DESCRIPTION
## Summary:

Fixes incorrect parsing of decimal percentage and pixel values in the string form of `transformOrigin`.

The current tokenizer only matches integer numeric values followed by `%` or `px`. As a result, decimal pixel values are silently corrupted. For example:

```js
processTransformOrigin('12.5px 7.5px');
```

currently returns:

```js
[5, 5, 0]
```

instead of:

```js
[12.5, 7.5, 0]
```

Decimal percentage values are also incorrectly tokenized. For example, `50.5% 30.2%` is split into partial matches instead of preserving the decimal values.

This updates the numeric token pattern from `\d+(?:%|px)` to `\d*\.?\d+(?:%|px)`, supporting decimal values such as `12.5px`, `50.5%`, and leading-dot decimal values such as `.5%`.

Regression coverage is added for decimal percentages, decimal pixels, and leading-dot decimal values.

## Changelog:

[GENERAL] [FIXED] - Fix `transformOrigin` string parsing for decimal percentage and pixel values.

## Test Plan:

Added regression coverage in `processTransformOrigin-itest.js` for:

* decimal percentages: `50.5% 30.2%`
* decimal pixels: `12.5px 7.5px`
* leading-dot decimals: `.5% .5px`

A focused local execution against `processTransformOrigin` confirmed:

```text
Before fix:
"12.5px 7.5px" -> [5, 5, 0]

After fix:
"12.5px 7.5px" -> [12.5, 7.5, 0]
```

Also attempted the targeted Fantom integration test with:

```text
node node_modules/jest/bin/jest.js --config private/react-native-fantom/config/jest.config.js packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js
```

The Fantom test could not complete locally because Metro failed to resolve a generated runtime setup path containing Windows path separators.
