### PR TITLE
Add unstable-internals entry point (#57489)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -56,6 +56,7 @@ experimental.multi_platform.extensions=.android
 munge_underscores=true
 
 module.name_mapper='^react-native$' -> '<PROJECT_ROOT>/packages/react-native/index.js'
+module.name_mapper='^react-native/react-private-interface$' -> '<PROJECT_ROOT>/packages/react-native/src/react-private-interface.js'
 module.name_mapper='^react-native/setup-env$' -> '<PROJECT_ROOT>/packages/react-native/src/setup-env.js'
 module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/packages/react-native/\1'
 module.name_mapper='^@react-native/dev-middleware$' -> '<PROJECT_ROOT>/packages/dev-middleware'

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -8,124 +8,13 @@
  * @format
  */
 
-import typeof dispatchNativeEvent from '../../src/private/renderer/events/dispatchNativeEvent';
-import typeof CustomEvent from '../../src/private/webapis/dom/events/CustomEvent';
-import typeof BatchedBridge from '../BatchedBridge/BatchedBridge';
-import typeof legacySendAccessibilityEvent from '../Components/AccessibilityInfo/legacySendAccessibilityEvent';
-import typeof TextInputState from '../Components/TextInput/TextInputState';
-import typeof ExceptionsManager from '../Core/ExceptionsManager';
-import typeof RawEventEmitter from '../Core/RawEventEmitter';
-import typeof ReactFiberErrorDialog from '../Core/ReactFiberErrorDialog';
-import typeof RCTEventEmitter from '../EventEmitter/RCTEventEmitter';
-import typeof {
-  createPublicInstance,
-  createPublicRootInstance,
-  createPublicTextInstance,
-  getInternalInstanceHandleFromPublicInstance,
-  getNativeTagFromPublicInstance,
-  getNodeFromPublicInstance,
-} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
-import typeof {
-  create as createAttributePayload,
-  diff as diffAttributePayloads,
-} from '../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
-import typeof UIManager from '../ReactNative/UIManager';
-import typeof * as ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
-import typeof flattenStyle from '../StyleSheet/flattenStyle';
-import type {DangerouslyImpreciseStyleProp} from '../StyleSheet/StyleSheet';
-import typeof deepFreezeAndThrowOnMutationInDev from '../Utilities/deepFreezeAndThrowOnMutationInDev';
-import typeof deepDiffer from '../Utilities/differ/deepDiffer';
-import typeof Platform from '../Utilities/Platform';
+import typeof {createPublicTextInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
 
 export type {PublicRootInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
 export type PublicTextInstance = ReturnType<createPublicTextInstance>;
 
-// flowlint unsafe-getters-setters:off
+/**
+ * @deprecated Since 0.88. Use 'react-native/react-private-interface' instead.
+ */
 // eslint-disable-next-line @react-native/monorepo/no-commonjs-exports
-module.exports = {
-  get BatchedBridge(): BatchedBridge {
-    return require('../BatchedBridge/BatchedBridge').default;
-  },
-  get ExceptionsManager(): ExceptionsManager {
-    return require('../Core/ExceptionsManager').default;
-  },
-  get Platform(): Platform {
-    return require('../Utilities/Platform').default;
-  },
-  get RCTEventEmitter(): RCTEventEmitter {
-    return require('../EventEmitter/RCTEventEmitter').default;
-  },
-  get ReactNativeViewConfigRegistry(): ReactNativeViewConfigRegistry {
-    return require('../Renderer/shims/ReactNativeViewConfigRegistry');
-  },
-  get TextInputState(): TextInputState {
-    return require('../Components/TextInput/TextInputState').default;
-  },
-  get UIManager(): UIManager {
-    return require('../ReactNative/UIManager').default;
-  },
-  // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
-  get deepDiffer(): deepDiffer {
-    return require('../Utilities/differ/deepDiffer').default;
-  },
-  get deepFreezeAndThrowOnMutationInDev(): deepFreezeAndThrowOnMutationInDev<
-    {...} | Array<unknown>,
-  > {
-    return require('../Utilities/deepFreezeAndThrowOnMutationInDev').default;
-  },
-  // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
-  get flattenStyle(): flattenStyle<DangerouslyImpreciseStyleProp> {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
-    // $FlowFixMe[incompatible-type]
-    return require('../StyleSheet/flattenStyle').default;
-  },
-  get ReactFiberErrorDialog(): ReactFiberErrorDialog {
-    return require('../Core/ReactFiberErrorDialog').default;
-  },
-  get legacySendAccessibilityEvent(): legacySendAccessibilityEvent {
-    return require('../Components/AccessibilityInfo/legacySendAccessibilityEvent')
-      .default;
-  },
-  get RawEventEmitter(): RawEventEmitter {
-    return require('../Core/RawEventEmitter').default;
-  },
-  get CustomEvent(): CustomEvent {
-    return require('../../src/private/webapis/dom/events/CustomEvent').default;
-  },
-  get createAttributePayload(): createAttributePayload {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload')
-      .create;
-  },
-  get diffAttributePayloads(): diffAttributePayloads {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload')
-      .diff;
-  },
-  get createPublicRootInstance(): createPublicRootInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .createPublicRootInstance;
-  },
-  get createPublicInstance(): createPublicInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .createPublicInstance;
-  },
-  get createPublicTextInstance(): createPublicTextInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .createPublicTextInstance;
-  },
-  get getNativeTagFromPublicInstance(): getNativeTagFromPublicInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .getNativeTagFromPublicInstance;
-  },
-  get getNodeFromPublicInstance(): getNodeFromPublicInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .getNodeFromPublicInstance;
-  },
-  get getInternalInstanceHandleFromPublicInstance(): getInternalInstanceHandleFromPublicInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .getInternalInstanceHandleFromPublicInstance;
-  },
-  get dispatchNativeEvent(): dispatchNativeEvent {
-    return require('../../src/private/renderer/events/dispatchNativeEvent')
-      .default;
-  },
-};
+module.exports = require('../../src/react-private-interface');

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js.flow
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js.flow
@@ -8,34 +8,8 @@
  * @format
  */
 
