### PR TITLE
fix(ios): add log advice back when using shadow w/o a background

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -21,6 +21,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTLinearGradient.h>
 #import <React/RCTLocalizedString.h>
+#import <React/RCTLog.h>
 #import <React/RCTRadialGradient.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/components/view/ViewComponentDescriptor.h>
@@ -1009,6 +1010,13 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     } else {
       // Can't accurately calculate box shadow, so fall back to pixel-based shadow.
       layer.shadowPath = nil;
+      
+      RCTLogAdvice(
+          @"View #%ld of type %@ has a shadow set but cannot calculate "
+           "shadow efficiently. Consider setting a solid background color to "
+           "fix this, or apply the shadow to a more specific component.",
+          (long)self.tag,
+          [self class]);
     }
   } else {
     layer.shadowPath = nil;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Back on old arch in RCTView.m we printed that warning:

https://github.com/react/react-native/blob/d13d2b0a5f7329d5fe9262259e8f846a86312f03/packages/react-native/React/Views/RCTView.m#L898-L906

This was missing on new arch and due to it we were missing some unoptimized views in our app which tanked performance.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [ADDED] - Print warning advice when using `shadow*` styles without providing a solid background color

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

In rn-tester go to APIs > Box Shadow example to see the warnings printed!
