### PR TITLE
Downgrade RCTStatusBarManager error to a warning under VC-based status bar (#57631)

### DIFF
--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -148,8 +148,8 @@ RCT_EXPORT_METHOD(setStyle : (NSString *)style animated : (BOOL)animated)
   dispatch_async(dispatch_get_main_queue(), ^{
     UIStatusBarStyle statusBarStyle = [RCTConvert UIStatusBarStyle:style];
     if (RCTViewControllerBasedStatusBarAppearance()) {
-      RCTLogError(@"RCTStatusBarManager module requires that the \
-                UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
+      RCTLogWarn(@"RCTStatusBarManager is a no-op when \
+                UIViewControllerBasedStatusBarAppearance is YES; set the status bar from your view controller instead");
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -164,8 +164,8 @@ RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (NSString *)withAnima
   dispatch_async(dispatch_get_main_queue(), ^{
     UIStatusBarAnimation animation = [RCTConvert UIStatusBarAnimation:withAnimation];
     if (RCTViewControllerBasedStatusBarAppearance()) {
-      RCTLogError(@"RCTStatusBarManager module requires that the \
-                UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
+      RCTLogWarn(@"RCTStatusBarManager is a no-op when \
+                UIViewControllerBasedStatusBarAppearance is YES; set the status bar from your view controller instead");
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
Summary:

`RCTStatusBarManager`'s `setStyle:` and `setHidden:` already no-op when
`UIViewControllerBasedStatusBarAppearance` is `YES`. Currently this path emits
`RCTLogError`, which redboxes in dev and logs a soft error in release — even
though the call is an expected no-op when the view controller owns the status bar.

Downgrade to `RCTLogWarn` with a more accurate message so apps adopting
VC-based status bar appearance aren't flooded with spurious errors on every
`StatusBar.setBarStyle` / `setHidden` call or `<StatusBar>` mount.

No behavior change; the methods remain no-ops under the flag.

Changelog: [iOS][Changed] - Downgrade RCTStatusBarManager error to a warning when UIViewControllerBasedStatusBarAppearance is YES

Differential Revision: D113043635