-import typeof {createPublicTextInstance as createPublicTextInstanceT} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
-
-export type {PublicRootInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
-export type PublicTextInstance = ReturnType<createPublicTextInstanceT>;
-
-export {default as BatchedBridge} from '../BatchedBridge/BatchedBridge';
-export {default as ExceptionsManager} from '../Core/ExceptionsManager';
-export {default as Platform} from '../Utilities/Platform';
-export {default as RCTEventEmitter} from '../EventEmitter/RCTEventEmitter';
-export * as ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
-export {default as TextInputState} from '../Components/TextInput/TextInputState';
-export {default as UIManager} from '../ReactNative/UIManager';
-export {default as deepDiffer} from '../Utilities/differ/deepDiffer';
-export {default as deepFreezeAndThrowOnMutationInDev} from '../Utilities/deepFreezeAndThrowOnMutationInDev';
-export {default as flattenStyle} from '../StyleSheet/flattenStyle';
-export {default as ReactFiberErrorDialog} from '../Core/ReactFiberErrorDialog';
-export {default as legacySendAccessibilityEvent} from '../Components/AccessibilityInfo/legacySendAccessibilityEvent';
-export {default as RawEventEmitter} from '../Core/RawEventEmitter';
-export {default as CustomEvent} from '../../src/private/webapis/dom/events/CustomEvent';
-export {
-  create as createAttributePayload,
-  diff as diffAttributePayloads,
-} from '../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
-export {
-  createPublicRootInstance,
-  createPublicInstance,
-  createPublicTextInstance,
-  getNativeTagFromPublicInstance,
-  getNodeFromPublicInstance,
-  getInternalInstanceHandleFromPublicInstance,
-} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+/**
+ * @deprecated Since 0.88. Use 'react-native/react-private-interface' instead.
+ */
+export type * from '../../src/react-private-interface';
+export * from '../../src/react-private-interface';

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -53,6 +53,11 @@
       "default": "./src/react-private-interface.js"
     },
     "./setup-env": "./src/setup-env.js",
