### PR TITLE
Expose react-private-interface subpath (#57495)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -56,6 +56,7 @@ experimental.multi_platform.extensions=.android
 munge_underscores=true
 
 module.name_mapper='^react-native$' -> '<PROJECT_ROOT>/packages/react-native/index.js'
+module.name_mapper='^react-native/react-private-interface$' -> '<PROJECT_ROOT>/packages/react-native/src/react-private-interface.js'
 module.name_mapper='^react-native/setup-env$' -> '<PROJECT_ROOT>/packages/react-native/src/setup-env.js'
 module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/packages/react-native/\1'
 module.name_mapper='^@react-native/dev-middleware$' -> '<PROJECT_ROOT>/packages/dev-middleware'

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -8,124 +8,13 @@
  * @format
  */
 
-import typeof dispatchNativeEvent from '../../src/private/renderer/events/dispatchNativeEvent';
-import typeof CustomEvent from '../../src/private/webapis/dom/events/CustomEvent';
-import typeof BatchedBridge from '../BatchedBridge/BatchedBridge';
-import typeof legacySendAccessibilityEvent from '../Components/AccessibilityInfo/legacySendAccessibilityEvent';
-import typeof TextInputState from '../Components/TextInput/TextInputState';
-import typeof ExceptionsManager from '../Core/ExceptionsManager';
-import typeof RawEventEmitter from '../Core/RawEventEmitter';
-import typeof ReactFiberErrorDialog from '../Core/ReactFiberErrorDialog';
-import typeof RCTEventEmitter from '../EventEmitter/RCTEventEmitter';
-import typeof {
-  createPublicInstance,
-  createPublicRootInstance,
-  createPublicTextInstance,
-  getInternalInstanceHandleFromPublicInstance,
-  getNativeTagFromPublicInstance,
-  getNodeFromPublicInstance,
-} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
-import typeof {
-  create as createAttributePayload,
-  diff as diffAttributePayloads,
-} from '../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
-import typeof UIManager from '../ReactNative/UIManager';
-import typeof * as ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
-import typeof flattenStyle from '../StyleSheet/flattenStyle';
-import type {DangerouslyImpreciseStyleProp} from '../StyleSheet/StyleSheet';
-import typeof deepFreezeAndThrowOnMutationInDev from '../Utilities/deepFreezeAndThrowOnMutationInDev';
-import typeof deepDiffer from '../Utilities/differ/deepDiffer';
-import typeof Platform from '../Utilities/Platform';
+import typeof {createPublicTextInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
 
 export type {PublicRootInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
 export type PublicTextInstance = ReturnType<createPublicTextInstance>;
 
-// flowlint unsafe-getters-setters:off
+/**
+ * @deprecated Since 0.88. Use 'react-native/react-private-interface' instead.
+ */
 // eslint-disable-next-line @react-native/monorepo/no-commonjs-exports
-module.exports = {
-  get BatchedBridge(): BatchedBridge {
-    return require('../BatchedBridge/BatchedBridge').default;
-  },
-  get ExceptionsManager(): ExceptionsManager {
-    return require('../Core/ExceptionsManager').default;
-  },
-  get Platform(): Platform {
-    return require('../Utilities/Platform').default;
-  },
-  get RCTEventEmitter(): RCTEventEmitter {
-    return require('../EventEmitter/RCTEventEmitter').default;
-  },
-  get ReactNativeViewConfigRegistry(): ReactNativeViewConfigRegistry {
-    return require('../Renderer/shims/ReactNativeViewConfigRegistry');
-  },
-  get TextInputState(): TextInputState {
-    return require('../Components/TextInput/TextInputState').default;
-  },
-  get UIManager(): UIManager {
-    return require('../ReactNative/UIManager').default;
-  },
-  // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
-  get deepDiffer(): deepDiffer {
-    return require('../Utilities/differ/deepDiffer').default;
-  },
-  get deepFreezeAndThrowOnMutationInDev(): deepFreezeAndThrowOnMutationInDev<
-    {...} | Array<unknown>,
-  > {
-    return require('../Utilities/deepFreezeAndThrowOnMutationInDev').default;
-  },
-  // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
-  get flattenStyle(): flattenStyle<DangerouslyImpreciseStyleProp> {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
-    // $FlowFixMe[incompatible-type]
-    return require('../StyleSheet/flattenStyle').default;
-  },
-  get ReactFiberErrorDialog(): ReactFiberErrorDialog {
-    return require('../Core/ReactFiberErrorDialog').default;
-  },
-  get legacySendAccessibilityEvent(): legacySendAccessibilityEvent {
-    return require('../Components/AccessibilityInfo/legacySendAccessibilityEvent')
-      .default;
-  },
-  get RawEventEmitter(): RawEventEmitter {
-    return require('../Core/RawEventEmitter').default;
-  },
-  get CustomEvent(): CustomEvent {
-    return require('../../src/private/webapis/dom/events/CustomEvent').default;
-  },
-  get createAttributePayload(): createAttributePayload {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload')
-      .create;
-  },
-  get diffAttributePayloads(): diffAttributePayloads {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload')
-      .diff;
-  },
-  get createPublicRootInstance(): createPublicRootInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .createPublicRootInstance;
-  },
-  get createPublicInstance(): createPublicInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .createPublicInstance;
-  },
-  get createPublicTextInstance(): createPublicTextInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .createPublicTextInstance;
-  },
-  get getNativeTagFromPublicInstance(): getNativeTagFromPublicInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .getNativeTagFromPublicInstance;
-  },
-  get getNodeFromPublicInstance(): getNodeFromPublicInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .getNodeFromPublicInstance;
-  },
-  get getInternalInstanceHandleFromPublicInstance(): getInternalInstanceHandleFromPublicInstance {
-    return require('../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
-      .getInternalInstanceHandleFromPublicInstance;
-  },
-  get dispatchNativeEvent(): dispatchNativeEvent {
-    return require('../../src/private/renderer/events/dispatchNativeEvent')
-      .default;
-  },
-};
+module.exports = require('../../src/react-private-interface');

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js.flow
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js.flow
@@ -8,34 +8,8 @@
  * @format
  */
 
