### PR TITLE
[iOS] Make scrollToEnd include adjusted content inset

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -959,12 +959,13 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 - (void)scrollToEnd:(BOOL)animated
 {
   BOOL isHorizontal = _scrollView.contentSize.width > self.frame.size.width;
+  UIEdgeInsets contentInset = _scrollView.adjustedContentInset;
   CGPoint offset;
   if (isHorizontal) {
-    CGFloat offsetX = _scrollView.contentSize.width - _scrollView.bounds.size.width + _scrollView.contentInset.right;
+    CGFloat offsetX = _scrollView.contentSize.width - _scrollView.bounds.size.width + contentInset.right;
     offset = CGPointMake(fmax(offsetX, 0), 0);
   } else {
-    CGFloat offsetY = _scrollView.contentSize.height - _scrollView.bounds.size.height + _scrollView.contentInset.bottom;
+    CGFloat offsetY = _scrollView.contentSize.height - _scrollView.bounds.size.height + contentInset.bottom;
     offset = CGPointMake(0, fmax(offsetY, 0));
   }
 

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C60EB1B226440DB0018C04F /* AppDelegate.mm */; };
 		8145AE06241172D900A3F8DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */; };
 		832F45BB2A8A6E1F0097B4E6 /* SwiftTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */; };
+		A11A00000000000000000002 /* RCTScrollViewComponentViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A11A00000000000000000001 /* RCTScrollViewComponentViewTests.mm */; };
 		A975CA6C2C05EADF0043F72A /* RCTNetworkTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A975CA6B2C05EADE0043F72A /* RCTNetworkTaskTests.m */; };
 		C175B6D9ED9336FB66637943 /* libPods-RNTester.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C706D402EE4AF9BE838CBA9 /* libPods-RNTester.a */; };
 		CD10C7A5290BD4EB0033E1ED /* RCTEventEmitterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD10C7A4290BD4EB0033E1ED /* RCTEventEmitterTests.m */; };
@@ -95,6 +96,7 @@
 		8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = RNTester/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwiftTest.swift; path = RNTester/SwiftTest.swift; sourceTree = "<group>"; };
 		93A243F0D4D5C54911E811C4 /* libPods-RNTesterIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A11A00000000000000000001 /* RCTScrollViewComponentViewTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RCTScrollViewComponentViewTests.mm; sourceTree = "<group>"; };
 		A975CA6B2C05EADE0043F72A /* RCTNetworkTaskTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTNetworkTaskTests.m; sourceTree = "<group>"; };
 		AC474BFB29BBD4A1002BDAED /* RNTester.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RNTester.xctestplan; path = RNTester/RNTester.xctestplan; sourceTree = "<group>"; };
 		B0E70A8A05E03E868F8703FE /* Pods-RNTesterIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -337,6 +339,7 @@
 				F1A0B1C23D4E5F6071829301 /* RCTTurboModuleArrayBufferTests.mm */,
 				E7DB20CF22B2BAA5005AC45F /* RCTMultipartStreamReaderTests.m */,
 				A975CA6B2C05EADE0043F72A /* RCTNetworkTaskTests.m */,
+				A11A00000000000000000001 /* RCTScrollViewComponentViewTests.mm */,
 				E7DB20BE22B2BAA4005AC45F /* RCTNativeAnimatedNodesManagerTests.m */,
 				E7DB20AD22B2BAA3005AC45F /* RCTPerformanceLoggerTests.m */,
 				E7DB20C122B2BAA4005AC45F /* RCTUnicodeDecodeTests.m */,
@@ -767,6 +770,7 @@
 				E7DB20E422B2BAA6005AC45F /* RCTFormatErrorTests.m in Sources */,
 				E7DB20EB22B2BAA6005AC45F /* RCTConvert_YGValueTests.m in Sources */,
 				E7DB20E922B2BAA6005AC45F /* RCTComponentPropsTests.m in Sources */,