+    "./unstable-internals-do-not-use": {
+      "react-native-unstable-internals": "./src/unstable-internals-do-not-use.d.ts",
+      "types": null,
+      "default": "./src/unstable-internals-do-not-use.js"
+    },
     "./src/fb_internal/*": "./src/fb_internal/*",
     "./package.json": "./package.json"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -48,6 +48,10 @@
       "types": null,
       "default": "./src/asset-registry.js"
     },
+    "./react-private-interface": {
+      "types": null,
+      "default": "./src/react-private-interface.js"
+    },
     "./setup-env": "./src/setup-env.js",
     "./src/fb_internal/*": "./src/fb_internal/*",
     "./package.json": "./package.json"

--- a/packages/react-native/src/react-private-interface.js
+++ b/packages/react-native/src/react-private-interface.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+// ----------------------------------------------------------------------------
+// react-native/react-private-interface
+//
+// This is a private entry point allowing React to require React Native
+// internals (previously, Libaries/ReactNativePrivateInterface.js).
+//
+// These APIs should ONLY be used by first party React internals and are not
+// part of our public API.
+//
+// IMPORTANT: Keep this file in sync with react-private-interface.js.flow.
+// ----------------------------------------------------------------------------
+
+import typeof BatchedBridge from '../Libraries/BatchedBridge/BatchedBridge';
+import typeof legacySendAccessibilityEvent from '../Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent';
+import typeof TextInputState from '../Libraries/Components/TextInput/TextInputState';
+import typeof ExceptionsManager from '../Libraries/Core/ExceptionsManager';
+import typeof RawEventEmitter from '../Libraries/Core/RawEventEmitter';
+import typeof ReactFiberErrorDialog from '../Libraries/Core/ReactFiberErrorDialog';
+import typeof RCTEventEmitter from '../Libraries/EventEmitter/RCTEventEmitter';
+import typeof {
+  createPublicInstance,
+  createPublicRootInstance,
+  createPublicTextInstance,
+  getInternalInstanceHandleFromPublicInstance,
+  getNativeTagFromPublicInstance,
+  getNodeFromPublicInstance,
+} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+import typeof {
+  create as createAttributePayload,
+  diff as diffAttributePayloads,
+} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
+import typeof UIManager from '../Libraries/ReactNative/UIManager';
+import typeof * as ReactNativeViewConfigRegistry from '../Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+import typeof flattenStyle from '../Libraries/StyleSheet/flattenStyle';
+import type {DangerouslyImpreciseStyleProp} from '../Libraries/StyleSheet/StyleSheet';
+import typeof deepFreezeAndThrowOnMutationInDev from '../Libraries/Utilities/deepFreezeAndThrowOnMutationInDev';
+import typeof deepDiffer from '../Libraries/Utilities/differ/deepDiffer';
+import typeof Platform from '../Libraries/Utilities/Platform';
+import typeof dispatchNativeEvent from './private/renderer/events/dispatchNativeEvent';
+import typeof CustomEvent from './private/webapis/dom/events/CustomEvent';
+
+export type {PublicRootInstance} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+export type PublicTextInstance = ReturnType<createPublicTextInstance>;
+
+// flowlint unsafe-getters-setters:off
+// eslint-disable-next-line @react-native/monorepo/no-commonjs-exports
+module.exports = {
+  get BatchedBridge(): BatchedBridge {
+    return require('../Libraries/BatchedBridge/BatchedBridge').default;
+  },
+  get ExceptionsManager(): ExceptionsManager {
+    return require('../Libraries/Core/ExceptionsManager').default;
+  },
+  get Platform(): Platform {
+    return require('../Libraries/Utilities/Platform').default;
+  },
+  get RCTEventEmitter(): RCTEventEmitter {
+    return require('../Libraries/EventEmitter/RCTEventEmitter').default;
+  },
+  get ReactNativeViewConfigRegistry(): ReactNativeViewConfigRegistry {
+    return require('../Libraries/Renderer/shims/ReactNativeViewConfigRegistry');
+  },
+  get TextInputState(): TextInputState {
+    return require('../Libraries/Components/TextInput/TextInputState').default;
+  },
+  get UIManager(): UIManager {
+    return require('../Libraries/ReactNative/UIManager').default;
+  },
+  // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
+  get deepDiffer(): deepDiffer {
+    return require('../Libraries/Utilities/differ/deepDiffer').default;
+  },
+  get deepFreezeAndThrowOnMutationInDev(): deepFreezeAndThrowOnMutationInDev<
+    {...} | Array<unknown>,
+  > {
+    return require('../Libraries/Utilities/deepFreezeAndThrowOnMutationInDev')
+      .default;
+  },
+  // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
+  get flattenStyle(): flattenStyle<DangerouslyImpreciseStyleProp> {
+    // $FlowFixMe[underconstrained-implicit-instantiation]
+    // $FlowFixMe[incompatible-type]
+    return require('../Libraries/StyleSheet/flattenStyle').default;
+  },
+  get ReactFiberErrorDialog(): ReactFiberErrorDialog {
+    return require('../Libraries/Core/ReactFiberErrorDialog').default;
+  },
+  get legacySendAccessibilityEvent(): legacySendAccessibilityEvent {
+    return require('../Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent')
+      .default;
+  },
+  get RawEventEmitter(): RawEventEmitter {
+    return require('../Libraries/Core/RawEventEmitter').default;
+  },
+  get CustomEvent(): CustomEvent {
+    return require('./private/webapis/dom/events/CustomEvent').default;
+  },
+  get createAttributePayload(): createAttributePayload {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload')
+      .create;
+  },
+  get diffAttributePayloads(): diffAttributePayloads {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload')
+      .diff;
+  },
+  get createPublicRootInstance(): createPublicRootInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .createPublicRootInstance;
+  },
+  get createPublicInstance(): createPublicInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .createPublicInstance;
+  },
+  get createPublicTextInstance(): createPublicTextInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .createPublicTextInstance;
+  },
+  get getNativeTagFromPublicInstance(): getNativeTagFromPublicInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .getNativeTagFromPublicInstance;
+  },
+  get getNodeFromPublicInstance(): getNodeFromPublicInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .getNodeFromPublicInstance;
+  },
+  get getInternalInstanceHandleFromPublicInstance(): getInternalInstanceHandleFromPublicInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .getInternalInstanceHandleFromPublicInstance;
+  },
+  get dispatchNativeEvent(): dispatchNativeEvent {
+    return require('./private/renderer/events/dispatchNativeEvent').default;
+  },
+};

