### PR TITLE
fix(rn-tester): use framework-style import for RCTFabricComponentsPlugins.h

### DIFF
--- a/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
+++ b/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
@@ -13,7 +13,7 @@
 #import <react/renderer/components/AppSpecs/Props.h>
 #import <react/renderer/components/AppSpecs/RCTComponentViewHelpers.h>
 
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTFabricComponentsPlugins.h>
 
 using namespace facebook::react;
 


### PR DESCRIPTION
## Summary:

rn-tester's `MyNativeView` example imports `RCTFabricComponentsPlugins.h` with the quoted form, which only resolves under CocoaPods (header maps re-vend the bare filename via `FACADE_REEXPOSED_HEADERS` in `rncore_facades.rb` — see also `scripts/ios-prebuild/__docs__/headers-rules.md`, which documents the quoted form as CocoaPods-only). Under SwiftPM the header is exposed as an include directory, so only `<React/RCTFabricComponentsPlugins.h>` resolves — the quoted import makes `MyNativeView` fail to compile when rn-tester is converted to SwiftPM (surfaced by the new SPM CI lane in #57659).

The angle form resolves under both distributions. One line, no behavior change under CocoaPods.

## Changelog:

[INTERNAL] [FIXED] - Fix rn-tester's NativeComponentExample header import so it compiles under SwiftPM

## Test Plan:

- Repro on clean `main`: converting rn-tester to SwiftPM (`spm add --deintegrate`) and building fails at `RNTMyNativeViewComponentView.mm:16` (`fatal error: 'RCTFabricComponentsPlugins.h' file not found`) — both against CI-composed prebuilt artifacts and locally-built ones (identical failure; clang search paths verified via the compile response file: the header is reachable only as `React/RCTFabricComponentsPlugins.h`).
- With this change applied: same conversion + `xcodebuild -configuration Debug -sdk iphonesimulator` → `BUILD SUCCEEDED`, embedded `React.framework` verified Debug-flavored.
- Existing CocoaPods CI (`test_ios_rntester`) covers the unchanged CocoaPods path.
