### PR TITLE
Clean up network inspection feature flags (#57577)

### DIFF
--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -15,7 +15,6 @@
 #import <React/RCTUtils.h>
 
 #import <React/RCTHTTPRequestHandler.h>
-#import <react/featureflags/ReactNativeFeatureFlags.h>
 
 #import "RCTInspectorNetworkReporter.h"
 #import "RCTNetworkPlugins.h"
@@ -452,9 +451,7 @@ RCT_EXPORT_MODULE()
     __weak RCTNetworkTask *weakTask = task;
     return ^{
       [weakTask cancel];
-      if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
-        [RCTInspectorNetworkReporter reportRequestFailed:devToolsRequestId cancelled:YES];
-      }
+      [RCTInspectorNetworkReporter reportRequestFailed:devToolsRequestId cancelled:YES];
       if (cancellationBlock) {
         cancellationBlock();
       }
@@ -574,19 +571,17 @@ RCT_EXPORT_MODULE()
     }
   }
 
-  if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
-    id responseDataForPreview;
-    if ([responseType isEqualToString:@"blob"]) {
-      responseDataForPreview = data;
-    } else if ([responseData isKindOfClass:[NSString class]]) {
-      responseDataForPreview = responseData;
-    }
-    bool base64Encoded = [responseType isEqualToString:@"base64"] || [responseType isEqualToString:@"blob"];
-
-    [RCTInspectorNetworkReporter maybeStoreResponseBody:task.devToolsRequestId
-                                                   data:responseDataForPreview
-                                          base64Encoded:base64Encoded];
+  id responseDataForPreview;
+  if ([responseType isEqualToString:@"blob"]) {
+    responseDataForPreview = data;
+  } else if ([responseData isKindOfClass:[NSString class]]) {
+    responseDataForPreview = responseData;
   }
+  bool base64Encoded = [responseType isEqualToString:@"base64"] || [responseType isEqualToString:@"blob"];
+
+  [RCTInspectorNetworkReporter maybeStoreResponseBody:task.devToolsRequestId
+                                                 data:responseDataForPreview
+                                        base64Encoded:base64Encoded];
 
   [self sendEventWithName:@"didReceiveNetworkData" body:@[ task.requestID, responseData ]];
 }
@@ -620,12 +615,10 @@ RCT_EXPORT_MODULE()
     id responseURL = response.URL ? response.URL.absoluteString : [NSNull null];
     NSArray<id> *responseJSON = @[ task.requestID, @(status), headers, responseURL ];
 
-    if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
-      [RCTInspectorNetworkReporter reportResponseStart:task.devToolsRequestId
-                                              response:response
-                                            statusCode:status
-                                               headers:headers];
-    }
+    [RCTInspectorNetworkReporter reportResponseStart:task.devToolsRequestId
+                                            response:response
+                                          statusCode:status
+                                             headers:headers];
     [weakSelf sendEventWithName:@"didReceiveNetworkResponse" body:responseJSON];
   };
 
@@ -660,10 +653,8 @@ RCT_EXPORT_MODULE()
           @(total)
         ];
 
-        if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
-          [RCTInspectorNetworkReporter reportDataReceived:task.devToolsRequestId data:data];
-          [RCTInspectorNetworkReporter maybeStoreResponseBodyIncremental:task.devToolsRequestId data:responseString];
-        }
+        [RCTInspectorNetworkReporter reportDataReceived:task.devToolsRequestId data:data];
+        [RCTInspectorNetworkReporter maybeStoreResponseBodyIncremental:task.devToolsRequestId data:responseString];
         [weakSelf sendEventWithName:@"didReceiveNetworkIncrementalData" body:responseJSON];
       };
     } else {
@@ -700,12 +691,10 @@ RCT_EXPORT_MODULE()
     NSArray *responseJSON =
         @[ task.requestID, RCTNullIfNil(error.localizedDescription), error.code == kCFURLErrorTimedOut ? @YES : @NO ];
 
-    if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
-      if (error != nullptr) {
-        [RCTInspectorNetworkReporter reportRequestFailed:task.devToolsRequestId cancelled:NO];
-      } else {
-        [RCTInspectorNetworkReporter reportResponseEnd:task.devToolsRequestId encodedDataLength:data.length];
-      }
+    if (error != nullptr) {
+      [RCTInspectorNetworkReporter reportRequestFailed:task.devToolsRequestId cancelled:NO];
+    } else {
+      [RCTInspectorNetworkReporter reportResponseEnd:task.devToolsRequestId encodedDataLength:data.length];
     }
     [strongSelf sendEventWithName:@"didCompleteNetworkResponse" body:responseJSON];
     [strongSelf->_tasksByRequestID removeObjectForKey:task.requestID];
@@ -723,12 +712,10 @@ RCT_EXPORT_MODULE()
     }
     _tasksByRequestID[task.requestID] = task;
     responseSender(@[ task.requestID ]);
-    if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
-      [RCTInspectorNetworkReporter reportRequestStart:task.devToolsRequestId
-                                              request:request
-                                    encodedDataLength:task.response.expectedContentLength];
-      [RCTInspectorNetworkReporter reportConnectionTiming:task.devToolsRequestId request:task.request];
-    }
+    [RCTInspectorNetworkReporter reportRequestStart:task.devToolsRequestId
+                                            request:request
+                                  encodedDataLength:task.response.expectedContentLength];
+    [RCTInspectorNetworkReporter reportConnectionTiming:task.devToolsRequestId request:task.request];
   }
 
   [task start];

--- a/packages/react-native/React/CoreModules/RCTInspectorWebSocketReporter.mm
+++ b/packages/react-native/React/CoreModules/RCTInspectorWebSocketReporter.mm
@@ -28,14 +28,14 @@ std::string toStdString(NSString *string)
 
 /**
  * Returns whether WebSocket events should be reported for the given request
- * ID. Reporting requires the `enableNetworkEventReporting` and
- * `fuseboxWebSocketEventsEnabled` feature flags, and a connected CDP debugger
- * with the Network domain enabled (dev or profiling builds only).
+ * ID. Reporting requires the `fuseboxWebSocketEventsEnabled` feature flag, and
+ * a connected CDP debugger with the Network domain enabled (dev or profiling
+ * builds only).
  */
 BOOL isReportingEnabled(NSString *requestId)
 {
-  return requestId != nil && ReactNativeFeatureFlags::enableNetworkEventReporting() &&
-      ReactNativeFeatureFlags::fuseboxWebSocketEventsEnabled() && NetworkReporter::getInstance().isDebuggingEnabled();
+  return requestId != nil && ReactNativeFeatureFlags::fuseboxWebSocketEventsEnabled() &&
+      NetworkReporter::getInstance().isDebuggingEnabled();
 }
 
 Headers convertNSDictionaryToHeaders(const NSDictionary<NSString *, NSString *> *headers)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<df3f81d0083a8ebe9d0fbcb86e652405>>
+ * @generated SignedSource<<c5ce707ba940ef24ca6c261fd9b2baf7>>
  */
 
 /**
@@ -265,12 +265,6 @@ public object ReactNativeFeatureFlags {
   public fun enableNativeCSSParsing(): Boolean = accessor.enableNativeCSSParsing()
 
   /**
-   * Enable network event reporting hooks in each native platform through `NetworkReporter` (Web Perf APIs + CDP). This flag should be combined with `fuseboxNetworkInspectionEnabled` to enable Network CDP debugging.
-   */
-  @JvmStatic
-  public fun enableNetworkEventReporting(): Boolean = accessor.enableNetworkEventReporting()
-
-  /**
    * Enables caching text layout artifacts for later reuse
    */
   @JvmStatic