--- a/packages/react-native/src/react-private-interface.js.flow
+++ b/packages/react-native/src/react-private-interface.js.flow
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// ----------------------------------------------------------------------------
+// Types entry point for react-native/react-private-interface
+//
+// IMPORTANT: Keep this file in sync with react-private-interface.js.
+// ----------------------------------------------------------------------------
+
+import typeof {createPublicTextInstance as createPublicTextInstanceT} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+
+export type {PublicRootInstance} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+export type PublicTextInstance = ReturnType<createPublicTextInstanceT>;
+
+export {default as BatchedBridge} from '../Libraries/BatchedBridge/BatchedBridge';
+export {default as ExceptionsManager} from '../Libraries/Core/ExceptionsManager';
+export {default as Platform} from '../Libraries/Utilities/Platform';
+export {default as RCTEventEmitter} from '../Libraries/EventEmitter/RCTEventEmitter';
+export * as ReactNativeViewConfigRegistry from '../Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+export {default as TextInputState} from '../Libraries/Components/TextInput/TextInputState';
+export {default as UIManager} from '../Libraries/ReactNative/UIManager';
+export {default as deepDiffer} from '../Libraries/Utilities/differ/deepDiffer';
+export {default as deepFreezeAndThrowOnMutationInDev} from '../Libraries/Utilities/deepFreezeAndThrowOnMutationInDev';
+export {default as flattenStyle} from '../Libraries/StyleSheet/flattenStyle';
+export {default as ReactFiberErrorDialog} from '../Libraries/Core/ReactFiberErrorDialog';
+export {default as legacySendAccessibilityEvent} from '../Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent';
+export {default as RawEventEmitter} from '../Libraries/Core/RawEventEmitter';
+export {default as CustomEvent} from './private/webapis/dom/events/CustomEvent';
+export {
+  create as createAttributePayload,
+  diff as diffAttributePayloads,
+} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
+export {
+  createPublicRootInstance,
+  createPublicInstance,
+  createPublicTextInstance,
+  getNativeTagFromPublicInstance,
+  getNodeFromPublicInstance,
+  getInternalInstanceHandleFromPublicInstance,
+} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';

