### PR TITLE
Fix bump-hermes-version.js to write hermes-v prefixed tag to .hermesv1version (#57619)

### DIFF
--- a/packages/react-native/scripts/hermes/bump-hermes-version.js
+++ b/packages/react-native/scripts/hermes/bump-hermes-version.js
@@ -60,9 +60,14 @@ async function main() {
     return;
   }
 
-  await setHermesTag(hermesVersion);
-  await updateHermesCompilerVersionInDependencies(hermesVersion);
-  await updateHermesRuntimeDependenciesVersions(hermesVersion);
+  // `.hermesv1version` is used as a git ref to download the Hermes source
+  // (https://github.com/facebook/hermes/tarball/<ref>), where release tags are
+  // named `hermes-v<version>`. While hermes-compiler and prebuilt dependencies
+  // use the bare npm version.
+  const bareVersion = hermesVersion.replace(/^hermes-v/, '');
+  await setHermesTag(`hermes-v${bareVersion}`);
+  await updateHermesCompilerVersionInDependencies(bareVersion);
+  await updateHermesRuntimeDependenciesVersions(bareVersion);
 }
 
 void main().then(() => {


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] - Fix bump-hermes-version.js to write hermes-v prefixed tag to .hermesv1version

`scripts/hermes/bump-hermes-version.js` fetches the **bare** `hermes-compiler` npm version (e.g. `250829098.0.16`) and wrote it verbatim into `packages/react-native/sdks/.hermesv1version` via `setHermesTag`.

But `.hermesv1version` is consumed by the Android Gradle build as a **git ref** to download the Hermes source:
```
https://github.com/facebook/hermes/tarball/<ref>   (ReactAndroid/hermes-engine/build.gradle.kts)
```
Release tags on `facebook/hermes` are named `hermes-v<version>` (e.g. `hermes-v250829098.0.16`). The bare value `250829098.0.16` is not a valid ref → **HTTP 404**, which breaks the `build_fantom_runner` / `downloadHermes` build.

### Fix
Normalize so `.hermesv1version` gets the `hermes-v`-prefixed **git tag**, while the `hermes-compiler` / prebuilt dependency versions (npm + Maven `HERMES_VERSION_NAME`) stay **bare**. Handles both bare and already-prefixed input.


Test Plan:
- `curl -sL -o /dev/null -w '%{http_code}' https://github.com/facebook/hermes/tarball/hermes-v250829098.0.16` → **200** (bare `250829098.0.16` → 404).
- After running the bump: `.hermesv1version` = `hermes-v<version>`; `hermes-compiler` dep and `HERMES_VERSION_NAME` remain the bare version.

Reviewed By: cortinico

Differential Revision: D112846952

Pulled By: zeyap


