### PR TITLE
Fix Android template E2E for PRs targeting stable branches

### DIFF
--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -56,9 +56,11 @@ jobs:
           MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
           echo "Maven local path is $MAVEN_LOCAL"
 
-          # For stable branches, we want to use the stable branch of the template
-          # In all the other cases, we want to use "main"
-          BRANCH=${{ github.ref_name }}
+          # For stable branches, we want to use the stable branch of the template.
+          # In all the other cases, we want to use "main".
+          # On pull_request events, ref_name is "<pr-number>/merge", so use the
+          # PR base branch instead to keep targeting the matching template branch.
+          BRANCH=${{ github.base_ref || github.ref_name }}
           if ! [[ $BRANCH == *-stable* ]]; then
             BRANCH=main
           fi


### PR DESCRIPTION
## Summary:

`test_e2e_android_templateapp` currently fails on PRs targeting 0.86-stable (both debug and release flavors), e.g. https://github.com/react/react-native/actions/runs/30006334544/job/89219502470?pr=57646.

The workflow picks which branch of `react-native-community/template` to generate the test project from:

```bash
BRANCH=${{ github.ref_name }}
if ! [[ $BRANCH == *-stable* ]]; then
  BRANCH=main
fi
```

On `pull_request` events `github.ref_name` is `<pr-number>/merge`, which never matches `*-stable*`, so PR runs always clone the template's `main` branch. That guard only works for direct pushes to the stable branch.

This recently started failing because template `main` bumped its Gradle wrapper to 9.4.1, which bundles the Kotlin 2.3.0 stdlib. The generated project compiles `@react-native/gradle-plugin` from source with Kotlin 2.1.0 on 0.86, and that compiler can only read Kotlin metadata up to 2.2.0, so `:gradle-plugin:settings-plugin:compileKotlin` fails with:

```
Module was compiled with an incompatible version of Kotlin.
The binary version of its metadata is 2.3.0, expected version is 2.1.0.
```

The fix is to use `github.base_ref` (the PR target branch, e.g. `0.86-stable`) when it is set, falling back to `github.ref_name` for branch pushes:

```bash
BRANCH=${{ github.base_ref || github.ref_name }}
```

With this, PRs targeting 0.86-stable check out the template's `0.86-stable` branch (Gradle 9.3.1 / Kotlin 2.2 metadata, readable by the 2.1.0 compiler), matching the intent of the original comment in the workflow.

Note: `e2e-ios-templateapp.yml` has the same pattern (currently not failing since the Kotlin issue is Android-only), and `main` carries the same logic in both files, so future stable branches will inherit this. Happy to follow up there if desired.

## Changelog:

[INTERNAL] [FIXED] - Use the PR base branch to pick the template branch in the Android template E2E workflow

## Test Plan:

- Verified `scripts/e2e/init-project-e2e.js` does a plain `git checkout` of the value passed as `--currentBranch` in the cloned template repo, and that the `0.86-stable` branch exists in `react-native-community/template` (with a Gradle 9.3.1 wrapper, vs 9.4.1 on template `main`).
- CI on this PR is the real test: `test_e2e_android_templateapp` should now generate the project from the template's `0.86-stable` branch and pass, while all other jobs remain unaffected.
