### PR TITLE
Add missing strictMode prop to FlatList TypeScript types

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.d.ts
+++ b/packages/react-native/Libraries/Lists/FlatList.d.ts
@@ -161,6 +161,11 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
    * @platform android
    */
   fadingEdgeLength?: number | {start: number; end: number} | undefined;
+
+  /**
+   * Enable an optimization to memoize the item renderer to prevent unnecessary rerenders.
+   */
+  strictMode?: boolean | undefined;
 }
 
 export abstract class FlatListComponent<


### PR DESCRIPTION
## Summary:

FlatList's `strictMode` prop is implemented in the component and declared in the Flow types (OptionalFlatListProps in FlatList.js), but missing from the shipped TypeScript definitions. TS users can't set it on <FlatList> without augmenting the module themselves. This adds `strictMode?: boolean` to the TypeScript FlatListProps, matching the Flow declaration. Types-only, no runtime change.

## Changelog:

[GENERAL] [ADDED] - Add missing strictMode prop to FlatList TypeScript types

## Test Plan:

Types-only change:
- Before, `<FlatList ... strictMode />` errored `(Property 'strictMode' does not exist);`
- After, it type-checks. Matches the Flow prop and the runtime use in `render(): const renderer = strictMode ? this._memoizedRenderer : this._renderer;`