### PR TITLE
Fix debug Hermes being embedded in iOS Release builds after hermes-engine pod re-install

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
+++ b/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
@@ -56,15 +56,29 @@ function shouldReplaceHermesConfiguration(configuration) {
 function replaceHermesConfiguration(configuration, version, podsRoot) {
   const tarballURLPath = `${podsRoot}/hermes-engine-artifacts/hermes-ios-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
 
+  if (!fs.existsSync(tarballURLPath)) {
+    throw new Error(`Hermes tarball not found at ${tarballURLPath}`);
+  }
+
   const finalLocation = 'hermes-engine';
   console.log('Preparing the final location');
   fs.rmSync(finalLocation, {force: true, recursive: true});
   fs.mkdirSync(finalLocation, {recursive: true});
 
   console.log('Extracting the tarball');
-  spawnSync('tar', ['-xf', tarballURLPath, '-C', finalLocation], {
-    stdio: 'inherit',
-  });
+  const result = spawnSync(
+    'tar',
+    ['-xf', tarballURLPath, '-C', finalLocation],
+    {
+      stdio: 'inherit',
+    },
+  );
+  if (result.status !== 0) {
+    fs.rmSync(finalLocation, {force: true, recursive: true});
+    throw new Error(
+      `Failed to extract ${tarballURLPath}: ${result.error?.message ?? `tar exited with status ${result.status}`}`,
+    );
+  }
 }
 
 function updateLastBuildConfiguration(configuration) {

--- a/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
+++ b/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
@@ -14,7 +14,7 @@ const {spawnSync} = require('child_process');
 const fs = require('fs');
 const yargs = require('yargs');
 
-const LAST_BUILD_FILENAME = '.last_build_configuration';
+const LAST_BUILD_FILENAME = 'hermes-engine/.last_build_configuration';
 
 function validateBuildConfiguration(configuration) {
   if (!['Debug', 'Release'].includes(configuration)) {


### PR DESCRIPTION
## Summary:

The `hermes-engine` pod is always installed from the debug tarball; the debug/release selection is deferred to a build phase that runs `sdks/hermes-engine/utils/replace_hermes_version.js`. The script tracks which variant currently sits in `Pods/hermes-engine` through a `.last_build_configuration` marker at the Pods root and skips the swap when the marker matches the requested configuration.

Whenever CocoaPods re-installs `hermes-engine`, the engine resets to the debug variant while the marker still claims `Release`. The next Release build takes the "Same config of the previous build" path and silently embeds the debug `hermesvm` into the Release app.

I moved the marker inside `Pods/hermes-engine/` so a pod re-install destroys it together with the engine it describes and the next build re-runs the swap — the same pattern `replace-rncore-version.js` and `replace_dependencies_version.js` already use for their prebuilts.

I also added some assertions.

## Changelog:

[IOS] [FIXED] - Fix debug Hermes being silently embedded in Release builds after the hermes-engine pod is re-installed

## Test Plan:

Reproduced on `react-native@0.86.0` before the change: Release build, then `rm -rf ios/Pods/hermes-engine && pod install`, then Release build again — the app's embedded `hermesvm` is the debug binary (`nm -gU -arch arm64 hermesvm | grep -c CDPDebugAPI` prints 6, ~12.2 MB; the release binary prints 0, ~10.2 MB) while the marker says `Release`.
