### PR TITLE
fix(iOS): gate prebuilt headers on Swift C++-interop importability

### DIFF
--- a/packages/react-native/scripts/ios-prebuild/headers-verify.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-verify.js
@@ -31,6 +31,10 @@
  *        every R9 textual Fabric header against ReactNativeHeaders.
  *     c. A Swift TU: `import React` + `RCTBridge.moduleRegistry` — the Expo
  *        Swift case, proving the R9 modular header is module-visible.
+ *     d. Swift C++-interop TUs that import React plus every importable module
+ *        declared by the composed ReactNativeHeaders module map, then the
+ *        shipped inspector umbrella as an isolated probe module, forcing
+ *        ClangImporter to instantiate imported C++ value-type special members.
  *
  * Usage:
  *   node scripts/ios-prebuild/headers-verify.js [--flavor Debug|Release]
@@ -62,6 +66,18 @@ const FOLLY_DEFINES = [
   '-DFOLLY_HAVE_CLOCK_GETTIME=1',
 ];
 const SIM_TARGET = 'arm64-apple-ios15.0-simulator';
+
+// This Objective-C app-bootstrap module is not importable with Swift C++
+// interop: its __cplusplus-only factory conformances cross-import React and
+// ReactCommon module members, which ClangImporter rejects for hidden
+// declarations and for re-reading the unguarded RCTComponentViewProtocol.h.
+// Any new exclusion must have its own explicit justification comment.
+const SWIFT_CXX_INTEROP_EXCLUDED_MODULES = new Set(['React_RCTAppDelegate']);
+const SWIFT_CXX_INTEROP_PROBE_MODULE = 'ReactNativeHeaders_CxxInteropProbe';
+const SWIFT_CXX_INTEROP_PROBE_TYPES = [
+  'facebook::react::jsinspector_modern::tracing::TraceRecordingState',
+  'facebook::react::jsinspector_modern::tracing::HostTracingProfile',
+];
 
 function log(msg /*: string */) {
   console.log(`[headers-verify] ${msg}`);
@@ -303,12 +319,49 @@ func _headersVerifyProbe(_ bridge: RCTBridge) {
 `;
 }
 
+/** Swift C++-interop fixture: every module shipped by ReactNativeHeaders. */
+function renderSwiftCxxInteropFixture(
+  moduleNames /*: Array<string> */,
+) /*: string */ {
+  return [
+    'import React',
+    ...moduleNames.map(name => `import ${name}`),
+    '',
+  ].join('\n');
+}
+
+function renderSwiftCxxInteropProbeFixture() /*: string */ {
+  return `import ${SWIFT_CXX_INTEROP_PROBE_MODULE}
+func _headersVerifyCxxValueProbe(
+  _ state: borrowing facebook.react.jsinspector_modern.tracing.TraceRecordingState
+) {
+  _ = state.mode
+}
+`;
+}
+
+function parseModuleNames(moduleMapPath /*: string */) /*: Array<string> */ {
+  const moduleMap = fs.readFileSync(moduleMapPath, 'utf8');
+  // Dotted submodule names may not be standalone-importable if the composed
+  // module map ever grows explicit submodules.
+  return Array.from(
+    moduleMap.matchAll(
+      /^\s*(?:explicit\s+)?(?:framework\s+)?module\s+([A-Za-z_][A-Za-z0-9_.]*)\s*\{/gm,
+    ),
+    match => match[1],
+  );
+}
+
 function xcrun(args /*: Array<string> */, what /*: string */) {
   try {
-    execFileSync('xcrun', args, {stdio: ['ignore', 'pipe', 'pipe']});
+    execFileSync('xcrun', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 64 * 1024 * 1024,
+    });
   } catch (e) {
+    const stdout = e.stdout != null ? String(e.stdout) : '';
     const stderr = e.stderr != null ? String(e.stderr) : String(e);
-    throw new Error(`${what} FAILED:\n${stderr}`);
+    throw new Error(`${what} FAILED:\n${stdout}${stderr}`);
   }
 }
 
@@ -405,6 +458,129 @@ function runCompileGates(
       'Swift gate (import React + RCTBridge.moduleRegistry)',
     );
     log('compile: Swift moduleRegistry fixture OK.');
+
+    const moduleMap = path.join(rnhHeaders, 'module.modulemap');
+    const moduleNames = parseModuleNames(moduleMap);
+    if (moduleNames.length === 0) {
+      throw new Error(
+        `No modules declared in composed module map: ${moduleMap}`,
+      );
+    }
+    const importableModuleNames = moduleNames.filter(
+      name => !SWIFT_CXX_INTEROP_EXCLUDED_MODULES.has(name),
+    );
+    // React_RCTAppDelegate is the only composed module that reaches the
+    // inspector C++ graph, but it cannot itself be imported in C++-interop
+    // mode (see the exclusion comment above). Wrap the shipped inspector
+    // umbrella in a temporary module so ClangImporter still checks that graph.
+    const cxxInteropProbeHeaders = path.join(tmp, 'rnh-cxx-interop-probe');
+    fs.cpSync(rnhHeaders, cxxInteropProbeHeaders, {
+      recursive: true,
+      filter: source => path.basename(source) !== 'module.modulemap',
+    });
+    const cxxInteropProbeHeader = path.join(tmp, 'cxx-interop-probe.h');
+    const cxxInteropCopyProbes = SWIFT_CXX_INTEROP_PROBE_TYPES.map(
+      (typeName, index) =>
+        `inline void probeCopy${index}(const ${typeName} &value) {\n` +
+        `  instantiateCopy(value);\n` +
+        `}\n`,
+    ).join('');
+    fs.writeFileSync(
+      cxxInteropProbeHeader,
+      `#include <jsinspector-modern/ReactCdp.h>\n` +
+        `#include <type_traits>\n` +
+        `namespace rn_headers_verify {\n` +
+        `template <typename T> void instantiateCopy(const T &value) {\n` +
+        `  if constexpr (std::is_copy_constructible_v<T>) {\n` +
+        `    T copy(value);\n` +
+        `    (void)copy;\n` +
+        `  }\n` +
+        `}\n` +
+        cxxInteropCopyProbes +
+        `}\n`,
+    );
+    const cxxInteropProbeModuleMap = path.join(
+      tmp,
+      'module-cxx-interop-probe.modulemap',
+    );
+    fs.writeFileSync(
+      cxxInteropProbeModuleMap,
+      `module ${SWIFT_CXX_INTEROP_PROBE_MODULE} {\n` +
+        `  header ${JSON.stringify(cxxInteropProbeHeader)}\n` +
+        `  export *\n` +
+        `}\n`,
+    );
+    const swiftCxxInterop = path.join(tmp, 'gate-swift-cxx-interop.swift');
+    fs.writeFileSync(
+      swiftCxxInterop,
+      renderSwiftCxxInteropFixture(importableModuleNames),
+    );
+    xcrun(
+      [
+        'swiftc',
+        '-typecheck',
+        '-cxx-interoperability-mode=default',
+        '-sdk',
+        sdk,
+        '-target',
+        SIM_TARGET,
+        '-module-cache-path',
+        path.join(tmp, 'mc-swift-cxx-interop'),
+        '-F',
+        reactSlice,
+        '-I',
+        rnhHeaders,
+        '-I',
+        depsHeaders,
+        '-Xcc',
+        '-std=c++20',
+        '-Xcc',
+        '-w',
+        '-Xcc',
+        `-fmodule-map-file=${moduleMap}`,
+        ...FOLLY_DEFINES.flatMap(flag => ['-Xcc', flag]),
+        swiftCxxInterop,
+      ],
+      'Swift C++-interop gate (React + importable ReactNativeHeaders modules)',
+    );
+
+    const swiftCxxInteropProbe = path.join(
+      tmp,
+      'gate-swift-cxx-interop-probe.swift',
+    );
+    fs.writeFileSync(swiftCxxInteropProbe, renderSwiftCxxInteropProbeFixture());
+    xcrun(
+      [
+        'swiftc',
+        '-typecheck',
+        '-cxx-interoperability-mode=default',
+        '-sdk',
+        sdk,
+        '-target',
+        SIM_TARGET,
+        '-module-cache-path',
+        path.join(tmp, 'mc-swift-cxx-interop-probe'),
+        '-I',
+        cxxInteropProbeHeaders,
+        '-I',
+        depsHeaders,
+        '-Xcc',
+        '-std=c++20',
+        '-Xcc',
+        '-w',
+        '-Xcc',
+        `-fmodule-map-file=${cxxInteropProbeModuleMap}`,
+        ...FOLLY_DEFINES.flatMap(flag => ['-Xcc', flag]),
+        swiftCxxInteropProbe,
+      ],
+      'Swift C++-interop gate (inspector value types)',
+    );
+    log(
+      `compile: Swift C++ interop React + ${importableModuleNames.length} ` +
+        `ReactNativeHeaders modules + inspector probes ` +
+        `[${SWIFT_CXX_INTEROP_PROBE_TYPES.join(', ')}] OK ` +
+        `(${moduleNames.length - importableModuleNames.length} excluded).`,
+    );
   } finally {
     fs.rmSync(tmp, {recursive: true, force: true});
   }


