### PR TITLE
Fix feature flag categorization metadata

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -161,7 +161,7 @@ const definitions: FeatureFlagDefinitions = {
     enableAccessibilityOrder: {
       defaultValue: false,
       metadata: {
-        dateAdded: '2025-4-3',
+        dateAdded: '2025-04-03',
         description:
           'When enabled, the accessibilityOrder prop will propagate to native platforms and define the accessibility order.',
         expectedReleaseValue: true,
@@ -246,10 +246,11 @@ const definitions: FeatureFlagDefinitions = {
     enableDoubleMeasurementFixAndroid: {
       defaultValue: false,
       metadata: {
+        dateAdded: '2025-04-29',
         description:
           'When enabled a subset of components will avoid double measurement on Android.',
         expectedReleaseValue: true,
-        purpose: 'operational',
+        purpose: 'experimentation',
       },
       ossReleaseStage: 'none',
     },
@@ -727,10 +728,9 @@ const definitions: FeatureFlagDefinitions = {
     preparedTextCacheSize: {
       defaultValue: 200,
       metadata: {
-        dateAdded: '2025-06-25',
         description: 'Number cached PreparedLayouts in TextLayoutManager cache',
         expectedReleaseValue: 200,
-        purpose: 'experimentation',
+        purpose: 'operational',
       },
       ossReleaseStage: 'none',
     },
@@ -857,7 +857,7 @@ const definitions: FeatureFlagDefinitions = {
         description:
           'Should this application enable the Fabric Interop Layer for Android? If yes, the application will behave so that it can accept non-Fabric components and render them on Fabric. This toggle is controlling extra logic such as custom event dispatching that are needed for the Fabric Interop Layer to work correctly.',
         expectedReleaseValue: false,
-        purpose: 'release',
+        purpose: 'operational',
       },
       ossReleaseStage: 'none',
     },
@@ -886,7 +886,7 @@ const definitions: FeatureFlagDefinitions = {
     useSharedAnimatedBackend: {
       defaultValue: false,
       metadata: {
-        dateAdded: '2025-08-2',
+        dateAdded: '2025-08-02',
         description: 'Use shared animation backend in C++ Animated',
         expectedReleaseValue: true,
         purpose: 'experimentation',
@@ -896,7 +896,7 @@ const definitions: FeatureFlagDefinitions = {
     useTraitHiddenOnAndroid: {
       defaultValue: false,
       metadata: {
-        dateAdded: '2025-10-9',
+        dateAdded: '2025-10-09',
         description: 'Use Trait::hidden on Android',
         expectedReleaseValue: true,
         purpose: 'experimentation',
@@ -917,11 +917,10 @@ const definitions: FeatureFlagDefinitions = {
     viewCullingOutsetRatio: {
       defaultValue: 0,
       metadata: {
-        dateAdded: '2025-09-18',
         description:
           'Outset the culling context frame with the provided ratio. The culling context frame size will be outset by width * ratio on the left and right, and height * ratio on the top and bottom.',
         expectedReleaseValue: 0,
-        purpose: 'experimentation',
+        purpose: 'operational',
       },
       ossReleaseStage: 'none',
     },


### PR DESCRIPTION
Summary:
Corrects categorization metadata in the feature flags config. These are metadata-only changes: flag default values and runtime behavior are unchanged, and no generated files are affected (the codegen does not consume the `purpose` or `dateAdded` fields).

- Zero-pad three malformed `dateAdded` values to the `YYYY-MM-DD` convention (`enableAccessibilityOrder`, `useSharedAnimatedBackend`, `useTraitHiddenOnAndroid`).
- Recategorize `enableDoubleMeasurementFixAndroid` as an experimentation flag (adding its `dateAdded`), since it gates a one-off fix that is still ramping rather than a long-lived operational toggle.
- Recategorize `useFabricInterop` as operational, since it is a long-lived compatibility toggle rather than a rollout toward becoming the default.
- Recategorize `preparedTextCacheSize` and `viewCullingOutsetRatio` as operational tuning values (dropping their now-unused `dateAdded`), matching `virtualViewPrerenderRatio`.

Changelog:
[Internal]

Differential Revision: D112803274


