### PR TITLE
fix(ios): replace crash-causing RCTAssert with RCTLogWarn in touch handler

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -8,6 +8,7 @@
 #import "RCTSurfaceTouchHandler.h"
 
 #import <React/RCTIdentifierPool.h>
+#import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 #import <React/RCTViewComponentView.h>
 
@@ -206,8 +207,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 {
   for (UITouch *touch in touches) {
     auto iterator = _activeTouches.find(touch);
-    RCTAssert(iterator != _activeTouches.end(), @"Inconsistency between local and UIKit touch registries");
     if (iterator == _activeTouches.end()) {
+      RCTLogWarn(@"Inconsistency between local and UIKit touch registries");
       continue;
     }
 
@@ -219,8 +220,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 {
   for (UITouch *touch in touches) {
     auto iterator = _activeTouches.find(touch);
-    RCTAssert(iterator != _activeTouches.end(), @"Inconsistency between local and UIKit touch registries");
     if (iterator == _activeTouches.end()) {
+      RCTLogWarn(@"Inconsistency between local and UIKit touch registries");
       continue;
     }
     auto &activeTouch = iterator->second;
@@ -236,8 +237,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 
   for (UITouch *touch in touches) {
     auto iterator = _activeTouches.find(touch);
-    RCTAssert(iterator != _activeTouches.end(), @"Inconsistency between local and UIKit touch registries");
     if (iterator == _activeTouches.end()) {
+      RCTLogWarn(@"Inconsistency between local and UIKit touch registries");
       continue;
     }
     activeTouches.push_back(iterator->second);


### PR DESCRIPTION
## Summary:

On iOS 17+, UITextView's text selection gesture recognizer can deliver `touchesMoved:`/`touchesEnded:` to `RCTSurfaceTouchHandler` without a prior `touchesBegan:` for the same touch. This happens because UIKit's internal selection gesture claims the touch begin exclusively and only forwards subsequent phases to sibling gesture recognizers.

When this occurs, `_activeTouches.find(touch)` returns `end()`, and the `RCTAssert` fires — throwing an `NSException` that crashes the app in debug builds. The existing `if (iterator == end) { continue; }` guard already handles this case gracefully (and is the only code path exercised in release builds, where `RCTAssert` is a no-op).

This PR downgrades the assertion to `RCTLogWarn`, preserving the diagnostic signal while eliminating the debug-only crash.

This issue was discovered while investigating text selection crashes in [react-native-enriched-markdown](https://github.com/software-mansion/react-native-enriched-markdown), where a custom `UITextView`-based Fabric component with rich text formatting (headings, paragraphs) consistently triggers the assertion during normal selection gestures.

## Changelog:

[IOS] [FIXED] - Fix debug-only crash "Inconsistency between local and UIKit touch registries" in RCTSurfaceTouchHandler triggered by UITextView selection gestures on iOS 17+

## Test Plan:

1. Create a React Native app with a multiline `<TextInput>` or a custom `UITextView`-based Fabric component
2. On iOS 17+ simulator or device, in a **debug** build:
   - Tap to place the cursor in a text block
   - Attempt to select text by long-pressing and dragging to a different paragraph
3. **Before this fix**: App crashes with `NSException: "Inconsistency between local and UIKit touch registries"`
4. **After this fix**: Selection works normally. A warning is logged to the console: `"Inconsistency between local and UIKit touch registries"`
5. Verified that release builds are unaffected (RCTAssert was already a no-op in release)
