### PR TITLE
fix(ios): prevent wrapped text clipping

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -581,8 +581,11 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
     size.height = enumeratedLinesHeight;
   }
 
-  size = (CGSize){ceil(size.width * layoutContext.pointScaleFactor) / layoutContext.pointScaleFactor,
-                  ceil(size.height * layoutContext.pointScaleFactor) / layoutContext.pointScaleFactor};
+  // Wrapped text needs one extra physical pixel so its final line remains visible after layout rounding.
+  CGFloat additionalHeightInPixels = textDidWrap ? 1.0 : 0.0;
+  size = (CGSize){
+      ceil(size.width * layoutContext.pointScaleFactor) / layoutContext.pointScaleFactor,
+      (ceil(size.height * layoutContext.pointScaleFactor) + additionalHeightInPixels) / layoutContext.pointScaleFactor};
 
   NSRange visibleGlyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
 


### PR DESCRIPTION
## Summary:

Fixes #53450.

React Native can measure wrapped iOS text to a height that becomes one physical pixel too short after layout rounding. The final visual line is then clipped even though TextKit produced it.

#54260 avoided the clipping by adding an epsilon to every measured width and height, but it changed unrelated measurements and was reverted in #54510 after breaking internal tests. This change narrows the adjustment to the existing `textDidWrap` signal: wrapped text receives one extra physical pixel of height, while width and all non-wrapped measurements remain unchanged.

This follows the narrower approach proposed by @douglowder in https://github.com/facebook/react-native/issues/53450#issuecomment-3820248176.

## Changelog:

[IOS] [FIXED] - Prevent the final line of wrapped text from being clipped

## Test Plan:

- Reproduced the issue with the canonical fixture from https://snack.expo.dev/@pekka.soutua/text-cut-off-on-ios on an iPhone 16 Pro simulator running iOS 18.5. Before the change, the target paragraph stopped at “This sente”.
- Applied this wrapped-height-only adjustment and confirmed the complete final line, “This sentence is cut off.”, renders and the following list item moves down by one line.
- Built RNTester from current `main`, including the modified source file, for the same iPhone 16 Pro / iOS 18.5 simulator destination.
- Ran the repository clang formatter on `RCTTextLayoutManager.mm`.
- No automated tests were added or run.
