### PR TITLE
Drop RCT_EXPORT_METHOD from RCTDevToolsRuntimeSettingsModule TurboModule (#57683)

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -274,9 +274,8 @@ RCT_EXPORT_MODULE()
   return _multipliers;
 }
 
-RCT_EXPORT_METHOD(
-    setAccessibilityContentSizeMultipliers : (
-        JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)JSMultipliers)
+- (void)setAccessibilityContentSizeMultipliers:
+    (JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)JSMultipliers
 {
   NSMutableDictionary<NSString *, NSNumber *> *multipliers = [NSMutableDictionary new];
   setMultipliers(multipliers, UIContentSizeCategoryExtraSmall, JSMultipliers.extraSmall());
@@ -308,7 +307,7 @@ static void setMultipliers(
   }
 }
 
-RCT_EXPORT_METHOD(setAccessibilityFocus : (double)reactTag)
+- (void)setAccessibilityFocus:(double)reactTag
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     UIView *view = [self.viewRegistry_DEPRECATED viewForReactTag:@(reactTag)];
@@ -316,14 +315,16 @@ RCT_EXPORT_METHOD(setAccessibilityFocus : (double)reactTag)
   });
 }
 
-RCT_EXPORT_METHOD(announceForAccessibility : (NSString *)announcement)
+- (void)announceForAccessibility:(NSString *)announcement
 {
   UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement);
 }
 
