### PR TITLE
Fix src/main/res warnings due to AGP9

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -625,16 +625,19 @@ android {
 
   sourceSets {
     named("main") {
-      res.directories.addAll(
-          listOf(
-              "src/main/res/devsupport",
-              "src/main/res/shell",
-              "src/main/res/views/alert",
-              "src/main/res/views/modal",
-              "src/main/res/views/uimanager",
-              "src/main/res/views/view",
-          )
-      )
+      res.directories.apply {
+        clear()
+        addAll(
+            listOf(
+                "src/main/res/devsupport",
+                "src/main/res/shell",
+                "src/main/res/views/alert",
+                "src/main/res/views/modal",
+                "src/main/res/views/uimanager",
+                "src/main/res/views/view",
+            )
+        )
+      }
     }
   }
 


### PR DESCRIPTION
## Summary:

Fixes this warning that will break soon due to AGP9:

```
> Task :packages:react-native:ReactAndroid:generateDebugResources
Nested resources detected.
+ src/main/res
-- src/main/res/devsupport
-- src/main/res/shell
-- src/main/res/views/alert
-- src/main/res/views/modal
-- src/main/res/views/uimanager
-- src/main/res/views/view

Nested resources means you have layout like this:
res.srcDirs = [
    'src/main/res/',
    'src/main/res/category1'
]
However, you should use following structure instead:
res.srcDirs = [packages:rn-tester:android:app:de
    'src/main/res/common',
    'src/main/res/category1',
    'src/main/res/category2'
]
This Warning will be transformed into Error in version VERSION_9_0
```

## Changelog:

[INTERNAL] - 

## Test Plan:

CI