### PR TITLE
remove backticks in NativeDOM.cpp

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
@@ -92,7 +92,7 @@ bool isRootShadowNode(const ShadowNode& shadowNode) {
 NativeDOM::NativeDOM(std::shared_ptr<CallInvoker> jsInvoker)
     : NativeDOMCxxSpec(std::move(jsInvoker)) {}
 
-#pragma mark - Methods from the `Node` interface (for `ReadOnlyNode`).
+#pragma mark - Methods from the Node interface (for ReadOnlyNode).
 
 double NativeDOM::compareDocumentPosition(
     jsi::Runtime& rt,
@@ -119,7 +119,7 @@ double NativeDOM::compareDocumentPosition(
 
       if (isRootShadowNode(*otherShadowNode)) {
         // If the other is a root node, we just need to check if it is its
-        // `documentElement`
+        // documentElement
         return (surfaceId == otherShadowNode->getSurfaceId())
             ? dom::DOCUMENT_POSITION_CONTAINED_BY |
                 dom::DOCUMENT_POSITION_FOLLOWING
@@ -232,7 +232,7 @@ bool NativeDOM::isConnected(jsi::Runtime& rt, jsi::Value nativeNodeReference) {
   return dom::isConnected(currentRevision, *shadowNode);
 }
 
-#pragma mark - Methods from the `Element` interface (for `ReactNativeElement`).
+#pragma mark - Methods from the Element interface (for ReactNativeElement).
 
 std::tuple<
     /* topWidth: */ int,
@@ -358,7 +358,7 @@ void NativeDOM::setPointerCapture(
       static_cast<PointerIdentifier>(pointerId), shadowNode);
 }
 
-#pragma mark - Methods from the `HTMLElement` interface (for `ReactNativeElement`).
+#pragma mark - Methods from the HTMLElement interface (for ReactNativeElement).
 
 std::tuple<
     /* offsetParent: */ jsi::Value,
@@ -401,7 +401,7 @@ jsi::Value NativeDOM::linkRootNode(
   return Bridging<std::shared_ptr<const ShadowNode>>::toJs(rt, currentRevision);
 }
 
-#pragma mark - Legacy layout APIs (for `ReactNativeElement`).
+#pragma mark - Legacy layout APIs (for ReactNativeElement).
 
 void NativeDOM::measure(
     jsi::Runtime& rt,
@@ -466,7 +466,7 @@ void NativeDOM::measureLayout(
   onSuccess(rect.x, rect.y, rect.width, rect.height);
 }
 
-#pragma mark - Legacy direct manipulation APIs (for `ReactNativeElement`).
+#pragma mark - Legacy direct manipulation APIs (for ReactNativeElement).
 
 void NativeDOM::setNativeProps(
     jsi::Runtime& rt,


### PR DESCRIPTION
MSVC is highly allergic to backticks in #pragma and will panic with error C2018: unknown character '0x60'

## Summary:

I'm currently preparing my React Native for Unreal Engine OOT platform, and as part of that I'm compiling with MSVC. MSVC doesn't tolerate the backticks here.

## Changelog:

[GENERAL] [FIXED] - fixed MSVC compilation of NativeDOM.cpp by removing backticks

## Test Plan:

Check that MSVC no longer complains about backticks