+				A11A00000000000000000002 /* RCTScrollViewComponentViewTests.mm in Sources */,
 				E7DB20D822B2BAA6005AC45F /* RCTJSONTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/packages/rn-tester/RNTesterUnitTests/RCTScrollViewComponentViewTests.mm
+++ b/packages/rn-tester/RNTesterUnitTests/RCTScrollViewComponentViewTests.mm
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <React/RCTEnhancedScrollView.h>
+#import <React/RCTScrollViewComponentView.h>
+
+@interface RCTScrollViewComponentView (Tests)
+
+- (void)scrollToEnd:(BOOL)animated;
+
+@end
+
+@interface RCTAdjustedContentInsetScrollView : RCTEnhancedScrollView
+
+@property (nonatomic, assign) UIEdgeInsets testAdjustedContentInset;
+
+@end
+
+@implementation RCTAdjustedContentInsetScrollView
+
+- (UIEdgeInsets)adjustedContentInset
+{
+  return self.testAdjustedContentInset;
+}
+
+@end
+
+@interface RCTScrollViewComponentViewTests : XCTestCase
+
+@end
+
+@implementation RCTScrollViewComponentViewTests
+
+- (void)testScrollToEndIncludesAdjustedContentInset
+{
+  RCTScrollViewComponentView *componentView =
+      [[RCTScrollViewComponentView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  RCTAdjustedContentInsetScrollView *scrollView =
+      [[RCTAdjustedContentInsetScrollView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  scrollView.contentSize = CGSizeMake(100, 200);
+  scrollView.contentInset = UIEdgeInsetsZero;
+  scrollView.testAdjustedContentInset = UIEdgeInsetsMake(0, 0, 20, 0);
+  componentView.scrollView = scrollView;
+
+  [componentView scrollToEnd:NO];
+
+  XCTAssertEqualWithAccuracy(componentView.scrollView.contentOffset.y, 120, 0.01);
+}
+
+@end


### PR DESCRIPTION
## Summary:

Fixes #57522.

`ScrollView.scrollToEnd()` currently computes its iOS Fabric endpoint from `UIScrollView.contentInset`. When UIKit supplies safe-area or bar adjustments through `adjustedContentInset`, the command stops before the same endpoint a user can reach by dragging.

This change uses `adjustedContentInset` when constructing the vertical or horizontal end target. It also adds a focused native regression test with a 100-point viewport, 200-point content height, zero raw inset, and a 20-point adjusted bottom inset. `scrollToEnd()` must finish at offset 120.

This is related to, but distinct from, #56189. That PR moves general `scrollTo` clamping into `scrollToOffset` and uses `adjustedContentInset`; however, `scrollToEnd()` still constructs an already-valid but too-small target from raw `contentInset`, so the later clamp does not increase it.

The public reproduction starts from the official React Native reproducer template and does not use Expo, navigation, a keyboard, or an explicit `contentInset`:

https://github.com/eliotgevers/react-native-scroll-to-end-adjusted-inset-repro

## Changelog:

[IOS] [FIXED] - Make `ScrollView.scrollToEnd()` include system-adjusted content insets

## Test Plan:

Tested on an iPhone 17 Pro Max simulator running iOS 26.5 with React Native compiled from source.

| Native implementation | `scrollToEnd()` | `scrollTo({y: 9999})` | Manual end |
| --- | ---: | ---: | ---: |
| Stock React Native 0.86.0 | 364 | 364 | 398 |
| #56189 effective Fabric logic | 364 | 398 | 398 |
| #56189 logic plus this change | 398 | 398 | 398 |

The 34-point difference equals the simulator's adjusted bottom safe-area inset.

| Stock React Native 0.86.0 | Patched native source |
| --- | --- |
| ![Stock React Native scrollToEnd stops at offset 364](https://raw.githubusercontent.com/eliotgevers/react-native-scroll-to-end-adjusted-inset-repro/main/evidence/unpatched-scroll-to-end.png) | ![Patched React Native scrollToEnd reaches offset 398](https://raw.githubusercontent.com/eliotgevers/react-native-scroll-to-end-adjusted-inset-repro/main/evidence/patched-scroll-to-end.png) |

Focused RNTester regression test:

```text
Test Suite 'RCTScrollViewComponentViewTests' passed.
Executed 1 test, with 0 failures in 0.034 seconds.
** TEST SUCCEEDED **
```

The test was run through `RNTesterPods.xcworkspace`, scheme `RNTester`, with:

```sh
xcodebuild test \
  -workspace RNTesterPods.xcworkspace \
  -scheme RNTester \
  -sdk iphonesimulator \
  -destination 'platform=iOS Simulator,id=<simulator-id>' \
  -only-testing:RNTesterUnitTests/RCTScrollViewComponentViewTests
```

<details>
<summary>Local RNTester harness note</summary>

Current `main` locally hit an unrelated compile error in `RCTTurboModuleArrayBufferTests.mm` (`detail::OwnedBytesBuffer` is not declared by that file's imports). I temporarily excluded that existing test source from the local focused build so this new test could compile and run. That exclusion is not included in this PR.

</details>
