### PR TITLE
Fix RNTester prebuild mode in iOS CI

### DIFF
--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -99,12 +99,19 @@ runs:
         if [[ "${{ steps.prebuilds.outputs.enabled }}" == "true" ]]; then
           export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
           export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ inputs.flavor }}.xcframework.tar.gz"
+        else
+          export RCT_USE_RN_DEP=0
+          export RCT_USE_PREBUILT_RNCORE=0
         fi
 
         cd packages/rn-tester
 
         bundle install
-        bundle exec pod update hermes-engine --no-repo-update
+        if [[ "${{ steps.prebuilds.outputs.enabled }}" == "true" ]]; then
+          bundle exec pod update hermes-engine ReactNativeDependencies React-Core-prebuilt --no-repo-update
+        else
+          bundle exec pod update hermes-engine --no-repo-update
+        fi
     - name: Build RNTester
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

- explicitly disable RN core and dependency prebuilts for RNTester source-mode jobs
- update the local ReactNativeDependencies and React-Core-prebuilt podspecs alongside Hermes for prebuilt jobs
- preserve the intended static/prebuilt and dynamic/source matrix behavior

The stable-branch Test All workflow exposed this after the 0.87.0-rc.1 version bump: CocoaPods rejected the locally resolved prebuilt podspecs because the action only updated Hermes. Dynamic jobs also selected the published RC prebuilts despite being configured for source mode.

Stable failure: https://github.com/react/react-native/actions/runs/29740840716

## Test Plan

- `./node_modules/.bin/prettier --check .github/actions/test-ios-rntester/action.yml`
- verified on 0.87-stable that `RCT_USE_RN_DEP=0 RCT_USE_PREBUILT_RNCORE=0` resolves both RN core and dependencies from source
- full CocoaPods probe on main was not run locally because the main bundle requires `concurrent-ruby >= 1.3.7`, which is not installed in the local Ruby environment