### PR TITLE
Fix SectionList.scrollToLocation no-op for itemIndex: 0

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -138,7 +138,14 @@ class VirtualizedSectionList<
   State,
 > {
   scrollToLocation(params: ScrollToLocationParamsType) {
-    let index = params.itemIndex;
+    // Each section prepends a header cell in the flattened VirtualizedList, so the
+    // first row of a section lives at the section's starting offset *plus one*. The
+    // leading `+ 1` maps `itemIndex: 0` to that first row (rather than the header),
+    // matching the documented behavior: "the item at the specified sectionIndex and
+    // itemIndex". Without it, `itemIndex: 0` resolved to the section header, which is
+    // already pinned to the top when sticky headers are enabled and therefore silently
+    // no-ops (facebook/react-native#50143).
+    let index = params.itemIndex + 1;
     for (let i = 0; i < params.sectionIndex; i++) {
       index += this.props.getItemCount(this.props.sections[i].data) + 2;
     }
@@ -147,10 +154,14 @@ class VirtualizedSectionList<
       return;
     }
     const listRef = this._listRef;
-    if (params.itemIndex > 0 && this.props.stickySectionHeadersEnabled) {
+    if (params.itemIndex >= 0 && this.props.stickySectionHeadersEnabled) {
+      // Every item sits below the (potentially sticky) section header, so the header's
+      // height is added for all items — including `itemIndex: 0` — to keep the target
+      // row from being obscured by the pinned header. The header's flattened index is
+      // now `index - params.itemIndex - 1`.
       const frame = listRef
         .__getListMetrics()
-        .getCellMetricsApprox(index - params.itemIndex, listRef.props);
+        .getCellMetricsApprox(index - params.itemIndex - 1, listRef.props);
       viewOffset += frame.length;
     }
     const toIndexParams: {

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
@@ -266,19 +266,83 @@ describe('VirtualizedSectionList', () => {
         viewOffset,
       });
       expect(spy).toHaveBeenCalledWith({
-        index: 1,
+        // Section header occupies flattened index 0, so itemIndex 1 (the second row)
+        // is flattened index 2.
+        index: 2,
         itemIndex: 1,
         sectionIndex: 0,
         viewOffset: viewOffset + ITEM_HEIGHT,
       });
     });
 
+    it('when sticky stickySectionHeadersEnabled={true}, itemIndex: 0 targets the first row and compensates for the sticky header (#50143)', async () => {
+      const {instance, spy} = await createVirtualizedSectionList({
+        stickySectionHeadersEnabled: true,
+      });
+
+      // $FlowFixMe[prop-missing] scrollToLocation isn't on instance
+      instance?.scrollToLocation({
+        sectionIndex: 0,
+        itemIndex: 0,
+      });
+      // Flattened index 1 is the first item (index 0 is the sticky header). The header
+      // height is added to viewOffset so the row is not obscured by the pinned header.
+      // Previously this produced index: 0 (the header) with viewOffset: 0, which no-ops
+      // against the already-pinned sticky header.
+      expect(spy).toHaveBeenCalledWith({
+        index: 1,
+        itemIndex: 0,
+        sectionIndex: 0,
+        viewOffset: ITEM_HEIGHT,
+      });
+    });
+
+    it('itemIndex: 0 in a later section resolves to that section first row (#50143)', async () => {
+      const {instance, spy} = await createVirtualizedSectionList();
+
+      // $FlowFixMe[prop-missing] scrollToLocation isn't on instance
+      instance?.scrollToLocation({
+        sectionIndex: 1,
+        itemIndex: 0,
+      });
+      // Section 0 occupies flattened indices 0..4 (header + 3 items + footer). Section 1
+      // starts at 5 (its header), so its first item is flattened index 6. Previously this
+      // resolved to index 5 (section 1's header) and silently no-oped.
+      expect(spy).toHaveBeenCalledWith({
+        index: 6,
+        itemIndex: 0,
+        sectionIndex: 1,
+        viewOffset: 0,
+      });
+    });
+
+    it('out-of-range itemIndex forwards to scrollToIndex so onScrollToIndexFailed can fire (#50143)', async () => {
+      const {instance, spy} = await createVirtualizedSectionList();
+
+      // $FlowFixMe[prop-missing] scrollToLocation isn't on instance
+      instance?.scrollToLocation({
+        sectionIndex: 1,
+        // Section 1 only has 3 items (valid itemIndex 0..2); 5 is out of range.
+        itemIndex: 5,
+      });
+      // The out-of-range location is still forwarded to VirtualizedList.scrollToIndex,
+      // which is responsible for range validation / firing onScrollToIndexFailed — it is
+      // no longer swallowed by scrollToLocation.
+      expect(spy).toHaveBeenCalledWith({
+        // 5 (header + 3 items + footer of section 0) + 1 (section 1 header) + 5 (itemIndex).
+        index: 11,
+        itemIndex: 5,
+        sectionIndex: 1,
+        viewOffset: 0,
+      });
+    });
+
     it.each([
       [
-        // prevents #18098
         {sectionIndex: 0, itemIndex: 0},
         {
-          index: 0,
+          // itemIndex 0 is the first row (flattened index 1), not the section header.
+          index: 1,
           itemIndex: 0,
           sectionIndex: 0,
           viewOffset: 0,
@@ -287,7 +351,7 @@ describe('VirtualizedSectionList', () => {
       [
         {sectionIndex: 2, itemIndex: 1},
         {
-          index: 11,
+          index: 12,
           itemIndex: 1,
           sectionIndex: 2,
           viewOffset: 0,
@@ -300,7 +364,7 @@ describe('VirtualizedSectionList', () => {
           viewOffset: 25,
         },
         {
-          index: 1,
+          index: 2,
           itemIndex: 1,
           sectionIndex: 0,
           viewOffset: 25,


### PR DESCRIPTION
## Summary

`SectionList.scrollToLocation({ sectionIndex, itemIndex: 0 })` silently does
nothing: no scroll happens, no error is logged, and `onScrollToIndexFailed`
never fires. `itemIndex: 1` (and higher) works. This is most visible on iOS,
where `stickySectionHeadersEnabled` defaults to `true`. Fixes #50143.

### Root cause

`VirtualizedSectionList` flattens all sections into a single `VirtualizedList`.
Every section contributes a header cell and a footer cell around its items, so
the flat-index layout for a section starting at flat offset `base` is:

```
base + 0     -> section header
base + 1     -> item (relative index 0)   <-- the "first row"
...
base + n     -> item (relative index n-1)
base + n + 1 -> section footer
```

(This layout is authoritatively defined by `_subExtractor`, which subtracts 1
for the header when resolving an item's relative index.)

Before this change, `scrollToLocation` mapped `{ sectionIndex, itemIndex }` to a
flat index without accounting for the current section's header:

```js
let index = params.itemIndex;                  // missing the header offset
for (let i = 0; i < params.sectionIndex; i++)
  index += getItemCount(sections[i].data) + 2; // header + items + footer of prior sections
```

So the mapping was off by one:

- `itemIndex: 0` resolved to `base` → the **section header**, not the first row.
- `itemIndex: 1` resolved to `base + 1` → the first row (relative item 0).

`itemIndex: 0` therefore targeted the header. With sticky headers enabled the
header is already pinned at the top of the viewport, so scrolling to its offset
lands where the viewport already is — a visually imperceptible no-op. And because
that header cell is typically already measured, `scrollToIndex` does not take its
`onScrollToIndexFailed` branch — hence "no scroll, no error, no callback", exactly
as reported. The sticky-header compensation block made the same off-by-one
assumption and was additionally gated on `itemIndex > 0`, so it skipped
`itemIndex: 0` entirely.

The public API documents `scrollToLocation` as scrolling to *"the item at the
specified sectionIndex and itemIndex"* (`SectionList.d.ts`), so `itemIndex: 0`
should target the first **item**, not the header.

Root cause: `packages/virtualized-lists/Lists/VirtualizedSectionList.js`,
`scrollToLocation` (the `let index = params.itemIndex` seed and the sticky block).

### The fix

1. Add `+ 1` when seeding the flat index so `itemIndex: 0` maps to the first row
   (`base + 1`) rather than the section header.
2. Apply the sticky-header height compensation for `itemIndex >= 0` (was `> 0`)
   so `itemIndex: 0` also lands below the pinned header; the header's flat index
   is correspondingly `index - params.itemIndex - 1`.

Out-of-range indices are now forwarded to `VirtualizedList.scrollToIndex` instead
of silently resolving to a header/footer cell, so its existing range validation
and `onScrollToIndexFailed` path run as documented.

### Behavior-change note (for reviewers)

This corrects a long-standing off-by-one dating to commit `8a82503b5` (2019),
which locked `{sectionIndex: 0, itemIndex: 0} -> index: 0` into a regression test
with a `// prevents #18098` comment. That change's actual goal (per its
description) was to stop `viewOffset` from being **overridden** — the `index: 0`
value was incidental, not the point of the test. #18098 was about `scrollToLocation`
overscrolling past content on the last section; the `viewOffset`-preservation
guarantee that fixed it is retained here, and only the index/header mapping is
corrected. Existing `scrollToLocation` test expectations were updated to the
corrected semantics.

## Changelog:

[General] [Fixed] - `SectionList.scrollToLocation` now scrolls to `itemIndex: 0`
(the first row of a section) instead of silently no-op'ing on the sticky section
header.

## Test Plan

Added/updated tests in
`packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js`:

- Updated the existing `scrollToLocation` expectations to the corrected mapping
  (indices +1; `itemIndex: 0` no longer resolves to the header).
- `itemIndex: 0` with sticky headers → `index: 1` with the header height added to
  `viewOffset` (regression test for #50143).
- `itemIndex: 0` in a later section → that section's first row
  (`{sectionIndex: 1, itemIndex: 0} -> index: 6`), not its header.
- An out-of-range `itemIndex` is still forwarded to `scrollToIndex` (so
  `onScrollToIndexFailed` can fire) rather than being swallowed.

Ran the suite locally (Node 24):

```
yarn jest packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
→ 14 passed, 14 total
```

Confirmed the tests catch the bug: reverting the source change makes the 7
`scrollToLocation` expectations fail; restoring it makes them pass.
