### PR TITLE
Fix HelloWorld Jest preset after react-native/jest-preset removal

### DIFF
--- a/private/helloworld/jest.config.js
+++ b/private/helloworld/jest.config.js
@@ -9,5 +9,5 @@
  */
 
 module.exports = {
-  preset: 'react-native',
+  preset: '@react-native/jest-preset',
 };

--- a/private/helloworld/package.json
+++ b/private/helloworld/package.json
@@ -22,6 +22,7 @@
     "@react-native/babel-preset": "0.87.0-main",
     "@react-native/core-cli-utils": "*",
     "@react-native/eslint-config": "0.87.0-main",
+    "@react-native/jest-preset": "0.87.0-main",
     "@react-native/metro-config": "0.87.0-main",
     "@react-native/typescript-config": "0.87.0-main",
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
## Summary

#57481 removed the `react-native/jest-preset.js` redirect module (and the `react-native/jest-preset` public export), but the in-repo `private/helloworld` app still referenced `preset: 'react-native'` in its Jest config. This breaks `yarn test` in the `test_ios_helloworld` CI job (which cascade-cancels the rest of the iOS matrix and turns the e2e retry `report` jobs red):

```
● Validation Error:
  Module react-native should have "jest-preset.js" or "jest-preset.json" file at the root.
```

This migrates HelloWorld to the standalone `@react-native/jest-preset` package — the documented migration path (see `packages/jest-preset/README.md`).

## Changes
- `private/helloworld/jest.config.js`: `preset: 'react-native'` → `preset: '@react-native/jest-preset'`
- `private/helloworld/package.json`: add `@react-native/jest-preset` devDependency (`0.87.0-main`, matching the sibling `@react-native/*` packages)

## Changelog:
[Internal] [Fixed] - Fix HelloWorld Jest preset after `react-native/jest-preset` removal

## Test Plan
- `cd private/helloworld && yarn test` resolves the preset and runs (previously failed with the validation error above).
- CI `test_ios_helloworld` job.