--- a/packages/react-native/src/unstable-internals-do-not-use.d.ts
+++ b/packages/react-native/src/unstable-internals-do-not-use.d.ts
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// ----------------------------------------------------------------------------
+// Types entry point for react-native/unstable-internals-do-not-use.
+//
+// IMPORTANT: Keep this file in sync with unstable-internals-do-not-use.js.
+// ----------------------------------------------------------------------------
+
+import type * as React from 'react';
+
+// #region AppContainer
+
+interface AppContainerProps {
+  children?: React.ReactNode | undefined;
+  rootTag: number;
+  initialProps?: object | undefined;
+  WrapperComponent?: React.ComponentType<any> | null | undefined;
+  rootViewStyle?: unknown | undefined;
+  internal_excludeLogBox?: boolean | undefined;
+  internal_excludeInspector?: boolean | undefined;
+}
+
+/** Root component that wraps and mounts a React Native app tree. */
+export const AppContainer: React.ComponentType<AppContainerProps>;
+
+// #endregion
+// #region AssetSourceResolver
+
+interface ResolvedAssetSource {
+  readonly __packager_asset: boolean;
+  readonly width: number | null | undefined;
+  readonly height: number | null | undefined;
+  readonly uri: string;
+  readonly scale: number;
+}
+
+/** Resolves a packager asset descriptor to a loadable source for the current platform. */
+export class AssetSourceResolver {
+  serverUrl: string | null | undefined;
+  jsbundleUrl: string | null | undefined;
+  asset: unknown;
+  constructor(
+    serverUrl: string | null | undefined,
+    jsbundleUrl: string | null | undefined,
+    asset: unknown,
+  );
+  isLoadedFromServer(): boolean;
+  isLoadedFromFileSystem(): boolean;
+  defaultAsset(): ResolvedAssetSource;
+  getAssetUsingResolver(resolver: 'android' | 'generic'): ResolvedAssetSource;
+  assetServerURL(): ResolvedAssetSource;
+  scaledAssetPath(): ResolvedAssetSource;
+  scaledAssetURLNearBundle(): ResolvedAssetSource;
+  resourceIdentifierWithoutScale(): ResolvedAssetSource;
+  drawableFolderInBundle(): ResolvedAssetSource;
+  fromSource(source: string): ResolvedAssetSource;
+  static pickScale(scales: number[], deviceScale?: number): number;
+}
+
+// #endregion
+// #region customDirectEventTypes
+
+/** Registry mapping custom direct (non-bubbling) event names to their registration names. */
+export const customDirectEventTypes: {
+  [eventName: string]: Readonly<{
+    registrationName: string;
+  }>;
+};
+
+// #endregion
+// #region DevLoadingView
+
+/** Dev-only overlay banner showing bundle load, refresh, and error status. */
+export const DevLoadingView: {
+  showMessage(
+    message: string,
+    type: 'load' | 'refresh' | 'error',
+    options?: {dismissButton?: boolean | undefined},
+  ): void;
+  hide(): void;
+};
+
+// #endregion
+// #region getDevServer
+
+interface DevServerInfo {
+  url: string;
+  fullBundleUrl: string | null;
+  bundleLoadedFromServer: boolean;
+}
+
+/** Returns information about the running dev server. */
+export function getDevServer(): DevServerInfo;
+
+// #endregion
+// #region HMRClient
+
+/** Client that receives Fast Refresh updates and applies them at runtime. */
+export class HMRClient {
+  enable(): void;
+  disable(): void;
+  registerBundle(requestUrl: string): void;
+  log(
+    level:
+      | 'trace'
+      | 'info'
+      | 'warn'
+      | 'error'
+      | 'log'
+      | 'group'
+      | 'groupCollapsed'
+      | 'groupEnd'
+      | 'debug',
+    data: ReadonlyArray<unknown>,
+  ): void;
+  setup(
+    platform: string,
+    bundleEntry: string,
+    host: string,
+    port: number | string,
+    isEnabled: boolean,
+    scheme?: string,
+  ): void;
+}
+
+// #endregion
+// #region NativeExceptionsManager
+
+interface StackFrame {
+  column: number | null;
+  file: string | null;
+  lineNumber: number | null;
+  methodName: string;
+  collapse?: boolean | undefined;
+}
+
+interface ExceptionData {
+  message: string;
+  originalMessage: string | null;
+  name: string | null;
+  componentStack: string | null;
+  stack: StackFrame[];
+  id: number;
+  isFatal: boolean;
+  extraData?: object | undefined;
+}
+
+/** Reports JS exceptions to native and manages RedBox. */
+export const NativeExceptionsManager: {
+  reportFatalException(
+    message: string,
+    stack: StackFrame[],
+    exceptionId: number,
+  ): void;
+  reportSoftException(
+    message: string,
+    stack: StackFrame[],
+    exceptionId: number,
+  ): void;
+  dismissRedbox(): void;
+  reportException(data: ExceptionData): void;
+};
+
+// #endregion
+// #region NativeRedBox
+
+interface NativeRedBoxSpec {
+  setExtraData(extraData: object, forIdentifier: string): void;
+  dismiss(): void;
+}
+
+/** Native module for the RedBox error overlay; null when unavailable. */
+export const NativeRedBox: NativeRedBoxSpec | null;
+
+// #endregion
+// #region NativeSourceCode
+
+interface SourceCodeConstants {
+  scriptURL: string;
+}
+
+/** Native module exposing source-code constants such as the bundle scriptURL. */
+export const NativeSourceCode: {
+  getConstants(): SourceCodeConstants;
+};
+
+// #endregion
+// #region PressabilityDebugView
+
+type Rect = Readonly<{
+  bottom?: number | null | undefined;
+  left?: number | null | undefined;
+  right?: number | null | undefined;
+  top?: number | null | undefined;
+}>;
+
+type RectOrSize = Rect | number;
+
+interface PressabilityDebugViewProps {
+  color: unknown;
+  hitSlop: RectOrSize | null | undefined;
+}
+
+/** Debug overlay that visualizes press targets when enabled via the Inspector. */
+export const PressabilityDebugView: React.ComponentType<PressabilityDebugViewProps>;
+
+// #endregion