### PR DESCRIPTION
## Summary

Adds a generator-time gate so a Swift-C++-interop-hostile C++ type can never silently ship in the prebuilt iOS core headers again.

**The class this guards:** the prebuilt core headers ship as real clang modules. A C++ value type reachable from a shipped module whose *implicit copy constructor is declared but ill-formed on instantiation* — e.g. an implicit-copy struct with a `std::vector<move-only-T>` member — compiles fine in C++ but hard-errors when a Swift target with `-cxx-interoperability-mode=default` imports the module and its generated bridging uses the type as a copyable value. This is invisible to C++ CI (plain C++ never instantiates the copy), so it only surfaced as a broken community-library nightly (react-native-unistyles, via `TraceRecordingState` / `HostTracingProfile` — fixed in #57605).

**The gate:** a fourth compile gate (stage 3d) in `headers-verify.js`'s `runCompileGates`, compiling a Swift TU with `-cxx-interoperability-mode=default` that imports every module declared by the composed `ReactNativeHeaders` module map (parsed at runtime, not hardcoded), plus a probe that forces the ClangImporter copyability path for a small explicit list of value types (`SWIFT_CXX_INTEROP_PROBE_TYPES`). Because a bare `import` does not eagerly instantiate copy constructors on the current toolchain, the probe reproduces what a real interop consumer's generated code does: for each listed type it conditionally instantiates a copy, which fails exactly as the real consumer fails if the type regresses to an implicit copy. Adding future coverage is a one-line list edit.

One module (`React_RCTAppDelegate`) is excluded as non-importable under interop by design (ObjC bootstrap module with C++-only factory conformances); the inspector C++ graph it would reach is covered directly by the probe instead. The exclusion is documented in-source, and new exclusions are required to carry a justification.

Independent review confirmed the probe reproduces the real failure for the right reason (the dangerous shape reports `is_copy_constructible_v == true`, so the probe enters the branch and forces the ill-formed body instantiation — mirroring ClangImporter, not masking the bug), and that both offender types are covered.

⚠️ **Land after #57605** — the gate runs against the composed artifacts, which are built from source; until the move-only type fixes are in, the gate correctly fails the prebuild on the unfixed types.

## Changelog:

[INTERNAL] [ADDED] - Prebuild gate that fails composed iOS headers unusable from a Swift C++-interop consumer

## Test Plan

Against a freshly composed Debug artifact (`node scripts/ios-prebuild -c -f Debug`):

- **Green**: `node scripts/ios-prebuild/headers-verify.js --flavor Debug` passes the new gate with both probe types (`TraceRecordingState`, `HostTracingProfile`) fixed in the artifact.
- **Red, TraceRecordingState**: restoring the unfixed `TraceRecordingState.h` into the composed artifact fails the gate with the exact `__construct_at` / implicit-copy diagnostic; restoring the fix → green.
- **Red, HostTracingProfile** (proves coverage isn't accidental): same protocol with `HostTracingProfile` unfixed (TraceRecordingState left fixed) → gate fails naming `HostTracingProfile` and its probe specialization; restore → green.
- `node --check`, `prettier --check`, `flow focus-check` clean. Gate is skipped by `--skip-compile` like the other compile gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