-RCT_EXPORT_METHOD(
-    announceForAccessibilityWithOptions : (NSString *)announcement options : (
-        JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions &)options)
+- (void)
+    announceForAccessibilityWithOptions:(NSString *)announcement
+                                options:
+                                    (JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions &)
+                                        options
 {
   NSMutableDictionary<NSString *, id> *attrsDictionary = [NSMutableDictionary new];
   if (options.queue()) {
@@ -356,47 +357,41 @@ RCT_EXPORT_METHOD(
   }
 }
 
-RCT_EXPORT_METHOD(getMultiplier : (RCTResponseSenderBlock)callback)
+- (void)getMultiplier:(RCTResponseSenderBlock)callback
 {
   if (callback) {
     callback(@[ @(self.multiplier) ]);
   }
 }
 
-RCT_EXPORT_METHOD(
-    getCurrentBoldTextState : (RCTResponseSenderBlock)onSuccess onError : (__unused RCTResponseSenderBlock)onError)
+- (void)getCurrentBoldTextState:(RCTResponseSenderBlock)onSuccess onError:(__unused RCTResponseSenderBlock)onError
 {
   onSuccess(@[ @(_isBoldTextEnabled) ]);
 }
 
-RCT_EXPORT_METHOD(
-    getCurrentGrayscaleState : (RCTResponseSenderBlock)onSuccess onError : (__unused RCTResponseSenderBlock)onError)
+- (void)getCurrentGrayscaleState:(RCTResponseSenderBlock)onSuccess onError:(__unused RCTResponseSenderBlock)onError
 {
   onSuccess(@[ @(_isGrayscaleEnabled) ]);
 }
 
-RCT_EXPORT_METHOD(
-    getCurrentInvertColorsState : (RCTResponseSenderBlock)onSuccess onError : (__unused RCTResponseSenderBlock)onError)
+- (void)getCurrentInvertColorsState:(RCTResponseSenderBlock)onSuccess onError:(__unused RCTResponseSenderBlock)onError
 {
   onSuccess(@[ @(_isInvertColorsEnabled) ]);
 }
 
-RCT_EXPORT_METHOD(
-    getCurrentReduceMotionState : (RCTResponseSenderBlock)onSuccess onError : (__unused RCTResponseSenderBlock)onError)
+- (void)getCurrentReduceMotionState:(RCTResponseSenderBlock)onSuccess onError:(__unused RCTResponseSenderBlock)onError
 {
   onSuccess(@[ @(_isReduceMotionEnabled) ]);
 }
 
-RCT_EXPORT_METHOD(
-    getCurrentDarkerSystemColorsState : (RCTResponseSenderBlock)onSuccess onError : (__unused RCTResponseSenderBlock)
-        onError)
+- (void)getCurrentDarkerSystemColorsState:(RCTResponseSenderBlock)onSuccess
+                                  onError:(__unused RCTResponseSenderBlock)onError
 {
   onSuccess(@[ @(_isDarkerSystemColorsEnabled) ]);
 }
 
-RCT_EXPORT_METHOD(
-    getCurrentPrefersCrossFadeTransitionsState : (RCTResponseSenderBlock)
-        onSuccess onError : (__unused RCTResponseSenderBlock)onError)
+- (void)getCurrentPrefersCrossFadeTransitionsState:(RCTResponseSenderBlock)onSuccess
+                                           onError:(__unused RCTResponseSenderBlock)onError
 {
   if (@available(iOS 14.0, *)) {
     onSuccess(@[ @(UIAccessibilityPrefersCrossFadeTransitions()) ]);
@@ -405,15 +400,13 @@ RCT_EXPORT_METHOD(
   }
 }
 
-RCT_EXPORT_METHOD(
-    getCurrentReduceTransparencyState : (RCTResponseSenderBlock)onSuccess onError : (__unused RCTResponseSenderBlock)
-        onError)
+- (void)getCurrentReduceTransparencyState:(RCTResponseSenderBlock)onSuccess
+                                  onError:(__unused RCTResponseSenderBlock)onError
 {
   onSuccess(@[ @(_isReduceTransparencyEnabled) ]);
 }
 
-RCT_EXPORT_METHOD(
-    getCurrentVoiceOverState : (RCTResponseSenderBlock)onSuccess onError : (__unused RCTResponseSenderBlock)onError)
+- (void)getCurrentVoiceOverState:(RCTResponseSenderBlock)onSuccess onError:(__unused RCTResponseSenderBlock)onError
 {
   onSuccess(@[ @(_isVoiceOverEnabled) ]);
 }

--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -76,9 +76,8 @@ RCT_EXPORT_MODULE()
   [parentViewController presentViewController:alertController animated:YES completion:nil];
 }
 
-RCT_EXPORT_METHOD(
-    showActionSheetWithOptions : (JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)
-        options callback : (RCTResponseSenderBlock)callback)
+- (void)showActionSheetWithOptions:(JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options
+                          callback:(RCTResponseSenderBlock)callback
 {
   if (RCTRunningInAppExtension()) {
     RCTLogError(@"Unable to show action sheet from app extension");
@@ -219,7 +218,7 @@ RCT_EXPORT_METHOD(
   });
 }
 
-RCT_EXPORT_METHOD(dismissActionSheet)
+- (void)dismissActionSheet
 {
   if (_alertControllers.count == 0) {
     RCTLogWarn(@"Unable to dismiss action sheet");
@@ -232,10 +231,10 @@ RCT_EXPORT_METHOD(dismissActionSheet)
   });
 }
 
-RCT_EXPORT_METHOD(
-    showShareActionSheetWithOptions : (JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)
-        options failureCallback : (RCTResponseSenderBlock)failureCallback successCallback : (RCTResponseSenderBlock)
-            successCallback)
+- (void)showShareActionSheetWithOptions:
+            (JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options
+                        failureCallback:(RCTResponseSenderBlock)failureCallback
+                        successCallback:(RCTResponseSenderBlock)successCallback
 {
   if (RCTRunningInAppExtension()) {
     RCTLogError(@"Unable to show action sheet from app extension");

--- a/packages/react-native/React/CoreModules/RCTAlertManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertManager.mm
@@ -65,7 +65,7 @@ RCT_EXPORT_MODULE()
  * The key from the `buttons` dictionary is passed back in the callback on click.
  * Buttons are displayed in the order they are specified.
  */
-RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback : (RCTResponseSenderBlock)callback)
+- (void)alertWithArgs:(JS::NativeAlertManager::Args &)args callback:(RCTResponseSenderBlock)callback
 {
   NSString *title = [RCTConvert NSString:args.title()];
   NSString *message = [RCTConvert NSString:args.message()];

--- a/packages/react-native/React/CoreModules/RCTAppState.mm
+++ b/packages/react-native/React/CoreModules/RCTAppState.mm
@@ -135,7 +135,7 @@ RCT_EXPORT_MODULE()
 /**
  * Get the current background/foreground state of the app
  */
-RCT_EXPORT_METHOD(getCurrentAppState : (RCTResponseSenderBlock)callback error : (__unused RCTResponseSenderBlock)error)
+- (void)getCurrentAppState:(RCTResponseSenderBlock)callback error:(__unused RCTResponseSenderBlock)error
 {
   callback(@[ @{@"app_state" : RCTCurrentAppState()} ]);
 }

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -109,7 +109,7 @@ RCT_EXPORT_MODULE(Appearance)
   return std::make_shared<NativeAppearanceSpecJSI>(params);
 }
 
-RCT_EXPORT_METHOD(setColorScheme : (NSString *)style)
+- (void)setColorScheme:(NSString *)style
 {
   UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:style];
   NSMutableArray<UIWindow *> *windows = [NSMutableArray new];

--- a/packages/react-native/React/CoreModules/RCTClipboard.mm
+++ b/packages/react-native/React/CoreModules/RCTClipboard.mm
@@ -26,7 +26,7 @@ RCT_EXPORT_MODULE()
   return dispatch_get_main_queue();
 }
 
-RCT_EXPORT_METHOD(setString : (NSString *)content)
+- (void)setString:(NSString *)content
 {
 #if !TARGET_OS_TV
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
@@ -34,7 +34,7 @@ RCT_EXPORT_METHOD(setString : (NSString *)content)
 #endif
 }
 
-RCT_EXPORT_METHOD(getString : (RCTPromiseResolveBlock)resolve reject : (__unused RCTPromiseRejectBlock)reject)
+- (void)getString:(RCTPromiseResolveBlock)resolve reject:(__unused RCTPromiseRejectBlock)reject
 {
 #if !TARGET_OS_TV
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -244,16 +244,17 @@ RCT_EXPORT_MODULE()
   });
 }
 
