### PR TITLE
fix(cli): resolve react-native script subpaths through the exports map

### DIFF
--- a/packages/community-cli-plugin/src/commands/__tests__/reactNativeSubpathResolution-test.js
+++ b/packages/community-cli-plugin/src/commands/__tests__/reactNativeSubpathResolution-test.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const {execFileSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const COMMANDS_DIR = path.join(__dirname, '..');
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+
+/**
+ * The command wrappers reach into the `react-native` package with
+ * `require.resolve('react-native/...')`. Those specifiers go through
+ * react-native's `exports` map, which — unlike legacy CJS resolution — neither
+ * appends extensions nor falls back to a directory's `index.js`. A specifier
+ * missing either therefore throws, but only at runtime when the command is
+ * invoked.
+ *
+ * Resolution must be checked in a real `node` process: Jest's `moduleNameMapper`
+ * remaps `react-native` to the source tree and bypasses the `exports` map
+ * entirely, so resolving in-band here would pass even when production fails.
+ */
+function collectReactNativeSpecifiers(): Array<{file: string, spec: string}> {
+  const found = [];
+  for (const entry of fs.readdirSync(COMMANDS_DIR, {withFileTypes: true})) {
+    if (!entry.isFile() || !entry.name.endsWith('.js')) {
+      continue;
+    }
+    const source = fs.readFileSync(path.join(COMMANDS_DIR, entry.name), 'utf8');
+    for (const match of source.matchAll(/'(react-native\/[^']+)'/g)) {
+      found.push({file: entry.name, spec: match[1]});
+    }
+  }
+  return found;
+}
+
+function resolvesInNode(spec: string): boolean {
+  try {
+    execFileSync(
+      process.execPath,
+      ['-e', `require.resolve(${JSON.stringify(spec)})`],
+      {cwd: REPO_ROOT, stdio: 'ignore'},
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('react-native subpath specifiers used by the command wrappers', () => {
+  const specifiers = collectReactNativeSpecifiers();
+
+  test('at least one specifier is covered by this test', () => {
+    expect(specifiers.length).toBeGreaterThan(0);
+  });
+
+  test.each(specifiers)(
+    "$file resolves $spec through react-native's exports map",
+    ({spec}) => {
+      expect(resolvesInNode(spec)).toBe(true);
+    },
+  );
+});

--- a/packages/community-cli-plugin/src/commands/__tests__/reactNativeSubpathResolution-test.js
+++ b/packages/community-cli-plugin/src/commands/__tests__/reactNativeSubpathResolution-test.js
@@ -15,60 +15,29 @@ const path = require('node:path');
 const COMMANDS_DIR = path.join(__dirname, '..');
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
 
-/**
- * The command wrappers reach into the `react-native` package with
- * `require.resolve('react-native/...')`. Those specifiers go through
- * react-native's `exports` map, which — unlike legacy CJS resolution — neither
- * appends extensions nor falls back to a directory's `index.js`. A specifier
- * missing either therefore throws, but only at runtime when the command is
- * invoked.
- *
- * Resolution must be checked in a real `node` process: Jest's `moduleNameMapper`
- * remaps `react-native` to the source tree and bypasses the `exports` map
- * entirely, so resolving in-band here would pass even when production fails.
- */
-function collectReactNativeSpecifiers(): Array<{file: string, spec: string}> {
-  const found = [];
-  for (const name of fs.readdirSync(COMMANDS_DIR)) {
-    if (!name.endsWith('.js')) {
-      continue;
-    }
-    const filePath = path.join(COMMANDS_DIR, name);
-    if (!fs.statSync(filePath).isFile()) {
-      continue;
-    }
-    const source = fs.readFileSync(filePath, 'utf8');
-    for (const match of source.matchAll(/'(react-native\/[^']+)'/g)) {
-      found.push({file: name, spec: match[1]});
-    }
-  }
-  return found;
-}
+// The wrappers load scripts as `react-native/<subpath>`, resolved through
+// react-native's `exports` map: no extension guessing, no index.js fallback.
+// Must run in a real node process — Jest's moduleNameMapper bypasses `exports`
+// and would pass either way.
+const specifiers = fs
+  .readdirSync(COMMANDS_DIR)
+  .filter(name => name.endsWith('.js'))
+  .flatMap(name =>
+    [
+      ...fs
+        .readFileSync(path.join(COMMANDS_DIR, name), 'utf8')
+        .matchAll(/'(react-native\/[^']+)'/g),
+    ].map(match => ({file: name, spec: match[1]})),
+  );
 
-function resolvesInNode(spec: string): boolean {
-  try {
-    execFileSync(
-      process.execPath,
-      ['-e', `require.resolve(${JSON.stringify(spec)})`],
-      {cwd: REPO_ROOT, stdio: 'ignore'},
-    );
-    return true;
-  } catch {
-    return false;
-  }
-}
+test('found specifiers to check', () => {
+  expect(specifiers.length).toBeGreaterThan(0);
+});
 
-describe('react-native subpath specifiers used by the command wrappers', () => {
-  const specifiers = collectReactNativeSpecifiers();
-
-  test('at least one specifier is covered by this test', () => {
-    expect(specifiers.length).toBeGreaterThan(0);
-  });
-
-  test.each(specifiers)(
-    "$file resolves $spec through react-native's exports map",
-    ({spec}) => {
-      expect(resolvesInNode(spec)).toBe(true);
-    },
+test.each(specifiers)('$file resolves $spec', ({spec}) => {
+  execFileSync(
+    process.execPath,
+    ['-e', `require.resolve(${JSON.stringify(spec)})`],
+    {cwd: REPO_ROOT, stdio: 'ignore'},
   );
 });

--- a/packages/community-cli-plugin/src/commands/__tests__/reactNativeSubpathResolution-test.js
+++ b/packages/community-cli-plugin/src/commands/__tests__/reactNativeSubpathResolution-test.js
@@ -8,9 +8,9 @@
  * @format
  */
 
-const {execFileSync} = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const {execFileSync} = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const COMMANDS_DIR = path.join(__dirname, '..');
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
@@ -29,13 +29,17 @@ const REPO_ROOT = path.resolve(__dirname, '../../../../..');
  */
 function collectReactNativeSpecifiers(): Array<{file: string, spec: string}> {
   const found = [];
-  for (const entry of fs.readdirSync(COMMANDS_DIR, {withFileTypes: true})) {
-    if (!entry.isFile() || !entry.name.endsWith('.js')) {
+  for (const name of fs.readdirSync(COMMANDS_DIR)) {
+    if (!name.endsWith('.js')) {
       continue;
     }
-    const source = fs.readFileSync(path.join(COMMANDS_DIR, entry.name), 'utf8');
+    const filePath = path.join(COMMANDS_DIR, name);
+    if (!fs.statSync(filePath).isFile()) {
+      continue;
+    }
+    const source = fs.readFileSync(filePath, 'utf8');
     for (const match of source.matchAll(/'(react-native\/[^']+)'/g)) {
-      found.push({file: entry.name, spec: match[1]});
+      found.push({file: name, spec: match[1]});
     }
   }
   return found;

--- a/packages/community-cli-plugin/src/commands/codegen.js
+++ b/packages/community-cli-plugin/src/commands/codegen.js
@@ -47,7 +47,7 @@ const codegenCommand: Command = {
     args: CodegenCommandArgs,
   ): void => {
     const generateArtifactsExecutor = require.resolve(
-      'react-native/scripts/codegen/generate-artifacts-executor',
+      'react-native/scripts/codegen/generate-artifacts-executor/index.js',
       {paths: [config.root]},
     );
     // $FlowFixMe[unsupported-syntax] dynamic require of a resolved path

--- a/packages/community-cli-plugin/src/commands/spm.js
+++ b/packages/community-cli-plugin/src/commands/spm.js
@@ -107,7 +107,7 @@ const spmCommand: Command = {
       }
     }
     const setupAppleSpm = require.resolve(
-      'react-native/scripts/setup-apple-spm',
+      'react-native/scripts/setup-apple-spm.js',
       {paths: [config.root]},
     );
     // $FlowFixMe[unsupported-syntax] dynamic require of a resolved path


### PR DESCRIPTION
## Summary:

Two CLI commands are broken on `main` right now. Both fail the moment you run them:

```
$ npx react-native spm add
error Cannot find module '.../node_modules/react-native/scripts/setup-apple-spm'

$ npx react-native codegen
error Cannot find module '.../node_modules/react-native/scripts/codegen/generate-artifacts-executor'
```

**What happened.** #57652 moved these two command wrappers into `community-cli-plugin`. Each one loads a helper script out of the `react-native` package by name:

```js
require.resolve('react-native/scripts/setup-apple-spm');
```

Anything starting with `react-native/` is looked up through the `exports` list in that package's `package.json`. This lookup is strict — it takes the path exactly as written. It will **not** add a missing `.js`, and it will **not** find the `index.js` inside a folder. Node's older lookup style did both of those automatically, and both wrappers were relying on it:

| what the wrapper asked for | what's actually there | needed |
|---|---|---|
| `scripts/setup-apple-spm` | a file named `setup-apple-spm.js` | `.js` on the end |
| `scripts/codegen/generate-artifacts-executor` | a **folder** containing `index.js` | `/index.js` on the end |

**The fix.** Write both paths out in full. That's a one-line change in each wrapper; nothing else about the commands changes.

This was found by the new SwiftPM iOS CI job in #57659, where every build failed on the `spm` command.

## Changelog:

[GENERAL] [FIXED] - Fix `react-native spm` and `react-native codegen` failing with "Cannot find module"

## Test Plan:

Added `packages/community-cli-plugin/src/commands/__tests__/reactNativeSubpathResolution-test.js`. It reads the command wrapper files, picks out every `react-native/...` path they reference, and checks each one can actually be loaded. That covers both commands today and any wrapper added later.

**Why the test runs `node` in a subprocess:** Jest redirects `react-native` to the source folder, which skips the `exports` list altogether. A test that does the lookup inside Jest therefore passes even while the real command is broken — I wrote that version first and it went green against the broken code. Running a separate `node` process is what makes the test meaningful.

Test fails before the fix, passes after:

```
# before
✕ codegen.js resolves react-native/scripts/codegen/generate-artifacts-executor
✕ spm.js resolves react-native/scripts/setup-apple-spm
Tests: 2 failed, 1 passed, 3 total

# after
✓ codegen.js resolves react-native/scripts/codegen/generate-artifacts-executor/index.js
✓ spm.js resolves react-native/scripts/setup-apple-spm.js
Tests: 3 passed, 3 total
```

Same result checking the paths directly, outside Jest:

```
node -e "require.resolve('react-native/scripts/setup-apple-spm')"                                # fails
node -e "require.resolve('react-native/scripts/setup-apple-spm.js')"                             # works
node -e "require.resolve('react-native/scripts/codegen/generate-artifacts-executor')"            # fails
node -e "require.resolve('react-native/scripts/codegen/generate-artifacts-executor/index.js')"   # works
```

`flow focus-check`, ESLint and Prettier are clean on the changed files.
