### PR TITLE
fix(android): convert outlineColor values before delegation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -104,7 +104,12 @@ public abstract class BaseViewManagerDelegate<
         mViewManager.setAccessibilityLabelledBy(view, dynamicFromObject)
       }
       ViewProps.OPACITY -> mViewManager.setOpacity(view, (value as Double?)?.toFloat() ?: 1.0f)
-      ViewProps.OUTLINE_COLOR -> mViewManager.setOutlineColor(view, value as Int?)
+      ViewProps.OUTLINE_COLOR ->
+          mViewManager.setOutlineColor(
+              view,
+              // outlineColor의 nullable 계약을 보존하기 위해 기본값이 없는 변환을 사용한다.
+              ColorPropConverter.getColor(value, view.context),
+          )
 
       ViewProps.OUTLINE_OFFSET ->
           mViewManager.setOutlineOffset(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -107,7 +107,7 @@ public abstract class BaseViewManagerDelegate<
       ViewProps.OUTLINE_COLOR ->
           mViewManager.setOutlineColor(
               view,
-              // outlineColor의 nullable 계약을 보존하기 위해 기본값이 없는 변환을 사용한다.
+              // Use the overload without a default value to preserve outlineColor's nullable contract.
               ColorPropConverter.getColor(value, view.context),
           )
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerDelegateTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerDelegateTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.facebook.react.bridge.BridgeReactContext;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.facebook.react.views.view.ReactViewManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class BaseViewManagerDelegateTest {
+  private ReactViewManager viewManager;
+  private ReactViewGroup view;
+  private BaseViewManagerDelegate<ReactViewGroup, ReactViewManager> delegate;
+
+  @Before
+  public void setUp() {
+    viewManager = mock(ReactViewManager.class);
+    BridgeReactContext context = new BridgeReactContext(RuntimeEnvironment.getApplication());
+    ThemedReactContext themedReactContext = new ThemedReactContext(context, context, null, -1);
+    view = new ReactViewGroup(themedReactContext);
+    delegate = new BaseViewManagerDelegate<>(viewManager) {};
+  }
+
+  @Test
+  public void setOutlineColorConvertsDoubleToInt() {
+    int color = 0xFF336699;
+
+    delegate.setProperty(view, ViewProps.OUTLINE_COLOR, (double) color);
+
+    verify(viewManager).setOutlineColor(view, color);
+  }
+}


### PR DESCRIPTION
## Summary

- Convert Android `outlineColor` values with `ColorPropConverter` before delegating them to the view manager.
- Preserve the nullable color contract by using the converter overload without a default value.
- Add a regression test for `Double` color values that previously threw `ClassCastException`.

Fixes #57190

## Changelog:

[Android] [Fixed] - Fix crashes when `outlineColor` is provided as a numeric color value

## Test plan

- [x] Confirmed that the regression test fails with `ClassCastException` before the fix
- [x] `BaseViewManagerDelegateTest`
- [x] `:packages:react-native:ReactAndroid:test`
- [x] `npx prettier --write .`
- [ ] Full JavaScript lint: stops while loading `@react-native/specs/react-native-modules` for the unchanged `NativeDevMenu.js` file with `SyntaxError: Unexpected token '{'`
