### PR TITLE
Fix npm package build for docs-only changes

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -325,7 +325,10 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+      !contains(needs.*.result, 'cancelled') &&
+      (needs.build_android.result == 'success' ||
+        needs.prebuild_apple_dependencies.result == 'success' ||
+        needs.prebuild_react_native_core.result == 'success')
     container:
       image: reactnativecommunity/react-native-android:latest
       env:


### PR DESCRIPTION
## Summary:

The build_npm_package job uses always() so it can run when one platform-specific prerequisite is skipped. However, that also caused it to run when every artifact-producing prerequisite was skipped, as happens for Markdown-only pull requests. It then failed because there were no artifacts to download.

Require at least one Android or Apple artifact-producing prerequisite to have succeeded before running the package build.

Failing run: https://github.com/react/react-native/actions/runs/30290299313/job/90058215494?pr=57703

## Changelog:

[INTERNAL] [FIXED] - Skip the npm package build when all artifact-producing prerequisites are skipped

## Test Plan:

- ./node_modules/.bin/prettier --check .github/workflows/test-all.yml
- Parsed .github/workflows/test-all.yml with Ruby YAML
- git diff --check