### PR TITLE
[0.87] Consolidate react-native/setup-env in Metro configs

### DIFF
--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -58,15 +58,15 @@ function getCommunityCliDefaultConfig(
   return {
     resolver,
     serializer: {
-      // We can include multiple copies of InitializeCore here because metro will
+      // We can include multiple copies of setup-env here because Metro will
       // only add ones that are already part of the bundle
       getModulesRunBeforeMainModule: () => [
-        require.resolve('react-native/Libraries/Core/InitializeCore', {
+        require.resolve('react-native/setup-env', {
           paths: [ctx.root],
         }),
         ...outOfTreePlatforms.map(platform =>
           require.resolve(
-            `${ctx.platforms[platform].npmPackageName}/Libraries/Core/InitializeCore`,
+            `${ctx.platforms[platform].npmPackageName}/setup-env`,
             {paths: [ctx.root]},
           ),
         ),

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -61,7 +61,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
     serializer: {
       // NOTE: Overridden in community-cli-plugin
       getModulesRunBeforeMainModule: () => [
-        require.resolve('react-native/Libraries/Core/InitializeCore'),
+        require.resolve('react-native/setup-env'),
       ],
       getPolyfills: () => require('@react-native/js-polyfills')(),
       isThirdPartyModule({path: modulePath}: Readonly<{path: string, ...}>) {

--- a/packages/react-native/Libraries/Core/InitializeCore.js
+++ b/packages/react-native/Libraries/Core/InitializeCore.js
@@ -27,4 +27,11 @@
 
 'use strict';
 
-require('../../src/private/setup/setUpDefaultReactNativeEnvironment').default();
+// NOTE: This delegates to the `'react-native/setup-env'` entry point (rather
+// than calling `setUpDefaultReactNativeEnvironment` directly) so that
+// `src/setup-env.js` is pulled into the module graph. Metro's
+// `getModulesRunBeforeMainModule` only runs modules that are already part of
+// the bundle, and `InitializeCore` is a guaranteed graph entry (via
+// `ReactNativePrivateInitializeCore`). This keeps `'react-native/setup-env'`
+// reachable so it runs before the main module.
+require('../../src/setup-env');


### PR DESCRIPTION
## Summary

Tidy ups following https://github.com/react/react-native/pull/57557.

**Cause**

Ultimately, a race condition on `0.87-stable` from not having all of the following changes at once:

- https://github.com/react/react-native/pull/57492
- #57498
- Conflicting with #57484

This PR aligns the branch state with `main` (and undoes https://github.com/react/react-native/pull/57557).

Changelog: [Internal]

## Test Plan

Template E2E (`test_e2e_ios_templateapp` / `test_e2e_android_templateapp`)