-RCT_EXPORT_METHOD(
-    showMessage : (NSString *)message withColor : (NSNumber *__nonnull)color withBackgroundColor : (NSNumber *__nonnull)
-        backgroundColor withDismissButton : (NSNumber *)dismissButton)
+- (void)showMessage:(NSString *)message
+              withColor:(NSNumber *__nonnull)color
+    withBackgroundColor:(NSNumber *__nonnull)backgroundColor
+      withDismissButton:(NSNumber *)dismissButton
 {
   [self showMessage:message
                 color:[RCTConvert UIColor:color]
       backgroundColor:[RCTConvert UIColor:backgroundColor]
         dismissButton:[dismissButton boolValue]];
 }
-RCT_EXPORT_METHOD(hide)
+- (void)hide
 {
   if (!RCTDevLoadingViewGetEnabled()) {
     return;

--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -430,7 +430,7 @@ RCT_EXPORT_MODULE()
   return items;
 }
 
-RCT_EXPORT_METHOD(show)
+- (void)show
 {
   if ((_actionSheet != nullptr) || RCTRunningInAppExtension() || !_devMenuEnabled) {
     return;
@@ -495,13 +495,13 @@ RCT_EXPORT_METHOD(show)
   return ((RCTDevSettings *)[_moduleRegistry moduleForName:"DevSettings"]).isShakeToShowDevMenuEnabled;
 }
 
-RCT_EXPORT_METHOD(reload)
+- (void)reload
 {
   WARN_DEPRECATED_DEV_MENU_EXPORT();
   RCTTriggerReloadCommandListeners(@"Unknown from JS");
 }
 
-RCT_EXPORT_METHOD(setProfilingEnabled : (BOOL)enabled)
+- (void)setProfilingEnabled:(BOOL)enabled
 {
   WARN_DEPRECATED_DEV_MENU_EXPORT();
   ((RCTDevSettings *)[_moduleRegistry moduleForName:"DevSettings"]).isProfilingEnabled = enabled;
@@ -512,7 +512,7 @@ RCT_EXPORT_METHOD(setProfilingEnabled : (BOOL)enabled)
   return ((RCTDevSettings *)[_moduleRegistry moduleForName:"DevSettings"]).isProfilingEnabled;
 }
 
-RCT_EXPORT_METHOD(setHotLoadingEnabled : (BOOL)enabled)
+- (void)setHotLoadingEnabled:(BOOL)enabled
 {
   WARN_DEPRECATED_DEV_MENU_EXPORT();
   ((RCTDevSettings *)[_moduleRegistry moduleForName:"DevSettings"]).isHotLoadingEnabled = enabled;

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -313,22 +313,22 @@ RCT_EXPORT_MODULE()
   return NO;
 }
 
-RCT_EXPORT_METHOD(reload)
+- (void)reload
 {
   RCTTriggerReloadCommandListeners(@"Unknown From JS");
 }
 
-RCT_EXPORT_METHOD(reloadWithReason : (NSString *)reason)
+- (void)reloadWithReason:(NSString *)reason
 {
   RCTTriggerReloadCommandListeners(reason);
 }
 
-RCT_EXPORT_METHOD(onFastRefresh)
+- (void)onFastRefresh
 {
   [self.bridge onFastRefresh];
 }
 
-RCT_EXPORT_METHOD(setIsShakeToShowDevMenuEnabled : (BOOL)enabled)
+- (void)setIsShakeToShowDevMenuEnabled:(BOOL)enabled
 {
   [self _updateSettingWithValue:@(enabled) forKey:kRCTDevSettingShakeToShowDevMenu];
 }
@@ -338,7 +338,7 @@ RCT_EXPORT_METHOD(setIsShakeToShowDevMenuEnabled : (BOOL)enabled)
   return _isShakeGestureEnabled && [[self settingForKey:kRCTDevSettingShakeToShowDevMenu] boolValue];
 }
 
-RCT_EXPORT_METHOD(setProfilingEnabled : (BOOL)enabled)
+- (void)setProfilingEnabled:(BOOL)enabled
 {
   [self _updateSettingWithValue:@(enabled) forKey:kRCTDevSettingProfilingEnabled];
   [self _profilingSettingDidChange];
@@ -368,7 +368,7 @@ RCT_EXPORT_METHOD(setProfilingEnabled : (BOOL)enabled)
   }
 }
 
