### PR TITLE
[LOCAL] Fix CI: build rntester dynamic-frameworks lane from source

### DIFF
--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -27,6 +27,13 @@ inputs:
       config of the 2026-07-03 SocketRocket dual-copy regression).
     required: false
     default: auto
+  build-from-source:
+    description: >-
+      Force building ReactCore/ReactNativeDependencies from source, disabling the
+      prebuilt Maven fallback (RCT_USE_PREBUILT_RNCORE / RCT_USE_RN_DEP, which
+      otherwise default to '1'). Used by the from-source dynamic-frameworks lane.
+    required: false
+    default: false
 
 runs:
   using: composite
@@ -99,6 +106,17 @@ runs:
         if [[ "${{ steps.prebuilds.outputs.enabled }}" == "true" ]]; then
           export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
           export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ inputs.flavor }}.xcframework.tar.gz"
+        fi
+        if [[ "${{ inputs.build-from-source }}" == "true" ]]; then
+          # Force building ReactCore/ReactNativeDependencies from source. Both
+          # RCT_USE_PREBUILT_RNCORE and RCT_USE_RN_DEP default to '1', so on a stable
+          # branch (where released Maven artifacts exist for the current version) the
+          # install would otherwise consume those prebuilts instead of building from
+          # source. That is wrong for the from-source dynamic-frameworks lane and also
+          # fails when a published artifact predates newer podspec layout changes
+          # (e.g. a React core tarball without ReactNativeHeaders.xcframework).
+          export RCT_USE_PREBUILT_RNCORE=0
+          export RCT_USE_RN_DEP=0
         fi
 
         cd packages/rn-tester

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -136,6 +136,7 @@ jobs:
         with:
           flavor: ${{ matrix.flavor }}
           use-frameworks: true
+          build-from-source: true
           run-unit-tests: false # tests for dynamic frameworks are already run in the test_ios_rntester job; this is to just a test build from source (no prebuilds)
 
   test_ios_rntester:


### PR DESCRIPTION
## Summary

Follow-up to #57614. That PR fixed the `Podfile.lock` version staleness, which unblocked the `test_ios_rntester` lanes but advanced `test_ios_rntester_dynamic_frameworks` (Debug + Release) to the next error:

```
[React-Core-prebuilt] ERROR: ReactNativeHeaders.xcframework not found in the prebuilt tarball.
```

### Root cause
`test_ios_rntester_dynamic_frameworks` is meant to be the **from-source** dynamic-frameworks lane. But the CocoaPods install never disabled the prebuilt *defaults*: `RCT_USE_PREBUILT_RNCORE` and `RCT_USE_RN_DEP` both default to `'1'` (`react_native_pods.rb`), so the pods resolve to the released **Maven** artifacts whenever they exist.

- On `main` the version is `1000.0.0`, which has no Maven artifact (404) → `build_from_source=true` → the lane builds from source and passes.
- On a stable branch the version (`0.87.0-rc.1`) *does* have Maven artifacts, so the lane consumes the released React core tarball — which predates the `ReactNativeHeaders.xcframework` layout that current HEAD's podspec requires → the prepare_command fails.

### Fix
Add an explicit `build-from-source` input to the `test-ios-rntester` action that exports `RCT_USE_PREBUILT_RNCORE=0` and `RCT_USE_RN_DEP=0`, and set it **only** on the `test_ios_rntester_dynamic_frameworks` job. This makes that lane truly build from source (its documented intent, matching `main`), independent of what's published to Maven, without changing behavior for any other caller of the shared action (`test_ios_rntester`, `test_ios_rntester_ruby_3_2_0` leave it at the default `false`).

## Changelog:
[Internal] -

## Test plan
Reproduced the lane locally against the rc.1 lock:
- Before: `pod update hermes-engine --no-repo-update` with the prebuilt defaults pulls the Maven rc.1 React core tarball and fails on missing `ReactNativeHeaders.xcframework`.
- After (`RCT_USE_PREBUILT_RNCORE=0 RCT_USE_RN_DEP=0 USE_FRAMEWORKS=dynamic`): both resolve to `Building from source: true`, `React-Core-prebuilt` / prebuilt `ReactNativeDependencies` are removed, and `pod install` completes successfully.