### PR TITLE
Pause RedBox auto-retry reload while app is backgrounded (#57593)

### DIFF
--- a/packages/react-native/React/CoreModules/RCTRedBox2Controller.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox2Controller.mm
@@ -373,6 +373,12 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
 
 - (void)autoRetryTick
 {
+  // Don't reload while backgrounded: it re-inits TurboModules, and a
+  // requiresMainQueueSetup module dispatch_syncs onto the blocked main queue,
+  // deadlocking until the watchdog kills the app.
+  if (RCTSharedApplication().applicationState != UIApplicationStateActive) {
+    return;
+  }
   _autoRetryCountdown--;
   if (_autoRetryCountdown <= 0) {
     [self stopAutoRetry];


### PR DESCRIPTION
Summary:

The RedBox auto-retry timer could fire a reload while the app was in the
background. That reload restarts the instance and re-initializes native
modules; a module requiring main-queue setup is dispatched synchronously onto
the main queue, which is itself blocked inside the reload, deadlocking the app
until the watchdog terminates it.

Gate the countdown in `autoRetryTick` on foreground state, so the timer only
advances (and eventually reloads) while the app is active. In app extensions
`RCTSharedApplication()` is nil, which reads as active and preserves the prior
behavior.

Changelog:
[iOS][Fixed] - Prevent RedBox auto-retry from reloading while backgrounded

Differential Revision: D112543586


