### PR TITLE
Flush created animated nodes before handling events (#57656)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -208,14 +208,14 @@ class NativeAnimatedNodesManager : public std::enable_shared_from_this<NativeAni
 
   bool isOnRenderThread() const noexcept;
 
+  void flushAnimatedNodesCreatedAsync() noexcept;
+
   void resolvePlatformColor(SurfaceId surfaceId, const RawValue &value, SharedColor &result) const;
 
  private:
   void stopRenderCallbackIfNeeded(bool isAsync) noexcept;
 
   bool onAnimationFrame(double timestamp);
-
-  void flushAnimatedNodesCreatedAsync() noexcept;
 
   bool isAnimationUpdateNeeded() const noexcept;
 

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -3523,6 +3523,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -3407,6 +3407,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -3520,6 +3520,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -5756,6 +5756,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -5668,6 +5668,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -5753,6 +5753,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -2365,6 +2365,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -2289,6 +2289,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -2362,6 +2362,7 @@ class facebook::react::NativeAnimatedNodesManager : public std::enable_shared_fr
   public void dropAnimatedNode(facebook::react::Tag tag) noexcept;
   public void extractAnimatedNodeOffsetOp(facebook::react::Tag tag);
   public void flattenAnimatedNodeOffset(facebook::react::Tag tag);
+  public void flushAnimatedNodesCreatedAsync() noexcept;
   public void insertMutations(std::unordered_map<facebook::react::Tag, std::pair<facebook::react::ShadowNodeFamily::Weak, folly::dynamic>>& updates, facebook::react::AnimationMutations& mutations, facebook::react::AnimatedPropsBuilder& propsBuilder, bool hasLayoutUpdates = false);
   public void onManagedPropsRemoved(facebook::react::Tag tag) noexcept;
   public void onRender();


### PR DESCRIPTION
Summary:

Changelog: [Internal]

View event handlers can run synchronously before NativeAnimated nodes created on the async path have been flushed into the active graph. Flush pending async-created nodes on the render thread before evaluating a view event, so focus-driven animations can resolve their value nodes on the first native focus event instead of needing another runloop/event.


There was a very frequent problem in airwave-tvos where a view would not receive it's NVE focus event on the commit it was created, this solves that problem without having to naively re-emit the focus event.

Differential Revision: D111257551


