### PR TITLE
Fix ConcurrentModificationException in IntentModule.getInitialURL re-entrancy

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.kt
@@ -87,11 +87,19 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
           override fun onHostResume() {
             reactApplicationContext.removeLifecycleEventListener(this)
             synchronized(this@IntentModule) {
-              for (pendingPromise in pendingOpenURLPromises) {
+              // Snapshot and clear the pending promises before draining them. If the current
+              // activity is still null at resume time (e.g. a deep link arriving mid
+              // activity-transition), getInitialURL re-enters waitForActivityAndGetInitialURL and
+              // adds back into pendingOpenURLPromises. Draining a copy keeps that re-queue from
+              // mutating the list being iterated, which previously threw
+              // ConcurrentModificationException. Re-queued promises land in the now-empty list and
+              // are picked up on the next resume.
+              val pendingPromises = ArrayList(pendingOpenURLPromises)
+              pendingOpenURLPromises.clear()
+              initialURLListener = null
+              for (pendingPromise in pendingPromises) {
                 getInitialURL(pendingPromise)
               }
-              initialURLListener = null
-              pendingOpenURLPromises.clear()
             }
           }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/intent/IntentModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/intent/IntentModuleTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.intent
+
+import com.facebook.react.bridge.LifecycleEventListener
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class IntentModuleTest {
+
+  private lateinit var context: ReactApplicationContext
+  private lateinit var intentModule: IntentModule
+
+  @Before
+  fun setUp() {
+    context = mock<ReactApplicationContext>()
+    intentModule = IntentModule(context)
+  }
+
+  /**
+   * Regression test for the ConcurrentModificationException thrown from onHostResume. When the
+   * current activity is still null at resume time, draining pendingOpenURLPromises re-enters
+   * getInitialURL -> waitForActivityAndGetInitialURL, which adds back into the same list. Before
+   * the fix this mutated the list mid-iteration and crashed. The synchronized guard does not help:
+   * the re-entrancy is on the same thread and already holds the lock.
+   */
+  @Test
+  fun getInitialURL_onHostResumeWithNullActivity_doesNotThrowAndPreservesPromise() {
+    // No current activity: getInitialURL queues the promise and registers a lifecycle listener.
+    whenever(context.currentActivity).thenReturn(null)
+
+    val promise = SimplePromise()
+    intentModule.getInitialURL(promise)
+
+    val listenerCaptor = argumentCaptor<LifecycleEventListener>()
+    verify(context).addLifecycleEventListener(listenerCaptor.capture())
+
+    // Resume while the activity is still null (e.g. a deep link landing mid activity-transition).
+    // The drain re-queues the promise; before the fix this threw ConcurrentModificationException.
+    assertThatCode { listenerCaptor.firstValue.onHostResume() }.doesNotThrowAnyException()
+
+    // The promise was re-queued rather than silently dropped: a fresh listener is registered for
+    // the next resume, and the promise is left pending (neither resolved nor rejected).
+    verify(context, times(2)).addLifecycleEventListener(any())
+    assertThat(promise.resolved).isEqualTo(0)
+    assertThat(promise.rejected).isEqualTo(0)
+  }
+
+  internal class SimplePromise : Promise {
+    companion object {
+      private const val ERROR_DEFAULT_CODE = "EUNSPECIFIED"
+      private const val ERROR_DEFAULT_MESSAGE = "Error not specified."
+    }
+
+    var resolved = 0
+      private set
+
+    var rejected = 0
+      private set
+
+    var value: Any? = null
+      private set
+
+    var errorCode: String? = null
+      private set
+
+    var errorMessage: String? = null
+      private set
+
+    override fun resolve(value: Any?) {
+      resolved++
+      this.value = value
+    }
+
+    override fun reject(code: String?, message: String?) {
+      reject(code, message, null, null)
+    }
+
+    override fun reject(code: String?, throwable: Throwable?) {
+      reject(code, null, throwable, null)
+    }
+
+    override fun reject(code: String?, message: String?, throwable: Throwable?) {
+      reject(code, message, throwable, null)
+    }
+
+    override fun reject(throwable: Throwable) {
+      reject(null, null, throwable, null)
+    }
+
+    override fun reject(throwable: Throwable, userInfo: WritableMap) {
+      reject(null, null, throwable, userInfo)
+    }
+
+    override fun reject(code: String?, userInfo: WritableMap) {
+      reject(code, null, null, userInfo)
+    }
+
+    override fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap) {
+      reject(code, null, throwable, userInfo)
+    }
+
+    override fun reject(code: String?, message: String?, userInfo: WritableMap) {
+      reject(code, message, null, userInfo)
+    }
+
+    override fun reject(
+        code: String?,
+        message: String?,
+        throwable: Throwable?,
+        userInfo: WritableMap?,
+    ) {
+      rejected++
+
+      errorCode = code ?: ERROR_DEFAULT_CODE
+      errorMessage = message ?: throwable?.message ?: ERROR_DEFAULT_MESSAGE
+    }
+
+    @Deprecated("Method deprecated", ReplaceWith("reject(code, message)"))
+    override fun reject(message: String) {
+      reject(null, message, null, null)
+    }
+  }
+}


