### PR TITLE
[iOS] Ensure RCTScrollViewComponentView scroll view always matches its bounds

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -315,6 +315,39 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     _containerView.transform = transform;
     _scrollView.transform = transform;
   }
+  [self _ensureScrollViewMatchesBounds];
+}
+
+// The scroll view is sized only by its autoresizing mask (set in init), which
+// propagates deltas at the moment this view's frame changes. If a frame change
+// lands while the delta cannot propagate (observed on-device: heavy mount /
+// teardown churn under thermal throttle), the scroll view is left at
+// CGRectZero permanently: fully mounted, correctly laid-out content is clipped
+// into invisibility while ShadowTree layout events keep firing. Enforce the
+// invariant explicitly so any desync self-heals on the next layout pass.
+- (void)_ensureScrollViewMatchesBounds
+{
+  CGRect bounds = self.bounds;
+  if (CGSizeEqualToSize(bounds.size, CGSizeZero)) {
+    return;
+  }
+  CGPoint center = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
+  if (!CGSizeEqualToSize(_scrollView.bounds.size, bounds.size) ||
+      !CGPointEqualToPoint(_scrollView.center, center)) {
+    // Adjust bounds.size + center rather than frame so the RTL transform is
+    // respected, and preserve bounds.origin - for UIScrollView it is the
+    // contentOffset.
+    CGRect scrollViewBounds = _scrollView.bounds;
+    scrollViewBounds.size = bounds.size;
+    _scrollView.bounds = scrollViewBounds;
+    _scrollView.center = center;
+  }
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  [self _ensureScrollViewMatchesBounds];
 }
 
 - (bool)isInverted


### PR DESCRIPTION
## Summary

Fixes the "ScrollView content laid out but never drawn" failure on Fabric iOS: `RCTScrollViewComponentView` sizes its inner `RCTEnhancedScrollView` only via an autoresizing mask, and the scroll view is created at `CGRectZero` (`initWithFrame:self.bounds` at component-view creation time). Autoresizing propagates deltas only at the instant the parent's frame changes — if that moment is missed (observed reliably under heavy mount/teardown churn on thermally-throttled devices), the inner scroll view remains 0×0 forever: the shell carries its correct Yoga frame, `onLayout`/`onContentSizeChange` fire normally, the content subtree is fully mounted and laid out — and everything is clipped into a zero-size viewport.

This change enforces the invariant explicitly instead of relying on autoresizing alone: `_ensureScrollViewMatchesBounds` re-glues the scroll view to the shell's bounds in `updateLayoutMetrics:` and `layoutSubviews`. It adjusts `bounds.size` + `center` (not `frame`) so the RTL `scale(-1, 1)` transform is respected, and preserves `bounds.origin`, which for `UIScrollView` is the `contentOffset`. No-op when everything is healthy.

Diagnosis evidence (native view-hierarchy capture of a live occurrence, plus a `setFrame:` veto-swizzle proving nothing ever *writes* the zero frame — the view is born at zero and the grow-delta is missed) is in the linked issue.

Fixes #57520

## Changelog:[iOS] [Fixed] - Ensure ScrollView's native scroll view always matches its component view bounds (fixes permanently-invisible ScrollView content when the autoresizing delta is missed)

## Test Plan

- On-device verification (iPhone 15 Pro Max, iOS 26.5, RN 0.83.6 + this change applied): under the reproduction conditions (thermal state `serious`, screen whose ScrollView mounts one frame after the screen, repeated navigation) the desync still occurs and is now corrected within one layout pass — logged heals confirm the code path executes; the invisible-content state no longer reproduces (previously ~every mount).
- Scrolled/RTL/contentOffset behavior unchanged: sizing uses bounds.size + center and preserves bounds.origin (contentOffset) and the RTL transform.
- Existing behavior is unchanged whenever the scroll view already matches its shell (the guard makes the method a no-op).