-import typeof {createPublicTextInstance as createPublicTextInstanceT} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
-
-export type {PublicRootInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
-export type PublicTextInstance = ReturnType<createPublicTextInstanceT>;
-
-export {default as BatchedBridge} from '../BatchedBridge/BatchedBridge';
-export {default as ExceptionsManager} from '../Core/ExceptionsManager';
-export {default as Platform} from '../Utilities/Platform';
-export {default as RCTEventEmitter} from '../EventEmitter/RCTEventEmitter';
-export * as ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
-export {default as TextInputState} from '../Components/TextInput/TextInputState';
-export {default as UIManager} from '../ReactNative/UIManager';
-export {default as deepDiffer} from '../Utilities/differ/deepDiffer';
-export {default as deepFreezeAndThrowOnMutationInDev} from '../Utilities/deepFreezeAndThrowOnMutationInDev';
-export {default as flattenStyle} from '../StyleSheet/flattenStyle';
-export {default as ReactFiberErrorDialog} from '../Core/ReactFiberErrorDialog';
-export {default as legacySendAccessibilityEvent} from '../Components/AccessibilityInfo/legacySendAccessibilityEvent';
-export {default as RawEventEmitter} from '../Core/RawEventEmitter';
-export {default as CustomEvent} from '../../src/private/webapis/dom/events/CustomEvent';
-export {
-  create as createAttributePayload,
-  diff as diffAttributePayloads,
-} from '../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
-export {
-  createPublicRootInstance,
-  createPublicInstance,
-  createPublicTextInstance,
-  getNativeTagFromPublicInstance,
-  getNodeFromPublicInstance,
-  getInternalInstanceHandleFromPublicInstance,
-} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+/**
+ * @deprecated Since 0.88. Use 'react-native/react-private-interface' instead.
+ */
+export type * from '../../src/react-private-interface';
+export * from '../../src/react-private-interface';

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -48,6 +48,10 @@
       "types": null,
       "default": "./src/asset-registry.js"
     },
+    "./react-private-interface": {
+      "types": null,
+      "default": "./src/react-private-interface.js"
+    },
     "./setup-env": "./src/setup-env.js",
     "./src/fb_internal/*": "./src/fb_internal/*",
     "./package.json": "./package.json"

