### PR TITLE
Fix adjustsFontSizeToFit clipping when container height shrinks on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -313,6 +313,14 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     }
   }
 
+  @Override
+  protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+    super.onSizeChanged(w, h, oldw, oldh);
+    if (mAdjustsFontSizeToFit && (w != oldw || h != oldh)) {
+      mShouldAdjustSpannableFontSize = true;
+    }
+  }
+
   public void setText(ReactTextUpdate update) {
     try (SystraceSection s = new SystraceSection("ReactTextView.setText(ReactTextUpdate)")) {
       // Android's TextView crashes when it tries to relayout if LayoutParams are


### PR DESCRIPTION
## Summary:

When a `<Text adjustsFontSizeToFit>` component's container height decreases dynamically (e.g. height=60 → height=20), the text is clipped instead of having its font size recalculated.

**Root cause:** `mShouldAdjustSpannableFontSize` — the gate that triggers font recalculation in `onDraw` — is only set by text-content setters (`setSpanned`, `setNumberOfLines`, etc.). A pure container resize never sets it. Meanwhile the background Fabric measurement thread mutates the shared cached spannable (`tagToSpannableCache`) to the larger font size. When the container then shrinks, `onDraw` skips recalculation and draws the stale large font in the smaller container, causing clipping.

**Fix:** Override `onSizeChanged` in `ReactTextView` to set `mShouldAdjustSpannableFontSize = true` whenever the view dimensions change and `adjustsFontSizeToFit` is active. Android automatically schedules a redraw on size change, so the next `onDraw` recalculates the font with the correct current height.

## Changelog:

[ANDROID] [FIXED] - Fix Text with adjustsFontSizeToFit being clipped when container height decreases dynamically

## Test Plan:

Tested using the existing RNTester example which already reproduces this bug:

1. Build and run RNTester on Android
2. Navigate to **Text** → **Font Size Adjustment with Dynamic Layout**
3. Press **Set Height to 60** — text grows to fill the yellow container
4. Press **Set Height to 20** — before this fix, text is clipped; after this fix, text shrinks to fit correctly
5. Repeat steps 3–4 rapidly — no clipping at any point

The reproducer is `packages/rn-tester/js/examples/Text/TextAdjustsDynamicLayoutExample.js`.