@@ -379,19 +373,13 @@ public object ReactNativeFeatureFlags {
   public fun fuseboxFrameRecordingEnabled(): Boolean = accessor.fuseboxFrameRecordingEnabled()
 
   /**
-   * Enable network inspection support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
-   */
-  @JvmStatic
-  public fun fuseboxNetworkInspectionEnabled(): Boolean = accessor.fuseboxNetworkInspectionEnabled()
-
-  /**
    * Enable Page.captureScreenshot CDP method support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
    */
   @JvmStatic
   public fun fuseboxScreenshotCaptureEnabled(): Boolean = accessor.fuseboxScreenshotCaptureEnabled()
 
   /**
-   * Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend. Requires `fuseboxNetworkInspectionEnabled`.
+   * Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend.
    */
   @JvmStatic
   public fun fuseboxWebSocketEventsEnabled(): Boolean = accessor.fuseboxWebSocketEventsEnabled()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c31110405f1c9cd5ae0627fb114585a6>>
+ * @generated SignedSource<<628ede95c745280c1ceaa73c6dc45de0>>
  */
 
 /**
@@ -59,7 +59,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var enableModuleArgumentNSNullConversionIOSCache: Boolean? = null
   private var enableMutationObserverByDefaultCache: Boolean? = null
   private var enableNativeCSSParsingCache: Boolean? = null
-  private var enableNetworkEventReportingCache: Boolean? = null
   private var enablePreparedTextLayoutCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
   private var enableRuntimeSchedulerQueueClearingOnErrorCache: Boolean? = null
@@ -78,7 +77,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var fuseboxAssertSingleHostStateCache: Boolean? = null
   private var fuseboxEnabledReleaseCache: Boolean? = null
   private var fuseboxFrameRecordingEnabledCache: Boolean? = null
-  private var fuseboxNetworkInspectionEnabledCache: Boolean? = null
   private var fuseboxScreenshotCaptureEnabledCache: Boolean? = null
   private var fuseboxWebSocketEventsEnabledCache: Boolean? = null
   private var optimizedAnimatedPropUpdatesCache: Boolean? = null
@@ -459,15 +457,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     return cached
   }
 
-  override fun enableNetworkEventReporting(): Boolean {
-    var cached = enableNetworkEventReportingCache
-    if (cached == null) {
-      cached = ReactNativeFeatureFlagsCxxInterop.enableNetworkEventReporting()
-      enableNetworkEventReportingCache = cached
-    }
-    return cached
-  }
-
   override fun enablePreparedTextLayout(): Boolean {
     var cached = enablePreparedTextLayoutCache
     if (cached == null) {
@@ -626,15 +615,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.fuseboxFrameRecordingEnabled()
       fuseboxFrameRecordingEnabledCache = cached
-    }
-    return cached
-  }
-
-  override fun fuseboxNetworkInspectionEnabled(): Boolean {
-    var cached = fuseboxNetworkInspectionEnabledCache
-    if (cached == null) {
-      cached = ReactNativeFeatureFlagsCxxInterop.fuseboxNetworkInspectionEnabled()
-      fuseboxNetworkInspectionEnabledCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<87b76f5c2af82462dc66c7721cd66ac4>>
+ * @generated SignedSource<<6a0e60fe118f3651dc76c895a37fbce2>>
  */
 
 /**
@@ -106,8 +106,6 @@ public object ReactNativeFeatureFlagsCxxInterop {
 
   @DoNotStrip @JvmStatic public external fun enableNativeCSSParsing(): Boolean
 
-  @DoNotStrip @JvmStatic public external fun enableNetworkEventReporting(): Boolean
-
   @DoNotStrip @JvmStatic public external fun enablePreparedTextLayout(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enablePropsUpdateReconciliationAndroid(): Boolean
@@ -143,8 +141,6 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun fuseboxEnabledRelease(): Boolean
 
   @DoNotStrip @JvmStatic public external fun fuseboxFrameRecordingEnabled(): Boolean
-
-  @DoNotStrip @JvmStatic public external fun fuseboxNetworkInspectionEnabled(): Boolean
 
   @DoNotStrip @JvmStatic public external fun fuseboxScreenshotCaptureEnabled(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8a117541421f413e517e1be1acf8be7d>>
+ * @generated SignedSource<<37e483d52d12a735e646c8ac06acb62c>>
  */
 
 /**
@@ -101,8 +101,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableNativeCSSParsing(): Boolean = false
 
-  override fun enableNetworkEventReporting(): Boolean = true
-
   override fun enablePreparedTextLayout(): Boolean = false
 
   override fun enablePropsUpdateReconciliationAndroid(): Boolean = false
@@ -138,8 +136,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun fuseboxEnabledRelease(): Boolean = false
 
   override fun fuseboxFrameRecordingEnabled(): Boolean = false
-
-  override fun fuseboxNetworkInspectionEnabled(): Boolean = true
 
   override fun fuseboxScreenshotCaptureEnabled(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9a2806b3934d130010954a92a7b48e0f>>
+ * @generated SignedSource<<5b7a6ca47ca43f473596e35dfced16e0>>
  */
 
 /**
@@ -63,7 +63,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var enableModuleArgumentNSNullConversionIOSCache: Boolean? = null
   private var enableMutationObserverByDefaultCache: Boolean? = null
   private var enableNativeCSSParsingCache: Boolean? = null
-  private var enableNetworkEventReportingCache: Boolean? = null
   private var enablePreparedTextLayoutCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
   private var enableRuntimeSchedulerQueueClearingOnErrorCache: Boolean? = null
@@ -82,7 +81,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var fuseboxAssertSingleHostStateCache: Boolean? = null
   private var fuseboxEnabledReleaseCache: Boolean? = null
   private var fuseboxFrameRecordingEnabledCache: Boolean? = null
-  private var fuseboxNetworkInspectionEnabledCache: Boolean? = null
   private var fuseboxScreenshotCaptureEnabledCache: Boolean? = null
   private var fuseboxWebSocketEventsEnabledCache: Boolean? = null
   private var optimizedAnimatedPropUpdatesCache: Boolean? = null
@@ -502,16 +500,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
     return cached
   }
 
-  override fun enableNetworkEventReporting(): Boolean {
-    var cached = enableNetworkEventReportingCache
-    if (cached == null) {
-      cached = currentProvider.enableNetworkEventReporting()
-      accessedFeatureFlags.add("enableNetworkEventReporting")
-      enableNetworkEventReportingCache = cached
-    }
-    return cached
-  }
-
   override fun enablePreparedTextLayout(): Boolean {
     var cached = enablePreparedTextLayoutCache
     if (cached == null) {
@@ -688,16 +676,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.fuseboxFrameRecordingEnabled()
       accessedFeatureFlags.add("fuseboxFrameRecordingEnabled")
       fuseboxFrameRecordingEnabledCache = cached
-    }
-    return cached
-  }
-
-  override fun fuseboxNetworkInspectionEnabled(): Boolean {
-    var cached = fuseboxNetworkInspectionEnabledCache
-    if (cached == null) {
-      cached = currentProvider.fuseboxNetworkInspectionEnabled()
-      accessedFeatureFlags.add("fuseboxNetworkInspectionEnabled")
-      fuseboxNetworkInspectionEnabledCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<49c76b8072c1bd29135086c9e0a5da2f>>
+ * @generated SignedSource<<ee254c53ae1b4bc03045926028e898e5>>
  */
 
 /**
@@ -101,8 +101,6 @@ public interface ReactNativeFeatureFlagsProvider {
 
   @DoNotStrip public fun enableNativeCSSParsing(): Boolean
 
-  @DoNotStrip public fun enableNetworkEventReporting(): Boolean
-
   @DoNotStrip public fun enablePreparedTextLayout(): Boolean
 
   @DoNotStrip public fun enablePropsUpdateReconciliationAndroid(): Boolean
@@ -138,8 +136,6 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun fuseboxEnabledRelease(): Boolean
 
   @DoNotStrip public fun fuseboxFrameRecordingEnabled(): Boolean
-
-  @DoNotStrip public fun fuseboxNetworkInspectionEnabled(): Boolean
 
   @DoNotStrip public fun fuseboxScreenshotCaptureEnabled(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -15,7 +15,6 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableArray
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import java.io.IOException
 import java.net.SocketTimeoutException
 import okhttp3.Headers
@@ -39,17 +38,15 @@ internal object NetworkEventUtil {
       requestBodyForDevTools: String?,
       encodedDataLength: Long,
   ) {
-    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
-      InspectorNetworkReporter.reportRequestStart(
-          devToolsRequestId,
-          requestUrl,
-          requestMethod,
-          requestHeaders,
-          requestBodyForDevTools.orEmpty(),
-          encodedDataLength,
-      )
-      InspectorNetworkReporter.reportConnectionTiming(devToolsRequestId, requestHeaders)
-    }
+    InspectorNetworkReporter.reportRequestStart(
+        devToolsRequestId,
+        requestUrl,
+        requestMethod,
+        requestHeaders,
+        requestBodyForDevTools.orEmpty(),
+        encodedDataLength,
+    )
+    InspectorNetworkReporter.reportConnectionTiming(devToolsRequestId, requestHeaders)
   }
 
   @JvmStatic
@@ -78,7 +75,7 @@ internal object NetworkEventUtil {
       progress: Long,
       total: Long,
   ) {
-    if (ReactNativeFeatureFlags.enableNetworkEventReporting() && data != null) {
+    if (data != null) {
       InspectorNetworkReporter.reportDataReceived(devToolsRequestId, data)
       InspectorNetworkReporter.maybeStoreResponseBodyIncremental(devToolsRequestId, data)
     }
@@ -118,13 +115,11 @@ internal object NetworkEventUtil {
       data: String?,
       responseType: String,
   ) {
-    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
-      InspectorNetworkReporter.maybeStoreResponseBody(
-          devToolsRequestId,
-          data.orEmpty(),
-          responseType == "base64",
-      )
-    }
+    InspectorNetworkReporter.maybeStoreResponseBody(
+        devToolsRequestId,
+        data.orEmpty(),
+        responseType == "base64",
+    )
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkData",
         buildReadableArray {
@@ -142,13 +137,11 @@ internal object NetworkEventUtil {
       data: WritableMap,
       rawData: ByteArray,
   ) {
-    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
-      InspectorNetworkReporter.maybeStoreResponseBody(
-          devToolsRequestId,
-          Base64.encodeToString(rawData, Base64.NO_WRAP),
-          true,
-      )
-    }
+    InspectorNetworkReporter.maybeStoreResponseBody(
+        devToolsRequestId,
+        Base64.encodeToString(rawData, Base64.NO_WRAP),
+        true,
+    )
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkData",
         Arguments.createArray().apply {
@@ -166,9 +159,7 @@ internal object NetworkEventUtil {
       error: String?,
       e: Throwable?,
   ) {
-    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
-      InspectorNetworkReporter.reportRequestFailed(devToolsRequestId, false)
-    }
+    InspectorNetworkReporter.reportRequestFailed(devToolsRequestId, false)
     reactContext?.emitDeviceEvent(
         "didCompleteNetworkResponse",
         buildReadableArray {
@@ -188,9 +179,7 @@ internal object NetworkEventUtil {
       devToolsRequestId: String,
       encodedDataLength: Long,
   ) {
-    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
-      InspectorNetworkReporter.reportResponseEnd(devToolsRequestId, encodedDataLength)
-    }
+    InspectorNetworkReporter.reportResponseEnd(devToolsRequestId, encodedDataLength)
     reactContext?.emitDeviceEvent(
         "didCompleteNetworkResponse",
         buildReadableArray {
@@ -215,15 +204,13 @@ internal object NetworkEventUtil {
       headersBundle.putString(headerName, headerValue)
     }
 
-    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
-      InspectorNetworkReporter.reportResponseStart(
-          devToolsRequestId,
-          requestUrl.orEmpty(),
-          statusCode,
-          headers,
-          contentLength,
-      )
-    }
+    InspectorNetworkReporter.reportResponseStart(
+        devToolsRequestId,
+        requestUrl.orEmpty(),
+        statusCode,
+        headers,
+        contentLength,
+    )
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkResponse",
         Arguments.createArray().apply {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
@@ -69,8 +69,7 @@ public class WebSocketModule(context: ReactApplicationContext) :
 
   /** Whether WebSocket events should be reported to the modern debugger server. */
   private fun isInspectorNetworkReportingEnabled(): Boolean =
-      ReactNativeFeatureFlags.enableNetworkEventReporting() &&
-          ReactNativeFeatureFlags.fuseboxWebSocketEventsEnabled()
+      ReactNativeFeatureFlags.fuseboxWebSocketEventsEnabled()
 
   /**
    * Run [block] with the connection's CDP request ID, when WebSocket event reporting to the modern

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<42f1901c8b7cb568cc761a791991a333>>
+ * @generated SignedSource<<41ff49e9305aa1ff144582dfcac650d0>>
  */
 
 /**
@@ -273,12 +273,6 @@ class ReactNativeFeatureFlagsJavaProvider
     return method(javaProvider_);
   }
 
-  bool enableNetworkEventReporting() override {
-    static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableNetworkEventReporting");
-    return method(javaProvider_);
-  }
-
   bool enablePreparedTextLayout() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enablePreparedTextLayout");
@@ -384,12 +378,6 @@ class ReactNativeFeatureFlagsJavaProvider
   bool fuseboxFrameRecordingEnabled() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("fuseboxFrameRecordingEnabled");
-    return method(javaProvider_);
-  }
-
-  bool fuseboxNetworkInspectionEnabled() override {
-    static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("fuseboxNetworkInspectionEnabled");
     return method(javaProvider_);
   }
 
@@ -760,11 +748,6 @@ bool JReactNativeFeatureFlagsCxxInterop::enableNativeCSSParsing(
   return ReactNativeFeatureFlags::enableNativeCSSParsing();
 }
 
-bool JReactNativeFeatureFlagsCxxInterop::enableNetworkEventReporting(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
-  return ReactNativeFeatureFlags::enableNetworkEventReporting();
-}
-
 bool JReactNativeFeatureFlagsCxxInterop::enablePreparedTextLayout(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::enablePreparedTextLayout();
@@ -853,11 +836,6 @@ bool JReactNativeFeatureFlagsCxxInterop::fuseboxEnabledRelease(
 bool JReactNativeFeatureFlagsCxxInterop::fuseboxFrameRecordingEnabled(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::fuseboxFrameRecordingEnabled();
-}
-
-bool JReactNativeFeatureFlagsCxxInterop::fuseboxNetworkInspectionEnabled(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
-  return ReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled();
 }
 
 bool JReactNativeFeatureFlagsCxxInterop::fuseboxScreenshotCaptureEnabled(
@@ -1149,9 +1127,6 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
         "enableNativeCSSParsing",
         JReactNativeFeatureFlagsCxxInterop::enableNativeCSSParsing),
       makeNativeMethod(
-        "enableNetworkEventReporting",
-        JReactNativeFeatureFlagsCxxInterop::enableNetworkEventReporting),
-      makeNativeMethod(
         "enablePreparedTextLayout",
         JReactNativeFeatureFlagsCxxInterop::enablePreparedTextLayout),
       makeNativeMethod(
@@ -1205,9 +1180,6 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "fuseboxFrameRecordingEnabled",
         JReactNativeFeatureFlagsCxxInterop::fuseboxFrameRecordingEnabled),
-      makeNativeMethod(
-        "fuseboxNetworkInspectionEnabled",
-        JReactNativeFeatureFlagsCxxInterop::fuseboxNetworkInspectionEnabled),
       makeNativeMethod(
         "fuseboxScreenshotCaptureEnabled",
         JReactNativeFeatureFlagsCxxInterop::fuseboxScreenshotCaptureEnabled),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9967d87b794ba46797ed78a845683dc7>>
+ * @generated SignedSource<<9c5bd61122f068c919c70399828585d1>>
  */
 
 /**
@@ -147,9 +147,6 @@ class JReactNativeFeatureFlagsCxxInterop
   static bool enableNativeCSSParsing(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
-  static bool enableNetworkEventReporting(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
-
   static bool enablePreparedTextLayout(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
@@ -202,9 +199,6 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool fuseboxFrameRecordingEnabled(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
-
-  static bool fuseboxNetworkInspectionEnabled(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool fuseboxScreenshotCaptureEnabled(

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
@@ -13,17 +13,15 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsDefaults
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.testutils.shadows.ShadowArguments
+import com.facebook.testutils.shadows.ShadowInspectorNetworkReporter
+import com.facebook.testutils.shadows.ShadowSoLoader
 import java.io.ByteArrayInputStream
 import java.net.SocketTimeoutException
 import okhttp3.MediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,7 +33,9 @@ import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
-@Config(shadows = [ShadowArguments::class])
+@Config(
+    shadows = [ShadowArguments::class, ShadowSoLoader::class, ShadowInspectorNetworkReporter::class]
+)
 @RunWith(RobolectricTestRunner::class)
 class NetworkEventUtilTest {
   private lateinit var reactContext: ReactApplicationContext
@@ -43,18 +43,6 @@ class NetworkEventUtilTest {
   @Before
   fun setUp() {
     reactContext = mock()
-
-    ReactNativeFeatureFlagsForTests.setUp()
-    ReactNativeFeatureFlags.override(
-        object : ReactNativeFeatureFlagsDefaults() {
-          override fun enableNetworkEventReporting(): Boolean = false
-        }
-    )
-  }
-
-  @After
-  fun tearDown() {
-    ReactNativeFeatureFlags.dangerouslyReset()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.kt
@@ -17,10 +17,9 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.network.OkHttpCallUtil
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsDefaults
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.testutils.shadows.ShadowArguments
+import com.facebook.testutils.shadows.ShadowInspectorNetworkReporter
+import com.facebook.testutils.shadows.ShadowSoLoader
 import java.io.IOException
 import java.io.InputStream
 import java.nio.charset.StandardCharsets
@@ -54,7 +53,9 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /** Tests [NetworkingModule] */
-@Config(shadows = [ShadowArguments::class])
+@Config(
+    shadows = [ShadowArguments::class, ShadowSoLoader::class, ShadowInspectorNetworkReporter::class]
+)
 @RunWith(RobolectricTestRunner::class)
 class NetworkingModuleTest {
 
@@ -77,13 +78,6 @@ class NetworkingModuleTest {
 
     context = mock()
     whenever(context.hasActiveReactInstance()).thenReturn(true)
-
-    ReactNativeFeatureFlagsForTests.setUp()
-    ReactNativeFeatureFlags.override(
-        object : ReactNativeFeatureFlagsDefaults() {
-          override fun enableNetworkEventReporting(): Boolean = false
-        }
-    )
 
     networkingModule = NetworkingModule(context, "", httpClient, null)
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowInspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowInspectorNetworkReporter.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.testutils.shadows
+
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+/**
+ * Robolectric shadow that stubs out `InspectorNetworkReporter`'s JNI methods, so that tests
+ * exercising `NetworkEventUtil` do not attempt to call into the `react_devsupportjni` native
+ * library. `isDebuggingEnabled` returns `false`, which also short-circuits the reporting wrappers
+ * that guard on it (e.g. `reportDataReceived`, `maybeStoreResponseBody`).
+ */
+@Suppress("UNUSED_PARAMETER")
+@Implements(className = "com.facebook.react.modules.network.InspectorNetworkReporter")
+class ShadowInspectorNetworkReporter {
+  companion object {
+    @JvmStatic @Implementation fun isDebuggingEnabled(): Boolean = false
+
+    @JvmStatic
+    @Implementation
+    fun reportRequestStart(
+        requestId: String,
+        requestUrl: String,
+        requestMethod: String,
+        requestHeaders: Map<String, String>,
+        requestBody: String,
+        encodedDataLength: Long,
+    ) {}
+
+    @JvmStatic
+    @Implementation
+    fun reportConnectionTiming(requestId: String, headers: Map<String, String>) {}
+
+    @JvmStatic
+    @Implementation
+    fun reportResponseStart(
+        requestId: String,
+        requestUrl: String,
+        responseStatus: Int,
+        responseHeaders: Map<String, String>,
+        expectedDataLength: Long,
+    ) {}
+
+    @JvmStatic @Implementation fun reportResponseEnd(requestId: String, encodedDataLength: Long) {}
+
+    @JvmStatic @Implementation fun reportRequestFailed(requestId: String, cancelled: Boolean) {}
+  }
+}

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -148,36 +148,34 @@ class HostAgent::Impl final {
           .shouldSendOKResponse = true,
       };
     }
-    if (InspectorFlags::getInstance().getNetworkInspectionEnabled()) {
-      if (req.method == "Network.enable") {
-        auto& inspector = getInspectorInstance();
-        if (inspector.getSystemState().registeredHostsCount > 1) {
-          frontendChannel_(
-              cdp::jsonError(
-                  req.id,
-                  cdp::ErrorCode::InternalError,
-                  "The Network domain is unavailable when multiple React Native hosts are registered."));
-          return {
-              .isFinishedHandlingRequest = true,
-              .shouldSendOKResponse = false,
-          };
-        }
-
-        sessionState_.isNetworkDomainEnabled = true;
-
+    if (req.method == "Network.enable") {
+      auto& inspector = getInspectorInstance();
+      if (inspector.getSystemState().registeredHostsCount > 1) {
+        frontendChannel_(
+            cdp::jsonError(
+                req.id,
+                cdp::ErrorCode::InternalError,
+                "The Network domain is unavailable when multiple React Native hosts are registered."));
         return {
-            .isFinishedHandlingRequest = false,
-            .shouldSendOKResponse = true,
+            .isFinishedHandlingRequest = true,
+            .shouldSendOKResponse = false,
         };
       }
-      if (req.method == "Network.disable") {
-        sessionState_.isNetworkDomainEnabled = false;
 
-        return {
-            .isFinishedHandlingRequest = false,
-            .shouldSendOKResponse = true,
-        };
-      }
+      sessionState_.isNetworkDomainEnabled = true;
+
+      return {
+          .isFinishedHandlingRequest = false,
+          .shouldSendOKResponse = true,
+      };
+    }
+    if (req.method == "Network.disable") {
+      sessionState_.isNetworkDomainEnabled = false;
+
+      return {
+          .isFinishedHandlingRequest = false,
+          .shouldSendOKResponse = true,
+      };
     }
 
     // Methods other than domain enables/disables: handle anything we know how

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -336,7 +336,7 @@ StaticHostTargetMetadata getStaticHostMetadata() {
 
   return {
       .isProfilingBuild = inspectorFlags.getIsProfilingBuild(),
-      .networkInspectionEnabled = inspectorFlags.getNetworkInspectionEnabled(),
+      .networkInspectionEnabled = true,
       .frameRecordingEnabled = inspectorFlags.getFrameRecordingEnabled()};
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -41,10 +41,6 @@ bool InspectorFlags::getIsProfilingBuild() const {
   return loadFlagsAndAssertUnchanged().isProfilingBuild;
 }
 
-bool InspectorFlags::getNetworkInspectionEnabled() const {
-  return loadFlagsAndAssertUnchanged().networkInspectionEnabled;
-}
-
 bool InspectorFlags::getPerfIssuesEnabled() const {
   return loadFlagsAndAssertUnchanged().perfIssuesEnabled;
 }
@@ -81,8 +77,6 @@ const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
 #else
           false,
 #endif
-      .networkInspectionEnabled =
-          ReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled(),
       .perfIssuesEnabled = ReactNativeFeatureFlags::perfIssuesEnabled(),
   };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -51,11 +51,6 @@ class InspectorFlags {
   bool getFrameRecordingEnabled() const;
 
   /**
-   * Flag determining if network inspection is enabled.
-   */
-  bool getNetworkInspectionEnabled() const;
-
-  /**
    * Flag determining if the V2 in-app Performance Monitor is enabled.
    */
   bool getPerfIssuesEnabled() const;
@@ -79,7 +74,6 @@ class InspectorFlags {
     bool frameRecordingEnabled;
     bool fuseboxEnabled;
     bool isProfilingBuild;
-    bool networkInspectionEnabled;
     bool perfIssuesEnabled;
     bool operator==(const Values &) const = default;
   };

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -280,31 +280,29 @@ bool NetworkIOAgent::handleRequest(
     return true;
   }
 
-  if (InspectorFlags::getInstance().getNetworkInspectionEnabled()) {
-    auto& networkHandler = NetworkHandler::getInstance();
+  auto& networkHandler = NetworkHandler::getInstance();
 
-    // @cdp Network.enable support is experimental.
-    if (req.method == "Network.enable") {
-      networkAgentId_ = networkHandler.enableAgent(frontendChannel_);
-      // NOTE: Domain enable/disable responses are sent by HostAgent.
-      return false;
-    }
+  // @cdp Network.enable support is experimental.
+  if (req.method == "Network.enable") {
+    networkAgentId_ = networkHandler.enableAgent(frontendChannel_);
+    // NOTE: Domain enable/disable responses are sent by HostAgent.
+    return false;
+  }
 
-    // @cdp Network.disable support is experimental.
-    if (req.method == "Network.disable") {
-      if (networkAgentId_) {
-        networkHandler.disableAgent(*networkAgentId_);
-        networkAgentId_ = std::nullopt;
-      }
-      // NOTE: Domain enable/disable responses are sent by HostAgent.
-      return false;
+  // @cdp Network.disable support is experimental.
+  if (req.method == "Network.disable") {
+    if (networkAgentId_) {
+      networkHandler.disableAgent(*networkAgentId_);
+      networkAgentId_ = std::nullopt;
     }
+    // NOTE: Domain enable/disable responses are sent by HostAgent.
+    return false;
+  }
 
-    // @cdp Network.getResponseBody support is experimental.
-    if (req.method == "Network.getResponseBody") {
-      handleGetResponseBody(req);
-      return true;
-    }
+  // @cdp Network.getResponseBody support is experimental.
+  if (req.method == "Network.getResponseBody") {
+    handleGetResponseBody(req);
+    return true;
   }
 
   return false;

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetNetwork.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetNetwork.cpp
@@ -41,9 +41,6 @@ Object objectFreeze(Runtime& runtime, Object object) {
 } // namespace
 
 void RuntimeTarget::installNetworkReporterAPI() {
-  if (!InspectorFlags::getInstance().getNetworkInspectionEnabled()) {
-    return;
-  }
   auto jsiCreateDevToolsRequestId = [selfWeak = weak_from_this()](
                                         Runtime& runtime,
                                         const Value& /*thisVal*/,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkReporterTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkReporterTest.cpp
@@ -19,9 +19,7 @@ namespace facebook::react::jsinspector_modern {
 
 namespace {
 
-struct NetworkReporterTestParams {
-  bool enableNetworkEventReporting;
-};
+struct NetworkReporterTestParams {};
 
 } // namespace
 
@@ -36,13 +34,7 @@ class NetworkReporterTestBase : public TracingTestBase<
                                     folly::QueuedImmediateExecutor>,
                                 public WithParamInterface<Params> {
  protected:
-  NetworkReporterTestBase()
-      : TracingTestBase({
-            .enableNetworkEventReporting =
-                WithParamInterface<Params>::GetParam()
-                    .enableNetworkEventReporting,
-            .networkInspectionEnabled = true,
-        }) {}
+  NetworkReporterTestBase() : TracingTestBase(InspectorFlagOverrides{}) {}
 
   void SetUp() override {
     JsiIntegrationPortableTestBase::SetUp();
@@ -803,13 +795,10 @@ TEST_P(NetworkReporterTest, testTwoSessionsReceiveNetworkEvents) {
 }
 
 struct NetworkReporterTracingTestParams {
-  bool enableNetworkEventReporting;
   bool enableNetworkDomain;
 
   operator NetworkReporterTestParams() const {
-    return NetworkReporterTestParams{
-        .enableNetworkEventReporting = enableNetworkEventReporting,
-    };
+    return NetworkReporterTestParams{};
   }
 };
 
@@ -982,19 +971,12 @@ TEST_P(
           AtJsonPtr("/args/data/didFail", false))));
 }
 
-static const auto networkReporterTestParamValues = testing::Values(
-    NetworkReporterTestParams{.enableNetworkEventReporting = true},
-    NetworkReporterTestParams{
-        .enableNetworkEventReporting = false,
-    });
+static const auto networkReporterTestParamValues =
+    testing::Values(NetworkReporterTestParams{});
 
 static const auto networkReporterTracingTestParamValues = testing::Values(
-    NetworkReporterTracingTestParams{
-        .enableNetworkEventReporting = true,
-        .enableNetworkDomain = true},
-    NetworkReporterTracingTestParams{
-        .enableNetworkEventReporting = true,
-        .enableNetworkDomain = false});
+    NetworkReporterTracingTestParams{.enableNetworkDomain = true},
+    NetworkReporterTracingTestParams{.enableNetworkDomain = false});
 
 INSTANTIATE_TEST_SUITE_P(
     NetworkReporterTest,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.cpp
@@ -41,16 +41,6 @@ class ReactNativeFeatureFlagsOverrides
         ReactNativeFeatureFlagsDefaults::fuseboxFrameRecordingEnabled());
   }
 
-  bool fuseboxNetworkInspectionEnabled() override {
-    return overrides_.networkInspectionEnabled.value_or(
-        ReactNativeFeatureFlagsDefaults::fuseboxNetworkInspectionEnabled());
-  }
-
-  bool enableNetworkEventReporting() override {
-    return overrides_.enableNetworkEventReporting.value_or(
-        ReactNativeFeatureFlagsDefaults::enableNetworkEventReporting());
-  }
-
  private:
   InspectorFlagOverrides overrides_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
@@ -20,10 +20,8 @@ struct InspectorFlagOverrides {
   // NOTE: Keep these entries in sync with ReactNativeFeatureFlagsOverrides in
   // the implementation file.
   std::optional<bool> screenshotCaptureEnabled;
-  std::optional<bool> enableNetworkEventReporting;
   std::optional<bool> frameRecordingEnabled;
   std::optional<bool> fuseboxEnabledRelease;
-  std::optional<bool> networkInspectionEnabled;
 };
 
 /**

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6f2362e9844cab731ca01e4af563fde9>>
+ * @generated SignedSource<<77401595559dc52e1b2b206527deb341>>
  */
 
 /**
@@ -182,10 +182,6 @@ bool ReactNativeFeatureFlags::enableNativeCSSParsing() {
   return getAccessor().enableNativeCSSParsing();
 }
 
-bool ReactNativeFeatureFlags::enableNetworkEventReporting() {
-  return getAccessor().enableNetworkEventReporting();
-}
-
 bool ReactNativeFeatureFlags::enablePreparedTextLayout() {
   return getAccessor().enablePreparedTextLayout();
 }
@@ -256,10 +252,6 @@ bool ReactNativeFeatureFlags::fuseboxEnabledRelease() {
 
 bool ReactNativeFeatureFlags::fuseboxFrameRecordingEnabled() {
   return getAccessor().fuseboxFrameRecordingEnabled();
-}
-
-bool ReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled() {
-  return getAccessor().fuseboxNetworkInspectionEnabled();
 }
 
 bool ReactNativeFeatureFlags::fuseboxScreenshotCaptureEnabled() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f871b2203c86dd7f25640cd3a6ea7d00>>
+ * @generated SignedSource<<df8968adcf11283d6745bb2e0f5f7a5b>>
  */
 
 /**
@@ -235,11 +235,6 @@ class ReactNativeFeatureFlags {
   RN_EXPORT static bool enableNativeCSSParsing();
 
   /**
-   * Enable network event reporting hooks in each native platform through `NetworkReporter` (Web Perf APIs + CDP). This flag should be combined with `fuseboxNetworkInspectionEnabled` to enable Network CDP debugging.
-   */
-  RN_EXPORT static bool enableNetworkEventReporting();
-
-  /**
    * Enables caching text layout artifacts for later reuse
    */
   RN_EXPORT static bool enablePreparedTextLayout();
@@ -330,17 +325,12 @@ class ReactNativeFeatureFlags {
   RN_EXPORT static bool fuseboxFrameRecordingEnabled();
 
   /**
-   * Enable network inspection support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
-   */
-  RN_EXPORT static bool fuseboxNetworkInspectionEnabled();
-
-  /**
    * Enable Page.captureScreenshot CDP method support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
    */
   RN_EXPORT static bool fuseboxScreenshotCaptureEnabled();
 
   /**
-   * Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend. Requires `fuseboxNetworkInspectionEnabled`.
+   * Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend.
    */
   RN_EXPORT static bool fuseboxWebSocketEventsEnabled();
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4c6a965958d151f22574bc85a6714c11>>
+ * @generated SignedSource<<4b3689511d39c0ba8e1d78f34df7d348>>
  */
 
 /**
@@ -731,24 +731,6 @@ bool ReactNativeFeatureFlagsAccessor::enableNativeCSSParsing() {
   return flagValue.value();
 }
 
-bool ReactNativeFeatureFlagsAccessor::enableNetworkEventReporting() {
-  auto flagValue = enableNetworkEventReporting_.load();
-
-  if (!flagValue.has_value()) {
-    // This block is not exclusive but it is not necessary.
-    // If multiple threads try to initialize the feature flag, we would only
-    // be accessing the provider multiple times but the end state of this
-    // instance and the returned flag value would be the same.
-
-    markFlagAsAccessed(39, "enableNetworkEventReporting");
-
-    flagValue = currentProvider_->enableNetworkEventReporting();
-    enableNetworkEventReporting_ = flagValue;
-  }
-
-  return flagValue.value();
-}
-
 bool ReactNativeFeatureFlagsAccessor::enablePreparedTextLayout() {
   auto flagValue = enablePreparedTextLayout_.load();
 
@@ -758,7 +740,7 @@ bool ReactNativeFeatureFlagsAccessor::enablePreparedTextLayout() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(40, "enablePreparedTextLayout");
+    markFlagAsAccessed(39, "enablePreparedTextLayout");
 
     flagValue = currentProvider_->enablePreparedTextLayout();
     enablePreparedTextLayout_ = flagValue;
@@ -776,7 +758,7 @@ bool ReactNativeFeatureFlagsAccessor::enablePropsUpdateReconciliationAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(41, "enablePropsUpdateReconciliationAndroid");
+    markFlagAsAccessed(40, "enablePropsUpdateReconciliationAndroid");
 
     flagValue = currentProvider_->enablePropsUpdateReconciliationAndroid();
     enablePropsUpdateReconciliationAndroid_ = flagValue;
@@ -794,7 +776,7 @@ bool ReactNativeFeatureFlagsAccessor::enableRuntimeSchedulerQueueClearingOnError
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(42, "enableRuntimeSchedulerQueueClearingOnError");
+    markFlagAsAccessed(41, "enableRuntimeSchedulerQueueClearingOnError");
 
     flagValue = currentProvider_->enableRuntimeSchedulerQueueClearingOnError();
     enableRuntimeSchedulerQueueClearingOnError_ = flagValue;
@@ -812,7 +794,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSchedulerDelegateInvalidation() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(43, "enableSchedulerDelegateInvalidation");
+    markFlagAsAccessed(42, "enableSchedulerDelegateInvalidation");
 
     flagValue = currentProvider_->enableSchedulerDelegateInvalidation();
     enableSchedulerDelegateInvalidation_ = flagValue;
@@ -830,7 +812,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSwiftUIBasedFilters() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(44, "enableSwiftUIBasedFilters");
+    markFlagAsAccessed(43, "enableSwiftUIBasedFilters");
 
     flagValue = currentProvider_->enableSwiftUIBasedFilters();
     enableSwiftUIBasedFilters_ = flagValue;
@@ -848,7 +830,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewCulling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(45, "enableViewCulling");
+    markFlagAsAccessed(44, "enableViewCulling");
 
     flagValue = currentProvider_->enableViewCulling();
     enableViewCulling_ = flagValue;
@@ -866,7 +848,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecycling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(46, "enableViewRecycling");
+    markFlagAsAccessed(45, "enableViewRecycling");
 
     flagValue = currentProvider_->enableViewRecycling();
     enableViewRecycling_ = flagValue;
@@ -884,7 +866,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForImage() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(47, "enableViewRecyclingForImage");
+    markFlagAsAccessed(46, "enableViewRecyclingForImage");
 
     flagValue = currentProvider_->enableViewRecyclingForImage();
     enableViewRecyclingForImage_ = flagValue;
@@ -902,7 +884,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForScrollView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(48, "enableViewRecyclingForScrollView");
+    markFlagAsAccessed(47, "enableViewRecyclingForScrollView");
 
     flagValue = currentProvider_->enableViewRecyclingForScrollView();
     enableViewRecyclingForScrollView_ = flagValue;
@@ -920,7 +902,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForText() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(49, "enableViewRecyclingForText");
+    markFlagAsAccessed(48, "enableViewRecyclingForText");
 
     flagValue = currentProvider_->enableViewRecyclingForText();
     enableViewRecyclingForText_ = flagValue;
@@ -938,7 +920,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(50, "enableViewRecyclingForView");
+    markFlagAsAccessed(49, "enableViewRecyclingForView");
 
     flagValue = currentProvider_->enableViewRecyclingForView();
     enableViewRecyclingForView_ = flagValue;
@@ -956,7 +938,7 @@ bool ReactNativeFeatureFlagsAccessor::enableVirtualViewContainerStateExperimenta
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(51, "enableVirtualViewContainerStateExperimental");
+    markFlagAsAccessed(50, "enableVirtualViewContainerStateExperimental");
 
     flagValue = currentProvider_->enableVirtualViewContainerStateExperimental();
     enableVirtualViewContainerStateExperimental_ = flagValue;
@@ -974,7 +956,7 @@ bool ReactNativeFeatureFlagsAccessor::fixDifferentiatorParentTagForUnflattenCase
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(52, "fixDifferentiatorParentTagForUnflattenCase");
+    markFlagAsAccessed(51, "fixDifferentiatorParentTagForUnflattenCase");
 
     flagValue = currentProvider_->fixDifferentiatorParentTagForUnflattenCase();
     fixDifferentiatorParentTagForUnflattenCase_ = flagValue;
@@ -992,7 +974,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMappingOfEventPrioritiesBetweenFabricAn
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(53, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
+    markFlagAsAccessed(52, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
 
     flagValue = currentProvider_->fixMappingOfEventPrioritiesBetweenFabricAndReact();
     fixMappingOfEventPrioritiesBetweenFabricAndReact_ = flagValue;
@@ -1010,7 +992,7 @@ bool ReactNativeFeatureFlagsAccessor::fixYogaFlexBasisFitContentInMainAxis() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(54, "fixYogaFlexBasisFitContentInMainAxis");
+    markFlagAsAccessed(53, "fixYogaFlexBasisFitContentInMainAxis");
 
     flagValue = currentProvider_->fixYogaFlexBasisFitContentInMainAxis();
     fixYogaFlexBasisFitContentInMainAxis_ = flagValue;
@@ -1028,7 +1010,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxAssertSingleHostState() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(55, "fuseboxAssertSingleHostState");
+    markFlagAsAccessed(54, "fuseboxAssertSingleHostState");
 
     flagValue = currentProvider_->fuseboxAssertSingleHostState();
     fuseboxAssertSingleHostState_ = flagValue;
@@ -1046,7 +1028,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxEnabledRelease() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(56, "fuseboxEnabledRelease");
+    markFlagAsAccessed(55, "fuseboxEnabledRelease");
 
     flagValue = currentProvider_->fuseboxEnabledRelease();
     fuseboxEnabledRelease_ = flagValue;
@@ -1064,28 +1046,10 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxFrameRecordingEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(57, "fuseboxFrameRecordingEnabled");
+    markFlagAsAccessed(56, "fuseboxFrameRecordingEnabled");
 
     flagValue = currentProvider_->fuseboxFrameRecordingEnabled();
     fuseboxFrameRecordingEnabled_ = flagValue;
-  }
-
-  return flagValue.value();
-}
-
-bool ReactNativeFeatureFlagsAccessor::fuseboxNetworkInspectionEnabled() {
-  auto flagValue = fuseboxNetworkInspectionEnabled_.load();
-
-  if (!flagValue.has_value()) {
-    // This block is not exclusive but it is not necessary.
-    // If multiple threads try to initialize the feature flag, we would only
-    // be accessing the provider multiple times but the end state of this
-    // instance and the returned flag value would be the same.
-
-    markFlagAsAccessed(58, "fuseboxNetworkInspectionEnabled");
-
-    flagValue = currentProvider_->fuseboxNetworkInspectionEnabled();
-    fuseboxNetworkInspectionEnabled_ = flagValue;
   }
 
   return flagValue.value();
@@ -1100,7 +1064,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxScreenshotCaptureEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(59, "fuseboxScreenshotCaptureEnabled");
+    markFlagAsAccessed(57, "fuseboxScreenshotCaptureEnabled");
 
     flagValue = currentProvider_->fuseboxScreenshotCaptureEnabled();
     fuseboxScreenshotCaptureEnabled_ = flagValue;
@@ -1118,7 +1082,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxWebSocketEventsEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(60, "fuseboxWebSocketEventsEnabled");
+    markFlagAsAccessed(58, "fuseboxWebSocketEventsEnabled");
 
     flagValue = currentProvider_->fuseboxWebSocketEventsEnabled();
     fuseboxWebSocketEventsEnabled_ = flagValue;
@@ -1136,7 +1100,7 @@ bool ReactNativeFeatureFlagsAccessor::optimizedAnimatedPropUpdates() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(61, "optimizedAnimatedPropUpdates");
+    markFlagAsAccessed(59, "optimizedAnimatedPropUpdates");
 
     flagValue = currentProvider_->optimizedAnimatedPropUpdates();
     optimizedAnimatedPropUpdates_ = flagValue;
@@ -1154,7 +1118,7 @@ bool ReactNativeFeatureFlagsAccessor::overrideBySynchronousMountPropsAtMountingA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(62, "overrideBySynchronousMountPropsAtMountingAndroid");
+    markFlagAsAccessed(60, "overrideBySynchronousMountPropsAtMountingAndroid");
 
     flagValue = currentProvider_->overrideBySynchronousMountPropsAtMountingAndroid();
     overrideBySynchronousMountPropsAtMountingAndroid_ = flagValue;
@@ -1172,7 +1136,7 @@ bool ReactNativeFeatureFlagsAccessor::perfIssuesEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(63, "perfIssuesEnabled");
+    markFlagAsAccessed(61, "perfIssuesEnabled");
 
     flagValue = currentProvider_->perfIssuesEnabled();
     perfIssuesEnabled_ = flagValue;
@@ -1190,7 +1154,7 @@ bool ReactNativeFeatureFlagsAccessor::perfMonitorV2Enabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(64, "perfMonitorV2Enabled");
+    markFlagAsAccessed(62, "perfMonitorV2Enabled");
 
     flagValue = currentProvider_->perfMonitorV2Enabled();
     perfMonitorV2Enabled_ = flagValue;
@@ -1208,7 +1172,7 @@ double ReactNativeFeatureFlagsAccessor::preparedTextCacheSize() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(65, "preparedTextCacheSize");
+    markFlagAsAccessed(63, "preparedTextCacheSize");
 
     flagValue = currentProvider_->preparedTextCacheSize();
     preparedTextCacheSize_ = flagValue;
@@ -1226,7 +1190,7 @@ bool ReactNativeFeatureFlagsAccessor::preventShadowTreeCommitExhaustion() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(66, "preventShadowTreeCommitExhaustion");
+    markFlagAsAccessed(64, "preventShadowTreeCommitExhaustion");
 
     flagValue = currentProvider_->preventShadowTreeCommitExhaustion();
     preventShadowTreeCommitExhaustion_ = flagValue;
@@ -1244,7 +1208,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2Android() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(67, "redBoxV2Android");
+    markFlagAsAccessed(65, "redBoxV2Android");
 
     flagValue = currentProvider_->redBoxV2Android();
     redBoxV2Android_ = flagValue;
@@ -1262,7 +1226,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2IOS() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(68, "redBoxV2IOS");
+    markFlagAsAccessed(66, "redBoxV2IOS");
 
     flagValue = currentProvider_->redBoxV2IOS();
     redBoxV2IOS_ = flagValue;
@@ -1280,7 +1244,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldPressibilityUseW3CPointerEventsForHo
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(69, "shouldPressibilityUseW3CPointerEventsForHover");
+    markFlagAsAccessed(67, "shouldPressibilityUseW3CPointerEventsForHover");
 
     flagValue = currentProvider_->shouldPressibilityUseW3CPointerEventsForHover();
     shouldPressibilityUseW3CPointerEventsForHover_ = flagValue;
@@ -1298,7 +1262,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldTriggerResponderTransferOnScrollAndr
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(70, "shouldTriggerResponderTransferOnScrollAndroid");
+    markFlagAsAccessed(68, "shouldTriggerResponderTransferOnScrollAndroid");
 
     flagValue = currentProvider_->shouldTriggerResponderTransferOnScrollAndroid();
     shouldTriggerResponderTransferOnScrollAndroid_ = flagValue;
@@ -1316,7 +1280,7 @@ bool ReactNativeFeatureFlagsAccessor::skipActivityIdentityAssertionOnHostPause()
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(71, "skipActivityIdentityAssertionOnHostPause");
+    markFlagAsAccessed(69, "skipActivityIdentityAssertionOnHostPause");
 
     flagValue = currentProvider_->skipActivityIdentityAssertionOnHostPause();
     skipActivityIdentityAssertionOnHostPause_ = flagValue;
@@ -1334,7 +1298,7 @@ bool ReactNativeFeatureFlagsAccessor::syncAndroidClipBoundsWithOverflow() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(72, "syncAndroidClipBoundsWithOverflow");
+    markFlagAsAccessed(70, "syncAndroidClipBoundsWithOverflow");
 
     flagValue = currentProvider_->syncAndroidClipBoundsWithOverflow();
     syncAndroidClipBoundsWithOverflow_ = flagValue;
@@ -1352,7 +1316,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(73, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(71, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -1370,7 +1334,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommit(
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(74, "updateRuntimeShadowNodeReferencesOnCommit");
+    markFlagAsAccessed(72, "updateRuntimeShadowNodeReferencesOnCommit");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommit();
     updateRuntimeShadowNodeReferencesOnCommit_ = flagValue;
@@ -1388,7 +1352,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommitT
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(75, "updateRuntimeShadowNodeReferencesOnCommitThread");
+    markFlagAsAccessed(73, "updateRuntimeShadowNodeReferencesOnCommitThread");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommitThread();
     updateRuntimeShadowNodeReferencesOnCommitThread_ = flagValue;
@@ -1406,7 +1370,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(76, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(74, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -1424,7 +1388,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(77, "useFabricInterop");
+    markFlagAsAccessed(75, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -1442,7 +1406,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(78, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(76, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -1460,7 +1424,7 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(79, "useNestedScrollViewAndroid");
+    markFlagAsAccessed(77, "useNestedScrollViewAndroid");
 
     flagValue = currentProvider_->useNestedScrollViewAndroid();
     useNestedScrollViewAndroid_ = flagValue;
@@ -1478,7 +1442,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(80, "useSharedAnimatedBackend");
+    markFlagAsAccessed(78, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1496,7 +1460,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(79, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1514,7 +1478,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "useTurboModuleInterop");
+    markFlagAsAccessed(80, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1532,7 +1496,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "viewCullingOutsetRatio");
+    markFlagAsAccessed(81, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1550,7 +1514,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "viewTransitionEnabled");
+    markFlagAsAccessed(82, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1568,7 +1532,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionUseHardwareBitmapAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "viewTransitionUseHardwareBitmapAndroid");
+    markFlagAsAccessed(83, "viewTransitionUseHardwareBitmapAndroid");
 
     flagValue = currentProvider_->viewTransitionUseHardwareBitmapAndroid();
     viewTransitionUseHardwareBitmapAndroid_ = flagValue;
@@ -1586,7 +1550,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(84, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b7bbe7f2fe25baf5528263c4b02c3c6d>>
+ * @generated SignedSource<<bd4719f8224fbe4fa9462da503b09894>>
  */
 
 /**
@@ -71,7 +71,6 @@ class ReactNativeFeatureFlagsAccessor {
   bool enableModuleArgumentNSNullConversionIOS();
   bool enableMutationObserverByDefault();
   bool enableNativeCSSParsing();
-  bool enableNetworkEventReporting();
   bool enablePreparedTextLayout();
   bool enablePropsUpdateReconciliationAndroid();
   bool enableRuntimeSchedulerQueueClearingOnError();
@@ -90,7 +89,6 @@ class ReactNativeFeatureFlagsAccessor {
   bool fuseboxAssertSingleHostState();
   bool fuseboxEnabledRelease();
   bool fuseboxFrameRecordingEnabled();
-  bool fuseboxNetworkInspectionEnabled();
   bool fuseboxScreenshotCaptureEnabled();
   bool fuseboxWebSocketEventsEnabled();
   bool optimizedAnimatedPropUpdates();
@@ -130,7 +128,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 87> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 85> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -171,7 +169,6 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enableModuleArgumentNSNullConversionIOS_;
   std::atomic<std::optional<bool>> enableMutationObserverByDefault_;
   std::atomic<std::optional<bool>> enableNativeCSSParsing_;
-  std::atomic<std::optional<bool>> enableNetworkEventReporting_;
   std::atomic<std::optional<bool>> enablePreparedTextLayout_;
   std::atomic<std::optional<bool>> enablePropsUpdateReconciliationAndroid_;
   std::atomic<std::optional<bool>> enableRuntimeSchedulerQueueClearingOnError_;
@@ -190,7 +187,6 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> fuseboxAssertSingleHostState_;
   std::atomic<std::optional<bool>> fuseboxEnabledRelease_;
   std::atomic<std::optional<bool>> fuseboxFrameRecordingEnabled_;
-  std::atomic<std::optional<bool>> fuseboxNetworkInspectionEnabled_;
   std::atomic<std::optional<bool>> fuseboxScreenshotCaptureEnabled_;
   std::atomic<std::optional<bool>> fuseboxWebSocketEventsEnabled_;
   std::atomic<std::optional<bool>> optimizedAnimatedPropUpdates_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<96887197bdbba2c13e11046b73572e56>>
+ * @generated SignedSource<<f06add35653810c872a7ac0bee2b198a>>
  */
 
 /**
@@ -183,10 +183,6 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
     return false;
   }
 
-  bool enableNetworkEventReporting() override {
-    return true;
-  }
-
   bool enablePreparedTextLayout() override {
     return false;
   }
@@ -257,10 +253,6 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
 
   bool fuseboxFrameRecordingEnabled() override {
     return false;
-  }
-
-  bool fuseboxNetworkInspectionEnabled() override {
-    return true;
   }
 
   bool fuseboxScreenshotCaptureEnabled() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b34b31496393a84b7d4950bfc87e04a7>>
+ * @generated SignedSource<<518b44f36bbff8631afae71847c943f0>>
  */
 
 /**
@@ -396,15 +396,6 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     return ReactNativeFeatureFlagsDefaults::enableNativeCSSParsing();
   }
 
-  bool enableNetworkEventReporting() override {
-    auto value = values_["enableNetworkEventReporting"];
-    if (!value.isNull()) {
-      return value.getBool();
-    }
-
-    return ReactNativeFeatureFlagsDefaults::enableNetworkEventReporting();
-  }
-
   bool enablePreparedTextLayout() override {
     auto value = values_["enablePreparedTextLayout"];
     if (!value.isNull()) {
@@ -565,15 +556,6 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::fuseboxFrameRecordingEnabled();
-  }
-
-  bool fuseboxNetworkInspectionEnabled() override {
-    auto value = values_["fuseboxNetworkInspectionEnabled"];
-    if (!value.isNull()) {
-      return value.getBool();
-    }
-
-    return ReactNativeFeatureFlagsDefaults::fuseboxNetworkInspectionEnabled();
   }
 
   bool fuseboxScreenshotCaptureEnabled() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2d4757d38664169286dacd779b0e267a>>
+ * @generated SignedSource<<31a9106d7fbb65a6bf61b87e23ba93e0>>
  */
 
 /**
@@ -64,7 +64,6 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enableModuleArgumentNSNullConversionIOS() = 0;
   virtual bool enableMutationObserverByDefault() = 0;
   virtual bool enableNativeCSSParsing() = 0;
-  virtual bool enableNetworkEventReporting() = 0;
   virtual bool enablePreparedTextLayout() = 0;
   virtual bool enablePropsUpdateReconciliationAndroid() = 0;
   virtual bool enableRuntimeSchedulerQueueClearingOnError() = 0;
@@ -83,7 +82,6 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool fuseboxAssertSingleHostState() = 0;
   virtual bool fuseboxEnabledRelease() = 0;
   virtual bool fuseboxFrameRecordingEnabled() = 0;
-  virtual bool fuseboxNetworkInspectionEnabled() = 0;
   virtual bool fuseboxScreenshotCaptureEnabled() = 0;
   virtual bool fuseboxWebSocketEventsEnabled() = 0;
   virtual bool optimizedAnimatedPropUpdates() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2a0a030bafa14c6f20691f029703a642>>
+ * @generated SignedSource<<e064956fa1ca7954fc2f1bdb3c166dac>>
  */
 
 /**
@@ -239,11 +239,6 @@ bool NativeReactNativeFeatureFlags::enableNativeCSSParsing(
   return ReactNativeFeatureFlags::enableNativeCSSParsing();
 }
 
-bool NativeReactNativeFeatureFlags::enableNetworkEventReporting(
-    jsi::Runtime& /*runtime*/) {
-  return ReactNativeFeatureFlags::enableNetworkEventReporting();
-}
-
 bool NativeReactNativeFeatureFlags::enablePreparedTextLayout(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enablePreparedTextLayout();
@@ -332,11 +327,6 @@ bool NativeReactNativeFeatureFlags::fuseboxEnabledRelease(
 bool NativeReactNativeFeatureFlags::fuseboxFrameRecordingEnabled(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::fuseboxFrameRecordingEnabled();
-}
-
-bool NativeReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled(
-    jsi::Runtime& /*runtime*/) {
-  return ReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled();
 }
 
 bool NativeReactNativeFeatureFlags::fuseboxScreenshotCaptureEnabled(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<206f5586c0ea22387a48a484d6d96f54>>
+ * @generated SignedSource<<31af47566a5543079cc3b09567033a57>>
  */
 
 /**
@@ -114,8 +114,6 @@ class NativeReactNativeFeatureFlags
 
   bool enableNativeCSSParsing(jsi::Runtime& runtime);
 
-  bool enableNetworkEventReporting(jsi::Runtime& runtime);
-
   bool enablePreparedTextLayout(jsi::Runtime& runtime);
 
   bool enablePropsUpdateReconciliationAndroid(jsi::Runtime& runtime);
@@ -151,8 +149,6 @@ class NativeReactNativeFeatureFlags
   bool fuseboxEnabledRelease(jsi::Runtime& runtime);
 
   bool fuseboxFrameRecordingEnabled(jsi::Runtime& runtime);
-
-  bool fuseboxNetworkInspectionEnabled(jsi::Runtime& runtime);
 
   bool fuseboxScreenshotCaptureEnabled(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -29,11 +29,8 @@ std::vector<PerformanceEntryType> getSupportedEntryTypesInternal() {
       PerformanceEntryType::MEASURE,
       PerformanceEntryType::EVENT,
       PerformanceEntryType::LONGTASK,
+      PerformanceEntryType::RESOURCE,
   };
-
-  if (ReactNativeFeatureFlags::enableNetworkEventReporting()) {
-    supportedEntryTypes.emplace_back(PerformanceEntryType::RESOURCE);
-  }
 
   return supportedEntryTypes;
 }

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -463,16 +463,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    enableNetworkEventReporting: {
-      defaultValue: true,
-      metadata: {
-        description:
-          'Enable network event reporting hooks in each native platform through `NetworkReporter` (Web Perf APIs + CDP). This flag should be combined with `fuseboxNetworkInspectionEnabled` to enable Network CDP debugging.',
-        expectedReleaseValue: true,
-        purpose: 'release',
-      },
-      ossReleaseStage: 'none',
-    },
     enablePreparedTextLayout: {
       defaultValue: false,
       metadata: {
@@ -668,17 +658,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'experimental',
     },
-    fuseboxNetworkInspectionEnabled: {
-      defaultValue: true,
-      metadata: {
-        dateAdded: '2024-01-31',
-        description:
-          'Enable network inspection support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
     fuseboxScreenshotCaptureEnabled: {
       defaultValue: true,
       metadata: {
@@ -695,7 +674,7 @@ const definitions: FeatureFlagDefinitions = {
       metadata: {
         dateAdded: '2026-07-11',
         description:
-          'Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend. Requires `fuseboxNetworkInspectionEnabled`.',
+          'Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend.',
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cfeef081e12018ec3cb6f9d76049ce5e>>
+ * @generated SignedSource<<18f24b20806682b774fa5ba96f291fd2>>
  * @flow strict
  * @noformat
  */
@@ -87,7 +87,6 @@ export type ReactNativeFeatureFlags = Readonly<{
   enableModuleArgumentNSNullConversionIOS: Getter<boolean>,
   enableMutationObserverByDefault: Getter<boolean>,
   enableNativeCSSParsing: Getter<boolean>,
-  enableNetworkEventReporting: Getter<boolean>,
   enablePreparedTextLayout: Getter<boolean>,
   enablePropsUpdateReconciliationAndroid: Getter<boolean>,
   enableRuntimeSchedulerQueueClearingOnError: Getter<boolean>,
@@ -106,7 +105,6 @@ export type ReactNativeFeatureFlags = Readonly<{
   fuseboxAssertSingleHostState: Getter<boolean>,
   fuseboxEnabledRelease: Getter<boolean>,
   fuseboxFrameRecordingEnabled: Getter<boolean>,
-  fuseboxNetworkInspectionEnabled: Getter<boolean>,
   fuseboxScreenshotCaptureEnabled: Getter<boolean>,
   fuseboxWebSocketEventsEnabled: Getter<boolean>,
   optimizedAnimatedPropUpdates: Getter<boolean>,
@@ -363,10 +361,6 @@ export const enableMutationObserverByDefault: Getter<boolean> = createNativeFlag
  */
 export const enableNativeCSSParsing: Getter<boolean> = createNativeFlagGetter('enableNativeCSSParsing', false);
 /**
- * Enable network event reporting hooks in each native platform through `NetworkReporter` (Web Perf APIs + CDP). This flag should be combined with `fuseboxNetworkInspectionEnabled` to enable Network CDP debugging.
- */
-export const enableNetworkEventReporting: Getter<boolean> = createNativeFlagGetter('enableNetworkEventReporting', true);
-/**
  * Enables caching text layout artifacts for later reuse
  */
 export const enablePreparedTextLayout: Getter<boolean> = createNativeFlagGetter('enablePreparedTextLayout', false);
@@ -439,15 +433,11 @@ export const fuseboxEnabledRelease: Getter<boolean> = createNativeFlagGetter('fu
  */
 export const fuseboxFrameRecordingEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxFrameRecordingEnabled', false);
 /**
- * Enable network inspection support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
- */
-export const fuseboxNetworkInspectionEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxNetworkInspectionEnabled', true);
-/**
  * Enable Page.captureScreenshot CDP method support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
  */
 export const fuseboxScreenshotCaptureEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxScreenshotCaptureEnabled', true);
 /**
- * Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend. Requires `fuseboxNetworkInspectionEnabled`.
+ * Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend.
  */
 export const fuseboxWebSocketEventsEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxWebSocketEventsEnabled', false);
 /**

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4dd4bbc51723d64c94a8e7ba1bf67bf1>>
+ * @generated SignedSource<<848355c91c5827383c35686d975ebb08>>
  * @flow strict
  * @noformat
  */
@@ -64,7 +64,6 @@ export interface Spec extends TurboModule {
   readonly enableModuleArgumentNSNullConversionIOS?: () => boolean;
   readonly enableMutationObserverByDefault?: () => boolean;
   readonly enableNativeCSSParsing?: () => boolean;
-  readonly enableNetworkEventReporting?: () => boolean;
   readonly enablePreparedTextLayout?: () => boolean;
   readonly enablePropsUpdateReconciliationAndroid?: () => boolean;
   readonly enableRuntimeSchedulerQueueClearingOnError?: () => boolean;
@@ -83,7 +82,6 @@ export interface Spec extends TurboModule {
   readonly fuseboxAssertSingleHostState?: () => boolean;
   readonly fuseboxEnabledRelease?: () => boolean;
   readonly fuseboxFrameRecordingEnabled?: () => boolean;
-  readonly fuseboxNetworkInspectionEnabled?: () => boolean;
   readonly fuseboxScreenshotCaptureEnabled?: () => boolean;
   readonly fuseboxWebSocketEventsEnabled?: () => boolean;
   readonly optimizedAnimatedPropUpdates?: () => boolean;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -10676,7 +10676,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -10299,7 +10299,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -10529,7 +10529,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -12585,7 +12585,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -12270,7 +12270,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -12448,7 +12448,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -7740,7 +7740,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -7565,7 +7565,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -7731,7 +7731,6 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
-  public bool getNetworkInspectionEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;


### PR DESCRIPTION
Summary:

Network Inspection has been Stage 4 / rolled out since 0.83. Circle back to remove feature flags from the codebase.

**Changes**

- Remove `enableNetworkEventReporting` and `fuseboxNetworkInspectionEnabled` flag definitions.
- Remove all feature guards in code.
- Update tests (add mocks).
- (fbsource) Remove all overrides.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D111696522