--- a/packages/react-native/src/unstable-internals-do-not-use.js
+++ b/packages/react-native/src/unstable-internals-do-not-use.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @noflow
+ * @format
+ */
+
+'use strict';
+'use client';
+
+// ----------------------------------------------------------------------------
+// react-native/unstable-internals-do-not-use
+//
+// UNSTABLE WITH NO SEMVER GUARANTEES.
+// SHOULD NOT BE DEPENDED ON BY NEW CODE.
+//
+// This is a secondary entry point for frameworks and libraries that depend on
+// specific React Native internals, serving as a compatibility bridge.
+//
+// Consuming codebases must opt in via tsconfig.json:
+//   "customConditions": ["react-native-unstable-internals"]
+//
+// Having this entry point:
+// - Maintains a known list of which React Native internals are in use.
+// - Enables us to relocate supporting files more freely.
+// - Gives us time to decide on the future of these APIs (independent from
+//   removal of the Strict API opt out).
+//
+// The long term future of these exports is to formalize/delete them where
+// appropriate, and collapse this entry point.
+//
+// Replaces RFC0985
+// https://github.com/react-native-community/discussions-and-proposals/pull/985
+// where we reviewed internal APIs used in the ecosystem.
+//
+// IMPORTANT: Keep this file in sync with unstable-internals-do-not-use.d.ts.
+// ----------------------------------------------------------------------------
+
+// eslint-disable-next-line @react-native/monorepo/no-commonjs-exports
+module.exports = {
+  get AppContainer() {
+    return require('../Libraries/ReactNative/AppContainer').default;
+  },
+  get AssetSourceResolver() {
+    return require('../Libraries/Image/AssetSourceResolver').default;
+  },
+  get customDirectEventTypes() {
+    return require('../Libraries/Renderer/shims/ReactNativeViewConfigRegistry')
+      .customDirectEventTypes;
+  },
+  get DevLoadingView() {
+    return require('../Libraries/Utilities/DevLoadingView').default;
+  },
+  get getDevServer() {
+    return require('../Libraries/Core/Devtools/getDevServer').default;
+  },
+  get HMRClient() {
+    return require('../Libraries/Utilities/HMRClient').default;
+  },
+  get NativeExceptionsManager() {
+    return require('../Libraries/Core/NativeExceptionsManager').default;
+  },
+  get NativeRedBox() {
+    return require('../Libraries/NativeModules/specs/NativeRedBox').default;
+  },
+  get NativeSourceCode() {
+    return require('../Libraries/NativeModules/specs/NativeSourceCode').default;
+  },
+  get PressabilityDebugView() {
+    return require('../Libraries/Pressability/PressabilityDebug')
+      .PressabilityDebugView;
+  },
+};


