### PR TITLE
Perform AnimationEndSync commits on the React revision (#57493)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -347,7 +347,8 @@ CommitStatus ShadowTree::tryCommit(
       getShadowTreeCommitSourceName(commitOptions.source));
 
   auto isReactBranch = ReactNativeFeatureFlags::enableFabricCommitBranching() &&
-      commitOptions.source == CommitSource::React;
+      (commitOptions.source == CommitSource::React ||
+       commitOptions.source == CommitSource::AnimationEndSync);
 
   // Commits on the JS branch are never synchronous.
   react_native_assert(!isReactBranch || !commitOptions.mountSynchronously);

--- a/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
@@ -38,7 +38,8 @@ void updateMountedFlag(
   // Runtime shadow node references are updated during the React revision
   // commits so that JS can access layout data from the merged tree.
   bool shouldUpdateRuntimeReference =
-      (commitSource == ShadowTreeCommitSource::React &&
+      ((commitSource == ShadowTreeCommitSource::React ||
+        commitSource == ShadowTreeCommitSource::AnimationEndSync) &&
        ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit()) ||
       (ReactNativeFeatureFlags::
            updateRuntimeShadowNodeReferencesOnCommitThread() &&


### PR DESCRIPTION
Summary:

Changelog: [General][Fixed] Perform AnimationEndSync commits on the React revision

```
                    AB        Merge
UI thread -----------*----------*------------

JS thread ---*------------*------------------
           React       abFlush
```

In this scenario:
- AB - Animation Backend update
- React - React commit
- Merge - Merge commit
- abFlush - Animation Backend [flush](https://www.internalfb.com/code/fbsource/[aecb908843884d2fe57e866611a468e47b36518b]/xplat/js/react-native-github/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp?lines=242-268)

1. React revision captures the currently mounted main revision and applies the update on top of it. The result becomes the new `reactRevision`.
2. Animation Backend performs updates on the mounted tree, and requests a flush
3. The flush runs on the JS thread, clearing the `animatedPropsRegistry`
4. Merge commit runs, mounting the `reactRevision` and effectively dropping the updates.

This diff changes the flush to happen on the react revision instead, preventing this from happening.

Differential Revision: D111219420


