### PR TITLE
Keep react-native/setup-env reachable in the module graph

### DIFF
--- a/packages/react-native/Libraries/Core/InitializeCore.js
+++ b/packages/react-native/Libraries/Core/InitializeCore.js
@@ -27,4 +27,11 @@
 
 'use strict';
 
-require('../../src/private/setup/setUpDefaultReactNativeEnvironment').default();
+// NOTE: This delegates to the `'react-native/setup-env'` entry point (rather
+// than calling `setUpDefaultReactNativeEnvironment` directly) so that
+// `src/setup-env.js` is pulled into the module graph. Metro's
+// `getModulesRunBeforeMainModule` only runs modules that are already part of
+// the bundle, and `InitializeCore` is a guaranteed graph entry (via
+// `ReactNativePrivateInitializeCore`). This keeps `'react-native/setup-env'`
+// reachable so it runs before the main module.
+require('../../src/setup-env');


### PR DESCRIPTION
## Summary

#57475 pointed Metro's `getModulesRunBeforeMainModule` at `react-native/setup-env` (`src/setup-env.js`) instead of `InitializeCore`.

But Metro's serializer only emits a run-before-main require for modules **already in the bundle graph** — see `getAppendScripts`:

```js
const paths = [...options.runBeforeMainModule, entryPoint];
for (const path of paths) {
  if (modules.some(module => module.path === path)) { /* emit run stmt */ }
}
```

Nothing imports `src/setup-env.js` at runtime, so it was silently dropped. The RN environment setup (`setUpDefaultReactNativeEnvironment`: `HMRClient`, timers, batched bridge, `AppRegistry` setup, …) then never ran before the app's main module, and the app **redboxed on launch**:

```
Error: Failed to call into JavaScript module method HMRClient.setup().
Module has not been registered as callable.
Registered callable JavaScript modules (n = 1): AppRegistry.
```

This broke the **template E2E tests** on both iOS and Android — the app renders a redbox, so Maestro's `assertVisible: 'Welcome to React Native'` fails (the `test (…)` jobs are green only because the Maestro step runs with `continue-on-error: true`; the real failure surfaces via the retry chain and the `retry_2 / report` job).

## Fix

Have the deprecated `InitializeCore` delegate to `'react-native/setup-env'` via a side-effectful `require`. `InitializeCore` is a guaranteed graph entry (renderer → `ReactNativePrivateInitializeCore` → `InitializeCore`), so this pulls `src/setup-env.js` into the graph, and `getModulesRunBeforeMainModule` runs it before the main module again.

Behavior is unchanged: `setup-env` and `InitializeCore` both call the idempotent `setUpDefaultReactNativeEnvironment()`. This keeps #57475's move to `setup-env` intact rather than reverting it.

## Changelog:
[General][Fixed] - Fix app failing to initialize (`HMRClient.setup()` redbox) because the environment setup module was dropped from the bundle

## Test Plan
- Template E2E (`test_e2e_ios_templateapp` / `test_e2e_android_templateapp`) should pass: app launches and shows "Welcome to React Native" instead of the redbox.

cc @huntie (#57475)