### PR TITLE
Propage startJSSamplingProfiler error

### DIFF
--- a/private/react-native-fantom/runtime/setup.js
+++ b/private/react-native-fantom/runtime/setup.js
@@ -450,6 +450,7 @@ function runTest(): Array<TestCaseResult> {
     NativeFantom.startJSSamplingProfiler();
   } catch (e) {
     console.error('Could not start JS sampling profiler', e);
+    throw e;
   }
 
   try {


### PR DESCRIPTION
Summary:
Adds rethrow in catch blocks when `startJSSamplingProfiler()` fails, preventing the `finally` block from attempting to stop a profiler that was never started.

Changelog: [Internal]

Differential Revision: D112405579


