### PR TITLE
Fix UnsatisfiedLinkError in BaseViewManagerDelegateTest (#57665)

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerDelegateTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerDelegateTest.java
@@ -12,8 +12,11 @@ import static org.mockito.Mockito.verify;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.facebook.react.views.view.ReactViewManager;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,11 +30,19 @@ public class BaseViewManagerDelegateTest {
 
   @Before
   public void setUp() {
+    // Constructing a ReactViewGroup reads a native-backed feature flag; install the local
+    // (non-JNI) accessor so Robolectric doesn't try to load react_featureflagsjni.
+    ReactNativeFeatureFlagsForTests.INSTANCE.setUp();
     viewManager = mock(ReactViewManager.class);
     ReactApplicationContext context = ReactTestHelper.createCatalystContextForTest();
     ThemedReactContext themedReactContext = new ThemedReactContext(context, context, null, -1);
     view = new ReactViewGroup(themedReactContext);
     delegate = new BaseViewManagerDelegate<>(viewManager) {};
+  }
+
+  @After
+  public void tearDown() {
+    ReactNativeFeatureFlags.dangerouslyReset();
   }
 
   @Test


### PR DESCRIPTION
Summary:

Constructing a `ReactViewGroup` now reads the `syncAndroidClipBoundsWithOverflow` feature flag: the `pointerEvents` setter calls `ImportantForInteractionHelper.setImportantForInteraction`, which reads that flag, and `initView()` sets `pointerEvents`. Reading a feature flag loads the native `react_featureflagsjni` library, which is not on the Robolectric library path for this test, so `BaseViewManagerDelegateTest.setUp()` fails with:

```
java.lang.UnsatisfiedLinkError: no react_featureflagsjni
```

Install the local (non-native) feature-flags accessor in `setUp()` via `ReactNativeFeatureFlagsForTests.setUp()` and reset it in `tearDown()`, matching the approach already used in `ImportantForInteractionHelperTest`.

Changelog: [Internal]

Reviewed By: fabriziocucci, javache

Differential Revision: D113543605
