### PR TITLE
Fix build-from-source on Windows: use JVM temp dir instead of hardcoded /tmp

### DIFF
--- a/packages/react-native/settings.gradle.kts
+++ b/packages/react-native/settings.gradle.kts
@@ -34,7 +34,10 @@ project(":packages:react-native:ReactAndroid:hermes-engine").projectDir =
 // As we build :packages:react-native:ReactAndroid, we need to declare the folders
 // for :packages and :packages:react-native as well as otherwise the build from
 // source will fail with a missing folder exception.
+// We point them at the JVM temp dir rather than a hardcoded "/tmp": the latter is
+// not an absolute path on Windows, where Gradle would resolve it to a
+// non-existing <rootDir>\tmp and fail at configuration time.
 
-project(":packages").projectDir = file("/tmp")
+project(":packages").projectDir = file(System.getProperty("java.io.tmpdir", "/tmp"))
 
-project(":packages:react-native").projectDir = file("/tmp")
+project(":packages:react-native").projectDir = file(System.getProperty("java.io.tmpdir", "/tmp"))


### PR DESCRIPTION
## Summary

`packages/react-native/settings.gradle.kts` declares the intermediate container projects `:packages` and `:packages:react-native` with `projectDir = file("/tmp")`, to satisfy Gradle 9's requirement that every project in a path have an existing folder. `/tmp` exists on posix hosts, but on Windows it is not an absolute path, so Gradle resolves it to a non-existent `<rootDir>\tmp` and build-from-source fails at configuration time:

    Configuring project ':packages:react-native' without an existing directory
    is not allowed.

Use `System.getProperty("java.io.tmpdir", "/tmp")` instead — the JVM temp dir, which is `/tmp` on posix and `%TEMP%` on Windows, and always exists.

## Changelog:

[ANDROID] [FIXED] - Use the JVM temp dir instead of a hardcoded `/tmp` for the build-from-source container project dirs, fixing Gradle configuration on Windows

## Test Plan

- posix: the resolved dir is unchanged (`/tmp`); build-from-source configures as before.
- Windows: resolves to an existing temp dir, so `includeBuild(../node_modules/react-native)`
  configures successfully instead of erroring.
- Downstream evidence: this exact change greened the `windows-latest` Gradle lane in
  callstackincubator/react-native-node-api#387.
