### PR TITLE
[0.87] Fix helloworld Jest preset after react-native/jest-preset subpath removal

### DIFF
--- a/private/helloworld/jest.config.js
+++ b/private/helloworld/jest.config.js
@@ -9,5 +9,5 @@
  */
 
 module.exports = {
-  preset: 'react-native',
+  preset: '@react-native/jest-preset',
 };

--- a/private/helloworld/package.json
+++ b/private/helloworld/package.json
@@ -22,6 +22,7 @@
     "@react-native/babel-preset": "0.87.0-rc.0",
     "@react-native/core-cli-utils": "*",
     "@react-native/eslint-config": "0.87.0-rc.0",
+    "@react-native/jest-preset": "0.87.0-rc.0",
     "@react-native/metro-config": "0.87.0-rc.0",
     "@react-native/typescript-config": "0.87.0-rc.0",
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
## Changelog

[Internal] - Fix helloworld Jest preset on 0.87-stable

## Summary

#57481 (landed via #57508) removed the `react-native/jest-preset` subpath redirect, but the in-repo `private/helloworld` template still referenced `preset: 'react-native'`, which Jest resolves to the now-deleted `react-native/jest-preset.js`.

This broke **all `test_ios_helloworld*` jobs** on `0.87-stable` at the `yarn test` step (e.g. [run 29279033977](https://github.com/react/react-native/actions/runs/29279033977)):

```
● Validation Error:
  Module react-native should have "jest-preset.js" or "jest-preset.json" file at the root.
```

Since `private/helloworld` is **excluded from the yarn workspace** (`"!private/helloworld"`) and installed standalone, it also needs `@react-native/jest-preset` as an explicit `devDependency` for the preset to resolve.

## Changes

- Point `private/helloworld/jest.config.js` preset at `@react-native/jest-preset`.
- Add `@react-native/jest-preset` to `private/helloworld` `devDependencies`.

This mirrors the shipped community template and the current CLI-generated scaffold.

## Test Plan

CI: `test_ios_helloworld*` jobs pass (previously failing at `yarn test`).