### PR TITLE
Discard measured responder region that excludes the grant touch

### DIFF
--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -388,6 +388,10 @@ export default class Pressability {
     pageX: number,
     pageY: number,
   }>;
+  _touchGrantPosition: ?Readonly<{
+    pageX: number,
+    pageY: number,
+  }>;
   _touchActivateTime: ?number;
   _touchState: TouchState = 'NOT_RESPONDER';
 
@@ -710,6 +714,7 @@ export default class Pressability {
   ): void {
     if (isTerminalSignal(signal)) {
       this._touchActivatePosition = null;
+      this._touchGrantPosition = null;
       this._cancelLongPressDelayTimeout();
     }
 
@@ -719,6 +724,12 @@ export default class Pressability {
 
     const isActivationTransition =
       !isActivationSignal(prevState) && isActivationSignal(nextState);
+
+    if (isInitialTransition) {
+      const touch = getTouchFromPressEvent(event);
+      this._touchGrantPosition =
+        touch == null ? null : {pageX: touch.pageX, pageY: touch.pageY};
+    }
 
     if (isInitialTransition || isActivationTransition) {
       this._measureResponderRegion();
@@ -826,6 +837,23 @@ export default class Pressability {
       right: pageX + width,
       top: pageY,
     };
+
+    // The responder was granted by a native hit test, so the touch that
+    // granted it must lie inside the view's true on-screen region. If the
+    // measured region excludes that touch, the measurement is stale — e.g. the
+    // view was repositioned by native code (sheet footers, modals) after
+    // layout, and `measure` still reports the pre-move frame. Using such a
+    // region would cancel the press on the first touch move, so discard it.
+    const grantPosition = this._touchGrantPosition;
+    if (
+      grantPosition != null &&
+      !this._isTouchWithinResponderRegion(
+        grantPosition as $FlowFixMe,
+        this._responderRegion,
+      )
+    ) {
+      this._responderRegion = null;
+    }
   };
 
   _isTouchWithinResponderRegion(

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -641,6 +641,70 @@ describe('Pressability', () => {
       jest.advanceTimersByTime(CONFIGURED_DEFAULT_MIN_PRESS_DURATION);
       expect(config.onPressOut).toBeCalled();
     });
+
+    it('is called when the measured region excludes the grant touch', () => {
+      // A view repositioned by native code after layout (e.g. a native sheet
+      // footer) measures at its stale layout position, far from where the
+      // press actually landed. Such a measurement must not be used to cancel
+      // the press on the first touch move.
+      mockUIManagerMeasure();
+      const {config, handlers} = createMockPressability();
+
+      handlers.onStartShouldSetResponder();
+      handlers.onResponderGrant(
+        createMockPressEvent({
+          registrationName: 'onResponderGrant',
+          pageX: 276,
+          pageY: 467,
+        }),
+      );
+      handlers.onResponderMove(
+        createMockPressEvent({
+          registrationName: 'onResponderMove',
+          pageX: 276,
+          pageY: 467,
+        }),
+      );
+      handlers.onResponderRelease(
+        createMockPressEvent({
+          registrationName: 'onResponderRelease',
+          pageX: 276,
+          pageY: 467,
+        }),
+      );
+
+      expect(config.onPress).toBeCalled();
+    });
+
+    it('is not called when the touch leaves a region containing the grant touch', () => {
+      mockUIManagerMeasure();
+      const {config, handlers} = createMockPressability();
+
+      handlers.onStartShouldSetResponder();
+      handlers.onResponderGrant(
+        createMockPressEvent({
+          registrationName: 'onResponderGrant',
+          pageX: 10,
+          pageY: 10,
+        }),
+      );
+      handlers.onResponderMove(
+        createMockPressEvent({
+          registrationName: 'onResponderMove',
+          pageX: 500,
+          pageY: 500,
+        }),
+      );
+      handlers.onResponderRelease(
+        createMockPressEvent({
+          registrationName: 'onResponderRelease',
+          pageX: 500,
+          pageY: 500,
+        }),
+      );
+
+      expect(config.onPress).not.toBeCalled();
+    });
   });
 
   describe('onPressIn', () => {


### PR DESCRIPTION
## Summary:

Fixes #57502.

`Pressability` measures the responder view on grant and, on every `touchMove`, cancels the press if the touch is outside the measured rect. On Fabric, `measure()` answers from the shadow tree — so when a view has been repositioned by native code after layout (e.g. `@lodev09/react-native-true-sheet` pins its footer slot to the sheet bottom with AutoLayout — lodev09/react-native-true-sheet#726), the measured rect can be hundreds of points away from where the view actually is. A button that natively hit-tested and granted the responder then shows press feedback (`onPressIn`) but never fires `onPress`: the first move event deactivates the press via `LEAVE_PRESS_RECT`.

The failure is invisible in development: stationary simulator taps emit zero move events (the check never runs), and newer device/OS combos coalesce micro-jitter moves away. On older physical hardware (tested iPhone XS-class, iOS 16/18), every real-finger tap emits at least one move event — even zero-delta — and the press silently dies.

This PR validates the measurement against the press itself: the responder was granted by a **native hit test**, so the grant touch necessarily lies inside the view's true on-screen region. If the async-measured region *excludes* the grant point, the measurement is provably stale — discard it. A `null` region already means "skip press-rect checks" (that state exists today whenever `measure` hasn't completed), and correct measurements are unaffected since they contain the grant point by construction. Precedent: `_measureCallback` already discards all-zero measurements.

Found while working on the Planning Center mobile app; diagnosed and fixed with the help of Claude (Fable). The identical patch is running in production and verified on the previously-failing devices.

## Changelog:

[GENERAL] [FIXED] - Pressability no longer cancels presses using a stale measured region that does not contain the touch that granted the responder

## Test Plan:

- Added two Jest tests in `Pressability-test.js`:
  - `onPress` fires when the measured region excludes the grant touch (press granted at page (276, 467) with the mock region at (0, 0, 50, 50) — models a natively repositioned view; previously the first move deactivated the press).
  - `onPress` still does **not** fire when a valid measurement contains the grant touch and the finger then leaves the region — confirming slide-off-to-cancel is unchanged.
- Verified on device: with this patch applied (via yarn patch on RN 0.83.6) in the Planning Center app, sheet-footer buttons fire correctly on physical iPhones running iOS 16/18, and slide-off-to-cancel still works on correctly-measured buttons.
