### PR TITLE
fix(android): use the active locale to detect RTL direction

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
@@ -19,8 +19,8 @@ public class I18nUtil private constructor() {
    * * allows RTL layout when using RTL locale
    */
   public fun isRTL(context: Context): Boolean =
-    applicationHasRtlSupport(context) &&
-      (isRTLForced(context) || (isRTLAllowed(context) && isDevicePreferredLanguageRTL(context)))
+      applicationHasRtlSupport(context) &&
+          (isRTLForced(context) || (isRTLAllowed(context) && isDevicePreferredLanguageRTL(context)))
 
   /**
    * Android relies on the presence of `android:supportsRtl="true"` being set in order to resolve

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
@@ -11,7 +11,6 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.view.View
 import androidx.core.text.TextUtilsCompat
-import java.util.Locale
 
 public class I18nUtil private constructor() {
   /**
@@ -20,8 +19,8 @@ public class I18nUtil private constructor() {
    * * allows RTL layout when using RTL locale
    */
   public fun isRTL(context: Context): Boolean =
-      applicationHasRtlSupport(context) &&
-          (isRTLForced(context) || (isRTLAllowed(context) && isDevicePreferredLanguageRTL))
+    applicationHasRtlSupport(context) &&
+      (isRTLForced(context) || (isRTLAllowed(context) && isDevicePreferredLanguageRTL(context)))
 
   /**
    * Android relies on the presence of `android:supportsRtl="true"` being set in order to resolve
@@ -60,13 +59,12 @@ public class I18nUtil private constructor() {
     setPref(context, KEY_FOR_PREFS_FORCERTL, forceRTL)
   }
 
-  private val isDevicePreferredLanguageRTL: Boolean
-    // Check if the current device language is RTL
-    get() {
-      val directionality =
-          TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getAvailableLocales()[0])
-      return directionality == View.LAYOUT_DIRECTION_RTL
-    }
+  // Check if the current device language is RTL
+  private fun isDevicePreferredLanguageRTL(context: Context): Boolean {
+    val directionality =
+        TextUtilsCompat.getLayoutDirectionFromLocale(context.resources.configuration.locales[0])
+    return directionality == View.LAYOUT_DIRECTION_RTL
+  }
 
   private fun isPrefSet(context: Context, key: String, defaultValue: Boolean): Boolean =
       context


### PR DESCRIPTION
## Summary:

On Android, RTL detection read the wrong locale. `isDevicePreferredLanguageRTL` use `Locale.getAvailableLocales()[0]`, which returns an arbitrary entry from the unordered list of **all runtime locales** (so, all locales that the current Android version supports), not the user's current system / app language. So layout direction was resolved from whatever locale happened to be first in that list, unrelated to the device (or per-app) language.

This fixes it to read the active locale from `context.resources.configuration.locales[0]`, the resolved preferred locale for the app.

See the screenshots below: `Locale.getAvailableLocales()[0]` returns all locales supported by Android, so the first one is **always** `af`, and `isRTL` is always `false`:

<img width="1862" height="383" alt="Locale getAvailableLocales" src="https://github.com/user-attachments/assets/7340959f-67bd-4537-a074-849a76f345f8" />

---

vs `context.resources.configuration.locales[0]` for the same device language (I chose `ar-JO` in app settings), `isRTL` is `true`:

<img width="1258" height="396" alt="app locales" src="https://github.com/user-attachments/assets/55159b65-a90c-40b7-9941-e5339c73d44c" />

## Changelog:

[ANDROID] [FIXED] - Detect RTL from the active locale instead of an arbitrary installed one

## Test Plan:

Switch the device (or per-app) language to an RTL language (e.g. Arabic) and confirm the app lays out RTL.

**`Locale.getAvailableLocales()[0]` (before, arbitrary):**

<img width="238" height="467" alt="android - before" src="https://github.com/user-attachments/assets/3f69e933-22b1-4d31-824a-b5e96057a76d" />

---

**`context.resources.configuration.locales[0]` (after, active locale):**

<img width="238" height="467" alt="android - after" src="https://github.com/user-attachments/assets/9c86ff1a-b0ab-489f-a84e-76e3b7507da8" />