### PR TITLE
Fix main-thread watchdog hang in PushNotificationIOS.setApplicationIconBadgeNumber (#57707)

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -322,7 +322,18 @@ RCT_EXPORT_METHOD(onFinishRemoteNotification : (NSString *)notificationId fetchR
  */
 RCT_EXPORT_METHOD(setApplicationIconBadgeNumber : (double)number)
 {
-  RCTSharedApplication().applicationIconBadgeNumber = number;
+  NSInteger badgeCount = (NSInteger)lround(number);
+  if (@available(iOS 16.0, *)) {
+    [UNUserNotificationCenter.currentNotificationCenter
+                setBadgeCount:badgeCount
+        withCompletionHandler:^(NSError *_Nullable error) {
+          if (error != nil) {
+            RCTLogWarn(@"Failed to set application icon badge number: %@", error);
+          }
+        }];
+  } else {
+    RCTSharedApplication().applicationIconBadgeNumber = badgeCount;
+  }
 }
 
 /**

--- a/packages/rn-tester/js/examples/PushNotificationIOS/PushNotificationIOSExample.js
+++ b/packages/rn-tester/js/examples/PushNotificationIOS/PushNotificationIOSExample.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
+import RNTesterText from '../../components/RNTesterText';
+import * as React from 'react';
+import {useCallback, useState} from 'react';
+import {Button, StyleSheet, View} from 'react-native';
+import PushNotificationIOS from 'react-native/Libraries/PushNotificationIOS/PushNotificationIOS';
+
+// Fires setApplicationIconBadgeNumber many times back-to-back.
+const RAPID_FIRE_COUNT = 50;
+
+function BadgeExample(): React.Node {
+  const [reported, setReported] = useState<?number>(null);
+
+  const updateBadge = useCallback((n: number) => {
+    PushNotificationIOS.setApplicationIconBadgeNumber(n);
+  }, []);
+
+  const readBadge = useCallback(() => {
+    PushNotificationIOS.getApplicationIconBadgeNumber((n: number) => {
+      setReported(n);
+    });
+  }, []);
+
+  const rapidFire = useCallback(() => {
+    for (let i = 1; i <= RAPID_FIRE_COUNT; i++) {
+      PushNotificationIOS.setApplicationIconBadgeNumber(i);
+    }
+  }, []);
+
+  return (
+    <View style={styles.wrapper}>
+      <RNTesterText style={styles.text}>
+        {reported == null
+          ? 'Tap "Read current badge" to query the badge number.'
+          : `Last read badge number: ${reported}`}
+      </RNTesterText>
+      <View style={styles.button}>
+        <Button title="Set badge to 5" onPress={() => updateBadge(5)} />
+      </View>
+      <View style={styles.button}>
+        <Button title="Clear badge (set 0)" onPress={() => updateBadge(0)} />
+      </View>
+      <View style={styles.button}>
+        <Button
+          title={`Rapid-fire ${RAPID_FIRE_COUNT}x set`}
+          onPress={rapidFire}
+        />
+      </View>
+      <View style={styles.button}>
+        <Button title="Read current badge" onPress={readBadge} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    padding: 10,
+  },
+  text: {
+    marginBottom: 10,
+  },
+  button: {
+    marginVertical: 4,
+  },
+});
+
+exports.framework = 'React';
+exports.title = 'PushNotificationIOS';
+exports.category = 'iOS';
+exports.documentationURL = 'https://reactnative.dev/docs/pushnotificationios';
+exports.description = 'Application icon badge number via UserNotifications.';
+
+exports.examples = [
+  {
+    title: 'Application icon badge number',
+    description:
+      'Set/clear/read the app icon badge. "Rapid-fire" stresses the setter ' +
+      'to confirm the main thread never blocks on the UserNotifications XPC ' +
+      'round-trip.',
+    render(): React.Node {
+      return <BadgeExample />;
+    },
+  },
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -278,6 +278,11 @@ const APIs: Array<RNTesterModuleInfo> = (
       module: require('../examples/PointerEvents/PointerEventsExample'),
     },
     {
+      key: 'PushNotificationIOSExample',
+      module: require('../examples/PushNotificationIOS/PushNotificationIOSExample'),
+      category: 'iOS',
+    },
+    {
       key: 'RCTRootViewIOSExample',
       module: require('../examples/RCTRootView/RCTRootViewIOSExample'),
     },


### PR DESCRIPTION
Summary:

Adopts the non-blocking `-[UNUserNotificationCenter setBadgeCount:withCompletionHandler:]` API (iOS 16+) to fix a chronic main-thread hang in `PushNotificationIOS.setApplicationIconBadgeNumber`. The deprecated `applicationIconBadgeNumber` setter performs a synchronous XPC round-trip to `usernotificationsd` on the calling thread, which triggers `0x8badf00d` watchdog kills when the daemon is slow. The async API returns immediately and invokes a completion handler later, keeping the main thread responsive.

Also adds an RNTester example screen with a "Rapid-fire 50x set" stress test to validate the fix.

API Documentation say:

```
property(nonatomic) NSInteger applicationIconBadgeNumber API_DEPRECATED("Use -[UNUserNotificationCenter setBadgeCount:withCompletionHandler:] instead.", ios(2.0, 17.0)) API_UNAVAILABLE(watchos);
```

Changelog: [iOS][Fixed] Fix main-thread watchdog hang in PushNotificationIOS.setApplicationIconBadgeNumber

Reviewed By: fkgozali

Differential Revision: D113810036


