### PR TITLE
Don't register unused RCTTimingCls in RN iOS (#57657)

### DIFF
--- a/packages/react-native/React/CoreModules/CoreModulesPlugins.h
+++ b/packages/react-native/React/CoreModules/CoreModulesPlugins.h
@@ -49,7 +49,9 @@ Class RCTPlatformCls(void) __attribute__((used));
 Class RCTRedBoxCls(void) __attribute__((used));
 Class RCTSourceCodeCls(void) __attribute__((used));
 Class RCTStatusBarManagerCls(void) __attribute__((used));
+#ifndef RCT_REMOVE_LEGACY_ARCH
 Class RCTTimingCls(void) __attribute__((used));
+#endif
 Class RCTWebSocketModuleCls(void) __attribute__((used));
 Class RCTBlobManagerCls(void) __attribute__((used));
 

--- a/packages/react-native/React/CoreModules/CoreModulesPlugins.mm
+++ b/packages/react-native/React/CoreModules/CoreModulesPlugins.mm
@@ -100,10 +100,6 @@ Class RCTCoreModulesClassProvider(const char *name)
     return RCTStatusBarManagerCls();
   }
 
-  if (name == "Timing"sv) {
-    return RCTTimingCls();
-  }
-
   if (name == "WebSocketModule"sv) {
     return RCTWebSocketModuleCls();
   }

--- a/packages/react-native/React/CoreModules/RCTTiming.mm
+++ b/packages/react-native/React/CoreModules/RCTTiming.mm
@@ -428,8 +428,3 @@ RCT_EXPORT_METHOD(setSendIdleEvents : (BOOL)sendIdleEvents)
 }
 
 @end
-
-Class RCTTimingCls(void)
-{
-  return RCTTiming.class;
-}


### PR DESCRIPTION
Summary:

Changelog: [INTERNAL]

RCTTiming is NOT used in the RN new architecture: https://github.com/react/react-native/pull/57081

And will be deleted in: https://github.com/react/react-native/pull/57037

This change removes it from the binary

Differential Revision: D113474826


