### PR TITLE
Blur focused TextInput before unregistering it on unmount (fixes Android keyboard staying open)

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -302,8 +302,6 @@ function InternalTextInput(props: TextInputProps): React.Node {
       TextInputState.registerInput(inputRefValue);
 
       return () => {
-        // Blur the input while it is still registered, otherwise `blur()`
-        // does not dispatch the blur command.
         if (TextInputState.currentlyFocusedInput() === inputRefValue) {
           nullthrows(inputRefValue).blur();
         }

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -302,11 +302,16 @@ function InternalTextInput(props: TextInputProps): React.Node {
       TextInputState.registerInput(inputRefValue);
 
       return () => {
-        TextInputState.unregisterInput(inputRefValue);
-
+        // Blur the input before unregistering it. `blur()` routes through
+        // `TextInputState.isTextInput()`, which checks the registered-inputs
+        // set — if the input is unregistered first, the blur is silently
+        // skipped, the soft keyboard is never hidden, and (on Android) focus
+        // escapes to whichever focusable view remains in the window.
         if (TextInputState.currentlyFocusedInput() === inputRefValue) {
           nullthrows(inputRefValue).blur();
         }
+
+        TextInputState.unregisterInput(inputRefValue);
       };
     }
   }, []);

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -302,11 +302,8 @@ function InternalTextInput(props: TextInputProps): React.Node {
       TextInputState.registerInput(inputRefValue);
 
       return () => {
-        // Blur the input before unregistering it. `blur()` routes through
-        // `TextInputState.isTextInput()`, which checks the registered-inputs
-        // set — if the input is unregistered first, the blur is silently
-        // skipped, the soft keyboard is never hidden, and (on Android) focus
-        // escapes to whichever focusable view remains in the window.
+        // Blur the input while it is still registered, otherwise `blur()`
+        // does not dispatch the blur command.
         if (TextInputState.currentlyFocusedInput() === inputRefValue) {
           nullthrows(inputRefValue).blur();
         }

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -597,6 +597,33 @@ describe('<TextInput>', () => {
           'Command {type: "AndroidTextInput", nativeID: "text-input", name: "blur"}',
         ]);
       });
+
+      it('dispatches the blur command when a focused input is unmounted', () => {
+        const root = Fantom.createRoot();
+        const ref = createRef<HostInstance>();
+
+        Fantom.runTask(() => {
+          root.render(<TextInput nativeID="text-input" ref={ref} />);
+        });
+
+        const instance = nullthrows(ref.current);
+
+        Fantom.runTask(() => {
+          instance.focus();
+        });
+
+        root.takeMountingManagerLogs();
+
+        Fantom.runTask(() => {
+          // unmount TextInput
+          root.render(<></>);
+        });
+
+        expect(root.takeMountingManagerLogs()).toContain(
+          'Command {type: "AndroidTextInput", nativeID: "text-input", name: "blur"}',
+        );
+        expect(TextInput.State.currentlyFocusedInput()).toBe(null);
+      });
     });
 
     describe('clear()', () => {


### PR DESCRIPTION
## Summary

Since #54085 ("Genalize focus/blur behavior in JS"), `ReactNativeElement.blur()` looks at `TextInputState.isTextInput(this)` to check if the text input is registered in the set before attempting to send the native command to blur.

`TextInput`'s unmount cleanup runs in this order:

```js
TextInputState.unregisterInput(inputRefValue);          // removes it from the set
if (TextInputState.currentlyFocusedInput() === inputRefValue) {
  nullthrows(inputRefValue).blur();                     // isTextInput() now false -> no-op
}
```

Since the input is unregistered first, `blur()` doesn't do anything: the native blur command is not dispatched. `unregisterInput` deletes the text input id from the set. 

On Android the visible symptom is that **the soft keyboard stays open after unmounting a focused TextInput**. Navigating back from a native-stack screen with a focused input will try to focus whatever focusable view remains in the window (a WebView, an SDK overlay, etc.), which then "owns" the stuck keyboard. Apps with no other touch-mode-focusable views don't see it (focus falls to null and Android hides the keyboard itself), which is likely why it went unnoticed.

This PR reorders the cleanup so `blur()` runs while the input is still registered, restoring the pre-0.83 behavior. This mirrors the fix #54085 itself applied on the `focus()` side, where `registerInput()` was moved into the ref callback so `focus()` could be called before the layout effect registers the input.

Bisect: 0.79.7 / 0.81.6 / 0.82.1 unaffected -> 0.83.0 broken -> reproduced through 0.86.0.

## Changelog:

[GENERAL] [FIXED] - TextInput: blur focused input before unregistering it on unmount, fixing the Android soft keyboard staying open after navigating away from a focused input

## Test Plan:

- New Fantom test in `TextInput-itest.js`: `dispatches the blur command when a focused input is unmounted` — asserts the `blur` command is dispatched and `TextInput.State.currentlyFocusedInput()` is cleared. Fails before this change, passes after.

I manually reproduced the bug and the bug fix with the following:
- React Native at 86
- `@react-navigation/native-stack`
- `react-native-screens`
- `react-native-webview`

The app has 2 screens: Screen A has a webview and Screen B has an input that is auto-focused.
1. User navigates from Screen A -> Screen B
2. The input is auto-focused. They keyboard opens
3. The user presses the back button and navigates to Screen B
4. The webview can still hold focus (according to Android OS) so the keyboard stays open


