### PR TITLE
[0.87] Bootstrap Metro from InitializeCore until setup-env is graph-reachable

### DIFF
--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -60,17 +60,16 @@ function getCommunityCliDefaultConfig(
   return {
     resolver,
     serializer: {
-      // We can include multiple copies of setup-env here because Metro will
+      // We can include multiple copies of InitializeCore here because metro will
       // only add ones that are already part of the bundle
       getModulesRunBeforeMainModule: () => [
-        // NOTE: ctx.reactNativePath is an absolute path, therefore we need to
-        // reference setup-env.js here by exact path specifier.
-        require.resolve(path.join(ctx.reactNativePath, 'src/setup-env.js'), {
-          paths: [ctx.root],
-        }),
+        require.resolve(
+          path.join(ctx.reactNativePath, 'Libraries/Core/InitializeCore'),
+          {paths: [ctx.root]},
+        ),
         ...outOfTreePlatforms.map(platform =>
           require.resolve(
-            `${ctx.platforms[platform].npmPackageName}/setup-env`,
+            `${ctx.platforms[platform].npmPackageName}/Libraries/Core/InitializeCore`,
             {paths: [ctx.root]},
           ),
         ),

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -61,7 +61,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
     serializer: {
       // Note: This option is overridden in cli-plugin-metro (getOverrideConfig)
       getModulesRunBeforeMainModule: () => [
-        require.resolve('react-native/setup-env'),
+        require.resolve('react-native/Libraries/Core/InitializeCore'),
       ],
       getPolyfills: () => require('@react-native/js-polyfills')(),
       isThirdPartyModule({path: modulePath}: Readonly<{path: string, ...}>) {


### PR DESCRIPTION
## Summary

Fresh 0.87 projects **redbox on launch**:

```
Failed to call into JavaScript module method RCTDeviceEventEmitter.emit().
Module has not been registered as callable.
Registered callable JavaScript modules (n = 1): AppRegistry.
```

Only `AppRegistry` is registered as callable — i.e. **core initialization never runs**.

## Root cause (#57475)

Core init runs via Metro's `serializer.getModulesRunBeforeMainModule`. Metro (`metro/src/lib/getAppendScripts.js`) only emits the run-before `__r()` for a module **already present in the bundle graph**, and silently skips it otherwise:

```js
const paths = [...options.runBeforeMainModule, entryPoint];
for (const path of paths) {
  if (modules.some((module) => module.path === path)) {  // only if already in the graph
    /* __r(moduleId) */
  }
}
```

**#57475** switched the run-before target from `Libraries/Core/InitializeCore` → `src/setup-env.js`.

- `InitializeCore.js` **is** reachable (imported by `Libraries/ReactPrivate/ReactNativePrivateInitializeCore.js`).
- `src/setup-env.js` is imported by **nothing** → not in the graph → silently skipped → core init never runs.

The two modules are functionally identical (both call `setUpDefaultReactNativeEnvironment().default()`), so only *reachability* changed.

### Evidence (bundle tail)

| Run-before target | Bundle tail | Boots? |
|---|---|---|
| `src/setup-env.js` (current) | `__r(0);` | ❌ |
| `Libraries/Core/InitializeCore` (this PR) | `__r(110); __r(0);` | ✅ |

Ruled out: Metro cache (cold `--reset-cache` identical), stale Metro, and #57484 (`./src/*` exports removal — restoring it did not help).

## Scope — interim stopgap

This only reverts the **internal Metro bootstrap target** back to `InitializeCore`. It does **not** touch the public `react-native/setup-env` entry point or its deprecation of `InitializeCore` — those ship unchanged.

The **proper fix** (make `setup-env` graph-reachable, or make Metro treat `getModulesRunBeforeMainModule` entries as graph roots) should land on `main` and supersede this. cc @huntie — this is your `setup-env` stack; flagging for the durable fix. Note `main` uses equivalent wiring (its follow-up #57498 is cosmetic — resolves to the same unreachable file), so `main` is likely affected too.

## Changelog

[General][Fixed] - Fix apps failing to boot ("RCTDeviceEventEmitter not registered as callable") caused by core init not running.

## Test Plan

- `yarn test-release-local -t RNTestProject -p iOS`: app boots without the redbox.
- Bundle tail contains `__r(<InitializeCore>); __r(0);` instead of just `__r(0);`.