### PR TITLE
Add missing 'auto' value for overflow in StyleSheets

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -83,7 +83,7 @@ export interface FlexStyle {
   maxWidth?: DimensionValue | undefined;
   minHeight?: DimensionValue | undefined;
   minWidth?: DimensionValue | undefined;
-  overflow?: 'visible' | 'hidden' | 'scroll' | undefined;
+  overflow?: 'visible' | 'hidden' | 'scroll' | 'auto' | undefined;
   padding?: DimensionValue | undefined;
   paddingBottom?: DimensionValue | undefined;
   paddingEnd?: DimensionValue | undefined;


### PR DESCRIPTION
## Summary:

'auto' is a valid option distinct from all other options and currently requires to do `overflow: 'auto' as any` to avoid a Typescript error


## Changelog:

GENERAL ADDED - Add 'auto' as a valid option to StyleSheet's overflow in types (already supported by CSS)


## Test Plan:

Have an item with overflow set to 'auto' in a StyleSheet: 
Before the fix: 
- works, has a different behaviour than visible, hidden, scroll and undefined
- genereates a Typescript error TS2820: Type '"auto"' is not assignable to type '"visible" | "hidden" | "scroll" | undefined'.
StyleSheetTypes.d.ts(98, 3): The expected type comes from property 'overflow' which is declared here on type 'ViewStyle | TextStyle | ImageStyle'
- requires a \<any\> cast or ts-ignore to remove the error

After the fix: 
- no Typescript error
- no behavioral change
- no breakage for people using the \<any\> cast