### PR TITLE
Drop stale $FlowFixMe suppressions for node: imports (#57612)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
 
   extends: ['@react-native'],
 
-  plugins: ['@react-native/monorepo', '@react-native/specs'],
+  plugins: ['@react-native/monorepo', '@react-native/specs', 'import'],
 
   overrides: [
     // overriding the JS config from @react-native/eslint-config to ensure
@@ -44,6 +44,7 @@ module.exports = {
       files: ['*.js', '*.jsx', '*.ts', '*.tsx'],
       rules: {
         '@react-native/no-deep-imports': 'off',
+        'import/enforce-node-protocol-usage': ['warn', 'always'],
       },
     },
     {
@@ -66,6 +67,9 @@ module.exports = {
       rules: {
         '@react-native/monorepo/valid-flow-typed-signature': 'error',
         'ft-flow/require-valid-file-annotation': 'off',
+        // These libdefs are kept byte-identical across projects (see
+        // flow-typed-sync-test), so they must not be migrated independently.
+        'import/enforce-node-protocol-usage': 'off',
         'no-shadow': 'off',
         'no-unused-vars': 'off',
         quotes: 'off',

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-ft-flow": "^2.0.1",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-jsx-a11y": "^6.6.0",
     "eslint-plugin-react": "^7.37.5",

--- a/packages/babel-plugin-codegen/index.js
+++ b/packages/babel-plugin-codegen/index.js
@@ -13,7 +13,7 @@
 let FlowParser, TypeScriptParser, RNCodegen;
 
 const {cheap: traverseCheap} = require('@babel/traverse').default;
-const {basename} = require('path');
+const {basename} = require('node:path');
 
 try {
   FlowParser =

--- a/packages/community-cli-plugin/src/commands/bundle/__tests__/getAssetDestPathAndroid-test.js
+++ b/packages/community-cli-plugin/src/commands/bundle/__tests__/getAssetDestPathAndroid-test.js
@@ -10,7 +10,7 @@
 
 import getAssetDestPathAndroid from '../getAssetDestPathAndroid';
 
-const path = require('path');
+const path = require('node:path');
 
 jest
   .dontMock('../getAssetDestPathAndroid')

--- a/packages/community-cli-plugin/src/commands/bundle/__tests__/getAssetDestPathIOS-test.js
+++ b/packages/community-cli-plugin/src/commands/bundle/__tests__/getAssetDestPathIOS-test.js
@@ -10,7 +10,7 @@
 
 import getAssetDestPathIOS from '../getAssetDestPathIOS';
 
-const path = require('path');
+const path = require('node:path');
 
 jest.dontMock('../getAssetDestPathIOS');
 

--- a/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
@@ -11,8 +11,8 @@
 import type {AssetData} from 'metro';
 
 import {getAndroidResourceIdentifier} from '@react-native/asset-utils';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export function cleanAssetCatalog(catalogDir: string): void {
   const files = fs

--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -14,10 +14,10 @@ import type {RunBuildOptions} from 'metro';
 import loadMetroConfig from '../../utils/loadMetroConfig';
 import parseKeyValueParamArray from '../../utils/parseKeyValueParamArray';
 import saveAssets from './saveAssets';
-import {promises as fs} from 'fs';
 import {runBuild} from 'metro';
-import path from 'path';
-import {styleText} from 'util';
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+import {styleText} from 'node:util';
 
 type HydratedMetroConfig = Awaited<ReturnType<typeof loadMetroConfig>>;
 

--- a/packages/community-cli-plugin/src/commands/bundle/createKeepFileAsync.js
+++ b/packages/community-cli-plugin/src/commands/bundle/createKeepFileAsync.js
@@ -14,8 +14,8 @@ import {
   drawableFileTypes,
   getAndroidResourceIdentifier,
 } from '@react-native/asset-utils';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 async function createKeepFileAsync(
   assets: ReadonlyArray<AssetData>,

--- a/packages/community-cli-plugin/src/commands/bundle/getAssetDestPathAndroid.js
+++ b/packages/community-cli-plugin/src/commands/bundle/getAssetDestPathAndroid.js
@@ -14,7 +14,7 @@ import {
   getAndroidResourceFolderName,
   getAndroidResourceIdentifier,
 } from '@react-native/asset-utils';
-import path from 'path';
+import path from 'node:path';
 
 function getAssetDestPathAndroid(asset: PackagerAsset, scale: number): string {
   const androidFolder = getAndroidResourceFolderName(asset, scale);

--- a/packages/community-cli-plugin/src/commands/bundle/getAssetDestPathIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/getAssetDestPathIOS.js
@@ -10,7 +10,7 @@
 
 import type {PackagerAsset} from '@react-native/asset-utils';
 
-import path from 'path';
+import path from 'node:path';
 
 function getAssetDestPathIOS(asset: PackagerAsset, scale: number): string {
   const suffix = scale === 1 ? '' : `@${scale}x`;

--- a/packages/community-cli-plugin/src/commands/bundle/index.js
+++ b/packages/community-cli-plugin/src/commands/bundle/index.js
@@ -11,7 +11,7 @@
 import type {Command} from '@react-native-community/cli-types';
 
 import buildBundle from './buildBundle';
-import path from 'path';
+import path from 'node:path';
 
 export type {BundleCommandArgs} from './buildBundle';
 

--- a/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
+++ b/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
@@ -20,9 +20,9 @@ import createKeepFileAsync from './createKeepFileAsync';
 import filterPlatformAssetScales from './filterPlatformAssetScales';
 import getAssetDestPathAndroid from './getAssetDestPathAndroid';
 import getAssetDestPathIOS from './getAssetDestPathIOS';
-import fs from 'fs';
-import path from 'path';
-import {styleText} from 'util';
+import fs from 'node:fs';
+import path from 'node:path';
+import {styleText} from 'node:util';
 
 type CopiedFiles = {
   [src: string]: string,

--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -10,7 +10,7 @@
 
 import type {TerminalReporter} from 'metro';
 
-import {styleText} from 'util';
+import {styleText} from 'node:util';
 
 type PageDescription = Readonly<{
   id: string,

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -12,9 +12,9 @@ import type {TerminalReporter} from 'metro';
 
 import OpenDebuggerKeyboardHandler from './OpenDebuggerKeyboardHandler';
 import invariant from 'invariant';
-import readline from 'readline';
-import {ReadStream} from 'tty';
-import {styleText} from 'util';
+import readline from 'node:readline';
+import {ReadStream} from 'node:tty';
+import {styleText} from 'node:util';
 
 const CTRL_C = '\u0003';
 const CTRL_D = '\u0004';

--- a/packages/community-cli-plugin/src/commands/start/index.js
+++ b/packages/community-cli-plugin/src/commands/start/index.js
@@ -11,7 +11,7 @@
 import type {Command} from '@react-native-community/cli-types';
 
 import runServer from './runServer';
-import path from 'path';
+import path from 'node:path';
 
 export type {StartCommandArgs} from './runServer';
 

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -19,9 +19,9 @@ import attachKeyHandlers from './attachKeyHandlers';
 import {createDevServerMiddleware} from './middleware';
 import {createDevMiddleware} from '@react-native/dev-middleware';
 import * as Metro from 'metro';
-import path from 'path';
-import url from 'url';
-import {styleText} from 'util';
+import path from 'node:path';
+import url from 'node:url';
+import {styleText} from 'node:util';
 
 export type StartCommandArgs = {
   assetPlugins?: string[],

--- a/packages/community-cli-plugin/src/utils/isDevServerRunning.js
+++ b/packages/community-cli-plugin/src/utils/isDevServerRunning.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import net from 'net';
+import net from 'node:net';
 
 /**
  * Determine whether we can run the dev server.

--- a/packages/community-cli-plugin/src/utils/version.js
+++ b/packages/community-cli-plugin/src/utils/version.js
@@ -11,8 +11,8 @@
 import type {Config} from '@react-native-community/cli-types';
 import type {TerminalReporter} from 'metro';
 
+import {styleText} from 'node:util';
 import semver from 'semver';
-import {styleText} from 'util';
 
 const debug = require('debug')('ReactNative:CommunityCliPlugin');
 

--- a/packages/debugger-frontend/index.js
+++ b/packages/debugger-frontend/index.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-const path = require('path');
+const path = require('node:path');
 
 let frontEndPath /*:string */ = path.join(
   __dirname,

--- a/packages/debugger-shell/__tests__/dotslash-test.js
+++ b/packages/debugger-shell/__tests__/dotslash-test.js
@@ -11,10 +11,10 @@
 const {
   prepareDebuggerShellFromDotSlashFile,
 } = require('../src/node/private/LaunchUtils');
-const fs = require('fs').promises;
-const http = require('http');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs').promises;
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
 
 // The implementation of prepareDebuggerShellFromDotSlashFile relies on
 // details of DotSlash that are not guaranteed to be stable (support for

--- a/packages/debugger-shell/src/electron/MainInstanceEntryPoint.js
+++ b/packages/debugger-shell/src/electron/MainInstanceEntryPoint.js
@@ -11,8 +11,8 @@
 import {configureAppMenu} from './AppMenu.js';
 import SettingsStore from './SettingsStore.js';
 
-const path = require('path');
-const util = require('util');
+const path = require('node:path');
+const util = require('node:util');
 
 // $FlowFixMe[unclear-type] We have no Flow types for the Electron API.
 const {BrowserWindow, app, shell, ipcMain} = require('electron') as any;

--- a/packages/debugger-shell/src/electron/SettingsStore.js
+++ b/packages/debugger-shell/src/electron/SettingsStore.js
@@ -11,8 +11,8 @@
 
 // $FlowFixMe[unclear-type] We have no Flow types for the Electron API.
 const {app} = require('electron') as any;
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 type Options = Readonly<{
   name?: string,

--- a/packages/debugger-shell/src/electron/index.flow.js
+++ b/packages/debugger-shell/src/electron/index.flow.js
@@ -12,7 +12,7 @@ import buildInfo from './BuildInfo';
 
 // $FlowFixMe[untyped-import] Flow doesn't infer JSON types
 const pkg = require('../../package.json');
-const util = require('util');
+const util = require('node:util');
 // $FlowFixMe[unclear-type] We have no Flow types for the Electron API.
 const {app} = require('electron') as any;
 

--- a/packages/debugger-shell/src/node/index.flow.js
+++ b/packages/debugger-shell/src/node/index.flow.js
@@ -12,7 +12,7 @@ import {prepareDebuggerShellFromDotSlashFile} from './private/LaunchUtils';
 
 const {spawn} = require('cross-spawn');
 const debug = require('debug')('Metro:DebuggerShell');
-const path = require('path');
+const path = require('node:path');
 
 // The 'prebuilt' flavor will use the prebuilt shell binary (and the JavaScript embedded in it).
 // The 'dev' flavor will use a stock Electron binary and run the shell code from the `electron/` directory.

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -20,7 +20,7 @@ import {
   serveStaticText,
   withServerForEachTest,
 } from './ServerUtils';
-import {createHash} from 'crypto';
+import {createHash} from 'node:crypto';
 
 // WebSocket is unreliable when using fake timers.
 jest.useRealTimers();

--- a/packages/dev-middleware/src/__tests__/ServerUtils.js
+++ b/packages/dev-middleware/src/__tests__/ServerUtils.js
@@ -13,8 +13,8 @@ import type {HandleFunction} from 'connect';
 
 import {createDevMiddleware} from '../';
 import connect from 'connect';
-import http from 'http';
-import https from 'https';
+import http from 'node:http';
+import https from 'node:https';
 import * as selfsigned from 'selfsigned';
 
 type CreateDevMiddlewareOptions = Parameters<typeof createDevMiddleware>[0];

--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -21,7 +21,7 @@ import openDebuggerMiddleware from './middleware/openDebuggerMiddleware';
 import DefaultToolLauncher from './utils/DefaultToolLauncher';
 import reactNativeDebuggerFrontendPath from '@react-native/debugger-frontend';
 import connect from 'connect';
-import path from 'path';
+import path from 'node:path';
 import serveStaticMiddleware from 'serve-static';
 
 type Options = Readonly<{

--- a/packages/dev-middleware/src/inspector-proxy/CdpDebugLogging.js
+++ b/packages/dev-middleware/src/inspector-proxy/CdpDebugLogging.js
@@ -8,10 +8,8 @@
  * @format
  */
 
-// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
 import type {Timeout} from 'node:timers';
 
-// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
 import {setTimeout} from 'node:timers';
 import util from 'node:util';
 

--- a/packages/dev-middleware/src/inspector-proxy/CdpDebugLogging.js
+++ b/packages/dev-middleware/src/inspector-proxy/CdpDebugLogging.js
@@ -9,11 +9,11 @@
  */
 
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
-import type {Timeout} from 'timers';
+import type {Timeout} from 'node:timers';
 
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
-import {setTimeout} from 'timers';
-import util from 'util';
+import {setTimeout} from 'node:timers';
+import util from 'node:util';
 
 const debug = require('debug')('Metro:InspectorProxy');
 const debugCDPMessages = require('debug')('Metro:InspectorProxyCDPMessages');

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -30,8 +30,8 @@ import type {
 
 import CdpDebugLogging from './CdpDebugLogging';
 import DeviceEventReporter from './DeviceEventReporter';
-import crypto from 'crypto';
 import invariant from 'invariant';
+import crypto from 'node:crypto';
 import WS from 'ws';
 
 const debug = require('debug')('Metro:InspectorProxy');

--- a/packages/dev-middleware/src/inspector-proxy/EventLoopPerfTracker.js
+++ b/packages/dev-middleware/src/inspector-proxy/EventLoopPerfTracker.js
@@ -11,9 +11,7 @@
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
 import type {DebuggerSessionIDs} from '../types/EventReporter';
 
-// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
 import {monitorEventLoopDelay, performance} from 'node:perf_hooks';
-// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
 import {setTimeout} from 'node:timers';
 
 export type EventLoopPerfTrackerArgs = {

--- a/packages/dev-middleware/src/inspector-proxy/EventLoopPerfTracker.js
+++ b/packages/dev-middleware/src/inspector-proxy/EventLoopPerfTracker.js
@@ -12,9 +12,9 @@
 import type {DebuggerSessionIDs} from '../types/EventReporter';
 
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
-import {monitorEventLoopDelay, performance} from 'perf_hooks';
+import {monitorEventLoopDelay, performance} from 'node:perf_hooks';
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
-import {setTimeout} from 'timers';
+import {setTimeout} from 'node:timers';
 
 export type EventLoopPerfTrackerArgs = {
   perfMeasurementDuration: number,

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -20,7 +20,7 @@ import type {
   Page,
   PageDescription,
 } from './types';
-import type {IncomingMessage, ServerResponse} from 'http';
+import type {IncomingMessage, ServerResponse} from 'node:http';
 
 import getBaseUrlFromRequest from '../utils/getBaseUrlFromRequest';
 import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxyHeartbeat.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxyHeartbeat.js
@@ -9,11 +9,11 @@
  */
 
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
-import type {Timeout} from 'timers';
+import type {Timeout} from 'node:timers';
 
 // Import these from node:timers to get the correct Flow types.
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
-import {clearTimeout, setTimeout} from 'timers';
+import {clearTimeout, setTimeout} from 'node:timers';
 import WS from 'ws';
 
 export type HeartbeatTrackerArgs = {

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxyHeartbeat.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxyHeartbeat.js
@@ -8,11 +8,9 @@
  * @format
  */
 
-// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
 import type {Timeout} from 'node:timers';
 
 // Import these from node:timers to get the correct Flow types.
-// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
 import {clearTimeout, setTimeout} from 'node:timers';
 import WS from 'ws';
 

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -19,10 +19,10 @@ import type {Experiments} from '../types/Experiments';
 import type {Logger} from '../types/Logger';
 import type {ReadonlyURL} from '../types/ReadonlyURL';
 import type {NextHandleFunction} from 'connect';
-import type {IncomingMessage, ServerResponse} from 'http';
+import type {IncomingMessage, ServerResponse} from 'node:http';
 
 import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';
-import {createHash} from 'crypto';
+import {createHash} from 'node:crypto';
 
 const LEGACY_SYNTHETIC_PAGE_TITLE =
   'React Native Experimental (Improved Chrome Reloads)';

--- a/packages/dev-middleware/src/utils/DefaultToolLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultToolLauncher.js
@@ -14,9 +14,9 @@ const {
   unstable_prepareDebuggerShell,
   unstable_spawnDebuggerShellWithArgs,
 } = require('@react-native/debugger-shell');
-const {spawn} = require('child_process');
 const ChromeLauncher = require('chrome-launcher');
 const {Launcher: EdgeLauncher} = require('chromium-edge-launcher');
+const {spawn} = require('node:child_process');
 const open = require('open');
 
 /**

--- a/packages/eslint-plugin-specs/postpack.js
+++ b/packages/eslint-plugin-specs/postpack.js
@@ -8,7 +8,7 @@
  * @noflow
  */
 
-const fs = require('fs');
+const fs = require('node:fs');
 
 /**
  * script to prepare package for publish.

--- a/packages/eslint-plugin-specs/prepack.js
+++ b/packages/eslint-plugin-specs/prepack.js
@@ -8,7 +8,7 @@
  * @noflow
  */
 
-const fs = require('fs');
+const fs = require('node:fs');
 
 /**
  * script to prepare package for publish.

--- a/packages/eslint-plugin-specs/react-native-modules.js
+++ b/packages/eslint-plugin-specs/react-native-modules.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const withBabelRegister = require('./with-babel-register');
-const path = require('path');
+const path = require('node:path');
 
 // We use the prepack hook before publishing package to set this value to true
 const PACKAGE_USAGE = false;

--- a/packages/eslint-plugin-specs/with-babel-register/disk-cache.js
+++ b/packages/eslint-plugin-specs/with-babel-register/disk-cache.js
@@ -8,10 +8,10 @@
  * @noflow
  */
 
-const fs = require('fs');
 const {sync: makeDirSync} = require('make-dir');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const packageJson = JSON.parse(
   fs.readFileSync(require.resolve('../package.json'), 'utf8'),

--- a/packages/eslint-plugin-specs/with-babel-register/index.js
+++ b/packages/eslint-plugin-specs/with-babel-register/index.js
@@ -11,8 +11,8 @@
 const diskCache = require('./disk-cache');
 const babel = require('@babel/core');
 const {DEFAULT_EXTENSIONS, OptionManager} = require('@babel/core');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {addHook} = require('pirates');
 const sourceMapSupport = require('source-map-support');
 

--- a/packages/jest-preset/jest-preset.js
+++ b/packages/jest-preset/jest-preset.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
   haste: {

--- a/packages/jest-preset/jest/assetFileTransformer.js
+++ b/packages/jest-preset/jest/assetFileTransformer.js
@@ -14,7 +14,7 @@
 
 const createCacheKeyFunction =
   require('@jest/create-cache-key-function').default;
-const path = require('path');
+const path = require('node:path');
 
 // NOTE: This file used to be at `react-native/jest/assetFileTransformer.js`
 // To keep the mock `testUri` paths the same, we create a fake path that outputs the same relative path as before

--- a/packages/jest-preset/jest/setup.js
+++ b/packages/jest-preset/jest/setup.js
@@ -81,7 +81,7 @@ try {
    */
   jest.mock('prettier', () => {
     // $FlowExpectedError[underconstrained-implicit-instantiation]
-    const module = jest.requireActual('module');
+    const module = jest.requireActual('node:module');
     return module.prototype.require(require.resolve('prettier'));
   });
 } catch {}

--- a/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
@@ -13,8 +13,8 @@
 // $FlowExpectedError[untyped-import] - Preset is untyped
 const preset = require('../index');
 const babel = require('@babel/core');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const FIXTURES_DIR = path.join(__dirname, '__fixtures__');
 const OUTPUT_DIR = path.join(FIXTURES_DIR, 'output');

--- a/packages/react-native-babel-preset/src/index.js
+++ b/packages/react-native-babel-preset/src/index.js
@@ -31,8 +31,8 @@ module.exports.getCacheKey = () => {
   // For anyone working with a `-main` version, contents may vary over time
   // even though the version does not. Hash the relevant contents of this
   // package. Lazy-load dependencies we only need on this slow path.
-  const {createHash} = require('crypto');
-  const {readFileSync} = require('fs');
+  const {createHash} = require('node:crypto');
+  const {readFileSync} = require('node:fs');
   const key = createHash('md5');
   [
     readFileSync(__filename),

--- a/packages/react-native-babel-transformer/src/__tests__/transform-test.js
+++ b/packages/react-native-babel-transformer/src/__tests__/transform-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const {transform} = require('../index.js');
-const path = require('path');
+const path = require('node:path');
 
 const PROJECT_ROOT = path.sep === '/' ? '/my/project' : 'C:\\my\\project';
 

--- a/packages/react-native-babel-transformer/src/index.js
+++ b/packages/react-native-babel-transformer/src/index.js
@@ -25,10 +25,10 @@ import type {
 const {parseSync, transformFromAstSync} = require('@babel/core');
 const {getCacheKey: getPresetCacheKey} = require('@react-native/babel-preset');
 const makeHMRConfig = require('@react-native/babel-preset/src/configs/hmr');
-const crypto = require('crypto');
-const fs = require('fs');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 const nullthrows = require('nullthrows');
-const path = require('path');
 
 const cacheKeyParts = [getPresetCacheKey(), fs.readFileSync(__filename)];
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateComponentDescriptorH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateComponentDescriptorH-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateComponentDescriptorH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateComponentHObjCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateComponentHObjCpp-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateComponentHObjCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateEventEmitterCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateEventEmitterCpp-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateEventEmitterCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateEventEmitterH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateEventEmitterH-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateEventEmitterH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsCpp-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GeneratePropsCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsH-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GeneratePropsH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsJavaDelegate-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsJavaDelegate-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GeneratePropsJavaDelegate');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsJavaInterface-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsJavaInterface-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GeneratePropsJavaInterface');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 const fixtures = fs.readdirSync(FIXTURE_DIR);

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateShadowNodeCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateShadowNodeCpp-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateShadowNodeCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 const fixtures = fs.readdirSync(FIXTURE_DIR);

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateShadowNodeH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateShadowNodeH-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateShadowNodeH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 const fixtures = fs.readdirSync(FIXTURE_DIR);

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateViewConfigJs-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateViewConfigJs-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateViewConfigJs');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleH-test.js
@@ -14,7 +14,7 @@ import type {SchemaType} from '../../../../src/CodegenSchema';
 
 const generator = require('../../../../src/generators/modules/GenerateModuleH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/modules`;
 

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleObjCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleObjCpp-test.js
@@ -14,7 +14,7 @@ import type {SchemaType} from '../../../../src/CodegenSchema';
 
 const generator = require('../../../../src/generators/modules/GenerateModuleObjCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/modules`;
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateComponentDescriptorH-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateComponentDescriptorH-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateComponentDescriptorH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateComponentHObjCpp-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateComponentHObjCpp-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateComponentHObjCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateEventEmitterCpp-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateEventEmitterCpp-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateEventEmitterCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateEventEmitterH-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateEventEmitterH-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateEventEmitterH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsCpp-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsCpp-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GeneratePropsCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsH-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsH-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GeneratePropsH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsJavaDelegate-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsJavaDelegate-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GeneratePropsJavaDelegate');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsJavaInterface-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsJavaInterface-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GeneratePropsJavaInterface');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 const fixtures = fs.readdirSync(FIXTURE_DIR);

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateShadowNodeCpp-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateShadowNodeCpp-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateShadowNodeCpp');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 const fixtures = fs.readdirSync(FIXTURE_DIR);

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateShadowNodeH-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateShadowNodeH-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateShadowNodeH');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 const fixtures = fs.readdirSync(FIXTURE_DIR);

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateViewConfigJs-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateViewConfigJs-test.js
@@ -12,7 +12,7 @@
 
 const generator = require('../../../../src/generators/components/GenerateViewConfigJs');
 const {FlowParser} = require('../../../../src/parsers/flow/parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const FIXTURE_DIR = `${__dirname}/../../__test_fixtures__/components`;
 

--- a/packages/react-native-codegen/scripts/build.js
+++ b/packages/react-native-codegen/scripts/build.js
@@ -24,12 +24,12 @@
 'use strict';
 
 const babel = require('@babel/core');
-const fs = require('fs');
 const micromatch = require('micromatch');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
+const {styleText} = require('node:util');
 const prettier = require('prettier');
 const {globSync} = require('tinyglobby');
-const {styleText} = require('util');
 
 const prettierConfig = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '..', 'build.prettierrc'), 'utf8'),

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
@@ -14,8 +14,8 @@ import type {SchemaType} from '../../CodegenSchema.js';
 const {FlowParser} = require('../../parsers/flow/parser');
 const {TypeScriptParser} = require('../../parsers/typescript/parser');
 const {filterJSFile} = require('./combine-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {globSync} = require('tinyglobby');
 
 const flowParser = new FlowParser();

--- a/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
@@ -16,8 +16,8 @@ import type {
   SchemaType,
 } from '../../CodegenSchema.js';
 
-const assert = require('assert');
-const fs = require('fs');
+const assert = require('node:assert');
+const fs = require('node:fs');
 const yargs = require('yargs');
 
 const argv = yargs

--- a/packages/react-native-codegen/src/cli/combine/combine-utils.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-utils.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 /**
  * This function is used by the CLI to decide whether a JS/TS file has to be

--- a/packages/react-native-codegen/src/cli/generators/generate-all.js
+++ b/packages/react-native-codegen/src/cli/generators/generate-all.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const RNCodegen = require('../../generators/RNCodegen.js');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const args = process.argv.slice(2);
 if (args.length < 3) {

--- a/packages/react-native-codegen/src/cli/parser/parser.js
+++ b/packages/react-native-codegen/src/cli/parser/parser.js
@@ -12,7 +12,7 @@
 
 const {FlowParser} = require('../../parsers/flow/parser');
 const {TypeScriptParser} = require('../../parsers/typescript/parser');
-const path = require('path');
+const path = require('node:path');
 
 const flowParser = new FlowParser();
 const typescriptParser = new TypeScriptParser();

--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -35,8 +35,8 @@ const generateModuleJavaSpec = require('./modules/GenerateModuleJavaSpec.js');
 const generateModuleJniCpp = require('./modules/GenerateModuleJniCpp.js');
 const generateModuleJniH = require('./modules/GenerateModuleJniH.js');
 const generateModuleObjCpp = require('./modules/GenerateModuleObjCpp');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const ALL_GENERATORS = {
   generateComponentDescriptorH: generateComponentDescriptorH.generate,

--- a/packages/react-native-codegen/src/generators/__tests__/RNCodegen-test.js
+++ b/packages/react-native-codegen/src/generators/__tests__/RNCodegen-test.js
@@ -21,7 +21,7 @@ describe('RNCodegen.generate', () => {
   });
 
   it('when type `all`, with default paths', () => {
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       existsSync: location => {
         return true;
       },
@@ -29,7 +29,7 @@ describe('RNCodegen.generate', () => {
         // Jest in the OSS does not allow to capture variables in closures.
         // Therefore, we have to bring the variables inside the closure.
         // see: https://github.com/facebook/jest/issues/2567
-        const path = require('path');
+        const path = require('node:path');
         const outputDirectory = 'tmp/out/';
         const componentsOutputDir = 'react/renderer/components/library';
         const modulesOutputDir = 'library';

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
@@ -14,7 +14,7 @@ const failureFixtures = require('../__test_fixtures__/failures.js');
 const fixtures = require('../__test_fixtures__/fixtures.js');
 const {FlowParser} = require('../../parser');
 
-jest.mock('fs', () => ({
+jest.mock('node:fs', () => ({
   readFileSync: filename => {
     // Jest in the OSS does not allow to capture variables in closures.
     // Therefore, we have to bring the variables inside the closure.

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-snapshot-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-snapshot-test.js
@@ -16,7 +16,7 @@ const {FlowParser} = require('../../parser');
 
 const flowParser = new FlowParser();
 
-jest.mock('fs', () => ({
+jest.mock('node:fs', () => ({
   readFileSync: filename => {
     // Jest in the OSS does not allow to capture variables in closures.
     // Therefore, we have to bring the variables inside the closure.

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -56,8 +56,8 @@ const {
 } = require('./components/componentsUtils');
 const {flowTranslateTypeAnnotation} = require('./modules');
 const {parseFlowAndThrowErrors} = require('./parseFlowAndThrowErrors');
-const fs = require('fs');
 const invariant = require('invariant');
+const fs = require('node:fs');
 
 type ExtendsForProp = null | {
   type: 'ReactNativeBuiltInType',

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/typescript-component-parser-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/typescript-component-parser-test.js
@@ -14,7 +14,7 @@ const failureFixtures = require('../__test_fixtures__/failures.js');
 const fixtures = require('../__test_fixtures__/fixtures.js');
 const {TypeScriptParser} = require('../../parser');
 
-jest.mock('fs', () => ({
+jest.mock('node:fs', () => ({
   readFileSync: filename => {
     // Jest in the OSS does not allow to capture variables in closures.
     // Therefore, we have to bring the variables inside the closure.

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-snapshot-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-snapshot-test.js
@@ -16,7 +16,7 @@ const {TypeScriptParser} = require('../../parser');
 
 const typeScriptParser = new TypeScriptParser();
 
-jest.mock('fs', () => ({
+jest.mock('node:fs', () => ({
   readFileSync: filename => {
     // Jest in the OSS does not allow to capture variables in closures.
     // Therefore, we have to bring the variables inside the closure.

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -59,8 +59,8 @@ const {typeScriptTranslateTypeAnnotation} = require('./modules');
 const {parseTopLevelType} = require('./parseTopLevelType');
 // $FlowFixMe[untyped-import] Use flow-types for @babel/parser
 const babelParser = require('@babel/parser');
-const fs = require('fs');
 const invariant = require('invariant');
+const fs = require('node:fs');
 
 class TypeScriptParser implements Parser {
   typeParameterInstantiation: string = 'TSTypeParameterInstantiation';

--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const {ParserError} = require('./errors');
-const path = require('path');
+const path = require('node:path');
 
 export type TypeDeclarationMap = {[declarationName: string]: $FlowFixMe};
 

--- a/packages/react-native-compatibility-check/src/__tests__/utilities/getTestSchema.js
+++ b/packages/react-native-compatibility-check/src/__tests__/utilities/getTestSchema.js
@@ -11,7 +11,7 @@
 import type {SchemaType} from '@react-native/codegen/src/CodegenSchema';
 
 import {FlowParser} from '@react-native/codegen/src/parsers/flow/parser';
-import path from 'path';
+import path from 'node:path';
 
 const flowParser = new FlowParser();
 

--- a/packages/react-native-popup-menu-android/scripts/prepublish-popup-menu-android.js
+++ b/packages/react-native-popup-menu-android/scripts/prepublish-popup-menu-android.js
@@ -24,7 +24,7 @@ function extractVersion(tomlContent, regex) {
   return match && match[1] ? match[1] : null;
 }
 
-const fs = require('fs');
+const fs = require('node:fs');
 
 const buildGradleKtsPath = 'android/build.gradle.kts';
 const libsVersionsTomlPath = '../react-native/gradle/libs.versions.toml';

--- a/packages/react-native/Libraries/Core/__tests__/ExceptionsManager-test.js
+++ b/packages/react-native/Libraries/Core/__tests__/ExceptionsManager-test.js
@@ -14,8 +14,8 @@ import type {ExceptionData} from '../NativeExceptionsManager';
 
 const ExceptionsManager = require('../ExceptionsManager').default;
 const ReactFiberErrorDialog = require('../ReactFiberErrorDialog').default;
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const capturedErrorDefaults = {
   componentName: 'A',

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/generate-nested-scroll-view.js
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/generate-nested-scroll-view.js
@@ -26,9 +26,9 @@
 
 'use strict';
 
-const crypto = require('crypto');
-const fs = require('fs');
-const path = require('path');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // SignedSource token - this placeholder gets replaced with the actual hash
 // Use string concatenation to avoid marking THIS script as generated

--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -13,7 +13,7 @@
 
 // $FlowFixMe[untyped-import]
 const {name} = require('./package.json');
-const {styleText} = require('util');
+const {styleText} = require('node:util');
 
 const deprecated = () => {
   throw new Error(

--- a/packages/react-native/metro.config.js
+++ b/packages/react-native/metro.config.js
@@ -16,7 +16,7 @@ import type {ConfigT} from 'metro-config';
 
 const {getDefaultConfig} = require('@react-native/metro-config');
 const {mergeConfig} = require('metro-config');
-const path = require('path');
+const path = require('node:path');
 
 /**
  * This cli config is needed for development purposes, e.g. for running

--- a/packages/react-native/scripts/bundle.js
+++ b/packages/react-native/scripts/bundle.js
@@ -11,10 +11,10 @@
 'use strict';
 
 const {bundleCommand: bc} = require('@react-native/community-cli-plugin');
-const {execSync} = require('child_process');
 const commander = require('commander');
-const {readFileSync} = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const {readFileSync} = require('node:fs');
+const path = require('node:path');
 
 // Commander 12.0.0 changes from the global to named export
 // $FlowFixMe[signature-verification-failure]

--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -19,8 +19,8 @@ const {
   cleanupEmptyFilesAndFolders,
   extractLibrariesFromJSON,
 } = require('../generate-artifacts-executor/utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const rootPath = path.join(__dirname, '../../..');
 
@@ -186,7 +186,7 @@ describe('delete empty files and folders', () => {
     let statSyncInvocationCount = 0;
     let rmSyncInvocationCount = 0;
     let rmdirSyncInvocationCount = 0;
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       statSync: filepath => {
         statSyncInvocationCount += 1;
         expect(filepath).toBe(targetFilepath);
@@ -221,7 +221,7 @@ describe('delete empty files and folders', () => {
     let rmSyncInvocationCount = 0;
     let rmdirSyncInvocationCount = 0;
 
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       statSync: filepath => {
         statSyncInvocationCount += 1;
         expect(filepath).toBe(targetFilepath);
@@ -256,7 +256,7 @@ describe('delete empty files and folders', () => {
     let rmSyncInvocationCount = 0;
     let rmdirSyncInvocationCount = 0;
 
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       statSync: filepath => {
         statSyncInvocationCount += 1;
         expect(filepath).toBe(targetFolder);
@@ -306,7 +306,7 @@ describe('delete empty files and folders', () => {
     let rmdirSyncInvocation = [];
     let readdirInvocation = [];
 
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       statSync: filepath => {
         statSyncInvocation.push(filepath);
 
@@ -357,7 +357,7 @@ describe('delete empty files and folders', () => {
     let rmdirSyncInvocation = [];
     let readdirInvocation = [];
 
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       statSync: filepath => {
         statSyncInvocation.push(filepath);
 
@@ -416,7 +416,7 @@ describe('findFilesWithExtension', () => {
   it('skips hidden files and folders', () => {
     const targetFolder = '/project/ios';
 
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       readdirSync: dirPath => {
         if (dirPath === targetFolder) {
           return ['.hidden', '.git', 'visible.mm'];
@@ -443,7 +443,7 @@ describe('findFilesWithExtension', () => {
     const pnpmFolder = path.join(targetFolder, '.pnpm');
     const packageFolder = path.join(pnpmFolder, 'some-package');
 
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       readdirSync: dirPath => {
         if (dirPath === targetFolder) {
           return ['.pnpm', '.hidden'];
@@ -479,7 +479,7 @@ describe('findFilesWithExtension', () => {
     // like ~/.jenkins/workspace/ or /.hidden-ci/builds/
     const targetFolder = '/.jenkins/workspace/my-project/ios';
 
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       readdirSync: dirPath => {
         if (dirPath === targetFolder) {
           return ['Components'];

--- a/packages/react-native/scripts/codegen/__tests__/generate-specs-cli-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-specs-cli-executor-test.js
@@ -12,7 +12,7 @@
 
 const fixtures = require('../__fixtures__/fixtures');
 const sut = require('../generate-specs-cli-executor');
-const {normalize} = require('path');
+const {normalize} = require('node:path');
 
 describe('generateSpec', () => {
   it('invokes RNCodegen with the right params', () => {
@@ -27,7 +27,7 @@ describe('generateSpec', () => {
     // Create a mock for fs.mkdirSync
     const mkdirSyncMock = jest.fn();
 
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       readFileSync: (path, encoding) => {
         expect(path).toBe(schemaPath);
         expect(encoding).toBe('utf-8');

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/constants.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/constants.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const REACT_NATIVE_REPOSITORY_ROOT = path.join(
   __dirname,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateAppDependencyProvider.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateAppDependencyProvider.js
@@ -11,8 +11,8 @@
 'use strict';
 const {TEMPLATES_FOLDER_PATH, packageJson} = require('./constants');
 const {codegenLog, writeFileSyncIfChanged} = require('./utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const APP_DEPENDENCY_PROVIDER_H_TEMPLATE_PATH = path.join(
   TEMPLATES_FOLDER_PATH,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateCustomURLHandlers.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateCustomURLHandlers.js
@@ -12,8 +12,8 @@
 
 const {TEMPLATES_FOLDER_PATH} = require('./constants');
 const {parseiOSAnnotations, writeFileSyncIfChanged} = require('./utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const MODULES_PROTOCOLS_H_TEMPLATE_PATH = path.join(
   TEMPLATES_FOLDER_PATH,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateNativeCode.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateNativeCode.js
@@ -13,9 +13,9 @@
 const generateSpecsCLIExecutor = require('../generate-specs-cli-executor');
 const {CORE_LIBRARIES_WITH_OUTPUT_FOLDER} = require('./constants');
 const {codegenLog, cpSyncRecursiveIfChanged} = require('./utils');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 function generateNativeCode(
   outputPath /*: string */,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generatePackageSwift.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generatePackageSwift.js
@@ -11,8 +11,8 @@
 'use strict';
 const {TEMPLATES_FOLDER_PATH} = require('./constants');
 const {codegenLog, writeFileSyncIfChanged} = require('./utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const PACKAGE_SWIFT_TEMPLATE_PATH = path.join(
   TEMPLATES_FOLDER_PATH,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTModuleProviders.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTModuleProviders.js
@@ -16,8 +16,8 @@ const {
   parseiOSAnnotations,
   writeFileSyncIfChanged,
 } = require('./utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const MODULE_PROVIDERS_H_TEMPLATE_PATH = path.join(
   TEMPLATES_FOLDER_PATH,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
@@ -17,8 +17,8 @@ const {
   parseiOSAnnotations,
   writeFileSyncIfChanged,
 } = require('./utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const THIRD_PARTY_COMPONENTS_H_TEMPLATE_PATH = path.join(
   TEMPLATES_FOLDER_PATH,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
@@ -16,9 +16,9 @@ const {
   packageJson,
 } = require('./constants');
 const {codegenLog, writeFileSyncIfChanged} = require('./utils');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const REACT_CODEGEN_PODSPEC_TEMPLATE_PATH = path.join(
   TEMPLATES_FOLDER_PATH,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateSchemaInfos.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateSchemaInfos.js
@@ -12,8 +12,8 @@
 
 const CodegenUtils = require('../codegen-utils');
 const {codegenLog} = require('./utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {globSync} = require('tinyglobby');
 
 function generateSchemaInfos(

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateUnstableModulesRequiringMainQueueSetupProvider.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateUnstableModulesRequiringMainQueueSetupProvider.js
@@ -12,8 +12,8 @@
 
 const {TEMPLATES_FOLDER_PATH} = require('./constants');
 const {parseiOSAnnotations, writeFileSyncIfChanged} = require('./utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const UNSTABLE_MODULES_REQUIRING_MAIN_QUEUE_SETUP_PROVIDER_H_TEMPLATE_PATH =
   path.join(

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
@@ -43,7 +43,7 @@ const {
   readPkgJsonInDirectory,
   readReactNativeConfig,
 } = require('./utils');
-const path = require('path');
+const path = require('node:path');
 
 /**
  * This function is the entry point for the codegen. It:

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
@@ -14,9 +14,9 @@ const {
   CORE_LIBRARIES_WITH_OUTPUT_FOLDER,
   REACT_NATIVE,
 } = require('./constants');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function pkgJsonIncludesGeneratedCode(
   pkgJson /*: $FlowFixMe */,

--- a/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
+++ b/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
@@ -11,8 +11,8 @@
 'use strict';
 
 const utils = require('./codegen-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const GENERATORS /*: {[string]: {[string]: ReadonlyArray<string>}} */ = {
   all: {

--- a/packages/react-native/scripts/compose-source-maps.js
+++ b/packages/react-native/scripts/compose-source-maps.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const fs = require('fs');
 const {composeSourceMaps} = require('metro-source-map');
+const fs = require('node:fs');
 
 const argv = process.argv.slice(2);
 let outputPath;

--- a/packages/react-native/scripts/featureflags/generateAndroidModules.js
+++ b/packages/react-native/scripts/featureflags/generateAndroidModules.js
@@ -19,7 +19,7 @@ import ReactNativeFeatureFlagsDefaultsKt from './templates/android/ReactNativeFe
 import ReactNativeFeatureFlagsLocalAccessorKt from './templates/android/ReactNativeFeatureFlagsLocalAccessor.kt-template';
 import ReactNativeFeatureFlagsOverrides from './templates/android/ReactNativeFeatureFlagsOverrides_RNOSS__Stage__Android.kt-template.js';
 import ReactNativeFeatureFlagsProviderKt from './templates/android/ReactNativeFeatureFlagsProvider.kt-template';
-import path from 'path';
+import path from 'node:path';
 
 export default function generateAndroidModules(
   generatorConfig: GeneratorConfig,

--- a/packages/react-native/scripts/featureflags/generateCommonCxxModules.js
+++ b/packages/react-native/scripts/featureflags/generateCommonCxxModules.js
@@ -18,7 +18,7 @@ import ReactNativeFeatureFlagsDefaultsH from './templates/common-cxx/ReactNative
 import ReactNativeFeatureFlagsDynamicProviderH from './templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template';
 import ReactNativeFeatureFlagsOverrides from './templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template';
 import ReactNativeFeatureFlagsProviderH from './templates/common-cxx/ReactNativeFeatureFlagsProvider.h-template';
-import path from 'path';
+import path from 'node:path';
 
 export default function generateCommonCxxModules(
   generatorConfig: GeneratorConfig,

--- a/packages/react-native/scripts/featureflags/generateFiles.js
+++ b/packages/react-native/scripts/featureflags/generateFiles.js
@@ -13,8 +13,8 @@ import type {GeneratorConfig, GeneratorOptions} from './types';
 import generateAndroidModules from './generateAndroidModules';
 import generateCommonCxxModules from './generateCommonCxxModules';
 import generateJavaScriptModules from './generateJavaScriptModules';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export default function generateFiles(
   generatorConfig: GeneratorConfig,

--- a/packages/react-native/scripts/featureflags/generateJavaScriptModules.js
+++ b/packages/react-native/scripts/featureflags/generateJavaScriptModules.js
@@ -14,7 +14,7 @@ import NativeReactNativeFeatureFlagsCPP from './templates/js/NativeReactNativeFe
 import NativeReactNativeFeatureFlagsH from './templates/js/NativeReactNativeFeatureFlags.h-template';
 import NativeReactNativeFeatureFlagsJS from './templates/js/NativeReactNativeFeatureFlags.js-template';
 import ReactNativeFeatureFlagsJS from './templates/js/ReactNativeFeatureFlags.js-template';
-import path from 'path';
+import path from 'node:path';
 
 export default function generateCommonCxxModules(
   generatorConfig: GeneratorConfig,

--- a/packages/react-native/scripts/featureflags/update.js
+++ b/packages/react-native/scripts/featureflags/update.js
@@ -10,7 +10,7 @@
 
 import generateFiles from './generateFiles';
 import featureFlagDefinitions from './ReactNativeFeatureFlags.config';
-import path from 'path';
+import path from 'node:path';
 
 const REACT_NATIVE_PACKAGE_ROOT = path.join(__dirname, '..', '..');
 

--- a/packages/react-native/scripts/generate-provider-cli.js
+++ b/packages/react-native/scripts/generate-provider-cli.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const utils = require('./codegen/codegen-utils');
-const fs = require('fs');
+const fs = require('node:fs');
 const yargs = require('yargs');
 
 const argv = yargs

--- a/packages/react-native/scripts/hermes/__tests__/hermes-utils-test.js
+++ b/packages/react-native/scripts/hermes/__tests__/hermes-utils-test.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 const {readHermesTag, setHermesTag} = require('../hermes-utils');
 // $FlowFixMe[untyped-import] (OSS) memfs
@@ -24,8 +24,8 @@ describe('hermes-utils', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    jest.mock('fs', () => memfs().fs);
-    fs = require('fs');
+    jest.mock('node:fs', () => memfs().fs);
+    fs = require('node:fs');
 
     fs.mkdirSync(SDKS_DIR, {
       recursive: true,

--- a/packages/react-native/scripts/hermes/hermes-utils.js
+++ b/packages/react-native/scripts/hermes/hermes-utils.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const fs = require('fs');
 // $FlowFixMe[untyped-import]
 const inquirer = require('inquirer');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*::
 type BuildType = 'dry-run' | 'release' | 'nightly';

--- a/packages/react-native/scripts/hermes/release-hermes-for-branch-cut.js
+++ b/packages/react-native/scripts/hermes/release-hermes-for-branch-cut.js
@@ -16,12 +16,12 @@ const {
   updateHermesRuntimeDependenciesVersions,
 } = require('../../../../scripts/releases/utils/hermes-utils');
 const {setHermesTag} = require('./hermes-utils');
-const {execSync} = require('child_process');
-const fs = require('fs');
 // $FlowFixMe[untyped-import]
 const inquirer = require('inquirer');
-const os = require('os');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const {exit} = require('shelljs');
 const yargs = require('yargs');
 

--- a/packages/react-native/scripts/ios-prebuild.js
+++ b/packages/react-native/scripts/ios-prebuild.js
@@ -17,7 +17,7 @@ const {getCLIConfiguration} = require('./ios-prebuild/cli');
 const {setup} = require('./ios-prebuild/setup');
 const {createLogger, throwIfOnEden} = require('./ios-prebuild/utils');
 const {buildXCFrameworks} = require('./ios-prebuild/xcframework');
-const path = require('path');
+const path = require('node:path');
 
 const REACT_NATIVE_PACKAGE_ROOT_FOLDER = path.join(__dirname, '..');
 const packageJsonPath = path.join(

--- a/packages/react-native/scripts/ios-prebuild/__tests__/framework-resources-test.js
+++ b/packages/react-native/scripts/ios-prebuild/__tests__/framework-resources-test.js
@@ -21,9 +21,9 @@ const {
   serializePrivacyManifest,
 } = require('../framework-resources');
 const {emitReactFrameworkHeaders} = require('../headers-compose');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 // react-native package root (…/scripts/ios-prebuild/__tests__ -> …)
 const RN_PATH = path.resolve(__dirname, '..', '..', '..');

--- a/packages/react-native/scripts/ios-prebuild/__tests__/headers-compose-test.js
+++ b/packages/react-native/scripts/ios-prebuild/__tests__/headers-compose-test.js
@@ -14,8 +14,8 @@ const {
   COMPOSE_TOOLING_FILES,
   composeToolingHash,
 } = require('../headers-compose');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 describe('COMPOSE_TOOLING_FILES stays in sync with headers-compose.js requires', () => {
   test('every local sibling require is covered by the hashed file list', () => {

--- a/packages/react-native/scripts/ios-prebuild/__tests__/headers-spec-test.js
+++ b/packages/react-native/scripts/ios-prebuild/__tests__/headers-spec-test.js
@@ -16,7 +16,7 @@ const {
   renderNamespaceModuleMap,
   renderReactModuleMap,
 } = require('../headers-spec');
-const fs = require('fs');
+const fs = require('node:fs');
 
 /*::
 type TestInventoryManifest = {

--- a/packages/react-native/scripts/ios-prebuild/__tests__/headers-xcframework-test.js
+++ b/packages/react-native/scripts/ios-prebuild/__tests__/headers-xcframework-test.js
@@ -14,10 +14,10 @@ const {
   buildDepsHeadersXcframework,
   stubSlicesFromXcframework,
 } = require('../headers-xcframework');
-const childProcess = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 describe('buildDepsHeadersXcframework set-equality gate', () => {
   let tmp /*: string */ = '';

--- a/packages/react-native/scripts/ios-prebuild/build.js
+++ b/packages/react-native/scripts/ios-prebuild/build.js
@@ -13,9 +13,9 @@ import type {BuildFlavor, Destination} from './types';
 */
 
 const {createLogger} = require('./utils');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 const {globSync} = require('tinyglobby');
 
 const buildLog = createLogger('SPM');

--- a/packages/react-native/scripts/ios-prebuild/framework-resources.js
+++ b/packages/react-native/scripts/ios-prebuild/framework-resources.js
@@ -24,8 +24,8 @@
  *    framework-aware RCTLocalizedString loader resolves them via bundleForClass:.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const plist = require('plist');
 
 // Source roots whose pods compile into React.framework. third-party-podspecs is

--- a/packages/react-native/scripts/ios-prebuild/headers-compose.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-compose.js
@@ -40,10 +40,10 @@ const {
   buildDepsHeadersXcframework,
   composeHeadersOnlyXcframework,
 } = require('./headers-xcframework');
-const {execFileSync} = require('child_process');
-const crypto = require('crypto');
-const fs = require('fs');
-const path = require('path');
+const {execFileSync} = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // APFS clonefile (-c) is a macOS-only cp flag; plain -R elsewhere (Linux CI
 // exercises these paths through the jest integration tests).

--- a/packages/react-native/scripts/ios-prebuild/headers-inventory.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-inventory.js
@@ -32,8 +32,8 @@
 const {getHeaderFilesFromPodspecs} = require('./headers');
 // headers-spec.js requires only fs/path, so this cannot cycle.
 const {DEPS_NAMESPACES} = require('./headers-spec');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*::
 type Identity = {

--- a/packages/react-native/scripts/ios-prebuild/headers-spec.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-spec.js
@@ -81,8 +81,8 @@
  *     stay single-owned.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // Fallback root only — inventory `source` paths are relative to the root the
 // inventory was computed from, so callers with a different tree (SPM tooling,

--- a/packages/react-native/scripts/ios-prebuild/headers-verify.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-verify.js
@@ -44,10 +44,10 @@ const {
   renderReactModuleMap,
   renderUmbrellaHeader,
 } = require('./headers-spec');
-const {execFileSync} = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const {execFileSync} = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 /*:: import type {HeadersSpecPlan} from './headers-spec'; */
 

--- a/packages/react-native/scripts/ios-prebuild/headers-xcframework.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-xcframework.js
@@ -25,9 +25,9 @@
  * boundary.
  */
 
-const {execFileSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execFileSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // APFS clonefile (-c) is a macOS-only cp flag; plain -R elsewhere (Linux CI
 // exercises these paths through the jest integration tests).

--- a/packages/react-native/scripts/ios-prebuild/headers.js
+++ b/packages/react-native/scripts/ios-prebuild/headers.js
@@ -10,7 +10,7 @@
 
 const {PodspecExceptions} = require('./headers-config');
 const utils = require('./utils');
-const path = require('path');
+const path = require('node:path');
 const {globSync} = require('tinyglobby');
 
 const {createLogger} = utils;
@@ -63,7 +63,7 @@ function getHeaderFilesFromPodspecs(
     }
 
     // Open file and read content
-    const fileContent = require('fs').readFileSync(podspecPath, 'utf8');
+    const fileContent = require('node:fs').readFileSync(podspecPath, 'utf8');
 
     // Try to infer header_dir when it's a string literal.
     // We intentionally keep this simple and do not attempt to resolve Ruby variables.

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -9,11 +9,11 @@
  */
 
 const {createLogger} = require('./utils');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const stream = require('stream');
-const {promisify} = require('util');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const stream = require('node:stream');
+const {promisify} = require('node:util');
 
 const pipeline = promisify(stream.pipeline);
 const hermesLog = createLogger('Hermes');

--- a/packages/react-native/scripts/ios-prebuild/reactNativeDependencies.js
+++ b/packages/react-native/scripts/ios-prebuild/reactNativeDependencies.js
@@ -11,11 +11,11 @@
 /*:: import type {BuildFlavor} from './types'; */
 
 const {computeNightlyTarballURL, createLogger} = require('./utils');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const stream = require('stream');
-const {promisify} = require('util');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const stream = require('node:stream');
+const {promisify} = require('node:util');
 
 const pipeline = promisify(stream.pipeline);
 

--- a/packages/react-native/scripts/ios-prebuild/setup.js
+++ b/packages/react-native/scripts/ios-prebuild/setup.js
@@ -18,9 +18,9 @@ const {
   prepareReactNativeDependenciesArtifactsAsync,
 } = require('./reactNativeDependencies');
 const {createFolderIfNotExists, createLogger} = require('./utils');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 async function setup(
   root /*:string*/,

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -10,8 +10,8 @@
 
 /*:: import type {BuildFlavor, MavenSubGroup} from './types'; */
 
-const {execSync} = require('child_process');
-const fs = require('fs');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
 
 /**
  * Creates a folder if it does not exist

--- a/packages/react-native/scripts/ios-prebuild/xcframework.js
+++ b/packages/react-native/scripts/ios-prebuild/xcframework.js
@@ -14,9 +14,9 @@ const {
   generateFBReactNativeSpecIOS,
 } = require('../codegen/generate-artifacts-executor/generateFBReactNativeSpecIOS');
 const utils = require('./utils');
-const childProcess = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {execSync, execFileSync} = childProcess;
 const {createLogger} = utils;

--- a/packages/react-native/scripts/packager-reporter.js
+++ b/packages/react-native/scripts/packager-reporter.js
@@ -16,8 +16,8 @@ let reporter;
 const logPath = process.env.RCT_PACKAGER_LOG_PATH;
 if (logPath != null && logPath !== '') {
   const {JsonReporter} = require('metro');
-  const fs = require('fs');
-  const path = require('path');
+  const fs = require('node:fs');
+  const path = require('node:path');
   // $FlowFixMe[missing-type-arg]
   reporter = class extends JsonReporter {
     constructor() {

--- a/packages/react-native/scripts/prepack.js
+++ b/packages/react-native/scripts/prepack.js
@@ -11,7 +11,7 @@
 const {
   generateFBReactNativeSpecIOS,
 } = require('./codegen/generate-artifacts-executor/generateFBReactNativeSpecIOS');
-const fs = require('fs');
+const fs = require('node:fs');
 
 function main() {
   console.info('[Prepack] Copying README.md');

--- a/packages/react-native/scripts/replace-rncore-version.js
+++ b/packages/react-native/scripts/replace-rncore-version.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const {spawnSync} = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const {spawnSync} = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const yargs = require('yargs');
 
 const LAST_BUILD_FILENAME = 'React-Core-prebuilt/.last_build_configuration';

--- a/packages/react-native/scripts/setup-apple-spm.js
+++ b/packages/react-native/scripts/setup-apple-spm.js
@@ -107,10 +107,10 @@ const {
   remotePackageConfig,
   runCodegenAndInstallTemplate,
 } = require('./spm/spm-utils');
-const {execFileSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const readline = require('readline');
+const {execFileSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const readline = require('node:readline');
 const yargs = require('yargs');
 
 const {log, warn: logError} = makeLogger('setup-apple-spm');

--- a/packages/react-native/scripts/spm/__tests__/autolinking-plugins-test.js
+++ b/packages/react-native/scripts/spm/__tests__/autolinking-plugins-test.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const {discoverPlugins, invokePlugins} = require('../autolinking-plugins');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 describe('discoverPlugins', () => {
   let tmp;

--- a/packages/react-native/scripts/spm/__tests__/download-spm-artifacts-test.js
+++ b/packages/react-native/scripts/spm/__tests__/download-spm-artifacts-test.js
@@ -28,10 +28,10 @@ const {
   rnDepsReleaseUrl,
   validateArtifactsCache,
 } = require('../download-spm-artifacts');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 // Shared fetch router used by the URL-resolution tests below. Each key is a
 // URL substring; the matched value describes the response. Anything unmatched

--- a/packages/react-native/scripts/spm/__tests__/flavored-frameworks-plist-dep-test.js
+++ b/packages/react-native/scripts/spm/__tests__/flavored-frameworks-plist-dep-test.js
@@ -25,13 +25,13 @@ jest.mock('plist', () => {
 // hermetic on Linux CI. Module-level mock because flavored-frameworks.js
 // destructures execFileSync at require time (same pattern the old
 // swap-flavor-test used).
-jest.mock('child_process', () => {
-  const actual = jest.requireActual<$FlowFixMe>('child_process');
+jest.mock('node:child_process', () => {
+  const actual = jest.requireActual<$FlowFixMe>('node:child_process');
   return {
     ...actual,
     execFileSync: (cmd, args, opts) => {
       if (cmd === 'plutil') {
-        const fs = require('fs');
+        const fs = require('node:fs');
         const plist = jest.requireActual<$FlowFixMe>('plist');
         const file = args[args.length - 1];
         return Buffer.from(
@@ -43,9 +43,9 @@ jest.mock('child_process', () => {
   };
 });
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const realPlist = jest.requireActual<$FlowFixMe>('plist');
 

--- a/packages/react-native/scripts/spm/__tests__/flavored-frameworks-test.js
+++ b/packages/react-native/scripts/spm/__tests__/flavored-frameworks-test.js
@@ -14,13 +14,13 @@
 // Info.plists as JSON — plutil is macOS-only, so stand in with a portable
 // plist-parse for Linux CI. Module-level mock because the module destructures
 // `execFileSync` at require time (same pattern as the old swap-flavor-test).
-jest.mock('child_process', () => {
-  const actual = jest.requireActual('child_process');
+jest.mock('node:child_process', () => {
+  const actual = jest.requireActual('node:child_process');
   return {
     ...actual,
     execFileSync: (cmd, args, opts) => {
       if (cmd === 'plutil') {
-        const fsActual = require('fs');
+        const fsActual = require('node:fs');
         const plistActual = jest.requireActual('plist');
         const file = args[args.length - 1];
         return Buffer.from(
@@ -41,9 +41,9 @@ const {
   sdkConditionForSlice,
   transformReactModuleMap,
 } = require('../flavored-frameworks');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const plist = require('plist');
 
 const BUILTINS = [

--- a/packages/react-native/scripts/spm/__tests__/generate-spm-autolinking-config-test.js
+++ b/packages/react-native/scripts/spm/__tests__/generate-spm-autolinking-config-test.js
@@ -31,9 +31,9 @@ const {
   generateAutolinkingConfig,
   resolveDefaultConfigCommand,
 } = require('../generate-spm-autolinking-config');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 let tmpProjects = [];
 

--- a/packages/react-native/scripts/spm/__tests__/generate-spm-autolinking-test.js
+++ b/packages/react-native/scripts/spm/__tests__/generate-spm-autolinking-test.js
@@ -25,9 +25,9 @@ const {
   reactDescriptor,
   reportMissingManifests,
 } = require('../generate-spm-autolinking');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 // ---------------------------------------------------------------------------
 // reactDescriptor — the ReactDescriptor handed to autolinking plugins

--- a/packages/react-native/scripts/spm/__tests__/generate-spm-package-test.js
+++ b/packages/react-native/scripts/spm/__tests__/generate-spm-package-test.js
@@ -15,9 +15,9 @@ const {
   generateXCFrameworksPackageSwift,
   main,
 } = require('../generate-spm-package');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 // ---------------------------------------------------------------------------
 // generateXCFrameworksPackageSwift

--- a/packages/react-native/scripts/spm/__tests__/generate-spm-xcodeproj-test.js
+++ b/packages/react-native/scripts/spm/__tests__/generate-spm-xcodeproj-test.js
@@ -19,10 +19,10 @@ const {
   frameworkConditionalSettings,
   generateXcscheme,
 } = require('../generate-spm-xcodeproj');
-const {execFileSync} = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const {execFileSync} = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const FRAMEWORK = {
   id: 'react',

--- a/packages/react-native/scripts/spm/__tests__/inject-spm-xcodeproj-test.js
+++ b/packages/react-native/scripts/spm/__tests__/inject-spm-xcodeproj-test.js
@@ -14,8 +14,8 @@ const {
   injectSpmIntoPbxproj,
   planInjection,
 } = require('../generate-spm-xcodeproj');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const PLAIN = fs.readFileSync(
   path.join(__dirname, '__fixtures__', 'plain-app.pbxproj'),

--- a/packages/react-native/scripts/spm/__tests__/read-podspec-test.js
+++ b/packages/react-native/scripts/spm/__tests__/read-podspec-test.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const {flattenSubspecs, readPodspec, regexPodspec} = require('../read-podspec');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 // Real-world podspec fixtures inlined as strings. The regex parser is tested
 // against these directly; flattenSubspecs is tested against pod-ipc-style

--- a/packages/react-native/scripts/spm/__tests__/remove-spm-injection-test.js
+++ b/packages/react-native/scripts/spm/__tests__/remove-spm-injection-test.js
@@ -16,9 +16,9 @@ const {
   readArtifactsVersionOverride,
   removeSpmInjection,
 } = require('../generate-spm-xcodeproj');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const PLAIN = fs.readFileSync(
   path.join(__dirname, '__fixtures__', 'plain-app.pbxproj'),

--- a/packages/react-native/scripts/spm/__tests__/scaffold-package-swift-test.js
+++ b/packages/react-native/scripts/spm/__tests__/scaffold-package-swift-test.js
@@ -18,9 +18,9 @@ const {
   scaffoldPackageSwiftForDep,
   translatePodspecToSpmTarget,
 } = require('../scaffold-package-swift');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 // Minimal PodspecModel fixture builder so each test stays focused on the
 // field it exercises.

--- a/packages/react-native/scripts/spm/__tests__/setup-apple-spm-test.js
+++ b/packages/react-native/scripts/spm/__tests__/setup-apple-spm-test.js
@@ -19,10 +19,10 @@ const {
 } = require('../../setup-apple-spm');
 const {REQUIRED_ARTIFACTS} = require('../download-spm-artifacts');
 const {SPM_INJECTED_MARKER} = require('../generate-spm-xcodeproj');
-const {execFileSync} = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const {execFileSync} = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 // Create an in-place-injected xcodeproj fixture: a directory carrying the
 // `.spm-injected.json` marker (what injectSpmIntoExistingXcodeproj writes).

--- a/packages/react-native/scripts/spm/__tests__/spm-pbxproj-test.js
+++ b/packages/react-native/scripts/spm/__tests__/spm-pbxproj-test.js
@@ -33,8 +33,8 @@ const {
   setScalarField,
   uuidsInArray,
 } = require('../spm-pbxproj');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const PLAIN_PBXPROJ = fs.readFileSync(
   path.join(__dirname, '__fixtures__', 'plain-app.pbxproj'),

--- a/packages/react-native/scripts/spm/__tests__/spm-utils-test.js
+++ b/packages/react-native/scripts/spm/__tests__/spm-utils-test.js
@@ -25,9 +25,9 @@ const {
   sharedCacheDir,
   toSwiftName,
 } = require('../spm-utils');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 // ---------------------------------------------------------------------------
 // toSwiftName

--- a/packages/react-native/scripts/spm/__tests__/swift-tools-version-test.js
+++ b/packages/react-native/scripts/spm/__tests__/swift-tools-version-test.js
@@ -28,8 +28,8 @@ const {
 } = require('../generate-spm-autolinking');
 const {generateXCFrameworksPackageSwift} = require('../generate-spm-package');
 const {emitScaffoldedPackageSwift} = require('../scaffold-package-swift');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const TOOLS_VERSION_RE = /^\/\/ swift-tools-version: \d+\.\d+/;
 

--- a/packages/react-native/scripts/spm/__tests__/sync-spm-autolinking-test.js
+++ b/packages/react-native/scripts/spm/__tests__/sync-spm-autolinking-test.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const {main} = require('../sync-spm-autolinking');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 describe('sync-spm-autolinking main', () => {
   let appRoot;

--- a/packages/react-native/scripts/spm/autolinking-plugins.js
+++ b/packages/react-native/scripts/spm/autolinking-plugins.js
@@ -76,7 +76,7 @@
  * the merge, so regeneration stays deterministic and idempotent.
  */
 
-const path = require('path');
+const path = require('node:path');
 
 /*:: import type {
   AutolinkedDep,

--- a/packages/react-native/scripts/spm/download-spm-artifacts.js
+++ b/packages/react-native/scripts/spm/download-spm-artifacts.js
@@ -57,10 +57,10 @@ const {
   makeLogger,
   sharedCacheDir,
 } = require('./spm-utils');
-const {execFileSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const stream = require('stream');
+const {execFileSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const stream = require('node:stream');
 const yargs = require('yargs');
 
 const {log, warn, die} = makeLogger('download-spm-artifacts');

--- a/packages/react-native/scripts/spm/expand-spm-dependencies.js
+++ b/packages/react-native/scripts/spm/expand-spm-dependencies.js
@@ -11,8 +11,8 @@
 'use strict';
 
 const {toSwiftName} = require('./spm-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /**
  * expand-spm-dependencies.js — Resolves transitive native deps declared via

--- a/packages/react-native/scripts/spm/flavored-frameworks.js
+++ b/packages/react-native/scripts/spm/flavored-frameworks.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const {execFileSync} = require('child_process');
-const crypto = require('crypto');
-const fs = require('fs');
-const path = require('path');
+const {execFileSync} = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // Info.plist parsing goes through plutil (as the pre-B1 swap script did): the
 // `plist` npm module is NOT a react-native dependency, so it only resolves

--- a/packages/react-native/scripts/spm/generate-spm-autolinking-config.js
+++ b/packages/react-native/scripts/spm/generate-spm-autolinking-config.js
@@ -25,9 +25,9 @@
  * external dep discovery.
  */
 
-const {spawnSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {spawnSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*::
 import type {CliConfigJson} from './spm-types';

--- a/packages/react-native/scripts/spm/generate-spm-autolinking.js
+++ b/packages/react-native/scripts/spm/generate-spm-autolinking.js
@@ -70,8 +70,8 @@ const {
   remotePackageConfig,
   toSwiftName,
 } = require('./spm-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const yargs = require('yargs');
 
 const {log, warn} = makeLogger('generate-spm-autolinking');

--- a/packages/react-native/scripts/spm/generate-spm-package.js
+++ b/packages/react-native/scripts/spm/generate-spm-package.js
@@ -45,8 +45,8 @@ const {
   resolveReactNativeRoot,
   toSwiftName,
 } = require('./spm-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const yargs = require('yargs');
 
 const {log} = makeLogger('generate-spm-package');

--- a/packages/react-native/scripts/spm/generate-spm-xcodeproj.js
+++ b/packages/react-native/scripts/spm/generate-spm-xcodeproj.js
@@ -43,8 +43,8 @@ const {
   setScalarField,
 } = require('./spm-pbxproj');
 const {makeLogger, remotePackageConfig} = require('./spm-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*:: import type {
   FlavoredFrameworkManifestEntry,

--- a/packages/react-native/scripts/spm/read-podspec.js
+++ b/packages/react-native/scripts/spm/read-podspec.js
@@ -27,9 +27,9 @@
  * libraries in practice.
  */
 
-const {spawnSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {spawnSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*::
 type RawSpec = {[string]: unknown};

--- a/packages/react-native/scripts/spm/scaffold-package-swift.js
+++ b/packages/react-native/scripts/spm/scaffold-package-swift.js
@@ -48,8 +48,8 @@ const {
   remotePackageConfig,
   toSwiftName,
 } = require('./spm-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {log} = makeLogger('scaffold-package-swift');
 

--- a/packages/react-native/scripts/spm/spm-pbxproj.js
+++ b/packages/react-native/scripts/spm/spm-pbxproj.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 
 /**
  * Generate a deterministic 24-hex-character UUID from a seed string.

--- a/packages/react-native/scripts/spm/spm-utils.js
+++ b/packages/react-native/scripts/spm/spm-utils.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 /**
  * Creates a logger trio {log, warn, die} that prefixes messages with [name].
@@ -610,7 +610,7 @@ function runCodegenAndInstallTemplate(
     return;
   }
   logger.log('Running codegen...');
-  const {execSync} = require('child_process');
+  const {execSync} = require('node:child_process');
   const codegenArgs =
     `node "${codegenScript}" -p "${projectRoot}" -t ios` +
     (projectRoot !== appRoot ? ` -o "${appRoot}"` : '');

--- a/packages/react-native/scripts/spm/sync-spm-autolinking.js
+++ b/packages/react-native/scripts/spm/sync-spm-autolinking.js
@@ -47,8 +47,8 @@ const {
   makeLogger,
   runCodegenAndInstallTemplate,
 } = require('./spm-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const yargs = require('yargs');
 
 const {log} = makeLogger('sync-spm-autolinking');

--- a/packages/react-native/scripts/swiftpm/__tests__/headers-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/headers-utils-test.js
@@ -21,8 +21,8 @@ const {
 // Mock all required modules
 jest.mock('../utils');
 jest.mock('../headers-mappings');
-jest.mock('fs');
-jest.mock('path');
+jest.mock('node:fs');
+jest.mock('node:path');
 
 describe('symlinkHeadersFromPath', () => {
   let mockUtils;
@@ -34,8 +34,8 @@ describe('symlinkHeadersFromPath', () => {
   beforeEach(() => {
     // Setup mocks
     mockUtils = require('../utils');
-    mockFs = require('fs');
-    mockPath = require('path');
+    mockFs = require('node:fs');
+    mockPath = require('node:path');
 
     // Mock path functions
     mockPath.relative.mockImplementation((from, to) => {
@@ -307,8 +307,8 @@ describe('symlinkCodegenHeaders', () => {
   beforeEach(() => {
     // Setup mocks
     mockUtils = require('../utils');
-    mockFs = require('fs');
-    mockPath = require('path');
+    mockFs = require('node:fs');
+    mockPath = require('node:path');
 
     // Mock path functions
     mockPath.relative.mockImplementation((from, to) => {
@@ -470,8 +470,8 @@ describe('symlinkThirdPartyDependenciesHeaders', () => {
   beforeEach(() => {
     // Setup mocks
     mockUtils = require('../utils');
-    mockFs = require('fs');
-    mockPath = require('path');
+    mockFs = require('node:fs');
+    mockPath = require('node:path');
 
     // Mock path functions
     mockPath.relative.mockImplementation((from, to) => {
@@ -707,7 +707,7 @@ describe('symlinkReactAppleHeaders', () => {
   beforeEach(() => {
     // Setup mocks
     mockUtils = require('../utils');
-    mockPath = require('path');
+    mockPath = require('node:path');
 
     // Mock path functions
     mockPath.relative.mockImplementation((from, to) => {
@@ -930,7 +930,7 @@ describe('symlinkReactCommonHeaders', () => {
     mockUtils = require('../utils');
     mockReactCommonMappings =
       require('../headers-mappings').reactCommonMappings;
-    mockPath = require('path');
+    mockPath = require('node:path');
 
     // Mock path functions
     mockPath.relative.mockImplementation((from, to) => {

--- a/packages/react-native/scripts/swiftpm/__tests__/prepare-app-dependencies-headers-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/prepare-app-dependencies-headers-test.js
@@ -24,8 +24,8 @@ jest.mock('../headers-mappings', () => ({
 }));
 
 // Mock fs and path modules
-jest.mock('fs');
-jest.mock('path');
+jest.mock('node:fs');
+jest.mock('node:path');
 
 const {librariesMappings, reactMappings} = require('../headers-mappings');
 const {
@@ -36,8 +36,8 @@ const {
 const {
   symlinkReactNativeHeaders,
 } = require('../prepare-app-dependencies-headers');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 describe('symlinkReactNativeHeaders', () => {
   let originalConsoleLog;

--- a/packages/react-native/scripts/swiftpm/__tests__/prepare-app-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/prepare-app-utils-test.js
@@ -22,10 +22,10 @@ const {
 } = require('../prepare-app-utils');
 
 // Mock child_process module
-jest.mock('child_process');
+jest.mock('node:child_process');
 
 // Mock fs module
-jest.mock('fs');
+jest.mock('node:fs');
 
 // Mock headers-utils module
 jest.mock('../headers-utils');
@@ -37,8 +37,8 @@ jest.mock('../prepare-app-dependencies-headers');
 jest.mock('../../codegen/generate-artifacts-executor');
 
 // Mock path module for absolute paths
-jest.mock('path', () => {
-  const actualPath = jest.requireActual('path');
+jest.mock('node:path', () => {
+  const actualPath = jest.requireActual('node:path');
   return {
     ...actualPath,
     join: jest.fn((...args) => args.join('/')),
@@ -62,7 +62,7 @@ describe('createHardlinks', () => {
     mockSymlinkThirdPartyDependenciesHeaders =
       headersUtils.symlinkThirdPartyDependenciesHeaders;
 
-    mockPath = require('path');
+    mockPath = require('node:path');
     mockConsoleLog = console.log;
 
     // Clear and reset all mocks completely
@@ -376,7 +376,7 @@ describe('prepareHeaders', () => {
     mockPrepareAppDependenciesHeaders =
       prepareAppDependenciesHeadersModule.prepareAppDependenciesHeaders;
 
-    mockPath = require('path');
+    mockPath = require('node:path');
     mockConsoleLog = console.log;
 
     // Clear and reset all mocks completely
@@ -702,7 +702,7 @@ describe('findXcodeProjectDirectory', () => {
 
   beforeEach(() => {
     // Setup mock
-    const childProcess = require('child_process');
+    const childProcess = require('node:child_process');
     mockExecSync = childProcess.execSync;
 
     // Reset all mocks
@@ -846,8 +846,8 @@ describe('setBuildFromSource', () => {
 
   beforeEach(() => {
     // Setup mocks
-    mockFs = require('fs');
-    mockPath = require('path');
+    mockFs = require('node:fs');
+    mockPath = require('node:path');
     mockConsoleLog = console.log;
     mockConsoleWarn = console.warn;
 
@@ -1076,7 +1076,7 @@ describe('runIosPrebuild', () => {
 
   beforeEach(() => {
     // Setup mocks
-    const childProcess = require('child_process');
+    const childProcess = require('node:child_process');
     mockExecSync = childProcess.execSync;
 
     mockConsoleLog = console.log;
@@ -1235,7 +1235,7 @@ describe('runPodDeintegrate', () => {
 
   beforeEach(() => {
     // Setup mocks
-    const childProcess = require('child_process');
+    const childProcess = require('node:child_process');
     mockExecSync = childProcess.execSync;
 
     mockConsoleLog = console.log;
@@ -1370,8 +1370,8 @@ describe('configureAppForSwift', () => {
 
   beforeEach(() => {
     // Setup mocks
-    mockFs = require('fs');
-    mockPath = require('path');
+    mockFs = require('node:fs');
+    mockPath = require('node:path');
     mockConsoleLog = console.log;
 
     // Clear and reset all mocks completely

--- a/packages/react-native/scripts/swiftpm/__tests__/utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/utils-test.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const {listHeadersInFolder, setupSymlink} = require('../utils');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 describe('setupSymlink', () => {
   let tempDir;

--- a/packages/react-native/scripts/swiftpm/headers-mappings.js
+++ b/packages/react-native/scripts/swiftpm/headers-mappings.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-const path = require('path');
+const path = require('node:path');
 
 /*::
 type MappingOption = {

--- a/packages/react-native/scripts/swiftpm/headers-utils.js
+++ b/packages/react-native/scripts/swiftpm/headers-utils.js
@@ -10,8 +10,8 @@
 
 const {reactCommonMappings} = require('./headers-mappings');
 const {listHeadersInFolder, setupSymlink} = require('./utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /**
  * Helper function to create symlinks from a source path

--- a/packages/react-native/scripts/swiftpm/prepare-app-dependencies-headers.js
+++ b/packages/react-native/scripts/swiftpm/prepare-app-dependencies-headers.js
@@ -16,8 +16,8 @@ const {
   symlinkReactCommonHeaders,
   symlinkThirdPartyDependenciesHeaders,
 } = require('./headers-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*::
 type RequiredHeaders = 'react-native' | 'codegen' | 'third-party-dependencies' | 'all';

--- a/packages/react-native/scripts/swiftpm/prepare-app-utils.js
+++ b/packages/react-native/scripts/swiftpm/prepare-app-utils.js
@@ -14,9 +14,9 @@ const {
   prepareAppDependenciesHeaders,
   symlinkReactNativeHeaders,
 } = require('./prepare-app-dependencies-headers');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /**
  * Find the directory containing the Xcode project within the app path

--- a/packages/react-native/scripts/swiftpm/utils.js
+++ b/packages/react-native/scripts/swiftpm/utils.js
@@ -8,9 +8,9 @@
  * @format
  */
 
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function listHeadersInFolder(
   folder /*: string */,

--- a/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
@@ -11,9 +11,9 @@
 import typeof TNativeAnimatedModule from '../../specs_DEPRECATED/modules/NativeAnimatedModule';
 
 import {create, unmount, update} from '@react-native/jest-preset/jest/renderer';
+import {format} from 'node:util';
 import * as React from 'react';
 import {createRef} from 'react';
-import {format} from 'util';
 
 describe('Native Animated', () => {
   let NativeAnimatedModule: Exclude<TNativeAnimatedModule, null | void>;

--- a/packages/react-native/third-party-podspecs/replace_dependencies_version.js
+++ b/packages/react-native/third-party-podspecs/replace_dependencies_version.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const {spawnSync} = require('child_process');
-const fs = require('fs');
+const {spawnSync} = require('node:child_process');
+const fs = require('node:fs');
 const yargs = require('yargs');
 
 const LAST_BUILD_FILENAME = 'ReactNativeDependencies/.last_build_configuration';

--- a/packages/rn-tester/cli.flow.js
+++ b/packages/rn-tester/cli.flow.js
@@ -11,7 +11,7 @@
 import {run} from './scripts/utils';
 import {apple} from '@react-native/core-cli-utils';
 import {Option, program} from 'commander';
-import {readFileSync} from 'fs';
+import {readFileSync} from 'node:fs';
 
 program.version(JSON.parse(readFileSync('./package.json', 'utf8')).version);
 

--- a/packages/rn-tester/js/examples/WebSocket/http_test_server.js
+++ b/packages/rn-tester/js/examples/WebSocket/http_test_server.js
@@ -20,7 +20,7 @@ This will set a cookie named "wstest" on the response of any incoming request.
 `);
 
 const connect = require('connect');
-const http = require('http');
+const http = require('node:http');
 
 const app = connect();
 

--- a/packages/rn-tester/js/examples/WebSocket/websocket_test_server.js
+++ b/packages/rn-tester/js/examples/WebSocket/websocket_test_server.js
@@ -13,8 +13,8 @@
 
 /* eslint-env node */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const WebSocket = require('ws');
 
 console.log(`\

--- a/packages/rn-tester/metro.config.js
+++ b/packages/rn-tester/metro.config.js
@@ -12,7 +12,7 @@
 
 const {getDefaultConfig} = require('@react-native/metro-config');
 const {mergeConfig} = require('metro-config');
-const path = require('path');
+const path = require('node:path');
 
 /**
  * This cli config is needed for development purposes, e.g. for running

--- a/packages/rn-tester/scripts/utils.js
+++ b/packages/rn-tester/scripts/utils.js
@@ -14,8 +14,8 @@ import type {ExecaPromise} from 'execa';
 import type {TaskResult, TaskSpec} from 'listr2';
 
 import {Listr} from 'listr2';
+import {styleText} from 'node:util';
 import {Observable} from 'rxjs';
-import {styleText} from 'util';
 
 export function trim(
   line: string,

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -9,10 +9,10 @@
  */
 
 import VirtualizedList from '../VirtualizedList';
+import {format} from 'node:util';
 import * as React from 'react';
 import {createElement, createRef} from 'react';
 import {act, create} from 'react-test-renderer';
-import {format} from 'util';
 
 jest.useFakeTimers();
 

--- a/private/core-cli-utils/src/private/app.js
+++ b/private/core-cli-utils/src/private/app.js
@@ -16,8 +16,8 @@ import type {ExecaPromise} from 'execa';
 const {task} = require('./utils');
 const debug = require('debug');
 const execa = require('execa');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const log = debug('core-cli-utils');
 

--- a/private/core-cli-utils/src/private/apple.js
+++ b/private/core-cli-utils/src/private/apple.js
@@ -15,8 +15,8 @@ import type {ExecaPromise} from 'execa';
 
 const {assertDependencies, isOnPath, task} = require('./utils');
 const execa = require('execa');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*::
 type AppleBuildMode = 'Debug' | 'Release';

--- a/private/core-cli-utils/src/private/clean.js
+++ b/private/core-cli-utils/src/private/clean.js
@@ -21,9 +21,9 @@ const {
   task,
 } = require('./utils');
 const execa = require('execa');
-const {existsSync, readdirSync, rm} = require('fs');
-const os = require('os');
-const path = require('path');
+const {existsSync, readdirSync, rm} = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const FIRST = 1,
   SECOND = 2;

--- a/private/core-cli-utils/src/private/utils.js
+++ b/private/core-cli-utils/src/private/utils.js
@@ -13,7 +13,7 @@ import type {Task} from './types';
 */
 
 const execa = require('execa');
-const os = require('os');
+const os = require('node:os');
 
 function task /*:: <R> */(
   order /*: number */,

--- a/private/eslint-plugin-monorepo/__tests__/eslintrc-test.js
+++ b/private/eslint-plugin-monorepo/__tests__/eslintrc-test.js
@@ -10,7 +10,7 @@
 
 // $FlowFixMe[untyped-import] - Flow lib is not configured.
 import {ESLint} from 'eslint';
-import path from 'path';
+import path from 'node:path';
 
 const REPO_DIR = path.resolve(__dirname, '..', '..', '..');
 

--- a/private/helloworld/cli.flow.js
+++ b/private/helloworld/cli.flow.js
@@ -20,9 +20,9 @@ import {
 } from './lib/ios';
 import {android, app, apple} from '@react-native/core-cli-utils';
 import {Command, Option, program} from 'commander';
-import {readFileSync} from 'fs';
 import {Listr} from 'listr2';
-import path from 'path';
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
 
 program.version(JSON.parse(readFileSync('./package.json', 'utf8')).version);
 
@@ -246,7 +246,7 @@ bundle
             hermesc: hermesc ?? '',
           },
           callback: metroProcess => {
-            const readline = require('readline');
+            const readline = require('node:readline');
             readline.emitKeypressEvents(process.stdin);
             process.stdout.write('Press any key to close Metro...');
             // $FlowFixMe[prop-missing]

--- a/private/helloworld/lib/cli.js
+++ b/private/helloworld/lib/cli.js
@@ -14,8 +14,8 @@ import type {ExecaPromise} from 'execa';
 import type {TaskResult, TaskSpec} from 'listr2';
 
 import {Listr} from 'listr2';
+import {styleText} from 'node:util';
 import {Observable} from 'rxjs';
-import {styleText} from 'util';
 
 export function trim(
   line: string,

--- a/private/helloworld/lib/filesystem.js
+++ b/private/helloworld/lib/filesystem.js
@@ -8,10 +8,10 @@
  * @format
  */
 
-import {execSync, spawn} from 'child_process';
 import debug from 'debug';
-import {existsSync} from 'fs';
-import path from 'path';
+import {execSync, spawn} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import path from 'node:path';
 
 const logWatchman = debug('helloworld:cli:watchman');
 

--- a/private/helloworld/lib/ios.js
+++ b/private/helloworld/lib/ios.js
@@ -12,8 +12,8 @@ import type {XcodeBuildSettings} from './xcode';
 import type {Result} from 'execa';
 
 import execa from 'execa';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export type IOSDevice = {
   lastBootedAt: Date,

--- a/private/helloworld/metro.config.js
+++ b/private/helloworld/metro.config.js
@@ -13,7 +13,7 @@ import type {InputConfigT} from 'metro-config';
 */
 
 const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
-const path = require('path');
+const path = require('node:path');
 
 function repositoryPath(relativePath /*: string */) {
   return path.join(__dirname, '..', '..', relativePath);

--- a/private/helloworld/scripts/metro.js
+++ b/private/helloworld/scripts/metro.js
@@ -10,7 +10,7 @@
 
 const {startCommand} = require('@react-native/community-cli-plugin');
 const {program} = require('commander');
-const path = require('path');
+const path = require('node:path');
 
 program
   .description('Starts the React Native Metro bundler for internal testing app')

--- a/private/react-native-codegen-typescript-test/scripts/build.js
+++ b/private/react-native-codegen-typescript-test/scripts/build.js
@@ -9,8 +9,8 @@
  * @noflow
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function repositoryPath(relativePath) {
   return path.join(__dirname, '..', '..', '..', relativePath);

--- a/private/react-native-codegen-typescript-test/src/__tests__/simple-scenario-frontend-test.ts
+++ b/private/react-native-codegen-typescript-test/src/__tests__/simple-scenario-frontend-test.ts
@@ -7,7 +7,7 @@
  * @format
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import type {SchemaType} from '@react-native/codegen/lib/CodegenSchema';
 import {TypeScriptParser} from '@react-native/codegen/lib/parsers/typescript/parser';
 

--- a/private/react-native-fantom/config/hasteImpl.js
+++ b/private/react-native-fantom/config/hasteImpl.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const crypto = require('crypto');
-const fs = require('fs');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
 
 module.exports = {
   getHasteName(filePath /*: string */) /*: ?string */ {

--- a/private/react-native-fantom/config/jest.config.js
+++ b/private/react-native-fantom/config/jest.config.js
@@ -11,8 +11,8 @@
 'use strict';
 
 const baseConfig = require('../../../jest.config');
-const os = require('os');
-const path = require('path');
+const os = require('node:os');
+const path = require('node:path');
 
 // Every Fantom worker shares a single Metro server. With unbounded
 // parallelism, concurrent bundle builds pile up faster than the

--- a/private/react-native-fantom/config/metro-babel-transformer.flow.js
+++ b/private/react-native-fantom/config/metro-babel-transformer.flow.js
@@ -14,8 +14,8 @@ import type {
 } from 'metro-babel-transformer';
 
 import MetroBabelTransformer from '@react-native/metro-babel-transformer';
-import crypto from 'crypto';
-import fs from 'fs';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
 
 const transform: BabelTransformer['transform'] = (
   args: BabelTransformerArgs,

--- a/private/react-native-fantom/config/metro.config.js
+++ b/private/react-native-fantom/config/metro.config.js
@@ -16,7 +16,7 @@ import type {ConfigT, InputConfigT} from 'metro-config';
 
 const {getDefaultConfig} = require('@react-native/metro-config');
 const {mergeConfig} = require('metro-config');
-const path = require('path');
+const path = require('node:path');
 
 const rnTesterConfig = getDefaultConfig(
   path.resolve('../../../packages/rn-tester'),

--- a/private/react-native-fantom/repl/replBundling.js
+++ b/private/react-native-fantom/repl/replBundling.js
@@ -8,8 +8,8 @@
  * @format
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 // react-native-github repo root (repl -> ../../.. ).
 export const PROJECT_ROOT: string = path.resolve(__dirname, '..', '..', '..');

--- a/private/react-native-fantom/repl/replMetro.js
+++ b/private/react-native-fantom/repl/replMetro.js
@@ -8,13 +8,13 @@
  * @format
  */
 
-import type {Server as HttpServer} from 'http';
-import type {Server as HttpsServer} from 'https';
+import type {Server as HttpServer} from 'node:http';
+import type {Server as HttpsServer} from 'node:https';
 
 import * as Metro from 'metro';
 import {mergeConfig} from 'metro-config';
-import {Server as NetServer} from 'net';
-import path from 'path';
+import {Server as NetServer} from 'node:net';
+import path from 'node:path';
 
 let metroServer: ?(HttpServer | HttpsServer) = null;
 

--- a/private/react-native-fantom/repl/runRepl.js
+++ b/private/react-native-fantom/repl/runRepl.js
@@ -22,11 +22,11 @@ import {
 } from './replBundling';
 import {startMetroServer, stopMetroServer} from './replMetro';
 import {isRecoverableError, transform} from './replTransform';
-import fs from 'fs';
-import path from 'path';
-import readline from 'readline';
-import repl from 'repl';
-import tty from 'tty';
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import repl from 'node:repl';
+import tty from 'node:tty';
 
 type ReplMessage =
   | {type: 'console-log', level: 'info' | 'warn' | 'error', message: string}

--- a/private/react-native-fantom/runner/bundling.js
+++ b/private/react-native-fantom/runner/bundling.js
@@ -10,8 +10,8 @@
 
 import type {RunBuildOptions} from 'metro';
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 type BundleOptions = {
   ...RunBuildOptions,

--- a/private/react-native-fantom/runner/executables/hermesc.js
+++ b/private/react-native-fantom/runner/executables/hermesc.js
@@ -20,9 +20,9 @@ import {
   runBuck2Sync,
   runCommandSync,
 } from '../utils';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 type HermescOptions = Readonly<{
   enableCoverage: boolean,

--- a/private/react-native-fantom/runner/executables/tester.js
+++ b/private/react-native-fantom/runner/executables/tester.js
@@ -25,9 +25,9 @@ import {
   runCommand,
   runCommandSync,
 } from '../utils';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 const FANTOM_TESTER_BUCK_TARGET =
   'fbsource//xplat/js/react-native-github/private/react-native-fantom/tester:tester';

--- a/private/react-native-fantom/runner/global-setup/build.js
+++ b/private/react-native-fantom/runner/global-setup/build.js
@@ -17,9 +17,9 @@ import {build as buildFantomTester} from '../executables/tester';
 import {NATIVE_BUILD_OUTPUT_PATH} from '../paths';
 import {HermesVariant} from '../utils';
 // $FlowExpectedError[untyped-import]
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 async function tryOrLog(
   fn: () => void | Promise<void>,

--- a/private/react-native-fantom/runner/global-setup/globalSetup.js
+++ b/private/react-native-fantom/runner/global-setup/globalSetup.js
@@ -17,8 +17,8 @@ import build from './build';
 import {createDevMiddleware} from '@react-native/dev-middleware';
 import connect from 'connect';
 import * as Metro from 'metro';
-import {Server} from 'net';
-import path from 'path';
+import {Server} from 'node:net';
+import path from 'node:path';
 
 export default async function globalSetup(
   globalConfig: {

--- a/private/react-native-fantom/runner/llvm/processLLVMCoverage.js
+++ b/private/react-native-fantom/runner/llvm/processLLVMCoverage.js
@@ -22,9 +22,9 @@ import {
   runCommand,
   runCommandSync,
 } from '../utils';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 const FANTOM_DIR = path.resolve(__dirname, '..', '..');
 const RN_ROOT = path.resolve(FANTOM_DIR, '..', '..');

--- a/private/react-native-fantom/runner/paths.js
+++ b/private/react-native-fantom/runner/paths.js
@@ -11,7 +11,7 @@
 import type {FantomTestConfig} from './getFantomTestConfigs';
 
 import formatFantomConfig from './formatFantomConfig';
-import path from 'path';
+import path from 'node:path';
 
 export const PROJECT_ROOT: string = path.resolve(__dirname, '..', '..', '..');
 

--- a/private/react-native-fantom/runner/runner.js
+++ b/private/react-native-fantom/runner/runner.js
@@ -61,13 +61,13 @@ import {
   symbolicateJSTrace,
   symbolicateStackTrace,
 } from './utils';
-import fs from 'fs';
 // $FlowExpectedError[untyped-import]
 import {formatResultsErrors} from 'jest-message-util';
 import {SnapshotState, buildSnapshotResolver} from 'jest-snapshot';
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
 import nullthrows from 'nullthrows';
-import path from 'path';
-import readline from 'readline';
 
 const TEST_BUILD_OUTPUT_PATH = getTestBuildOutputPath();
 fs.mkdirSync(TEST_BUILD_OUTPUT_PATH, {recursive: true});

--- a/private/react-native-fantom/runner/snapshotUtils.js
+++ b/private/react-native-fantom/runner/snapshotUtils.js
@@ -15,8 +15,8 @@ import type {
 import type {SnapshotState} from 'jest-snapshot';
 
 import {symbolicateStackTrace} from './utils';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 type JestSnapshotResult = {
   added: number,

--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -9,9 +9,9 @@
  */
 
 import * as EnvironmentOptions from './EnvironmentOptions';
-import {spawn, spawnSync} from 'child_process';
-import fs from 'fs';
-import os from 'os';
+import {spawn, spawnSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
 // $FlowExpectedError[untyped-import]
 import {SourceMapConsumer} from 'source-map';
 

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -18,15 +18,15 @@ const {
   getTypeScriptCompilerOptions,
 } = require('./config');
 const babel = require('@babel/core');
-const {spawn} = require('child_process');
 const translate = require('flow-api-translator');
-const {promises: fs} = require('fs');
 const micromatch = require('micromatch');
-const path = require('path');
+const {spawn} = require('node:child_process');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
+const {parseArgs, styleText} = require('node:util');
 const prettier = require('prettier');
 const {globSync} = require('tinyglobby');
 const ts = require('typescript');
-const {parseArgs, styleText} = require('util');
 
 const SRC_DIR = 'src';
 const BUILD_DIR = 'dist';

--- a/scripts/build/clean.js
+++ b/scripts/build/clean.js
@@ -12,9 +12,9 @@ require('../shared/babelRegister').registerForScript();
 
 const {BUILD_DIR, PACKAGES_DIR} = require('./build');
 const {buildConfig} = require('./config');
-const fs = require('fs');
-const path = require('path');
-const {parseArgs} = require('util');
+const fs = require('node:fs');
+const path = require('node:path');
+const {parseArgs} = require('node:util');
 
 const config = {
   options: {

--- a/scripts/build/prepack.js
+++ b/scripts/build/prepack.js
@@ -10,8 +10,8 @@
 
 require('../shared/babelRegister').registerForScript();
 
-const {promises: fs} = require('fs');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
 
 // "prepack" script to prepare JavaScript packages for publishing.
 //

--- a/scripts/debugger-frontend/sync-and-build.js
+++ b/scripts/debugger-frontend/sync-and-build.js
@@ -11,18 +11,18 @@
 const {PACKAGES_DIR} = require('../shared/consts');
 // $FlowFixMe[untyped-import]: TODO type ansi-styles
 const ansiStyles = require('ansi-styles');
-const {execSync, spawnSync} = require('child_process');
-const {promises: fs} = require('fs');
+const {execSync, spawnSync} = require('node:child_process');
+const {promises: fs} = require('node:fs');
+const {hostname, tmpdir, userInfo} = require('node:os');
+const path = require('node:path');
+const {parseArgs, styleText} = require('node:util');
 const nullthrows = require('nullthrows');
-const {hostname, tmpdir, userInfo} = require('os');
-const path = require('path');
 // $FlowFixMe[untyped-import]: TODO type rimraf
 const rimraf = require('rimraf');
 // $FlowFixMe[untyped-import]: TODO type signedsource
 const SignedSource = require('signedsource');
 // $FlowFixMe[untyped-import]: TODO type supports-color
 const supportsColor = require('supports-color');
-const {parseArgs, styleText} = require('util');
 
 const DEVTOOLS_FRONTEND_REPO_URL =
   'https://github.com/react/react-native-devtools-frontend';

--- a/scripts/debugger-shell/build-binary.js
+++ b/scripts/debugger-shell/build-binary.js
@@ -28,10 +28,10 @@ if (isMetaInternal) {
 }
 
 const {packager} = require('@electron/packager');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
+const util = require('node:util');
 const signedsource = require('signedsource');
-const util = require('util');
 
 const APP_NAME = 'React Native DevTools';
 const COMPANY_NAME = 'Meta Platforms Technologies LLC';

--- a/scripts/e2e/init-project-e2e.js
+++ b/scripts/e2e/init-project-e2e.js
@@ -20,11 +20,11 @@ const {
   VERDACCIO_STORAGE_PATH,
   setupVerdaccio,
 } = require('./utils/verdaccio');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const {parseArgs, styleText} = require('node:util');
 const {popd, pushd} = require('shelljs');
-const {parseArgs, styleText} = require('util');
 
 const config = {
   options: {

--- a/scripts/e2e/utils/retry.js
+++ b/scripts/e2e/utils/retry.js
@@ -8,7 +8,7 @@
  * @noflow
  */
 
-const {spawnSync} = require('child_process');
+const {spawnSync} = require('node:child_process');
 
 async function retry(command, options, maxRetries, delay, args) {
   for (let i = 1; i <= maxRetries; i++) {

--- a/scripts/e2e/utils/verdaccio.js
+++ b/scripts/e2e/utils/verdaccio.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const {REPO_ROOT} = require('../../shared/consts');
-const {execSync, spawn} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync, spawn} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const NPM_CONFIG_PATH = path.join(REPO_ROOT, '.npmrc');
 const VERDACCIO_CONFIG_PATH = path.join(__dirname, '..', 'verdaccio.yml');

--- a/scripts/js-api/build-types/buildApiSnapshot.js
+++ b/scripts/js-api/build-types/buildApiSnapshot.js
@@ -22,13 +22,13 @@ const {
   ExtractorConfig,
   // $FlowFixMe[cannot-resolve-module]
 } = require('@microsoft/api-extractor');
-const {promises: fs} = require('fs');
 const {diff} = require('jest-diff');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
+const {styleText} = require('node:util');
 const prettier = require('prettier');
 const osTempDir = require('temp-dir');
 const {globSync} = require('tinyglobby');
-const {styleText} = require('util');
 
 const inputFilesPostTransforms: ReadonlyArray<PluginObj<unknown>> = [
   require('./transforms/typescript/renameDefaultExportedIdentifiers'),

--- a/scripts/js-api/build-types/buildGeneratedTypes.js
+++ b/scripts/js-api/build-types/buildGeneratedTypes.js
@@ -13,10 +13,10 @@ const {ENTRY_POINT, IGNORE_PATTERNS, TYPES_OUTPUT_DIR} = require('../config');
 const getRequireStack = require('./resolution/getRequireStack');
 const translatedModuleTemplate = require('./templates/translatedModule.d.ts-template');
 const translateSourceFile = require('./translateSourceFile');
-const {promises: fs, watch: fsWatch} = require('fs');
 const micromatch = require('micromatch');
-const path = require('path');
-const {styleText} = require('util');
+const {promises: fs, watch: fsWatch} = require('node:fs');
+const path = require('node:path');
+const {styleText} = require('node:util');
 
 /**
  * Build generated TypeScript types for react-native.

--- a/scripts/js-api/build-types/index.js
+++ b/scripts/js-api/build-types/index.js
@@ -16,7 +16,7 @@ const {
   watchGeneratedTypes,
 } = require('./buildGeneratedTypes');
 const debug = require('debug');
-const {parseArgs, styleText} = require('util');
+const {parseArgs, styleText} = require('node:util');
 
 const config = {
   options: {

--- a/scripts/js-api/build-types/resolution/resolveTypeInputFile.js
+++ b/scripts/js-api/build-types/resolution/resolveTypeInputFile.js
@@ -10,8 +10,8 @@
 
 const {REPO_ROOT} = require('../../../shared/consts');
 const debug = require('debug')('build-types:resolution');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const TYPEDEF_MAPPING: Record<string, ReadonlyArray<string>> = {
   '.android.js': ['.js.flow', '.js'],

--- a/scripts/js-api/build-types/resolution/simpleResolve.js
+++ b/scripts/js-api/build-types/resolution/simpleResolve.js
@@ -10,8 +10,8 @@
 
 const {PACKAGES_DIR} = require('../../../shared/consts');
 const {getPackages} = require('../../../shared/monorepoUtils');
-const {existsSync} = require('fs');
-const path = require('path');
+const {existsSync} = require('node:fs');
+const path = require('node:path');
 
 export type DependencyContext = Readonly<{
   reportUnresolvedDependency(importPath: string): void,

--- a/scripts/js-api/build-types/transforms/typescript/__tests__/organizeDeclarations-test.js
+++ b/scripts/js-api/build-types/transforms/typescript/__tests__/organizeDeclarations-test.js
@@ -10,8 +10,8 @@
 
 const organizeDeclarations = require('../organizeDeclarations');
 const babel = require('@babel/core');
-const {promises: fs} = require('fs');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
 
 async function translate(code: string): Promise<string> {
   const result = await babel.transformAsync(code, {

--- a/scripts/js-api/build-types/transforms/typescript/__tests__/sortProperties-test.js
+++ b/scripts/js-api/build-types/transforms/typescript/__tests__/sortProperties-test.js
@@ -10,8 +10,8 @@
 
 const sortPropertiesVisitor = require('../sortProperties');
 const babel = require('@babel/core');
-const {promises: fs} = require('fs');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
 
 async function translate(code: string): Promise<string> {
   const result = await babel.transformAsync(code, {

--- a/scripts/js-api/build-types/transforms/typescript/__tests__/sortUnions-test.js
+++ b/scripts/js-api/build-types/transforms/typescript/__tests__/sortUnions-test.js
@@ -10,8 +10,8 @@
 
 const sortUnionsVisitor = require('../sortUnions');
 const babel = require('@babel/core');
-const {promises: fs} = require('fs');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
 
 async function translate(code: string): Promise<string> {
   const result = await babel.transformAsync(code, {

--- a/scripts/js-api/build-types/transforms/typescript/versionExportedApis.js
+++ b/scripts/js-api/build-types/transforms/typescript/versionExportedApis.js
@@ -14,8 +14,8 @@ const generate = require('@babel/generator').default;
 const {parse} = require('@babel/parser');
 const traverse = require('@babel/traverse').default;
 const t = require('@babel/types');
-const {createHash} = require('crypto');
 const debug = require('debug')('build-types:transforms:versionExportedApis');
+const {createHash} = require('node:crypto');
 
 /**
  * A visitor that annotates all exported types in the API snapshot with a

--- a/scripts/js-api/build-types/utils/__tests__/resolveCyclicImportsInDefinition-test.js
+++ b/scripts/js-api/build-types/utils/__tests__/resolveCyclicImportsInDefinition-test.js
@@ -9,7 +9,7 @@
  */
 
 const resolveCyclicImportsInDefinition = require('../resolveCyclicImportsInDefinition');
-const path = require('path');
+const path = require('node:path');
 
 const packagesPath = '/path/to/package/definition/files';
 

--- a/scripts/js-api/build-types/utils/resolveCyclicImportsInDefinition.js
+++ b/scripts/js-api/build-types/utils/resolveCyclicImportsInDefinition.js
@@ -11,7 +11,7 @@
 import type {PluginObj} from '@babel/core';
 
 import * as babel from '@babel/core';
-import path from 'path';
+import path from 'node:path';
 
 type PackageConfig = ReadonlyArray<{
   directory: string,

--- a/scripts/js-api/diff-api-snapshot/index.js
+++ b/scripts/js-api/diff-api-snapshot/index.js
@@ -12,8 +12,8 @@
 require('../../shared/babelRegister').registerForScript();
 
 const {diffApiSnapshot} = require('./diffApiSnapshot');
-const fs = require('fs');
-const {parseArgs} = require('util');
+const fs = require('node:fs');
+const {parseArgs} = require('node:util');
 
 const config = {
   allowPositionals: true,

--- a/scripts/monorepo-tests/__tests__/check-packages-test.js
+++ b/scripts/monorepo-tests/__tests__/check-packages-test.js
@@ -14,7 +14,7 @@ import {
   getReactNativePackage,
   getWorkspaceRoot,
 } from '../../shared/monorepoUtils';
-import path from 'path';
+import path from 'node:path';
 import {globSync} from 'tinyglobby';
 
 describe('package manifests', () => {

--- a/scripts/release-testing/test-release-local.js
+++ b/scripts/release-testing/test-release-local.js
@@ -26,10 +26,10 @@ const {
   prepareArtifacts,
   setupGHAArtifacts,
 } = require('./utils/testing-utils');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
+const {styleText} = require('node:util');
 const {cd, exec, popd, pushd, pwd, sed} = require('shelljs');
-const {styleText} = require('util');
 const yargs = require('yargs');
 
 /* ::

--- a/scripts/release-testing/utils/github-actions-utils.js
+++ b/scripts/release-testing/utils/github-actions-utils.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const {execSync: exec} = require('child_process');
 const fetch = require('node-fetch');
-const {styleText} = require('util');
+const {execSync: exec} = require('node:child_process');
+const {styleText} = require('node:util');
 
 /*::
 type CIHeaders = {

--- a/scripts/release-testing/utils/testing-utils.js
+++ b/scripts/release-testing/utils/testing-utils.js
@@ -14,11 +14,11 @@ const {
   generateAndroidArtifacts,
 } = require('../../releases/utils/release-utils');
 const ghaArtifactsUtils = require('./github-actions-utils.js');
-const fs = require('fs');
 // $FlowFixMe[cannot-resolve-module]
 const {spawn} = require('node:child_process');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const {exec} = require('shelljs');
 
 /*::

--- a/scripts/releases-ci/__tests__/publish-npm-test.js
+++ b/scripts/releases-ci/__tests__/publish-npm-test.js
@@ -25,7 +25,7 @@ const getBranchName = jest.fn();
 
 const {REPO_ROOT} = require('../../shared/consts');
 const {publishNpm} = require('../publish-npm');
-const path = require('path');
+const path = require('node:path');
 
 let consoleLog;
 

--- a/scripts/releases-ci/__tests__/publish-updated-packages-test.js
+++ b/scripts/releases-ci/__tests__/publish-updated-packages-test.js
@@ -18,7 +18,7 @@ const execSync = jest.fn();
 const execMock = jest.fn();
 const fetchMock = jest.fn();
 
-jest.mock('child_process', () => ({execSync}));
+jest.mock('node:child_process', () => ({execSync}));
 jest.mock('shelljs', () => ({exec: execMock}));
 jest.mock('../../shared/monorepoUtils', () => ({
   getPackages: getPackagesMock,

--- a/scripts/releases-ci/publish-updated-packages.js
+++ b/scripts/releases-ci/publish-updated-packages.js
@@ -10,8 +10,8 @@
 
 const {publishPackage} = require('../releases/utils/npm-utils');
 const {getPackages} = require('../shared/monorepoUtils');
-const {execSync} = require('child_process');
-const {parseArgs} = require('util');
+const {execSync} = require('node:child_process');
+const {parseArgs} = require('node:util');
 
 const PUBLISH_PACKAGES_TAG = '#publish-packages-to-npm';
 

--- a/scripts/releases/__tests__/set-rn-artifacts-version-test.js
+++ b/scripts/releases/__tests__/set-rn-artifacts-version-test.js
@@ -11,10 +11,10 @@
 const readFileMock = jest.fn();
 const writeFileMock = jest.fn();
 
-jest.mock('fs', () => ({
-  ...jest.requireActual<$FlowFixMe>('fs'),
+jest.mock('node:fs', () => ({
+  ...jest.requireActual<$FlowFixMe>('node:fs'),
   promises: {
-    ...jest.requireActual<$FlowFixMe>('fs').promises,
+    ...jest.requireActual<$FlowFixMe>('node:fs').promises,
     readFile: readFileMock,
     writeFile: writeFileMock,
   },
@@ -22,7 +22,7 @@ jest.mock('fs', () => ({
 
 const {REPO_ROOT} = require('../../shared/consts');
 const {updateReactNativeArtifacts} = require('../set-rn-artifacts-version');
-const path = require('path');
+const path = require('node:path');
 
 describe('updateReactNativeArtifacts', () => {
   beforeAll(() => {

--- a/scripts/releases/__tests__/set-version-test.js
+++ b/scripts/releases/__tests__/set-version-test.js
@@ -9,7 +9,7 @@
  */
 
 const {setVersion} = require('../set-version');
-const path = require('path');
+const path = require('node:path');
 
 jest.mock('../../shared/consts', () => ({
   REPO_ROOT: path.join(__dirname, '__fixtures__', 'set-version'),
@@ -51,9 +51,9 @@ describe('setVersion', () => {
   });
 
   beforeAll(() => {
-    jest.mock('fs', () => {
+    jest.mock('node:fs', () => {
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      const originalFs = jest.requireActual('fs');
+      const originalFs = jest.requireActual('node:fs');
 
       return {
         ...originalFs,

--- a/scripts/releases/__tests__/upload-release-assets-for-dotslash-test.js
+++ b/scripts/releases/__tests__/upload-release-assets-for-dotslash-test.js
@@ -19,10 +19,10 @@ const {
   removeCurlPaths,
   sanitizeSnapshots,
 } = require('./snapshot-utils');
-const fs = require('fs/promises');
-const http = require('http');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
 
 let server, serverUrl, tmpDir, consoleLog;
 

--- a/scripts/releases/__tests__/write-dotslash-release-asset-urls-test.js
+++ b/scripts/releases/__tests__/write-dotslash-release-asset-urls-test.js
@@ -14,10 +14,10 @@ const {
   writeReleaseAssetUrlsToDotSlashFile,
 } = require('../write-dotslash-release-asset-urls');
 const {removeAnsiColors, sanitizeSnapshots} = require('./snapshot-utils');
-const fs = require('fs/promises');
-const http = require('http');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
 const signedsource = require('signedsource');
 
 let server, serverUrl, tmpDir, consoleLog;

--- a/scripts/releases/create-release-commit.js
+++ b/scripts/releases/create-release-commit.js
@@ -17,7 +17,7 @@ const {
   writeReleaseAssetUrlsToDotSlashFiles,
 } = require('../releases/write-dotslash-release-asset-urls');
 const {parseVersion} = require('./utils/version-utils');
-const {execSync} = require('child_process');
+const {execSync} = require('node:child_process');
 const yargs = require('yargs');
 
 async function main() {

--- a/scripts/releases/ios-prebuild/build.js
+++ b/scripts/releases/ios-prebuild/build.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-const {execSync} = require('child_process');
+const {execSync} = require('node:child_process');
 
 /*::
 import type { Dependency, Destination, Platform } from './types';

--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -18,9 +18,9 @@ const {
   stubSlicesFromXcframework,
 } = require('../../../packages/react-native/scripts/ios-prebuild/headers-xcframework');
 const {HEADERS_FOLDER, TARGET_FOLDER} = require('./constants');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*::
 import type { Dependency, Platform } from './types';

--- a/scripts/releases/ios-prebuild/folders.js
+++ b/scripts/releases/ios-prebuild/folders.js
@@ -12,11 +12,11 @@
 import type {Dependency} from './types';
 */
 
-const fs = require('fs');
-const path = require('path');
-const util = require('util');
+const fs = require('node:fs');
+const path = require('node:path');
+const util = require('node:util');
 
-const exec = util.promisify(require('child_process').exec);
+const exec = util.promisify(require('node:child_process').exec);
 
 /**
  * Removes and recreates the given folder

--- a/scripts/releases/ios-prebuild/setupDependencies.js
+++ b/scripts/releases/ios-prebuild/setupDependencies.js
@@ -15,17 +15,17 @@ const {
   SOURCE_FOLDER,
   TARGET_FOLDER,
 } = require('./constants');
-const {execSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const util = require('node:util');
 const {globSync} = require('tinyglobby');
-const util = require('util');
 
 /*::
 import type {Dependency} from './types';
 */
 
-const exec = util.promisify(require('child_process').exec);
+const exec = util.promisify(require('node:child_process').exec);
 
 /**
  * This function downloads, prepares and creates the structure for the dependencies

--- a/scripts/releases/ios-prebuild/swift-package.js
+++ b/scripts/releases/ios-prebuild/swift-package.js
@@ -9,8 +9,8 @@
  */
 
 const {RESOURCES_FOLDER, TARGET_FOLDER} = require('./constants');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /*::
   import type {Dependency} from './types';

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -14,7 +14,7 @@ const {createFramework} = require('./ios-prebuild/compose-framework');
 const {cleanFolder} = require('./ios-prebuild/folders');
 const {setupDependencies} = require('./ios-prebuild/setupDependencies');
 const {createSwiftPackageFile} = require('./ios-prebuild/swift-package');
-const path = require('path');
+const path = require('node:path');
 
 require('../shared/babelRegister').registerForScript();
 

--- a/scripts/releases/set-rn-artifacts-version.js
+++ b/scripts/releases/set-rn-artifacts-version.js
@@ -15,9 +15,9 @@ import type {BuildType, Version} from './utils/version-utils';
 const {getNpmInfo} = require('../releases/utils/npm-utils');
 const {REPO_ROOT} = require('../shared/consts');
 const {parseVersion, validateBuildType} = require('./utils/version-utils');
-const {promises: fs} = require('fs');
-const path = require('path');
-const {parseArgs} = require('util');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
+const {parseArgs} = require('node:util');
 
 const GRADLE_FILE_PATH = path.join(
   REPO_ROOT,

--- a/scripts/releases/set-version.js
+++ b/scripts/releases/set-version.js
@@ -20,7 +20,7 @@ const {
   updatePackageJson,
 } = require('../shared/monorepoUtils');
 const {updateReactNativeArtifacts} = require('./set-rn-artifacts-version');
-const {parseArgs} = require('util');
+const {parseArgs} = require('node:util');
 
 const config = {
   allowPositionals: true,

--- a/scripts/releases/upload-release-assets-for-dotslash.js
+++ b/scripts/releases/upload-release-assets-for-dotslash.js
@@ -21,9 +21,9 @@ const {
   FIRST_PARTY_DOTSLASH_FILES,
 } = require('./write-dotslash-release-asset-urls');
 const {Octokit} = require('@octokit/rest');
+const path = require('node:path');
+const {parseArgs} = require('node:util');
 const nullthrows = require('nullthrows');
-const path = require('path');
-const {parseArgs} = require('util');
 
 /*::
 import type {DotSlashProvider, DotSlashHttpProvider, DotSlashArtifactInfo} from './utils/dotslash-utils';

--- a/scripts/releases/utils/__tests__/curl-utils-test.js
+++ b/scripts/releases/utils/__tests__/curl-utils-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const {getWithCurl} = require('../curl-utils');
-const http = require('http');
+const http = require('node:http');
 
 let server, serverUrl;
 

--- a/scripts/releases/utils/__tests__/dotslash-utils-test.js
+++ b/scripts/releases/utils/__tests__/dotslash-utils-test.js
@@ -16,9 +16,9 @@ const {
   validateAndParseDotSlashFile,
   validateDotSlashArtifactData,
 } = require('../dotslash-utils');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 jest.useRealTimers();
 

--- a/scripts/releases/utils/__tests__/scm-utils-test.js
+++ b/scripts/releases/utils/__tests__/scm-utils-test.js
@@ -26,10 +26,10 @@ jest
       process.exit(exitCode);
     },
   }))
-  .mock('fs', () => ({
+  .mock('node:fs', () => ({
     existsSync: jest.fn().mockImplementation(_ => true),
   }))
-  .mock('path', () => ({
+  .mock('node:path', () => ({
     dirname: jest
       .fn()
       .mockImplementation(filePath =>

--- a/scripts/releases/utils/curl-utils.js
+++ b/scripts/releases/utils/curl-utils.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const spawnAsync = require('@expo/spawn-async');
-const {promises: fs} = require('fs');
-const os = require('os');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 /*::
 type CurlResult = {

--- a/scripts/releases/utils/dotslash-utils.js
+++ b/scripts/releases/utils/dotslash-utils.js
@@ -11,12 +11,14 @@
 'use strict';
 
 const dotslash = require('fb-dotslash');
-const {promises: fs} = require('fs');
 const {applyEdits, modify, parse} = require('jsonc-parser');
-const os = require('os');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const execFile = require('node:util').promisify(
+  require('node:child_process').execFile,
+);
 const signedsource = require('signedsource');
-const execFile = require('util').promisify(require('child_process').execFile);
 
 /*::
 export type DotSlashHttpProvider = {

--- a/scripts/releases/utils/hermes-utils.js
+++ b/scripts/releases/utils/hermes-utils.js
@@ -15,8 +15,8 @@ const {
   updatePackageJson,
 } = require('../../shared/monorepoUtils');
 const {getPackageVersionStrByTag} = require('./npm-utils');
-const {promises: fs} = require('fs');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
 
 const MAVEN_VERSIONS_FILE_PATH = path.join(
   REACT_NATIVE_PACKAGE_DIR,

--- a/scripts/releases/validate-dotslash-artifacts.js
+++ b/scripts/releases/validate-dotslash-artifacts.js
@@ -20,8 +20,8 @@ const {
 const {
   FIRST_PARTY_DOTSLASH_FILES,
 } = require('./write-dotslash-release-asset-urls');
-const path = require('path');
-const {parseArgs, styleText} = require('util');
+const path = require('node:path');
+const {parseArgs, styleText} = require('node:util');
 
 async function main() {
   const {

--- a/scripts/releases/write-dotslash-release-asset-urls.js
+++ b/scripts/releases/write-dotslash-release-asset-urls.js
@@ -24,8 +24,8 @@ const {
   validateDotSlashArtifactData,
 } = require('./utils/dotslash-utils');
 const {diff: jestDiff} = require('jest-diff');
-const path = require('path');
-const {parseArgs} = require('util');
+const path = require('node:path');
+const {parseArgs} = require('node:util');
 
 const FIRST_PARTY_DOTSLASH_FILES = [
   'packages/debugger-shell/bin/react-native-devtools',

--- a/scripts/run-ci-javascript-tests.js
+++ b/scripts/run-ci-javascript-tests.js
@@ -18,7 +18,7 @@
  * --yarnBinary [path] - path to yarn binary, defaults to yarn
  */
 
-const {execSync} = require('child_process');
+const {execSync} = require('node:child_process');
 const argv /*:Readonly<{
   maxWorkers?: number,
   jestBinary?: string,

--- a/scripts/shared/consts.js
+++ b/scripts/shared/consts.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-const path = require('path');
+const path = require('node:path');
 
 /**
  * The absolute path to the repo root.

--- a/scripts/shared/isGitRepo.js
+++ b/scripts/shared/isGitRepo.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const childProcess = require('child_process');
+const childProcess = require('node:child_process');
 
 function isGitRepo() /*: boolean */ {
   try {

--- a/scripts/shared/monorepoUtils.js
+++ b/scripts/shared/monorepoUtils.js
@@ -9,8 +9,8 @@
  */
 
 const {REACT_NATIVE_PACKAGE_DIR, REPO_ROOT} = require('./consts');
-const {promises: fs} = require('fs');
-const path = require('path');
+const {promises: fs} = require('node:fs');
+const path = require('node:path');
 const {globSync} = require('tinyglobby');
 
 const WORKSPACES_CONFIG = '{packages,private}/*';

--- a/scripts/try-set-hermes-compiler-prebuilt.js
+++ b/scripts/try-set-hermes-compiler-prebuilt.js
@@ -6,9 +6,9 @@
  */
 
 // @flow
-const { execSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function main() {
  const packageJsonPath = path.join(__dirname, '../packages/react-native/package.json');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,6 +2017,11 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
+"@rtsao/scc@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
+  integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
+
 "@rushstack/node-core-library@5.13.0":
   version "5.13.0"
   resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-5.13.0.tgz#f79d6868b74be102eee75b93c37be45fb9b47ead"
@@ -2186,6 +2191,11 @@
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
 "@types/katex@^0.16.0":
   version "0.16.7"
@@ -2751,6 +2761,20 @@ array-includes@^3.1.6, array-includes@^3.1.8:
     get-intrinsic "^1.2.4"
     is-string "^1.0.7"
 
+array-includes@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.9.tgz#1f0ccaa08e90cdbc3eb433210f903ad0f17c3f3a"
+  integrity sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    define-properties "^1.2.1"
+    es-abstract "^1.24.0"
+    es-object-atoms "^1.1.1"
+    get-intrinsic "^1.3.0"
+    is-string "^1.1.1"
+    math-intrinsics "^1.1.0"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
@@ -2768,6 +2792,19 @@ array.prototype.findlast@^1.2.5:
     es-object-atoms "^1.0.0"
     es-shim-unscopables "^1.0.2"
 
+array.prototype.findlastindex@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz#cfa1065c81dcb64e34557c9b81d012f6a421c564"
+  integrity sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.9"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    es-shim-unscopables "^1.1.0"
+
 array.prototype.flat@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz#1476217df8cff17d72ee8f3ba06738db5b387d18"
@@ -2777,6 +2814,16 @@ array.prototype.flat@^1.3.1:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
     es-shim-unscopables "^1.0.0"
+
+array.prototype.flat@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz#534aaf9e6e8dd79fb6b9a9917f839ef1ec63afe5"
+  integrity sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.5"
+    es-shim-unscopables "^1.0.2"
 
 array.prototype.flatmap@^1.3.2:
   version "1.3.2"
@@ -3637,6 +3684,13 @@ debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, d
   dependencies:
     ms "^2.1.3"
 
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
@@ -4019,6 +4073,66 @@ es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9, es-abstract@^1.24
     unbox-primitive "^1.1.0"
     which-typed-array "^1.1.19"
 
+es-abstract@^1.24.0:
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.2.tgz#2dbd38c180735ee983f77585140a2706a963ed9a"
+  integrity sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==
+  dependencies:
+    array-buffer-byte-length "^1.0.2"
+    arraybuffer.prototype.slice "^1.0.4"
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    data-view-buffer "^1.0.2"
+    data-view-byte-length "^1.0.2"
+    data-view-byte-offset "^1.0.1"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    es-set-tostringtag "^2.1.0"
+    es-to-primitive "^1.3.0"
+    function.prototype.name "^1.1.8"
+    get-intrinsic "^1.3.0"
+    get-proto "^1.0.1"
+    get-symbol-description "^1.1.0"
+    globalthis "^1.0.4"
+    gopd "^1.2.0"
+    has-property-descriptors "^1.0.2"
+    has-proto "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    internal-slot "^1.1.0"
+    is-array-buffer "^3.0.5"
+    is-callable "^1.2.7"
+    is-data-view "^1.0.2"
+    is-negative-zero "^2.0.3"
+    is-regex "^1.2.1"
+    is-set "^2.0.3"
+    is-shared-array-buffer "^1.0.4"
+    is-string "^1.1.1"
+    is-typed-array "^1.1.15"
+    is-weakref "^1.1.1"
+    math-intrinsics "^1.1.0"
+    object-inspect "^1.13.4"
+    object-keys "^1.1.1"
+    object.assign "^4.1.7"
+    own-keys "^1.0.1"
+    regexp.prototype.flags "^1.5.4"
+    safe-array-concat "^1.1.3"
+    safe-push-apply "^1.0.0"
+    safe-regex-test "^1.1.0"
+    set-proto "^1.0.0"
+    stop-iteration-iterator "^1.1.0"
+    string.prototype.trim "^1.2.10"
+    string.prototype.trimend "^1.0.9"
+    string.prototype.trimstart "^1.0.8"
+    typed-array-buffer "^1.0.3"
+    typed-array-byte-length "^1.0.3"
+    typed-array-byte-offset "^1.0.4"
+    typed-array-length "^1.0.7"
+    unbox-primitive "^1.1.0"
+    which-typed-array "^1.1.19"
+
 es-define-property@^1.0.0, es-define-property@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
@@ -4119,6 +4233,13 @@ es-shim-unscopables@^1.0.0, es-shim-unscopables@^1.0.2:
   dependencies:
     hasown "^2.0.0"
 
+es-shim-unscopables@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz#438df35520dac5d105f3943d927549ea3b00f4b5"
+  integrity sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==
+  dependencies:
+    hasown "^2.0.2"
+
 es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
@@ -4167,6 +4288,22 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz#3a06a662130807e2502fc3ff8b4143d8a0658e11"
   integrity sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==
 
+eslint-import-resolver-node@^0.3.9:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz#84ce3005abfc300588cf23bbac1aabec1fc6e8c1"
+  integrity sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==
+  dependencies:
+    debug "^3.2.7"
+    is-core-module "^2.16.1"
+    resolve "^2.0.0-next.6"
+
+eslint-module-utils@^2.12.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz#611f8e1c6ceb29a93eb949e1cc670b8287764819"
+  integrity sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==
+  dependencies:
+    debug "^3.2.7"
+
 eslint-plugin-babel@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz#75a2413ffbf17e7be57458301c60291f2cfbf560"
@@ -4189,6 +4326,31 @@ eslint-plugin-ft-flow@^2.0.1:
   dependencies:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
+
+eslint-plugin-import@^2.32.0:
+  version "2.32.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz#602b55faa6e4caeaa5e970c198b5c00a37708980"
+  integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
+  dependencies:
+    "@rtsao/scc" "^1.1.0"
+    array-includes "^3.1.9"
+    array.prototype.findlastindex "^1.2.6"
+    array.prototype.flat "^1.3.3"
+    array.prototype.flatmap "^1.3.3"
+    debug "^3.2.7"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.9"
+    eslint-module-utils "^2.12.1"
+    hasown "^2.0.2"
+    is-core-module "^2.16.1"
+    is-glob "^4.0.3"
+    minimatch "^3.1.2"
+    object.fromentries "^2.0.8"
+    object.groupby "^1.0.3"
+    object.values "^1.2.1"
+    semver "^6.3.1"
+    string.prototype.trimend "^1.0.9"
+    tsconfig-paths "^3.15.0"
 
 eslint-plugin-jest@^29.0.1:
   version "29.0.1"
@@ -4994,6 +5156,13 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
 hermes-compiler@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/hermes-compiler/-/hermes-compiler-0.0.0.tgz#8d9f6a0b2740ce34d71258fec684e7b6bfd97efa"
@@ -5321,6 +5490,13 @@ is-core-module@^2.13.0, is-core-module@^2.16.0:
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
   dependencies:
     hasown "^2.0.2"
+
+is-core-module@^2.16.1, is-core-module@^2.16.2:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
 
 is-data-view@^1.0.1:
   version "1.0.1"
@@ -6145,6 +6321,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+json5@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
+  dependencies:
+    minimist "^1.2.0"
 
 json5@^2.2.3:
   version "2.2.3"
@@ -7088,6 +7271,11 @@ minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.2"
 
+minimist@^1.2.0, minimist@^1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 minipass@^7.1.2, minipass@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
@@ -7103,7 +7291,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
-ms@2.1.3, ms@^2.1.3:
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -7137,6 +7325,16 @@ nocache@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-3.0.4.tgz#5b37a56ec6e09fc7d401dceaed2eab40c8bfdf79"
   integrity sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==
+
+node-exports-info@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.2.tgz#243a3105677d6781cd26e6a72350fd928a5cb46f"
+  integrity sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==
+  dependencies:
+    array.prototype.flatmap "^1.3.3"
+    es-errors "^1.3.0"
+    object.entries "^1.1.9"
+    semver "^6.3.1"
 
 node-fetch@^2.2.0:
   version "2.7.0"
@@ -7253,6 +7451,15 @@ object.fromentries@^2.0.8:
     define-properties "^1.2.1"
     es-abstract "^1.23.2"
     es-object-atoms "^1.0.0"
+
+object.groupby@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/object.groupby/-/object.groupby-1.0.3.tgz#9b125c36238129f6f7b61954a1e7176148d5002e"
+  integrity sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.2"
 
 object.values@^1.1.6:
   version "1.2.0"
@@ -7925,6 +8132,18 @@ resolve@^2.0.0-next.5:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^2.0.0-next.6:
+  version "2.0.0-next.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.7.tgz#ba3b035d4b1ee7c522426eee73cabcb0fd5515dd"
+  integrity sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.2"
+    node-exports-info "^1.6.0"
+    object-keys "^1.1.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 restore-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
@@ -8569,6 +8788,11 @@ strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   dependencies:
     ansi-regex "^6.0.1"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
 strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
@@ -8720,6 +8944,16 @@ ts-api-utils@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
+
+tsconfig-paths@^3.15.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
+  integrity sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
Summary:

Cleanup — these types are already declared in `react-native-github/flow-typed/environment/node.js` and resolve under Flow. The `$FlowFixMe[cannot-resolve-module]` suppressions on these imports are therefore stale.

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D112803683
