### PR TITLE
CSS Grid algorithm 2/N: auto-placement (#57532)

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/yoga/yoga/CMakeLists.txt
@@ -20,7 +20,8 @@ include(${YOGA_ROOT}/cmake/project-defaults.cmake)
 
 file(GLOB SOURCES CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/**/*.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/**/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/algorithm/grid/*.cpp)
 
 add_library(yogacore STATIC ${SOURCES})
 

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
@@ -8,7 +8,7 @@
 #include <yoga/Yoga.h>
 #include <yoga/debug/AssertFatal.h>
 #include <yoga/node/Node.h>
-#include <yoga/style/GridTrack.h>
+#include <yoga/style/GridTrackSize.h>
 
 using namespace facebook;
 using namespace facebook::yoga;

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/AutoPlacement.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/AutoPlacement.cpp
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <yoga/algorithm/grid/AutoPlacement.h>
+
+#include <yoga/algorithm/grid/LinePlacement.h>
+#include <yoga/algorithm/grid/OccupancyGrid.h>
+#include <yoga/debug/AssertFatal.h>
+#include <yoga/node/Node.h>
+#include <yoga/style/GridLine.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace facebook::yoga {
+
+namespace {
+
+bool isPlaceable(const Node* child) {
+  return child->style().positionType() != PositionType::Absolute &&
+      child->style().display() != Display::None;
+}
+
+} // namespace
+
+// 8.5. Grid Item Placement Algorithm
+// https://www.w3.org/TR/css-grid-1/#auto-placement-algo
+AutoPlacement AutoPlacement::performAutoPlacement(Node* node) {
+  std::vector<AutoPlacementItem> items;
+  items.reserve(node->getChildCount());
+  std::unordered_set<Node*> placedItems;
+  placedItems.reserve(node->getChildCount());
+
+  int32_t minColumnStart = 0;
+  int32_t minRowStart = 0;
+  int32_t maxColumnEnd =
+      static_cast<int32_t>(node->style().gridTemplateColumns().size());
+  int32_t maxRowEnd =
+      static_cast<int32_t>(node->style().gridTemplateRows().size());
+  OccupancyGrid occupancy;
+  occupancy.occupied.reserve(node->getChildCount());
+
+  // Records a placed grid area and updates the running grid bounds.
+  const auto recordGridArea = [&](const AutoPlacementItem& area) {
+    yoga::assertFatal(
+        area.columnEnd > area.columnStart,
+        "Grid item column end must be greater than column start");
+    yoga::assertFatal(
+        area.rowEnd > area.rowStart,
+        "Grid item row end must be greater than row start");
+    items.push_back(area);
+    placedItems.insert(area.node);
+    occupancy.markOccupied(
+        area.rowStart, area.rowEnd, area.columnStart, area.columnEnd);
+    minColumnStart = std::min(minColumnStart, area.columnStart);
+    minRowStart = std::min(minRowStart, area.rowStart);
+    maxColumnEnd = std::max(maxColumnEnd, area.columnEnd);
+    maxRowEnd = std::max(maxRowEnd, area.rowEnd);
+  };
+
+  const auto explicitColumnLineCount =
+      static_cast<int32_t>(node->style().gridTemplateColumns().size() + 1);
+  const auto explicitRowLineCount =
+      static_cast<int32_t>(node->style().gridTemplateRows().size() + 1);
+
+  // Step 1: Position anything that is not auto-positioned. In level 1 a span is
+  // always definite (default 1), so an item is definitely positioned when both
+  // its row and column have at least one integer line.
+  for (Node* child : node->getLayoutChildren()) {
+    if (!isPlaceable(child)) {
+      continue;
+    }
+
+    const auto& gridItemColumnStart = child->style().gridColumnStart();
+    const auto& gridItemColumnEnd = child->style().gridColumnEnd();
+    const auto& gridItemRowStart = child->style().gridRowStart();
+    const auto& gridItemRowEnd = child->style().gridRowEnd();
+    const bool hasDefiniteColumn = isDefiniteLine(gridItemColumnStart) ||
+        isDefiniteLine(gridItemColumnEnd);
+    const bool hasDefiniteRow =
+        isDefiniteLine(gridItemRowStart) || isDefiniteLine(gridItemRowEnd);
+
+    if (hasDefiniteColumn && hasDefiniteRow) {
+      const auto columnPlacement = resolveLinePlacement(
+          gridItemColumnStart, gridItemColumnEnd, explicitColumnLineCount);
+      const auto rowPlacement = resolveLinePlacement(
+          gridItemRowStart, gridItemRowEnd, explicitRowLineCount);
+
+      recordGridArea(
+          AutoPlacementItem{
+              .columnStart = columnPlacement.start,
+              .columnEnd = columnPlacement.end,
+              .rowStart = rowPlacement.start,
+              .rowEnd = rowPlacement.end,
+              .node = child});
+    }
+  }
+
+  // Step 2: Process the items locked to a given row (definite row, no definite
+  // column), placing each into the first non-overlapping slot to its right.
+  std::unordered_map<int32_t, int32_t> rowStartToColumnStartCache;
+  for (Node* child : node->getLayoutChildren()) {
+    if (!isPlaceable(child)) {
+      continue;
+    }
+
+    const auto& gridItemColumnStart = child->style().gridColumnStart();
+    const auto& gridItemColumnEnd = child->style().gridColumnEnd();
+    const auto& gridItemRowStart = child->style().gridRowStart();
+    const auto& gridItemRowEnd = child->style().gridRowEnd();
+    const bool hasDefiniteColumn = isDefiniteLine(gridItemColumnStart) ||
+        isDefiniteLine(gridItemColumnEnd);
+    const bool hasDefiniteRow =
+        isDefiniteLine(gridItemRowStart) || isDefiniteLine(gridItemRowEnd);
+
+    if (hasDefiniteRow && !hasDefiniteColumn) {
+      const auto rowPlacement = resolveLinePlacement(
+          gridItemRowStart, gridItemRowEnd, explicitRowLineCount);
+      const auto rowStart = rowPlacement.start;
+      const auto rowEnd = rowPlacement.end;
+
+      const auto columnSpan =
+          resolveLinePlacement(
+              gridItemColumnStart, gridItemColumnEnd, explicitColumnLineCount)
+              .span;
+
+      auto columnStart = rowStartToColumnStartCache.contains(rowStart)
+          ? rowStartToColumnStartCache[rowStart]
+          : minColumnStart;
+      auto columnEnd = columnStart + columnSpan;
+
+      while (const auto* overlap = occupancy.hasOverlap(
+                 rowStart, rowEnd, columnStart, columnEnd)) {
+        columnStart = overlap->columnEnd;
+        columnEnd = columnStart + columnSpan;
+      }
+
+      recordGridArea(
+          AutoPlacementItem{
+              .columnStart = columnStart,
+              .columnEnd = columnEnd,
+              .rowStart = rowStart,
+              .rowEnd = rowEnd,
+              .node = child});
+      rowStartToColumnStartCache[rowStart] = columnEnd;
+    }
+  }
+
+  // Step 3: Determine the columns of the implicit grid, accounting for definite
+  // columns that extend the grid and for the largest auto-placed column span.
+  auto largestColumnSpan = 1;
+  for (Node* child : node->getLayoutChildren()) {
+    if (!isPlaceable(child)) {
+      continue;
+    }
+
+    const auto& gridItemColumnStart = child->style().gridColumnStart();
+    const auto& gridItemColumnEnd = child->style().gridColumnEnd();
+    const bool hasDefiniteColumn = isDefiniteLine(gridItemColumnStart) ||
+        isDefiniteLine(gridItemColumnEnd);
+
+    const auto columnPlacement = resolveLinePlacement(
+        gridItemColumnStart, gridItemColumnEnd, explicitColumnLineCount);
+    if (hasDefiniteColumn) {
+      minColumnStart = std::min(minColumnStart, columnPlacement.start);
+      maxColumnEnd = std::max(maxColumnEnd, columnPlacement.end);
+    } else {
+      largestColumnSpan = std::max(largestColumnSpan, columnPlacement.span);
+    }
+  }
+
+  // If the largest span is wider than the current grid, extend the end.
+  const auto currentGridWidth = maxColumnEnd - minColumnStart;
+  if (largestColumnSpan > currentGridWidth) {
+    maxColumnEnd = minColumnStart + largestColumnSpan;
+  }
+
+  // Step 4: Position the remaining grid items using the auto-placement cursor.
+  std::array<int32_t, 2> autoPlacementCursor = {minColumnStart, minRowStart};
+  for (Node* child : node->getLayoutChildren()) {
+    if (!isPlaceable(child) || placedItems.contains(child)) {
+      continue;
+    }
+
+    const auto& gridItemColumnStart = child->style().gridColumnStart();
+    const auto& gridItemColumnEnd = child->style().gridColumnEnd();
+    const auto& gridItemRowStart = child->style().gridRowStart();
+    const auto& gridItemRowEnd = child->style().gridRowEnd();
+    const bool hasDefiniteColumn = isDefiniteLine(gridItemColumnStart) ||
+        isDefiniteLine(gridItemColumnEnd);
+    const bool hasDefiniteRow =
+        isDefiniteLine(gridItemRowStart) || isDefiniteLine(gridItemRowEnd);
+
+    const auto columnPlacement = resolveLinePlacement(
+        gridItemColumnStart, gridItemColumnEnd, explicitColumnLineCount);
+    const auto rowPlacement = resolveLinePlacement(
+        gridItemRowStart, gridItemRowEnd, explicitRowLineCount);
+
+    // If the item has a definite column position, keep it and search downward
+    // for a row where it does not overlap an occupied cell.
+    if (hasDefiniteColumn) {
+      const auto columnStart = columnPlacement.start;
+      const auto columnEnd = columnPlacement.end;
+
+      // Set the cursor to the item's column-start line; if that moves the
+      // cursor backwards, advance to the next row.
+      const auto previousColumnPosition = autoPlacementCursor[0];
+      autoPlacementCursor[0] = columnStart;
+      if (autoPlacementCursor[0] < previousColumnPosition) {
+        autoPlacementCursor[1]++;
+      }
+
+      const auto rowSpan = rowPlacement.span;
+      while (const auto* overlap = occupancy.hasOverlap(
+                 autoPlacementCursor[1],
+                 autoPlacementCursor[1] + rowSpan,
+                 columnStart,
+                 columnEnd)) {
+        autoPlacementCursor[1] = overlap->rowEnd;
+      }
+
+      recordGridArea(
+          AutoPlacementItem{
+              .columnStart = columnStart,
+              .columnEnd = columnEnd,
+              .rowStart = autoPlacementCursor[1],
+              .rowEnd = autoPlacementCursor[1] + rowSpan,
+              .node = child});
+    }
+    // If the item has an automatic position in both axes, sweep the cursor
+    // left-to-right then top-to-bottom until it fits.
+    else if (!hasDefiniteRow) {
+      const auto itemColumnSpan = columnPlacement.span;
+      const auto itemRowSpan = rowPlacement.span;
+
+      bool foundPosition = false;
+      while (!foundPosition) {
+        while (autoPlacementCursor[0] + itemColumnSpan <= maxColumnEnd) {
+          const auto columnStart = autoPlacementCursor[0];
+          const auto columnEnd = columnStart + itemColumnSpan;
+          const auto rowStart = autoPlacementCursor[1];
+          const auto rowEnd = rowStart + itemRowSpan;
+
+          if (const auto* overlap = occupancy.hasOverlap(
+                  rowStart, rowEnd, columnStart, columnEnd)) {
+            autoPlacementCursor[0] = overlap->columnEnd;
+          } else {
+            recordGridArea(
+                AutoPlacementItem{
+                    .columnStart = columnStart,
+                    .columnEnd = columnEnd,
+                    .rowStart = rowStart,
+                    .rowEnd = rowEnd,
+                    .node = child});
+            foundPosition = true;
+            break;
+          }
+        }
+
+        if (!foundPosition) {
+          // Cursor overflowed the grid width; move to the next row.
+          autoPlacementCursor[1]++;
+          autoPlacementCursor[0] = minColumnStart;
+        }
+      }
+    }
+  }
+
+  return AutoPlacement{
+      .gridItems = std::move(items),
+      .minColumnStart = minColumnStart,
+      .minRowStart = minRowStart,
+      .maxColumnEnd = maxColumnEnd,
+      .maxRowEnd = maxRowEnd};
+}
+
+// 1. Runs the grid placement algorithm and normalizes the output into the
+// 0-based coordinate space.
+// 2. Builds the baseline sharing groups for each row.
+ResolvedAutoPlacement ResolvedAutoPlacement::resolveGridItemPlacements(
+    Node* node) {
+  const AutoPlacement autoPlacement = AutoPlacement::performAutoPlacement(node);
+
+  const int32_t minColumnStart = autoPlacement.minColumnStart;
+  const int32_t minRowStart = autoPlacement.minRowStart;
+
+  ResolvedAutoPlacement resolved;
+  resolved.minColumnStart = minColumnStart;
+  resolved.minRowStart = minRowStart;
+  resolved.maxColumnEnd = autoPlacement.maxColumnEnd;
+  resolved.maxRowEnd = autoPlacement.maxRowEnd;
+
+  resolved.gridItems.reserve(autoPlacement.gridItems.size());
+
+  const Align alignItems = node->style().alignItems();
+
+  for (const auto& placement : autoPlacement.gridItems) {
+    resolved.gridItems.emplace_back(
+        static_cast<size_t>(placement.columnStart - minColumnStart),
+        static_cast<size_t>(placement.columnEnd - minColumnStart),
+        static_cast<size_t>(placement.rowStart - minRowStart),
+        static_cast<size_t>(placement.rowEnd - minRowStart),
+        placement.node);
+
+    GridItem& item = resolved.gridItems.back();
+    Align alignSelf = item.node->style().alignSelf();
+    if (alignSelf == Align::Auto) {
+      alignSelf = alignItems;
+    }
+    // https://www.w3.org/TR/css-grid-1/#algo-baseline-shims - only items that
+    // span a single row participate in a row's baseline sharing group.
+    const bool spansOneRow = (item.rowEnd - item.rowStart) == 1;
+    if (alignSelf == Align::Baseline && spansOneRow) {
+      resolved.baselineItemGroups[item.rowStart].push_back(&item);
+    }
+  }
+
+  return resolved;
+}
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/AutoPlacement.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/AutoPlacement.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/algorithm/grid/GridItem.h>
+#include <cstdint>
+#include <vector>
+
+namespace facebook::yoga {
+
+class Node;
+
+struct AutoPlacement {
+  // A grid item's placement in the algorithm's signed coordinate space.
+  struct AutoPlacementItem {
+    int32_t columnStart;
+    int32_t columnEnd;
+    int32_t rowStart;
+    int32_t rowEnd;
+    Node* node;
+  };
+
+  std::vector<AutoPlacementItem> gridItems;
+  int32_t minColumnStart;
+  int32_t minRowStart;
+  int32_t maxColumnEnd;
+  int32_t maxRowEnd;
+
+  // Runs the four-step auto-placement algorithm
+  // (https://www.w3.org/TR/css-grid-1/#auto-placement-algo) over node's in-flow
+  // children. Children that are display: none or absolutely positioned are
+  // ignored.
+  static AutoPlacement performAutoPlacement(Node* node);
+};
+
+// 1. Runs the grid placement algorithm and normalizes the output into the
+// 0-based coordinate space.
+// 2. Builds the baseline sharing groups for each row.
+struct ResolvedAutoPlacement {
+  // Items with resolved 0-based positions, in child order.
+  std::vector<GridItem> gridItems;
+
+  // Baseline-aligned items grouped by starting row.
+  BaselineItemGroups baselineItemGroups;
+
+  int32_t minColumnStart = 0;
+  int32_t minRowStart = 0;
+  int32_t maxColumnEnd = 0;
+  int32_t maxRowEnd = 0;
+
+  ResolvedAutoPlacement() = default;
+  ResolvedAutoPlacement(ResolvedAutoPlacement&&) = default;
+  ResolvedAutoPlacement& operator=(ResolvedAutoPlacement&&) = default;
+  ResolvedAutoPlacement(const ResolvedAutoPlacement&) = delete;
+  ResolvedAutoPlacement& operator=(const ResolvedAutoPlacement&) = delete;
+
+  // Normalizes performAutoPlacement's output to 0-based size_t coordinates and
+  // builds the baseline sharing groups.
+  static ResolvedAutoPlacement resolveGridItemPlacements(Node* node);
+};
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/GridItem.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/GridItem.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/enums/Dimension.h>
+#include <yoga/node/Node.h>
+#include <cstddef>
+#include <map>
+#include <vector>
+
+namespace facebook::yoga {
+
+// A grid item with its resolved position in the grid. Positions are set by the
+// auto-placement algorithm and consumed by the track sizing algorithm.
+struct GridItem {
+  size_t columnStart;
+  size_t columnEnd;
+  size_t rowStart;
+  size_t rowEnd;
+  yoga::Node* node;
+
+  // Additional offset added to item to align baselines
+  // https://www.w3.org/TR/css-grid-1/#algo-baseline-shims
+  float baselineShim = 0.0f;
+
+  // Flags used for optimizations in track sizing algorithm.
+  bool crossesIntrinsicRow = false;
+  bool crossesIntrinsicColumn = false;
+  bool crossesFlexibleRow = false;
+  bool crossesFlexibleColumn = false;
+
+  GridItem(
+      size_t columnStart,
+      size_t columnEnd,
+      size_t rowStart,
+      size_t rowEnd,
+      yoga::Node* node,
+      float baselineShim = 0.0f)
+      : columnStart(columnStart),
+        columnEnd(columnEnd),
+        rowStart(rowStart),
+        rowEnd(rowEnd),
+        node(node),
+        baselineShim(baselineShim) {}
+
+  // Helper functions used by the track sizing algorithm
+  bool crossesIntrinsicTrack(Dimension dimension) const {
+    return dimension == Dimension::Width ? crossesIntrinsicColumn
+                                         : crossesIntrinsicRow;
+  }
+  bool crossesFlexibleTrack(Dimension dimension) const {
+    return dimension == Dimension::Width ? crossesFlexibleColumn
+                                         : crossesFlexibleRow;
+  }
+};
+
+// Baseline sharing groups - items grouped by their starting row for the
+// resolve intrinsic size step in track sizing algorithm.
+// https://www.w3.org/TR/css-grid-1/#algo-baseline-shims
+using BaselineItemGroups = std::map<size_t, std::vector<GridItem*>>;
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/GridTrack.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/GridTrack.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/style/GridTrackSize.h>
+
+namespace facebook::yoga {
+
+// https://www.w3.org/TR/css-grid-1/#algo-track-sizing
+struct GridTrack {
+  // Mutable state used by the track sizing algorithm
+  // https://www.w3.org/TR/css-grid-1/#base-size
+  float baseSize = 0.0f;
+  // https://www.w3.org/TR/css-grid-1/#growth-limit
+  float growthLimit = 0.0f;
+  // https://www.w3.org/TR/css-grid-1/#infinitely-growable
+  bool infinitelyGrowable = false;
+
+  explicit GridTrack(const GridTrackSize& ts) : trackSize_(ts) {}
+
+  const GridTrackSize& trackSize() const {
+    return trackSize_;
+  }
+
+ private:
+  // Sizing functions for this track, immutable after construction
+  GridTrackSize trackSize_;
+};
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/LinePlacement.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/LinePlacement.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <yoga/algorithm/grid/LinePlacement.h>
+
+namespace facebook::yoga {
+
+LinePlacement resolveLinePlacement(
+    const GridLine& startLine,
+    const GridLine& endLine,
+    int32_t explicitLineCount) {
+  LinePlacement placement;
+
+  // Normalize invalid inputs per CSS Grid: line 0 is not a valid line (treated
+  // as auto), and a span must be at least 1 (an invalid 0 or negative span
+  // becomes 1).
+  const auto normalize = [](const GridLine& line) -> GridLine {
+    if (line.type == GridLineType::Integer && line.integer == 0) {
+      return GridLine::auto_();
+    }
+    if (line.type == GridLineType::Span && line.integer < 1) {
+      return GridLine::span(1);
+    }
+    return line;
+  };
+  const GridLine start = normalize(startLine);
+  const GridLine end = normalize(endLine);
+
+  const auto resolveNegativeLineValue = [](int32_t lineValue,
+                                           int32_t lineCount) -> int32_t {
+    // Negative lines count back from the last line, e.g. -1 is the last line.
+    return lineValue < 0 ? lineCount + lineValue + 1 : lineValue;
+  };
+
+  // If the placement for a grid item contains two lines.
+  if (start.type == GridLineType::Integer &&
+      end.type == GridLineType::Integer) {
+    const auto normalizedStartLine =
+        resolveNegativeLineValue(start.integer, explicitLineCount);
+    const auto normalizedEndLine =
+        resolveNegativeLineValue(end.integer, explicitLineCount);
+    // If the start line is further end-ward than the end line, swap the two.
+    if (normalizedStartLine > normalizedEndLine) {
+      placement.start = normalizedEndLine;
+      placement.end = normalizedStartLine;
+      placement.span = placement.end - placement.start;
+    }
+    // If the start line is equal to the end line, remove the end line.
+    else if (normalizedStartLine == normalizedEndLine) {
+      placement.start = normalizedStartLine;
+      placement.end = normalizedStartLine + 1;
+      placement.span = 1;
+    } else {
+      placement.start = normalizedStartLine;
+      placement.end = normalizedEndLine;
+      placement.span = placement.end - placement.start;
+    }
+  }
+  // If the placement contains two spans, remove the one contributed by the end
+  // grid-placement property.
+  else if (start.type == GridLineType::Span && end.type == GridLineType::Span) {
+    placement.start = 0;
+    placement.end = 0;
+    placement.span = start.integer;
+  } else if (
+      start.type == GridLineType::Integer && end.type == GridLineType::Span) {
+    const auto normalizedStartLine =
+        resolveNegativeLineValue(start.integer, explicitLineCount);
+    placement.start = normalizedStartLine;
+    placement.span = end.integer;
+    placement.end = placement.start + placement.span;
+  } else if (
+      start.type == GridLineType::Span && end.type == GridLineType::Integer) {
+    const auto normalizedEndLine =
+        resolveNegativeLineValue(end.integer, explicitLineCount);
+    placement.end = normalizedEndLine;
+    placement.span = start.integer;
+    placement.start = placement.end - placement.span;
+  } else if (start.type == GridLineType::Integer) {
+    const auto normalizedStartLine =
+        resolveNegativeLineValue(start.integer, explicitLineCount);
+    placement.start = normalizedStartLine;
+    placement.span = 1;
+    placement.end = placement.start + placement.span;
+  } else if (start.type == GridLineType::Span) {
+    placement.span = start.integer;
+    placement.start = 0;
+    placement.end = 0;
+  } else if (end.type == GridLineType::Integer) {
+    const auto normalizedEndLine =
+        resolveNegativeLineValue(end.integer, explicitLineCount);
+    placement.end = normalizedEndLine;
+    placement.span = 1;
+    placement.start = placement.end - placement.span;
+  } else if (end.type == GridLineType::Span) {
+    placement.span = end.integer;
+    placement.start = 0;
+    placement.end = 0;
+  } else {
+    placement.start = 0;
+    placement.end = 0;
+    placement.span = 1;
+  }
+
+  // Grid lines above are 1-based; convert to 0-based track indices. Negative
+  // values imply implicit grid lines before the explicit grid.
+  placement.start = placement.start - 1;
+  placement.end = placement.end - 1;
+
+  return placement;
+}
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/LinePlacement.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/LinePlacement.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/style/GridLine.h>
+#include <cstdint>
+
+namespace facebook::yoga {
+
+// A resolved grid-line placement: a half-open [start, end) track interval plus
+// its span. Line number can be negative to denote an implicit line before the
+// explicit grid.
+struct LinePlacement {
+  int32_t start = 0;
+  int32_t end = 0;
+  int32_t span = 1;
+};
+
+inline bool isDefiniteLine(const GridLine& line) {
+  return line.type == GridLineType::Integer && line.integer != 0;
+}
+
+// Handles placement errors as defined in
+// https://www.w3.org/TR/css-grid-1/#grid-placement-errors and returns 0 index
+// based line positions from user added grid-columns and grid-rows.
+LinePlacement resolveLinePlacement(
+    const GridLine& startLine,
+    const GridLine& endLine,
+    int32_t explicitLineCount);
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/OccupancyGrid.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/grid/OccupancyGrid.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace facebook::yoga {
+
+// Occupancy of the grid used by CSS Grid auto-placement.
+// TODO(optimisation): Better data structure can be used than a flat vector
+struct OccupancyGrid {
+  struct Rect {
+    int32_t rowStart;
+    int32_t rowEnd;
+    int32_t columnStart;
+    int32_t columnEnd;
+  };
+
+  std::vector<Rect> occupied;
+
+  void markOccupied(
+      int32_t rowStart,
+      int32_t rowEnd,
+      int32_t columnStart,
+      int32_t columnEnd) {
+    occupied.push_back({rowStart, rowEnd, columnStart, columnEnd});
+  }
+
+  const Rect* hasOverlap(
+      int32_t rowStart,
+      int32_t rowEnd,
+      int32_t columnStart,
+      int32_t columnEnd) const {
+    for (const auto& rect : occupied) {
+      if (rect.rowStart < rowEnd && rect.rowEnd > rowStart &&
+          rect.columnStart < columnEnd && rect.columnEnd > columnStart) {
+        return &rect;
+      }
+    }
+    return nullptr;
+  }
+};
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/style/GridTrackSize.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/GridTrackSize.h
@@ -11,17 +11,12 @@
 #include <vector>
 
 namespace facebook::yoga {
+// Represents a track size as defined in
 // https://www.w3.org/TR/css-grid-1/#typedef-track-size
+// and helper functions for creating common track sizes.
 struct GridTrackSize {
   StyleSizeLength minSizingFunction;
   StyleSizeLength maxSizingFunction;
-
-  // These are used in the grid layout algorithm when distributing spaces among
-  // tracks
-  // TODO: maybe move them to TrackSizing since these are track states
-  float baseSize = 0.0f;
-  float growthLimit = 0.0f;
-  bool infinitelyGrowable = false;
 
   // Static factory methods for common cases
   constexpr static GridTrackSize auto_() {

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -30,7 +30,7 @@
 #include <yoga/enums/Wrap.h>
 #include <yoga/numeric/FloatOptional.h>
 #include <yoga/style/GridLine.h>
-#include <yoga/style/GridTrack.h>
+#include <yoga/style/GridTrackSize.h>
 #include <yoga/style/StyleLength.h>
 #include <yoga/style/StyleSizeLength.h>
 #include <yoga/style/StyleValuePool.h>

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -12835,6 +12835,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -13560,6 +13561,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -13572,13 +13589,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -12852,6 +12852,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -12945,6 +12946,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -13469,6 +13471,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -13648,6 +13667,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -12475,6 +12475,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -12568,6 +12569,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -13092,6 +13094,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -13271,6 +13290,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -12458,6 +12458,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -13183,6 +13184,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -13195,13 +13212,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -12688,6 +12688,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -13413,6 +13414,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -13425,13 +13442,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -12705,6 +12705,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -12798,6 +12799,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -13322,6 +13324,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -13501,6 +13520,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -14655,6 +14655,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -15380,6 +15381,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -15392,13 +15409,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -14672,6 +14672,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -14765,6 +14766,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -15289,6 +15291,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -15468,6 +15487,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -14357,6 +14357,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -14450,6 +14451,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -14974,6 +14976,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -15153,6 +15172,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -14340,6 +14340,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -15065,6 +15066,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -15077,13 +15094,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -14518,6 +14518,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -15243,6 +15244,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -15255,13 +15272,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -14535,6 +14535,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -14628,6 +14629,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -15152,6 +15154,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -15331,6 +15350,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -9809,6 +9809,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -10534,6 +10535,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -10546,13 +10563,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -9826,6 +9826,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -9919,6 +9920,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -10443,6 +10445,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -10622,6 +10641,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -9634,6 +9634,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -10359,6 +10360,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -10371,13 +10388,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -9651,6 +9651,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -9744,6 +9745,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -10268,6 +10270,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -10447,6 +10466,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -9800,6 +9800,7 @@ struct facebook::jsi::detail::BeforeCaller<std::tuple<T...>> {
 }
 
 
+using facebook::yoga::BaselineItemGroups = std::map<size_t, std::vector<facebook::yoga::GridItem*>>;
 using facebook::yoga::GridTrackList = std::vector<facebook::yoga::GridTrackSize>;
 template <typename EnumT>
 concept facebook::yoga::Enumeration = std::is_enum_v<EnumT>;
@@ -10525,6 +10526,22 @@ struct facebook::yoga::FloatOptional {
   public constexpr float unwrapOrDefault(float defaultValue) const;
 }
 
+struct facebook::yoga::GridItem {
+  public GridItem(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd, facebook::yoga::Node* node, float baselineShim = 0.0f);
+  public bool crossesFlexibleColumn;
+  public bool crossesFlexibleRow;
+  public bool crossesFlexibleTrack(facebook::yoga::Dimension dimension) const;
+  public bool crossesIntrinsicColumn;
+  public bool crossesIntrinsicRow;
+  public bool crossesIntrinsicTrack(facebook::yoga::Dimension dimension) const;
+  public facebook::yoga::Node* node;
+  public float baselineShim;
+  public size_t columnEnd;
+  public size_t columnStart;
+  public size_t rowEnd;
+  public size_t rowStart;
+}
+
 struct facebook::yoga::GridLine {
   public bool operator==(const facebook::yoga::GridLine& other) const = default;
   public constexpr bool isAuto() const;
@@ -10537,13 +10554,18 @@ struct facebook::yoga::GridLine {
   public static constexpr facebook::yoga::GridLine span(int32_t value);
 }
 
-struct facebook::yoga::GridTrackSize {
+struct facebook::yoga::GridTrack {
+  public GridTrack(const facebook::yoga::GridTrackSize& ts);
   public bool infinitelyGrowable;
+  public const facebook::yoga::GridTrackSize& trackSize() const;
+  public float baseSize;
+  public float growthLimit;
+}
+
+struct facebook::yoga::GridTrackSize {
   public bool operator==(const facebook::yoga::GridTrackSize& other) const = default;
   public facebook::yoga::StyleSizeLength maxSizingFunction;
   public facebook::yoga::StyleSizeLength minSizingFunction;
-  public float baseSize;
-  public float growthLimit;
   public static constexpr facebook::yoga::GridTrackSize auto_();
   public static constexpr facebook::yoga::GridTrackSize fr(float fraction);
   public static constexpr facebook::yoga::GridTrackSize length(float points);

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -9817,6 +9817,7 @@ bool facebook::yoga::inexactEquals(facebook::yoga::FloatOptional lhs, facebook::
 bool facebook::yoga::inexactEquals(float a, float b);
 bool facebook::yoga::isBaselineLayout(const facebook::yoga::Node* node);
 bool facebook::yoga::isColumn(const facebook::yoga::FlexDirection flexDirection);
+bool facebook::yoga::isDefiniteLine(const facebook::yoga::GridLine& line);
 bool facebook::yoga::isRow(const facebook::yoga::FlexDirection flexDirection);
 bool facebook::yoga::layoutAbsoluteDescendants(facebook::yoga::Node* containingNode, facebook::yoga::Node* currentNode, facebook::yoga::SizingMode widthSizingMode, facebook::yoga::Direction currentNodeDirection, facebook::yoga::LayoutData& layoutMarkerData, uint32_t currentDepth, uint32_t generationCount, float currentNodeMainOffsetFromContainingBlock, float currentNodeCrossOffsetFromContainingBlock, float containingNodeAvailableInnerWidth, float containingNodeAvailableInnerHeight);
 bool facebook::yoga::needsTrailingPosition(const facebook::yoga::FlexDirection axis);
@@ -9910,6 +9911,7 @@ facebook::yoga::FlexDirection facebook::yoga::resolveDirection(const facebook::y
 facebook::yoga::FlexLine facebook::yoga::calculateFlexLine(facebook::yoga::Node* node, facebook::yoga::Direction ownerDirection, float ownerWidth, float mainAxisOwnerSize, float availableInnerWidth, float availableInnerMainDim, facebook::yoga::Node::LayoutableChildren::Iterator& iterator, size_t lineCount);
 facebook::yoga::FloatOptional facebook::yoga::boundAxisWithinMinAndMax(const facebook::yoga::Node *const node, const facebook::yoga::Direction direction, const facebook::yoga::FlexDirection axis, const facebook::yoga::FloatOptional value, const float axisSize, const float widthSize);
 facebook::yoga::Justify facebook::yoga::resolveChildJustification(const facebook::yoga::Node* node, const facebook::yoga::Node* child);
+facebook::yoga::LinePlacement facebook::yoga::resolveLinePlacement(const facebook::yoga::GridLine& startLine, const facebook::yoga::GridLine& endLine, int32_t explicitLineCount);
 facebook::yoga::MeasureMode facebook::yoga::measureMode(facebook::yoga::SizingMode mode);
 facebook::yoga::Node* facebook::yoga::resolveRef(const YGNodeRef ref);
 facebook::yoga::PhysicalEdge facebook::yoga::flexEndEdge(facebook::yoga::FlexDirection flexDirection);
@@ -10434,6 +10436,23 @@ enum facebook::yoga::Wrap : uint8_t {
   WrapReverse,
 }
 
+struct facebook::yoga::AutoPlacement {
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::AutoPlacement performAutoPlacement(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::AutoPlacement::AutoPlacementItem> gridItems;
+}
+
+struct facebook::yoga::AutoPlacement::AutoPlacementItem {
+  public facebook::yoga::Node* node;
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
 struct facebook::yoga::CachedMeasurement {
   public bool operator==(facebook::yoga::CachedMeasurement measurement) const;
   public facebook::yoga::SizingMode heightSizingMode;
@@ -10613,6 +10632,40 @@ struct facebook::yoga::LayoutResults {
   public void setPadding(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setPosition(facebook::yoga::PhysicalEdge physicalEdge, float dimension);
   public void setRawDimension(facebook::yoga::Dimension axis, float dimension);
+}
+
+struct facebook::yoga::LinePlacement {
+  public int32_t end;
+  public int32_t span;
+  public int32_t start;
+}
+
+struct facebook::yoga::OccupancyGrid {
+  public const facebook::yoga::OccupancyGrid::Rect* hasOverlap(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd) const;
+  public std::vector<facebook::yoga::OccupancyGrid::Rect> occupied;
+  public void markOccupied(int32_t rowStart, int32_t rowEnd, int32_t columnStart, int32_t columnEnd);
+}
+
+struct facebook::yoga::OccupancyGrid::Rect {
+  public int32_t columnEnd;
+  public int32_t columnStart;
+  public int32_t rowEnd;
+  public int32_t rowStart;
+}
+
+struct facebook::yoga::ResolvedAutoPlacement {
+  public ResolvedAutoPlacement() = default;
+  public ResolvedAutoPlacement(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public ResolvedAutoPlacement(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public facebook::yoga::BaselineItemGroups baselineItemGroups;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(const facebook::yoga::ResolvedAutoPlacement&) = delete;
+  public facebook::yoga::ResolvedAutoPlacement& operator=(facebook::yoga::ResolvedAutoPlacement&&) = default;
+  public int32_t maxColumnEnd;
+  public int32_t maxRowEnd;
+  public int32_t minColumnStart;
+  public int32_t minRowStart;
+  public static facebook::yoga::ResolvedAutoPlacement resolveGridItemPlacements(facebook::yoga::Node* node);
+  public std::vector<facebook::yoga::GridItem> gridItems;
 }
 
 template <size_t BufferSize>


### PR DESCRIPTION
Summary:

Implements the CSS Grid auto placement algorithm ([§8.5](https://www.w3.org/TR/css-grid-1/#auto-placement-algo)).

## How?
- **AutoPlacement** — the four-step placement algorithm.
- **LinePlacement** — grid-line resolution ([§8.3](https://www.w3.org/TR/css-grid-1/#grid-placement-errors)), including invalid-input handling: `line 0` is treated as `auto`, and `span 0` / negative spans clamp to `1`.
- **OccupancyGrid** — overlap tracking for placed items.
- Unit tests (line resolution), algorithm tests, and regression tests for the invalid-input cases.

## Not yet implemented
These will be introduced later. Default `grid-auto-flow` is `row` so it won't be an issue.

- **Dense packing** (`grid-auto-flow: dense`)
- **Column flow** (`grid-auto-flow: column`)

## Notes
- Stacked on https://github.com/react/yoga/issues/1923 (data structures); until that lands this diff also shows its `GridItem.h` / `GridTrack.h` — those belong to https://github.com/react/yoga/issues/1923.

cc - rozele This a small chunk from https://github.com/react/yoga/pull/1894 PR.

X-link: https://github.com/react/yoga/pull/1994

Differential Revision: D111722622

Pulled By: rozele