### PR DESCRIPTION
## Summary:

`IntentModule.onHostResume()` iterates `pendingOpenURLPromises` (an `ArrayList`) directly and calls `getInitialURL()` for each pending promise. When `getCurrentActivity()` returns `null` at that moment — e.g. a deep link or notification tap landing mid activity-transition during a rapid pause/resume — `getInitialURL()` re-enters `waitForActivityAndGetInitialURL()`, which calls `pendingOpenURLPromises.add(promise)` on the very list being iterated. The next iteration then throws `java.util.ConcurrentModificationException`:

```
java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
    at java.util.ArrayList$Itr.next(ArrayList.java:967)
    at com.facebook.react.modules.intent.IntentModule$waitForActivityAndGetInitialURL$1.onHostResume(IntentModule.kt:90)
```

The `synchronized(this@IntentModule)` guard does not prevent this: the re-entrancy is on the same thread, which already holds the (reentrant) lock, so no second lock acquisition happens. The crash is the `ArrayList` iterator's `modCount` check, not a cross-thread race.

The fix snapshots the pending promises into a local copy, clears the shared list, and nulls the listener **before** draining. Re-queued promises then land in the now-empty `pendingOpenURLPromises` and register a fresh listener for the next resume, instead of mutating the list being iterated. Behaviour is otherwise unchanged.

## Changelog:

[ANDROID] [FIXED] - Fix ConcurrentModificationException when getInitialURL re-enters during onHostResume

## Test Plan:

Added `IntentModuleTest.getInitialURL_onHostResumeWithNullActivity_doesNotThrowAndPreservesPromise`, a Robolectric regression test that registers a pending promise while the current activity is `null`, then drives `onHostResume` so the drain re-queues, and asserts the drain does not throw and the promise is preserved (neither resolved nor rejected).

Ran locally against `main` with the exact reproduction scenario:

**With the fix** — passes:
```
$ ./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest \
    --tests "com.facebook.react.modules.intent.IntentModuleTest"
BUILD SUCCESSFUL
# tests=1, failures=0, errors=0
```

**Without the fix** (reverting `IntentModule.kt` only) — fails with the exact crash, confirming the test is a genuine regression test:
```
IntentModuleTest > getInitialURL_onHostResumeWithNullActivity_doesNotThrowAndPreservesPromise FAILED
    java.util.ConcurrentModificationException
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
        at java.util.ArrayList$Itr.next(ArrayList.java:967)
        at com.facebook.react.modules.intent.IntentModule$waitForActivityAndGetInitialURL$1.onHostResume(IntentModule.kt:90)
```

`ktfmt` (Meta style, matching the repo's `ktfmt` configuration) reports both changed files as already formatted.