--- a/packages/react-native/src/react-private-interface.js
+++ b/packages/react-native/src/react-private-interface.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+// ----------------------------------------------------------------------------
+// react-native/react-private-interface
+//
+// This is a private entry point allowing React to require React Native
+// internals (previously, Libaries/ReactNativePrivateInterface.js).
+//
+// These APIs should ONLY be used by first party React internals and are not
+// part of our public API.
+//
+// IMPORTANT: Keep this file in sync with react-private-interface.js.flow.
+// ----------------------------------------------------------------------------
+
+import typeof BatchedBridge from '../Libraries/BatchedBridge/BatchedBridge';
+import typeof legacySendAccessibilityEvent from '../Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent';
+import typeof TextInputState from '../Libraries/Components/TextInput/TextInputState';
+import typeof ExceptionsManager from '../Libraries/Core/ExceptionsManager';
+import typeof RawEventEmitter from '../Libraries/Core/RawEventEmitter';
+import typeof ReactFiberErrorDialog from '../Libraries/Core/ReactFiberErrorDialog';
+import typeof RCTEventEmitter from '../Libraries/EventEmitter/RCTEventEmitter';
+import typeof {
+  createPublicInstance,
+  createPublicRootInstance,
+  createPublicTextInstance,
+  getInternalInstanceHandleFromPublicInstance,
+  getNativeTagFromPublicInstance,
+  getNodeFromPublicInstance,
+} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+import typeof {
+  create as createAttributePayload,
+  diff as diffAttributePayloads,
+} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
+import typeof UIManager from '../Libraries/ReactNative/UIManager';
+import typeof * as ReactNativeViewConfigRegistry from '../Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+import typeof flattenStyle from '../Libraries/StyleSheet/flattenStyle';
+import type {DangerouslyImpreciseStyleProp} from '../Libraries/StyleSheet/StyleSheet';
+import typeof deepFreezeAndThrowOnMutationInDev from '../Libraries/Utilities/deepFreezeAndThrowOnMutationInDev';
+import typeof deepDiffer from '../Libraries/Utilities/differ/deepDiffer';
+import typeof Platform from '../Libraries/Utilities/Platform';
+import typeof dispatchNativeEvent from './private/renderer/events/dispatchNativeEvent';
+import typeof CustomEvent from './private/webapis/dom/events/CustomEvent';
+
+export type {PublicRootInstance} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+export type PublicTextInstance = ReturnType<createPublicTextInstance>;
+
+// flowlint unsafe-getters-setters:off
+// eslint-disable-next-line @react-native/monorepo/no-commonjs-exports
+module.exports = {
+  get BatchedBridge(): BatchedBridge {
+    return require('../Libraries/BatchedBridge/BatchedBridge').default;
+  },
+  get ExceptionsManager(): ExceptionsManager {
+    return require('../Libraries/Core/ExceptionsManager').default;
+  },
+  get Platform(): Platform {
+    return require('../Libraries/Utilities/Platform').default;
+  },
+  get RCTEventEmitter(): RCTEventEmitter {
+    return require('../Libraries/EventEmitter/RCTEventEmitter').default;
+  },
+  get ReactNativeViewConfigRegistry(): ReactNativeViewConfigRegistry {
+    return require('../Libraries/Renderer/shims/ReactNativeViewConfigRegistry');
+  },
+  get TextInputState(): TextInputState {
+    return require('../Libraries/Components/TextInput/TextInputState').default;
+  },
+  get UIManager(): UIManager {
+    return require('../Libraries/ReactNative/UIManager').default;
+  },
+  // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
+  get deepDiffer(): deepDiffer {
+    return require('../Libraries/Utilities/differ/deepDiffer').default;
+  },
+  get deepFreezeAndThrowOnMutationInDev(): deepFreezeAndThrowOnMutationInDev<
+    {...} | Array<unknown>,
+  > {
+    return require('../Libraries/Utilities/deepFreezeAndThrowOnMutationInDev')
+      .default;
+  },
+  // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
+  get flattenStyle(): flattenStyle<DangerouslyImpreciseStyleProp> {
+    // $FlowFixMe[underconstrained-implicit-instantiation]
+    // $FlowFixMe[incompatible-type]
+    return require('../Libraries/StyleSheet/flattenStyle').default;
+  },
+  get ReactFiberErrorDialog(): ReactFiberErrorDialog {
+    return require('../Libraries/Core/ReactFiberErrorDialog').default;
+  },
+  get legacySendAccessibilityEvent(): legacySendAccessibilityEvent {
+    return require('../Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent')
+      .default;
+  },
+  get RawEventEmitter(): RawEventEmitter {
+    return require('../Libraries/Core/RawEventEmitter').default;
+  },
+  get CustomEvent(): CustomEvent {
+    return require('./private/webapis/dom/events/CustomEvent').default;
+  },
+  get createAttributePayload(): createAttributePayload {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload')
+      .create;
+  },
+  get diffAttributePayloads(): diffAttributePayloads {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload')
+      .diff;
+  },
+  get createPublicRootInstance(): createPublicRootInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .createPublicRootInstance;
+  },
+  get createPublicInstance(): createPublicInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .createPublicInstance;
+  },
+  get createPublicTextInstance(): createPublicTextInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .createPublicTextInstance;
+  },
+  get getNativeTagFromPublicInstance(): getNativeTagFromPublicInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .getNativeTagFromPublicInstance;
+  },
+  get getNodeFromPublicInstance(): getNodeFromPublicInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .getNodeFromPublicInstance;
+  },
+  get getInternalInstanceHandleFromPublicInstance(): getInternalInstanceHandleFromPublicInstance {
+    return require('../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
+      .getInternalInstanceHandleFromPublicInstance;
+  },
+  get dispatchNativeEvent(): dispatchNativeEvent {
+    return require('./private/renderer/events/dispatchNativeEvent').default;
+  },
+};

