### PR TITLE
Add TypeScript declarations for requestIdleCallback and cancelIdleCallback

### DIFF
--- a/packages/react-native/__typetests__/globals.tsx
+++ b/packages/react-native/__typetests__/globals.tsx
@@ -137,6 +137,25 @@ function testRequestAnimationFrame(){
     );
 }
 
+function testRequestIdleCallback() {
+    let handle = requestIdleCallback(deadline => {
+        const didTimeout: boolean = deadline.didTimeout;
+        const remaining: number = deadline.timeRemaining();
+        console.log(didTimeout, remaining);
+    });
+    cancelIdleCallback(handle);
+
+    handle = requestIdleCallback(noop, { timeout: 100 });
+    cancelIdleCallback(handle);
+
+    // @ts-expect-error
+    requestIdleCallback(noop, { timeout: 'wrong-type' });
+
+    // handle is opaque: object on New Architecture, number on legacy
+    // @ts-expect-error
+    const handleIsNotNumber: number = requestIdleCallback(noop);
+}
+
 const fetchCopy: WindowOrWorkerGlobalScope['fetch'] = fetch;
 
 const myHeaders = new Headers();

--- a/packages/react-native/__typetests__/globals.tsx
+++ b/packages/react-native/__typetests__/globals.tsx
@@ -138,6 +138,9 @@ function testRequestAnimationFrame(){
 }
 
 function testRequestIdleCallback() {
+    cancelIdleCallback(null);
+    cancelIdleCallback(undefined);
+
     let handle = requestIdleCallback(deadline => {
         const didTimeout: boolean = deadline.didTimeout;
         const remaining: number = deadline.timeRemaining();
@@ -151,9 +154,8 @@ function testRequestIdleCallback() {
     // @ts-expect-error
     requestIdleCallback(noop, { timeout: 'wrong-type' });
 
-    // handle is opaque: object on New Architecture, number on legacy
     // @ts-expect-error
-    const handleIsNotNumber: number = requestIdleCallback(noop);
+    cancelIdleCallback('wrong-type');
 }
 
 const fetchCopy: WindowOrWorkerGlobalScope['fetch'] = fetch;

--- a/packages/react-native/src/types/globals.d.ts
+++ b/packages/react-native/src/types/globals.d.ts
@@ -125,15 +125,14 @@ declare global {
   function cancelAnimationFrame(handle: number | null | undefined): void;
   function requestAnimationFrame(callback: (time: number) => void): number;
 
-  type IdleCallbackID = unknown;
   function requestIdleCallback(
     callback: (deadline: {
       didTimeout: boolean;
       timeRemaining: () => number;
     }) => void,
     options?: {timeout: number},
-  ): IdleCallbackID;
-  function cancelIdleCallback(handle: IdleCallbackID): void;
+  ): number;
+  function cancelIdleCallback(handle: number | null | undefined): void;
 
   function fetchBundle(
     bundleId: number,

--- a/packages/react-native/src/types/globals.d.ts
+++ b/packages/react-native/src/types/globals.d.ts
@@ -125,6 +125,16 @@ declare global {
   function cancelAnimationFrame(handle: number | null | undefined): void;
   function requestAnimationFrame(callback: (time: number) => void): number;
 
+  type IdleCallbackID = unknown;
+  function requestIdleCallback(
+    callback: (deadline: {
+      didTimeout: boolean;
+      timeRemaining: () => number;
+    }) => void,
+    options?: {timeout: number},
+  ): IdleCallbackID;
+  function cancelIdleCallback(handle: IdleCallbackID): void;
+
   function fetchBundle(
     bundleId: number,
     callback: (error?: Error | null) => void,


### PR DESCRIPTION

## Summary:

`requestIdleCallback` and `cancelIdleCallback` exist at runtime on both architectures. The New Architecture has a native implementation since 0.75 in #44759 (landed as abfadc6083, closing #44636). Legacy architecture has a JS-timer-based implementation in `JSTimers` since 2016 (18394fb179, follow-up to #5052). Support for the `options` param was added in cf51aee9a0. The API is documented at https://reactnative.dev/docs/global-requestIdleCallback

Flow libdefs already declare both functions in`flow/global.js`

The public TypeScript declarations never included them. 
React Native projects compile without `lib: ["dom"]`, so TypeScript users get no declaration

This PR adds the declarations to the `Timer Functions` region of `src/types/globals.d.ts`, based on the Flow signatures

## Changelog:

[GENERAL] [ADDED] - Add TypeScript declarations for `requestIdleCallback` and `cancelIdleCallback`

## Test Plan:

Added `testRequestIdleCallback()` to `packages/react-native/__typetests__/globals.tsx`

```
yarn test-generated-typescript
yarn test-typescript-legacy
yarn lint
yarn prettier
```