### PR TITLE
fix(requestIdleCallback): timeout not assigned at NativeIdleCallbacks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # Controls whether to use Hermes from stable builds. This will force hermes version
 # set in the sdks/hermes-engine/version.properties file to be used. This has a higher
 # priority than react.internal.useHermesNightly.
-react.internal.useHermesStable=false
+react.internal.useHermesStable=true
 
 # Controls whether to use Hermes from nightly builds. This will speed up builds
 # but should NOT be turned on for CI or release builds.

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/NativeIdleCallbacks.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/NativeIdleCallbacks.cpp
@@ -87,6 +87,7 @@ CallbackHandle NativeIdleCallbacks::requestIdleCallback(
   if (options.has_value() && options.value().timeout.has_value()) {
     HighResDuration userTimeout = options.value().timeout.value();
     if (userTimeout > HighResDuration::zero()) {
+      timeout = userTimeout;
       expirationTime = runtimeScheduler->now() + userTimeout;
     }
   }

--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -13,13 +13,63 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
+import {useState, useEffect} from 'react';
 
+/**
+ * Proves NativeIdleCallbacks forwards options.timeout into scheduleIdleTask.
+ *
+ * Strategy: keep scheduling LowPriority work (10s expiry each). That always
+ * beats an idle task with the default 5min expiry (bug), but after the first
+ * LowPriority tick a patched idle task (LowPriority + timeout ≈ 10s) becomes
+ * the earliest-expiring task and runs.
+ *
+ * Expect with the patch: fire within ~1s.
+ * Expect without (`timeout = userTimeout` removed): stuck on "starving…" for minutes.
+ */
 function Playground() {
+  const [label, setLabel] = useState('starving LowPriority queue…');
+
+  useEffect(() => {
+    const scheduler = global.nativeRuntimeScheduler;
+    const {unstable_scheduleCallback, unstable_LowPriority} = scheduler;
+
+    const start = performance.now();
+    let keepStarving = true;
+
+    const starve = () => {
+      if (!keepStarving) {
+        return;
+      }
+      unstable_scheduleCallback(unstable_LowPriority, () => {
+        const blockStart = performance.now();
+        while (performance.now() - blockStart < 30) {}
+        starve();
+      });
+    };
+
+    requestIdleCallback(
+      deadline => {
+        keepStarving = false;
+        const elapsedMs = Math.round(performance.now() - start);
+        setLabel(
+          `✅ PATCHED: fired after ${elapsedMs}ms under LowPriority load, didTimeout=${String(
+            deadline.didTimeout,
+          )}`,
+        );
+      },
+      {timeout: 10},
+    );
+
+    starve();
+
+    return () => {
+      keepStarving = false;
+    };
+  }, []);
+
   return (
     <View style={styles.container}>
-      <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
-      </RNTesterText>
+      <RNTesterText>{label}</RNTesterText>
     </View>
   );
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fix #57570 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Regression in `requestIdleCallback` introduced by:
- https://github.com/react/react-native/pull/51251

The `timeout` is never assigned, so it is never forwarded to `runtimeScheduler`.

Before the PR mentioned above, it was being assigned alongside `expirationTime`, but that was removed during the refactor.

Without this patch the task will keep running for up to `5 minutes` (default value).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Fix requestIdleCallback timeout option being ignored

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Before|After
--|--
<img width="1080" height="2424" alt="before" src="https://github.com/user-attachments/assets/1f5af3ee-a3cd-4bf1-b397-606c05ff3b52" />|<img width="1080" height="2424" alt="after" src="https://github.com/user-attachments/assets/8fb071ca-11ca-4cdb-bed3-009b1648ca8c" />