### PR TITLE
Fix local release testing: publish with --tag for prerelease versions (#57552)

### DIFF
--- a/scripts/e2e/init-project-e2e.js
+++ b/scripts/e2e/init-project-e2e.js
@@ -122,7 +122,10 @@ async function initNewProjectFromSource(
         `${desc} ${styleText('dim', '.').repeat(Math.max(0, 72 - desc.length))} `,
       );
       execSync(
-        `npm publish --registry ${VERDACCIO_SERVER_URL} --access public`,
+        // `--tag` is required by npm >= 11 when publishing a prerelease
+        // version. This is a throwaway local registry and the install step
+        // pins the exact version, so the dist-tag value is not significant.
+        `npm publish --registry ${VERDACCIO_SERVER_URL} --access public --tag react-native-e2e`,
         {
           cwd: packagePath,
           stdio: verbose ? 'inherit' : [process.stderr],


### PR DESCRIPTION
Summary:
`scripts/e2e/init-project-e2e.js` publishes in-repo packages to the local Verdaccio proxy with `npm publish`, but omits `--tag`. **npm ≥ 11** (bundled with Node 24+) refuses to publish a prerelease version (e.g. `0.87.0-rc.0`) without an explicit tag:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

This breaks `yarn test-release-local` immediately at the publish step on any machine using npm ≥ 11.

## Fix

Pass an explicit `--tag react-native-e2e`. This is a throwaway local registry and the install step pins the **exact** version, so the dist-tag value is not significant for resolution.

## Changelog

[Internal] - Fix `test-release-local` publishing on npm ≥ 11


Test Plan: `yarn test-release-local -t RNTestProject -p iOS` now gets past the publish step on npm 11 (previously failed immediately at `npm publish`).

Reviewed By: christophpurrer

Differential Revision: D111995913

Pulled By: zeyap


