### PR TITLE
Declare RCTBundleURLProviderAllowPackagerServerAccess unconditionally

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.h
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.h
@@ -14,15 +14,15 @@
 RCT_EXTERN NSString *_Nonnull const RCTBundleURLProviderUpdatedNotification;
 RCT_EXTERN const NSUInteger kRCTBundleURLProviderDefaultPort;
 
-#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
 /**
  * Allow/disallow accessing the packager server for various runtime scenario.
  * For instance, if a test run should never access the packager, disable it
  * by calling this function before initializing React Native (RCTBridge etc).
- * By default the access is enabled.
+ * By default the access is enabled. When packager support is compiled out
+ * (neither RCT_DEV_MENU nor RCT_PACKAGER_LOADING_FUNCTIONALITY is set),
+ * calling this function is a no-op.
  */
 RCT_EXTERN void RCTBundleURLProviderAllowPackagerServerAccess(BOOL allowed);
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -19,13 +19,14 @@ NSString *const RCTBundleURLProviderUpdatedNotification = @"RCTBundleURLProvider
 
 const NSUInteger kRCTBundleURLProviderDefaultPort = RCT_METRO_PORT;
 
-#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
+// Declared unconditionally so out-of-tree callers link in every configuration,
+// same shape as RCTDevLoadingViewSetEnabled. Reads stay gated below, so this is
+// a no-op when packager support is compiled out.
 static BOOL kRCTAllowPackagerAccess = YES;
 void RCTBundleURLProviderAllowPackagerServerAccess(BOOL allowed)
 {
   kRCTAllowPackagerAccess = allowed;
 }
-#endif
 static NSString *const kRCTPackagerSchemeKey = @"RCT_packager_scheme";
 static NSString *const kRCTJsLocationKey = @"RCT_jsLocation";
 static NSString *const kRCTEnableDevKey = @"RCT_enableDev";


### PR DESCRIPTION
## Summary:

`RCTBundleURLProviderAllowPackagerServerAccess` is declared inside `#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY`, so a Release build doesn't have it. Calling it fails to compile with `call to undeclared function`.

Nothing in react-native calls it. It's for apps outside the repo, to turn packager access off before startup.

This moves the declaration and the definition out of the guard. Every read of the flag stays inside, so with packager support off the call sets a value nothing reads and does nothing. Builds that have packager support are unchanged. `RCTDevLoadingViewSetEnabled` already works this way.

We hit it in expo. expo/expo#47638 called the function and broke every Release build in CI. That got worked around at the call sites in expo/expo#47688, but the fix belongs here.

## Changelog:

[IOS] [CHANGED] - Declare `RCTBundleURLProviderAllowPackagerServerAccess` unconditionally (no-op when packager support is compiled out)

## Test Plan:

- With the macros off, which is what Release does, compiling a call against today's headers fails with the undeclared-function error. With this change it compiles.
- Same call with `-DDEBUG=1` compiles before and after.
- Every read of `kRCTAllowPackagerAccess` is still behind the guard, so dev builds don't change.
- `clang-format --dry-run --Werror` passes on both files.
- `packages/rn-tester` builds in Release.
- RNTester unit tests pass, 162 tests, 0 failures. Ran with #57518 applied so the suite compiles.
