### PR TITLE
Restore react-native/setup-env references on main

### DIFF
--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -58,15 +58,15 @@ function getCommunityCliDefaultConfig(
   return {
     resolver,
     serializer: {
-      // We can include multiple copies of InitializeCore here because metro will
+      // We can include multiple copies of setup-env here because Metro will
       // only add ones that are already part of the bundle
       getModulesRunBeforeMainModule: () => [
-        require.resolve('react-native/Libraries/Core/InitializeCore', {
+        require.resolve('react-native/setup-env', {
           paths: [ctx.root],
         }),
         ...outOfTreePlatforms.map(platform =>
           require.resolve(
-            `${ctx.platforms[platform].npmPackageName}/Libraries/Core/InitializeCore`,
+            `${ctx.platforms[platform].npmPackageName}/setup-env`,
             {paths: [ctx.root]},
           ),
         ),

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -61,7 +61,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
     serializer: {
       // NOTE: Overridden in community-cli-plugin
       getModulesRunBeforeMainModule: () => [
-        require.resolve('react-native/Libraries/Core/InitializeCore'),
+        require.resolve('react-native/setup-env'),
       ],
       getPolyfills: () => require('@react-native/js-polyfills')(),
       isThirdPartyModule({path: modulePath}: Readonly<{path: string, ...}>) {


### PR DESCRIPTION
Summary:
Reverts D112002434.

This fix was needed on `0.87-stable` but not on `main`, since the `setup-env`-in-bundle-graph fix (https://github.com/react/react-native/pull/57492) was already present, see file at time of D112002434:

https://github.com/react/react-native/blob/08c323346be6c0fbbd70900d48435f977a78a1bb/packages/react-native/Libraries/Core/InitializeCore.js#L30-L37

See https://github.com/react/react-native/pull/57559 for more info.

Changelog: [Internal]

Differential Revision: D112101450


