### PR TITLE
Allow arbitrary values in ReactCxxPlatform NativeExceptionsManager extraData

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/logging/NativeExceptionsManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/logging/NativeExceptionsManager.h
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
+#include <folly/dynamic.h>
 #include <jserrorhandler/JsErrorHandler.h>
 #include <react/bridging/Base.h>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -29,6 +29,11 @@ using StackFrame = NativeExceptionsManagerStackFrame<
 template <>
 struct Bridging<StackFrame> : NativeExceptionsManagerStackFrameBridging<StackFrame> {};
 
+// extraData is `?Object` on the JS side and callers routinely populate it with
+// non-string values (e.g. jsBuild as a number, nested Error-decorated objects
+// via RN$ErrorExtraDataKey). A flat unordered_map<string, string> would fail
+// bridging with "Value is an object, expected a String" before reportException
+// runs.
 using ExceptionData = NativeExceptionsManagerExceptionData<
     std::string,
     std::optional<std::string>,
@@ -37,7 +42,7 @@ using ExceptionData = NativeExceptionsManagerExceptionData<
     std::vector<StackFrame>,
     int32_t,
     bool,
-    std::optional<std::unordered_map<std::string, std::string>>>;
+    std::optional<folly::dynamic>>;
 
 template <>
 struct Bridging<ExceptionData> : NativeExceptionsManagerExceptionDataBridging<ExceptionData> {};


### PR DESCRIPTION
Summary:
The JS-side `ExceptionData.extraData` field is spec'd as `?Object` — an
arbitrarily-nested plain object whose values can be numbers, sub-objects,
arrays, etc. Callers routinely populate it that way: `ExceptionsManager.js`
adds `jsEngine`/`rawStack` plus Hermes-style
`stackSymbols`/`stackReturnAddresses`/`stackElements`, decorators can attach
`jsBuild` as a number, and any `Error` with a decorated
`RN$ErrorExtraDataKey` may contribute nested objects.

The ReactCxxPlatform NativeExceptionsManager modeled that field as
`std::optional<std::unordered_map<std::string, std::string>>`, forcing every
value to be a string. As soon as a caller included a non-string value the
JSI bridging layer threw `Value is an object, expected a String` *before*
`reportException` even ran, so the JS `.catch` handler that issued the
report unwound its remaining synchronous work — including any `onComplete`
callback that follows the report call.

Relax the C++ spec to `std::optional<folly::dynamic>` to match the JS
`?Object` type. `reportException` doesn't currently forward `extraData`
into the JsErrorHandler, so no downstream code needs updating.

Changelog: [Internal]

Differential Revision: D112388436


