### PR TITLE
Fix compat with extensionless scripts/* imports

### DIFF
--- a/packages/community-cli-plugin/src/commands/codegen.js
+++ b/packages/community-cli-plugin/src/commands/codegen.js
@@ -47,7 +47,7 @@ const codegenCommand: Command = {
     args: CodegenCommandArgs,
   ): void => {
     const generateArtifactsExecutor = require.resolve(
-      'react-native/scripts/codegen/generate-artifacts-executor',
+      'react-native/scripts/codegen/generate-artifacts-executor/index',
       {paths: [config.root]},
     );
     // $FlowFixMe[unsupported-syntax] dynamic require of a resolved path

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -42,7 +42,9 @@
       "types": null,
       "default": "./Libraries/*.js"
     },
-    "./scripts/*": "./scripts/*",
+    "./scripts/*": "./scripts/*.js",
+    "./scripts/*.sh": "./scripts/*.sh",
+    "./scripts/*.rb": "./scripts/*.rb",
     "./asset-registry": {
       "types": null,
       "default": "./src/asset-registry.js"

--- a/private/core-cli-utils/src/private/app.js
+++ b/private/core-cli-utils/src/private/app.js
@@ -187,7 +187,7 @@ const bundleApp = (
       'Check if SourceMap script available',
       () => {
         composeSourceMaps = getNodePackagePath(
-          'react-native/scripts/compose-source-maps.js',
+          'react-native/scripts/compose-source-maps',
         );
       },
     );


### PR DESCRIPTION
Summary:
**Context**

Replaces https://github.com/react/react-native/pull/57709, which identified a real bug in 0.87 from the combination of:

- https://github.com/react/react-native/pull/57276
- https://github.com/react/react-native/pull/57652

```
$ npx react-native spm add
error Cannot find module '.../node_modules/react-native/scripts/setup-apple-spm'

$ npx react-native codegen
error Cannot find module '.../node_modules/react-native/scripts/codegen/generate-artifacts-executor'
```

Thanks @chrfalch for raising this!

**This diff**

- Fix — and exclusively switch to — extensionless imports rather than requiring `.js`.
- Update in-repo consumers.

The previous single mapping is now an extension-aware mapping:
- `./scripts/*` now appends `.js`, so `react-native/scripts/foo` resolves to `foo.js`.
- `.sh` and `.rb` stay reachable via explicit `./scripts/*.sh` and `./scripts/*.rb` passthrough patterns.

**Impact**

- Explicit `react-native/scripts/*.js` specifiers no longer resolve, so JavaScript paths must be imported without an extension.
- Files under `scripts/` with extensions other than `.js`, `.sh`, or `.rb` are no longer exposed through `./scripts/*`.
    - These have no open source consumers.

Changelog:
[General][Fixed] - (RC4 only, drop for main changelog): `react-native/scripts/*` imports once again expand `.js` extensions
[General][Breaking] - Extensionless `react-native/scripts/*` imports are now **mandated**; explicit `.js` import specifiers are rejected.

Differential Revision: D113898792


