### PR TITLE
Document why EventTarget feature flags stay at ossReleaseStage 'none' (#57527)

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -1033,8 +1033,10 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'release',
       },
+      // TODO: This should be "canary" now but the OSS renderer cannot be upgraded with the necessary changes until React 19.3.0 is released.
       ossReleaseStage: 'none',
     },
+    // TODO: This feature flag should be shipped and clean up now, but the OSS renderer cannot be upgraded with the necessary changes until React 19.3.0 is released.
     enableNativeEventTargetEventDispatching: {
       defaultValue: false,
       metadata: {


### PR DESCRIPTION
Summary:

Add TODO comments to the `enableImperativeEvents` and `enableNativeEventTargetEventDispatching` feature flags explaining why they haven't progressed yet (the OSS renderer cannot be upgraded with the necessary changes until React 19.3.0 is released).

This is a comment-only change with no functional impact.

Changelog:
[Internal]

Reviewed By: huntie

Differential Revision: D111695477


