### PR TITLE
Preserve negative values in transformOrigin strings

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js
@@ -122,5 +122,16 @@ describe('processTransformOrigin', () => {
       expect(processTransformOrigin('12.5px 7.5px')).toEqual([12.5, 7.5, 0]);
       expect(processTransformOrigin('.5% .5px')).toEqual(['.5%', 0.5, 0]);
     });
+    it('should preserve negative percentage and pixel values', () => {
+      expect(processTransformOrigin('-50.5% -30.2%')).toEqual([
+        '-50.5%',
+        '-30.2%',
+        0,
+      ]);
+      expect(processTransformOrigin('-12.5px -7.5px -2.5px')).toEqual([
+        -12.5, -7.5, -2.5,
+      ]);
+      expect(processTransformOrigin('-.5% -.5px')).toEqual(['-.5%', -0.5, 0]);
+    });
   });
 });

--- a/packages/react-native/Libraries/StyleSheet/processTransformOrigin.js
+++ b/packages/react-native/Libraries/StyleSheet/processTransformOrigin.js
@@ -12,7 +12,7 @@ import invariant from 'invariant';
 
 // Pre-compiled regex pattern for performance - avoids regex compilation on each call
 const TRANSFORM_ORIGIN_REGEX =
-  /(top|bottom|left|right|center|\d*\.?\d+(?:%|px)|0)/gi;
+  /(top|bottom|left|right|center|-?\d*\.?\d+(?:%|px)|0)/gi;
 
 const INDEX_X = 0;
 const INDEX_Y = 1;


### PR DESCRIPTION
## Summary:

The numeric tokenizer updated in #57487 still starts at the first digit when a percentage or pixel value is negative. This silently changes values such as `-12.5px -7.5px` into `[12.5, 7.5, 0]`.

Allow a leading minus in numeric tokens so negative percentages, pixel offsets, and leading-dot decimals retain their sign. The pattern is intentionally limited to the failing negative case and leaves leading-plus values unchanged.

## Changelog:

[GENERAL] [FIXED] - Preserve negative values in `transformOrigin` strings.

## Test Plan:

- Added Fantom regression coverage for negative percentages, x/y/z pixel offsets, and leading-dot decimals in `processTransformOrigin-itest.js`
- `./node_modules/.bin/prettier --check packages/react-native/Libraries/StyleSheet/processTransformOrigin.js packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js`
- `./node_modules/.bin/eslint --max-warnings 0 packages/react-native/Libraries/StyleSheet/processTransformOrigin.js packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-itest.js`
- Ran focused runtime checks against the Flow-stripped parser for the new negative cases and existing leading-plus behavior
