### PR TITLE
fix(iOS): classify CFNetwork as a system framework in the header include-health ratchet

### DIFF
--- a/packages/react-native/scripts/ios-prebuild/headers-inventory.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-inventory.js
@@ -86,6 +86,7 @@ const SDK_PREFIXES = new Set([
   'Accessibility',
   'AVFoundation',
   'AVKit',
+  'CFNetwork',
   'CommonCrypto',
   'CoreFoundation',
   'CoreGraphics',


### PR DESCRIPTION
## Summary

After the SwiftPM stack landed (#57332), the `prebuild_react_native_core / compose-xcframework` jobs (Debug and Release) went red on the **"Verify composed headers"** step (`headers-verify.js`), not on the XCFramework compile:

```
include-health ratchet: 2 NEW unresolvable include(s) in shipped headers
(work in source builds via pod header maps, break the packaged layout):
  unresolved CoreModules/RCTInspectorWebSocketReporter.h -> CFNetwork/CFNetwork.h
  unresolved React/RCTInspectorWebSocketReporter.h -> CFNetwork/CFNetwork.h
```

`React/CoreModules/RCTInspectorWebSocketReporter.h` (added in #57543, "Add CDP support for WebSocket events (iOS)") does `#import <CFNetwork/CFNetwork.h>` because it uses `CFHTTPMessageRef`. The include-health ratchet classifies any include whose first path segment isn't in the `SDK_PREFIXES` allowlist in `headers-inventory.js` as `unresolved`. **`CFNetwork` was missing from that allowlist** — even though it's a genuine Apple system framework that's always available in the SDK, exactly like `CoreFoundation`, `Security`, and `Network`, which are already listed. (Two offenders because the same header ships under two natural paths, `CoreModules/` and `React/`.)

## Fix

Add `CFNetwork` to `SDK_PREFIXES`. This is the accurate classification (it's a system framework), so **no baseline change is required**.

## Changelog:

[INTERNAL] [FIXED] - Classify `CFNetwork` as a system framework in the prebuilt-header include-health ratchet

## Test Plan

- Ran the include-health stage locally against the source tree + committed `headers-include-baseline.json`: `CFNetwork` is no longer flagged, **0 new offenders, 0 baseline entries to shrink**.
- `ios-prebuild` unit suite: **56/56 pass**.