### PR TITLE
RN: Overflow.fromString accepts null and returns non-null (#57638)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Overflow.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Overflow.kt
@@ -25,17 +25,18 @@ internal enum class Overflow {
     /**
      * Parses a string into an Overflow value.
      *
-     * @param overflow The string value (case-insensitive)
-     * @return The corresponding Overflow, or null if not recognized
+     * @param overflow The string value (case-insensitive), or null
+     * @param default The value to return when [overflow] is null or unrecognized
+     * @return The corresponding Overflow, or [default]
      */
     @JvmStatic
-    fun fromString(overflow: String): Overflow? {
-      return when (overflow.lowercase()) {
-        "visible" -> VISIBLE
-        "hidden" -> HIDDEN
-        "scroll" -> SCROLL
-        else -> null
-      }
-    }
+    @JvmOverloads
+    fun fromString(overflow: String?, default: Overflow = VISIBLE): Overflow =
+        when (overflow?.lowercase()) {
+          "visible" -> VISIBLE
+          "hidden" -> HIDDEN
+          "scroll" -> SCROLL
+          else -> default
+        }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
@@ -419,10 +419,11 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
         if (overflow == null) {
           Overflow.SCROLL
         } else {
-          Overflow.fromString(overflow)
-              ?: if (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid())
-                  Overflow.VISIBLE
-              else Overflow.SCROLL
+          Overflow.fromString(
+              overflow,
+              if (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()) Overflow.VISIBLE
+              else Overflow.SCROLL,
+          )
         }
     invalidate()
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cf60b52e15df339a179f392723007fab>>
+ * @generated SignedSource<<1ad8f84ac759d8d225ce0fd57dccea7b>>
  */
 
 /**
@@ -387,10 +387,11 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
         if (overflow == null) {
           Overflow.SCROLL
         } else {
-          Overflow.fromString(overflow)
-              ?: if (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid())
-                  Overflow.VISIBLE
-              else Overflow.SCROLL
+          Overflow.fromString(
+              overflow,
+              if (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()) Overflow.VISIBLE
+              else Overflow.SCROLL,
+          )
         }
     invalidate()
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollViewManager.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d321b1f5f7a34b5717cb7ef5300dda96>>
+ * @generated SignedSource<<543b6175d2ce5e4ec68f1625f0c04095>>
  */
 
 /**
@@ -450,17 +450,15 @@ constructor(private val fpsListener: FpsListener? = null) :
   public companion object {
     public const val REACT_CLASS: String = "RCTScrollView"
 
-    public fun createExportedCustomDirectEventTypeConstants(): Map<String, Any> =
-        mapOf(
-            getJSEventName(ScrollEventType.SCROLL) to mapOf("registrationName" to "onScroll"),
-            getJSEventName(ScrollEventType.BEGIN_DRAG) to
-                mapOf("registrationName" to "onScrollBeginDrag"),
-            getJSEventName(ScrollEventType.END_DRAG) to
-                mapOf("registrationName" to "onScrollEndDrag"),
-            getJSEventName(ScrollEventType.MOMENTUM_BEGIN) to
-                mapOf("registrationName" to "onMomentumScrollBegin"),
-            getJSEventName(ScrollEventType.MOMENTUM_END) to
-                mapOf("registrationName" to "onMomentumScrollEnd"),
-        )
+    public fun createExportedCustomDirectEventTypeConstants(): Map<String, Any> = mapOf(
+        getJSEventName(ScrollEventType.SCROLL) to mapOf("registrationName" to "onScroll"),
+        getJSEventName(ScrollEventType.BEGIN_DRAG) to
+            mapOf("registrationName" to "onScrollBeginDrag"),
+        getJSEventName(ScrollEventType.END_DRAG) to mapOf("registrationName" to "onScrollEndDrag"),
+        getJSEventName(ScrollEventType.MOMENTUM_BEGIN) to
+            mapOf("registrationName" to "onMomentumScrollBegin"),
+        getJSEventName(ScrollEventType.MOMENTUM_END) to
+            mapOf("registrationName" to "onMomentumScrollEnd"),
+    )
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.kt
@@ -379,10 +379,11 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
         if (overflow == null) {
           Overflow.SCROLL
         } else {
-          Overflow.fromString(overflow)
-              ?: if (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid())
-                  Overflow.VISIBLE
-              else Overflow.SCROLL
+          Overflow.fromString(
+              overflow,
+              if (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()) Overflow.VISIBLE
+              else Overflow.SCROLL,
+          )
         }
     invalidate()
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -108,7 +108,7 @@ internal class PreparedLayoutTextViewManager :
 
   @ReactProp(name = "overflow")
   fun setOverflow(view: PreparedLayoutTextView, overflow: String?): Unit {
-    view.overflow = overflow?.let { Overflow.fromString(it) } ?: Overflow.VISIBLE
+    view.overflow = Overflow.fromString(overflow)
   }
 
   @ReactProp(name = "accessible")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -673,13 +673,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   }
 
   public void setOverflow(@Nullable String overflow) {
-    if (overflow == null) {
-      mOverflow = Overflow.VISIBLE;
-    } else {
-      @Nullable Overflow parsedOverflow = Overflow.fromString(overflow);
-      mOverflow = parsedOverflow == null ? Overflow.VISIBLE : parsedOverflow;
-    }
-
+    mOverflow = Overflow.fromString(overflow);
     invalidate();
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -1185,13 +1185,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
   }
 
   public fun setOverflow(overflow: String?) {
-    if (overflow == null) {
-      this.overflow = Overflow.VISIBLE
-    } else {
-      val parsedOverflow = Overflow.fromString(overflow)
-      this.overflow = parsedOverflow ?: Overflow.VISIBLE
-    }
-
+    this.overflow = Overflow.fromString(overflow)
     invalidate()
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -818,22 +818,16 @@ public open class ReactViewGroup public constructor(context: Context?) :
     }
   }
 
-  private var _overflow: Overflow? = null
+  private var _overflow: Overflow = Overflow.VISIBLE
   override var overflow: String?
     get() =
         when (_overflow) {
           Overflow.HIDDEN -> "hidden"
           Overflow.SCROLL -> "scroll"
           Overflow.VISIBLE -> "visible"
-          else -> null
         }
     set(overflow) {
-      _overflow =
-          if (overflow == null) {
-            Overflow.VISIBLE
-          } else {
-            Overflow.fromString(overflow)
-          }
+      _overflow = Overflow.fromString(overflow)
       invalidate()
     }
 
@@ -846,9 +840,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
    */
   override fun getClipBounds(): Rect? {
     if (
-        ReactNativeFeatureFlags.syncAndroidClipBoundsWithOverflow() &&
-            _overflow != null &&
-            _overflow != Overflow.VISIBLE
+        ReactNativeFeatureFlags.syncAndroidClipBoundsWithOverflow() && _overflow != Overflow.VISIBLE
     ) {
       val rect = Rect()
       getPaddingBoxRect(this, rect)
@@ -860,9 +852,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
   /** See [getClipBounds]. */
   override fun getClipBounds(outRect: Rect): Boolean {
     if (
-        ReactNativeFeatureFlags.syncAndroidClipBoundsWithOverflow() &&
-            _overflow != null &&
-            _overflow != Overflow.VISIBLE
+        ReactNativeFeatureFlags.syncAndroidClipBoundsWithOverflow() && _overflow != Overflow.VISIBLE
     ) {
       getPaddingBoxRect(this, outRect)
       return true

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/style/OverflowTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/style/OverflowTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager.style
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/** Tests for [Overflow.fromString] */
+class OverflowTest {
+  @Test
+  fun recognizedValuesAreParsedCaseInsensitively() {
+    assertThat(Overflow.fromString("visible")).isEqualTo(Overflow.VISIBLE)
+    assertThat(Overflow.fromString("hidden")).isEqualTo(Overflow.HIDDEN)
+    assertThat(Overflow.fromString("scroll")).isEqualTo(Overflow.SCROLL)
+    assertThat(Overflow.fromString("HiDdEn")).isEqualTo(Overflow.HIDDEN)
+  }
+
+  @Test
+  fun nullDefaultsToVisible() {
+    assertThat(Overflow.fromString(null)).isEqualTo(Overflow.VISIBLE)
+  }
+
+  @Test
+  fun unrecognizedDefaultsToVisible() {
+    assertThat(Overflow.fromString("bogus")).isEqualTo(Overflow.VISIBLE)
+  }
+
+  @Test
+  fun customDefaultHonoredForNullAndUnrecognized() {
+    assertThat(Overflow.fromString(null, Overflow.SCROLL)).isEqualTo(Overflow.SCROLL)
+    assertThat(Overflow.fromString("bogus", Overflow.SCROLL)).isEqualTo(Overflow.SCROLL)
+  }
+
+  @Test
+  fun customDefaultDoesNotOverrideRecognizedValues() {
+    assertThat(Overflow.fromString("hidden", Overflow.SCROLL)).isEqualTo(Overflow.HIDDEN)
+  }
+}


### PR DESCRIPTION
Summary:

Simplifies current and future uses of overflow fields.

ReactViewGroup _overflow field is no longer nullable - it's default is now VISIBLE instead of null. The never-set or unrecognized case is no longer detectable, but it's fine - it will just default to VISIBLE, as all uses were already doing so.

Differential Revision: D113186028
