### PR TITLE
Flow: Fix `@babel/types` libdef for `getBindingIdentifiers` (#57488)

### DIFF
--- a/flow-typed/npm/babel-types_v7.x.x.js
+++ b/flow-typed/npm/babel-types_v7.x.x.js
@@ -3848,8 +3848,8 @@ declare module "@babel/types" {
   declare export function prependToMemberExpression(member: BabelNodeMemberExpression, prepend: BabelNodeExpression): BabelNodeMemberExpression
   declare export function removeProperties<T>(n: T, opts: ?{}): void;
   declare export function removePropertiesDeep<T>(n: T, opts: ?{}): T;
-  declare export function getBindingIdentifiers(node: BabelNode, duplicates: boolean, outerOnly?: boolean): { [key: string]: BabelNodeIdentifier | Array<BabelNodeIdentifier> }
-  declare export function getOuterBindingIdentifiers(node: Node, duplicates: boolean): { [key: string]: BabelNodeIdentifier | Array<BabelNodeIdentifier> }
+  declare export function getBindingIdentifiers(node: BabelNode, duplicates?: boolean, outerOnly?: boolean): { [key: string]: BabelNodeIdentifier | Array<BabelNodeIdentifier> }
+  declare export function getOuterBindingIdentifiers(node: Node, duplicates?: boolean): { [key: string]: BabelNodeIdentifier | Array<BabelNodeIdentifier> }
   declare export type TraversalAncestors = Array<{
     node: BabelNode,
     key: string,


### PR DESCRIPTION
Summary:
X-link: https://github.com/react/metro/pull/1770


The generated Flow libdef for `babel/types` declared `duplicates` as a required parameter on `getBindingIdentifiers` and `getOuterBindingIdentifiers`. 

It is actually optional, both at runtime (only read as a truthy flag, defaulting to the non-duplicate map) and in the upstream TS types:

https://github.com/babel/babel/blob/7.x/packages/babel-types/src/retrievers/getBindingIdentifiers.ts#L17-L36

This prevented legitimate single-argument use later in this stack. Separating it for export to RN + Metro.

Changelog: [Internal]

Reviewed By: GijsWeterings

Differential Revision: D111056985