--- a/packages/react-native/src/react-private-interface.js.flow
+++ b/packages/react-native/src/react-private-interface.js.flow
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// ----------------------------------------------------------------------------
+// Types entry point for react-native/react-private-interface
+//
+// IMPORTANT: Keep this file in sync with react-private-interface.js.
+// ----------------------------------------------------------------------------
+
+import typeof {createPublicTextInstance as createPublicTextInstanceT} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+
+export type {PublicRootInstance} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+export type PublicTextInstance = ReturnType<createPublicTextInstanceT>;
+
+export {default as BatchedBridge} from '../Libraries/BatchedBridge/BatchedBridge';
+export {default as ExceptionsManager} from '../Libraries/Core/ExceptionsManager';
+export {default as Platform} from '../Libraries/Utilities/Platform';
+export {default as RCTEventEmitter} from '../Libraries/EventEmitter/RCTEventEmitter';
+export * as ReactNativeViewConfigRegistry from '../Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+export {default as TextInputState} from '../Libraries/Components/TextInput/TextInputState';
+export {default as UIManager} from '../Libraries/ReactNative/UIManager';
+export {default as deepDiffer} from '../Libraries/Utilities/differ/deepDiffer';
+export {default as deepFreezeAndThrowOnMutationInDev} from '../Libraries/Utilities/deepFreezeAndThrowOnMutationInDev';
+export {default as flattenStyle} from '../Libraries/StyleSheet/flattenStyle';
+export {default as ReactFiberErrorDialog} from '../Libraries/Core/ReactFiberErrorDialog';
+export {default as legacySendAccessibilityEvent} from '../Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent';
+export {default as RawEventEmitter} from '../Libraries/Core/RawEventEmitter';
+export {default as CustomEvent} from './private/webapis/dom/events/CustomEvent';
+export {
+  create as createAttributePayload,
+  diff as diffAttributePayloads,
+} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
+export {
+  createPublicRootInstance,
+  createPublicInstance,
+  createPublicTextInstance,
+  getNativeTagFromPublicInstance,
+  getNodeFromPublicInstance,
+  getInternalInstanceHandleFromPublicInstance,
+} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+export {default as dispatchNativeEvent} from './private/renderer/events/dispatchNativeEvent';


### PR DESCRIPTION
Summary:

See [**RFC0894: Removing deep imports from react-native**](https://github.com/react-native-community/discussions-and-proposals/pull/894)

Exposes a `'react-native/react-private-interface'` subpath export on the main package, to replace `Libraries/ReactPrivate/ReactNativePrivateInterface.js`.

**Impact: Internal**

This is a private contract between `react` and `react-native`.

- `ReactNativePrivateInterface` is deprecated and we'll migrate React call sites in a future version before cleanup.

**Naming**

Translate directly to `react-private-interface` ("private interface for React"). There's alternatives here but the explicitness and continuity is helpful, I believe.

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D111231527


