### PR TITLE
fix(iOS): fix Prettier lint failure after SwiftPM support landed

### DIFF
--- a/packages/react-native/scripts/ios-prebuild/__tests__/headers-xcframework-test.js
+++ b/packages/react-native/scripts/ios-prebuild/__tests__/headers-xcframework-test.js
@@ -20,7 +20,7 @@ const os = require('os');
 const path = require('path');
 
 describe('buildDepsHeadersXcframework set-equality gate', () => {
-  let tmp /*: string */;
+  let tmp /*: string */ = '';
   beforeEach(() => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'deps-headers-test-'));
   });


### PR DESCRIPTION
## Summary

The OSS lint job went red after the SwiftPM stack landed (#57332 and its base PRs). The failing signal is the **Prettier** step of the `lint` job.

The offending file (introduced in base PR #57442) is:

`packages/react-native/scripts/ios-prebuild/__tests__/headers-xcframework-test.js`

```js
let tmp /*: string */;
```

This is a Flow *comment-type annotation* on an **uninitialized** `let`. Prettier reformats an uninitialized declaration by moving the trailing comment past the semicolon:

```js
let tmp; /*: string */   // annotation detached — no longer a type annotation
```

Because CI runs `prettier --list-different` (fails on any diff), this made the lint job fail. Prettier only keeps the `/*: string */` annotation inline when the declaration has an initializer, so the fix is to give `tmp` one:

```js
let tmp /*: string */ = '';
```

Semantically safe — `tmp` is assigned in `beforeEach` before any use.

## Changelog:

[INTERNAL] [FIXED] - Fix Prettier lint failure in `headers-xcframework` test

## Test Plan

- `yarn format-check` — clean across the repo
- `yarn lint` (ESLint) — passes
- `yarn lint-markdown` — passes
- `yarn test-typescript-legacy` — passes
- Jest `headers-xcframework-test.js` — all 5 tests pass