### PR TITLE
Fix stack-use-after-return in TaskDispatchThread Android ctor

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/threading/TaskDispatchThread.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/threading/TaskDispatchThread.cpp
@@ -27,9 +27,12 @@ TaskDispatchThread::TaskDispatchThread(
     int priorityOffset) noexcept
     : threadName_(threadName) {
 #ifdef ANDROID
-  // Attaches the thread to JVM just in case anything calls out to Java
-  thread_ = std::thread([&]() {
-    facebook::jni::ThreadScope::WithClassLoader([&]() {
+  // Attaches the thread to JVM just in case anything calls out to Java.
+  // Capture priorityOffset by value: it is a constructor parameter whose
+  // storage dies when the constructor returns, and the thread body reads it
+  // asynchronously.
+  thread_ = std::thread([this, priorityOffset]() {
+    facebook::jni::ThreadScope::WithClassLoader([this, priorityOffset]() {
       int result = setpriority(
           PRIO_PROCESS,
           static_cast<pid_t>(::syscall(SYS_gettid)),


### PR DESCRIPTION
Summary:
Under `dev_clang_asan`, `bloks_runtimeTestsAndroid` crashes at startup with `__asan_report_load4` inside `ThreadScope::WithClassLoader`. The Android branch of the `TaskDispatchThread` constructor captures the `priorityOffset` parameter by reference into the `std::thread` lambda; the constructor returns immediately, so by the time the thread runs and reads `priorityOffset` inside `setpriority(...)` the stack slot is gone. Non-asan builds tolerate the racy read; asan catches it deterministically.

Capture `priorityOffset` (and `this`) by value on both the outer thread lambda and the inner `WithClassLoader` lambda.

Changelog:
[Internal]

Differential Revision: D113046624


