### PR TITLE
add missing mutex include to HostTarget.h

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -20,6 +20,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <mutex>
 
 #include <jsinspector-modern/tracing/FrameTimingSequence.h>
 #include <jsinspector-modern/tracing/HostTracingProfile.h>


### PR DESCRIPTION
std::mutex is used here without the include, which fails to compile on MSVC

## Summary:

I'm going through MSVC compilation now, and this was one of the issues. We're using `std::mutex` without explicitly including it.

## Changelog:

[GENERAL] [FIXED] - added missing mutex include in HostTarget.h

## Test Plan:

Compile react native. 
