### PR TITLE
[0.87] Bootstrap Metro from InitializeCore until setup-env is graph-reachable

### DIFF
--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -58,15 +58,15 @@ function getCommunityCliDefaultConfig(
   return {
     resolver,
     serializer: {
-      // We can include multiple copies of setup-env here because Metro will
+      // We can include multiple copies of InitializeCore here because metro will
       // only add ones that are already part of the bundle
       getModulesRunBeforeMainModule: () => [
-        require.resolve('react-native/setup-env', {
+        require.resolve('react-native/Libraries/Core/InitializeCore', {
           paths: [ctx.root],
         }),
         ...outOfTreePlatforms.map(platform =>
           require.resolve(
-            `${ctx.platforms[platform].npmPackageName}/setup-env`,
+            `${ctx.platforms[platform].npmPackageName}/Libraries/Core/InitializeCore`,
             {paths: [ctx.root]},
           ),
         ),

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -61,7 +61,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
     serializer: {
       // NOTE: Overridden in community-cli-plugin
       getModulesRunBeforeMainModule: () => [
-        require.resolve('react-native/setup-env'),
+        require.resolve('react-native/Libraries/Core/InitializeCore'),
       ],
       getPolyfills: () => require('@react-native/js-polyfills')(),
       isThirdPartyModule({path: modulePath}: Readonly<{path: string, ...}>) {


### PR DESCRIPTION
> Supersedes #57551 (which was cut before #57498 and became conflicting). This version is rebased on the current `0.87-stable` and keeps the #57498 specifier style (no reintroduced `path` import).

## Summary

Fresh 0.87 projects **redbox on launch** — e.g.:

```
Failed to call into JavaScript module method RCTDeviceEventEmitter.emit().
Module has not been registered as callable.
Registered callable JavaScript modules (n = 1): AppRegistry.
```

(The named module varies — `HMRClient.setup()`, `RCTDeviceEventEmitter.emit()` — it's whichever callable module native calls first.) `n = 1: AppRegistry` is the tell: **core initialization never runs**.

## Root cause (#57475)

Core init runs via Metro's `serializer.getModulesRunBeforeMainModule`. Metro (`metro/src/lib/getAppendScripts.js`) only emits the run-before `__r()` for a module **already present in the bundle graph**, and silently skips it otherwise:

```js
const paths = [...options.runBeforeMainModule, entryPoint];
for (const path of paths) {
  if (modules.some((module) => module.path === path)) {  // only if already in the graph
    /* __r(moduleId) */
  }
}
```

**#57475** switched the run-before target from `Libraries/Core/InitializeCore` → `src/setup-env.js`.

- `InitializeCore.js` **is** reachable (imported by `Libraries/ReactPrivate/ReactNativePrivateInitializeCore.js`).
- `src/setup-env.js` is imported by **nothing** → not in the graph → silently skipped → core init never runs.

The two modules are functionally identical (both call `setUpDefaultReactNativeEnvironment().default()`), so only *reachability* changed. Note #57498 was cosmetic (same resolved file), so it does not fix this.

### Evidence (bundle tail)

| Run-before target | Bundle tail | Boots? |
|---|---|---|
| `setup-env` (current) | `__r(0);` | ❌ |
| `InitializeCore` (this PR) | `__r(<InitializeCore>); __r(0);` | ✅ |

Verified end-to-end via `test-release-local -t RNTestProject -p iOS`. Ruled out: Metro cache (cold `--reset-cache` identical), stale Metro, and #57484 (`./src/*` exports removal).

## Scope — interim stopgap

Only the **internal Metro bootstrap target** reverts to `InitializeCore`. The public `react-native/setup-env` entry point and its deprecation of `InitializeCore` are **unchanged**.

The **durable fix** (make `setup-env` graph-reachable, or make Metro treat `getModulesRunBeforeMainModule` entries as graph roots) should land on `main` and supersede this. cc @huntie — this is your `setup-env` stack. `main` uses equivalent wiring, so it's likely affected too.

## Changelog

[General][Fixed] - Fix apps failing to boot ("... not registered as callable") caused by core init not running.

## Test Plan

- `yarn test-release-local -t RNTestProject -p iOS`: app boots without the redbox.
- Bundle tail contains `__r(<InitializeCore>); __r(0);` instead of just `__r(0);`.