### PR TITLE
Export jserrorhandler headers in the reactnative prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -215,6 +215,8 @@ val preparePrefab by
                       Pair(File(buildDir, "third-party-ndk/glog/exported/").absolutePath, ""),
                       Pair("../ReactCommon/callinvoker/", ""),
                       Pair("../ReactCommon/cxxreact/", "cxxreact/"),
+                      // Exported because the public cxxreact/ErrorUtils.h includes it
+                      Pair("../ReactCommon/jserrorhandler/", "jserrorhandler/"),
                       Pair("../ReactCommon/react/bridging/", "react/bridging/"),
                       Pair("../ReactCommon/react/nativemodule/core/", ""),
                       Pair("../ReactCommon/react/nativemodule/core/platform/android/", ""),


### PR DESCRIPTION
## Summary:

Regression from #57236 which moved ErrorUtils into `jserrorhandler`. It didn't add `jserrorhandler` to the Android prefab header export list in `build.gradle.kts`. The Android prefab's header export is maintained separately from the CMake link graph, so the reactnative prefab module still ships cxxreact/ErrorUtils.h while never publishing the jserrorhandler/ErrorUtils.h it now includes. Any external consumer building against the react-android prefab fails. We caught this in our nightly tests.

## Changelog:

[ANDROID] [FIXED] - Export `jserrorhandler` headers in the `reactnative` prefab so external consumers of cxxreact/ErrorUtils.h can build.

## Test Plan:
Built the prefab headers and confirmed jserrorhandler/ErrorUtils.h is now published to the reactnative module:

```
./gradlew :packages:react-native:ReactAndroid:preparePrefab
find packages/react-native/ReactAndroid/build -path '*reactnative*jserrorhandler/ErrorUtils.h'
# → .../prefab-headers/reactnative/jserrorhandler/ErrorUtils.h
```
