### PR TITLE
Simplify react-native/setup-env require in community-cli-plugin

### DIFF
--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -14,7 +14,6 @@ import type {MetroConfig} from 'metro';
 import {CLIError} from './errors';
 import {reactNativePlatformResolver} from './metroPlatformResolver';
 import {loadConfig, resolveConfig} from 'metro';
-import path from 'path';
 
 const debug = require('debug')('ReactNative:CommunityCliPlugin');
 
@@ -25,7 +24,6 @@ export type {Config};
 
 export type ConfigLoadingContext = Readonly<{
   root: Config['root'],
-  reactNativePath: Config['reactNativePath'],
   platforms: Config['platforms'],
   ...
 }>;
@@ -63,9 +61,7 @@ function getCommunityCliDefaultConfig(
       // We can include multiple copies of setup-env here because Metro will
       // only add ones that are already part of the bundle
       getModulesRunBeforeMainModule: () => [
-        // NOTE: ctx.reactNativePath is an absolute path, therefore we need to
-        // reference setup-env.js here by exact path specifier.
-        require.resolve(path.join(ctx.reactNativePath, 'src/setup-env.js'), {
+        require.resolve('react-native/setup-env', {
           paths: [ctx.root],
         }),
         ...outOfTreePlatforms.map(platform =>

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -59,7 +59,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
       unstable_conditionNames: ['react-native'],
     },
     serializer: {
-      // Note: This option is overridden in cli-plugin-metro (getOverrideConfig)
+      // NOTE: Overridden in community-cli-plugin
       getModulesRunBeforeMainModule: () => [
         require.resolve('react-native/setup-env'),
       ],


### PR DESCRIPTION
Summary:
**Motivation**

While sanity checking https://github.com/react/react-native/pull/57492, I double checked why we use `path.join(ctx.reactNativePath, ...)` here when adjacent OOT platforms resolve by package name.

It turns out this complexity is historic and redundant:

- `reactNativePath` doesn't customize the `react-native` package name — it only resolves the `node_modules` directory. [[1]](https://github.com/react-native-community/cli/blame/main/packages/cli-tools/src/findPackageDependencyDir.ts#L81)
- We now (since ~2 years ago) resolve using `{paths: [ctx.root]}`, making the manual `path.join` redundant.

**This diff**

Drops the `reactNativePath` option and resolves `react-native/setup-env` directly by package name.

Purely a refactor. No need to pick to 0.87.

Changelog: [Internal]

Differential Revision: D111225671