### PR DESCRIPTION
Summary:

See [**RFC0894: Removing deep imports from react-native**](https://github.com/react-native-community/discussions-and-proposals/pull/894)

Adds a `'react-native/unstable-internals-do-not-use'` entry point that acts as an explicit, opt-in escape hatch for frameworks and libraries that depend on specific React Native internals.

Follows (and supersedes) https://github.com/react-native-community/discussions-and-proposals/pull/985.

Resolves T270727304.

**Motivation**

- Maintains a known list of which React Native internals are still in use.
- Decouples removal of the Strict API opt-out from the longer-term decisions about these APIs.
- Lets us relocate supporting source files freely, since consumers reference this subpath instead of deep internal paths.

**Notes**

- Reuses the runtime **object-with-getter pattern** (same as `index.js`), to avoid any native module side effects caused by loading adjacent file exports.
    - e.g. in Expo, [`hmrUtils.js`](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/src/async-require/hmrUtils.native.ts?fbclid=IwY2xjawS7GjNwZG9mA2V4dG4DYWVtAjExAGJyaWQRMTZ1ckEwU05oWUw2bDBVN21zcnRjBmFwcF9pZAEwAAEen3UuX4Ig-RD3n1ULZIHIHq21Mfk_ci9b2SxquY7UkngDs6qhnRt5YQlb8Os_aem_ylJy40egSOl1qhZ9bA9HTA) is designed to be run early in RN startup — preserve the lazy require characteristic and do not break this.
- TypeScript defs on this API are minimal, with complex internal input/handle types reduced to `unknown`. As with D110602194, these are intended to be feature-locked.

**Exposed internals and known consumers**

NOTE: The exports the community needs have reduced slightly since the spreadsheet in RFC0895 and would almost all align with `devsupport`. However, we're explicitly leaving a decision to formalise until later, and we may need to add in extra APIs quickly based on RC feedback.

| Export | Source module | Known consumers |
|---|---|---|
| `AppContainer` | `Libraries/ReactNative/AppContainer` | react-native-screens ([DebugContainer.tsx](https://github.com/software-mansion/react-native-screens/blob/6f38d76129d40cc8145d06b98f885b508fa7bf2d/src/components/DebugContainer.tsx#L5)) |
| `AssetSourceResolver` | `Libraries/Image/AssetSourceResolver` | Re.pack ([IncludeModules.ts](https://github.com/callstack/repack/blob/2498b3a426203daa4b81c7e6f7a88e86d88e77b9/packages/repack/src/modules/IncludeModules.ts#L9)) |
| `customDirectEventTypes` | `Libraries/Renderer/shims/ReactNativeViewConfigRegistry` | react-native-gesture-handler ([customDirectEventTypes.ts](https://github.com/software-mansion/react-native-gesture-handler/blob/ee147abf364bef48a02d3cf437572b4dddd30bec/packages/react-native-gesture-handler/src/handlers/customDirectEventTypes.ts#L2)) |
| `DevLoadingView` | `Libraries/Utilities/DevLoadingView` | Expo ([hmrUtils.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/src/async-require/hmrUtils.native.ts)), Re.pack ([WebpackHMRClient.ts](https://github.com/callstack/repack/blob/2498b3a426203daa4b81c7e6f7a88e86d88e77b9/packages/repack/src/modules/WebpackHMRClient.ts)) |
| `getDevServer` | `Libraries/Core/Devtools/getDevServer` | Expo ([getDevServer.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/src/async-require/getDevServer.native.ts), [hmrUtils.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/src/async-require/hmrUtils.native.ts), [base.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/src/dom/base.ts), [getDevServer.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/metro-runtime/src/getDevServer.native.ts), [devServerEndpoints.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/log-box/src/utils/devServerEndpoints.ts), [getConnectionInfo.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/devtools/src/getConnectionInfo.native.ts), [index.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo-router/src/getDevServer/index.native.ts)) |
| `HMRClient` | `Libraries/Utilities/HMRClient` | Expo ([metroServerLogs.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/metro-runtime/src/metroServerLogs.native.ts)) |
| `NativeExceptionsManager` | `Libraries/Core/NativeExceptionsManager` | Expo ([hmrUtils.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/src/async-require/hmrUtils.native.ts)), Re.pack ([WebpackHMRClient.ts](https://github.com/callstack/repack/blob/2498b3a426203daa4b81c7e6f7a88e86d88e77b9/packages/repack/src/modules/WebpackHMRClient.ts)) |
| `NativeRedBox` | `Libraries/NativeModules/specs/NativeRedBox` | Expo ([hmrUtils.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/src/async-require/hmrUtils.native.ts)), Re.pack ([WebpackHMRClient.ts](https://github.com/callstack/repack/blob/2498b3a426203daa4b81c7e6f7a88e86d88e77b9/packages/repack/src/modules/WebpackHMRClient.ts)) |
| `NativeSourceCode` | `Libraries/NativeModules/specs/NativeSourceCode` | Expo ([getBundleUrl.native.ts](https://github.com/expo/expo/blob/2d07e3a17f4be2284bbf579d8825fe32f762ce1a/packages/expo/src/utils/getBundleUrl.native.ts)) |
| `PressabilityDebugView` | `Libraries/Pressability/PressabilityDebug` | react-native-gesture-handler ([PressabilityDebugView.tsx](https://github.com/software-mansion/react-native-gesture-handler/blob/ee147abf364bef48a02d3cf437572b4dddd30bec/packages/react-native-gesture-handler/src/handlers/PressabilityDebugView.tsx#L2)) |

**Alternative names**

- `unstable-frameworks`
- `unstable-devsupport`
- `frameworks-private-interface` (mirroring `ReactPrivateInterface.js`) — this is likely a future stable shape candidate.

Changelog: [Internal]

Reviewed By: rubennorte

Differential Revision: D110911864