-RCT_EXPORT_METHOD(setHotLoadingEnabled : (BOOL)enabled)
+- (void)setHotLoadingEnabled:(BOOL)enabled
 {
   if (self.isHotLoadingEnabled != enabled) {
     [self _updateSettingWithValue:@(enabled) forKey:kRCTDevSettingHotLoadingEnabled];
@@ -390,7 +390,7 @@ RCT_EXPORT_METHOD(setHotLoadingEnabled : (BOOL)enabled)
   return [[self settingForKey:kRCTDevSettingHotLoadingEnabled] boolValue];
 }
 
-RCT_EXPORT_METHOD(toggleElementInspector)
+- (void)toggleElementInspector
 {
   BOOL value = [[self settingForKey:kRCTDevSettingIsInspectorShown] boolValue];
   [self _updateSettingWithValue:@(!value) forKey:kRCTDevSettingIsInspectorShown];
@@ -403,7 +403,7 @@ RCT_EXPORT_METHOD(toggleElementInspector)
   }
 }
 
-RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
+- (void)addMenuItem:(NSString *)title
 {
   __weak __typeof(self) weakSelf = self;
   [(RCTDevMenu *)[self.moduleRegistry moduleForName:"DevMenu"]
@@ -494,7 +494,7 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
   }
 }
 
-RCT_EXPORT_METHOD(openDebugger)
+- (void)openDebugger
 {
 #if RCT_ENABLE_INSPECTOR
   [RCTInspectorDevServerHelper

--- a/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm
+++ b/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm
@@ -25,8 +25,7 @@ static Config _config;
 @implementation RCTDevToolsRuntimeSettingsModule
 RCT_EXPORT_MODULE(ReactDevToolsRuntimeSettingsModule)
 
-RCT_EXPORT_METHOD(
-    setReloadAndProfileConfig : (JS::NativeReactDevToolsRuntimeSettingsModule::PartialReloadAndProfileConfig &)config)
+- (void)setReloadAndProfileConfig:(JS::NativeReactDevToolsRuntimeSettingsModule::PartialReloadAndProfileConfig &)config
 {
   if (config.shouldReloadAndProfile().has_value()) {
     _config.shouldReloadAndProfile = config.shouldReloadAndProfile().value();


### PR DESCRIPTION
Summary:

Changelog: [Internal]

`RCTDevToolsRuntimeSettingsModule` is a TurboModule: it conforms to `NativeReactDevToolsRuntimeSettingsModuleSpec` and implements `getTurboModule:` returning the codegen'd `...SpecJSI`. For TurboModules, the JS->ObjC dispatch is driven by codegen (the generated spec supplies the `selector` and argument kinds, invoked at runtime via `NSMethodSignature` / `NSInvocation`), not by the `RCT_EXPORT_METHOD` macro's `__rct_export__` metadata.

The exported methods here are async-void with concrete parameter types (no generic `id` requiring `RCTConvert` coercion), so the macro is not functionally required. Convert them to plain ObjC method declarations; conformance to the codegen'd `NativeReactDevToolsRuntimeSettingsModuleSpec` protocol keeps compiler-enforced signature parity.

Signature-only refactor with no change to the JS-facing API. Sync methods, methods with `id` params, and `constantsToExport` are intentionally left untouched.

Differential Revision: D113579881


