### PR TITLE
fix(vfs-removal, iOS) write the prebuilt module-map flag to OTHER_CPLUSPLUSFLAGS too

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -572,6 +572,7 @@ class ReactNativeCoreUtils
         # Quoted so a $(PODS_ROOT) containing spaces stays a single clang argument.
         module_map_flag = " \"-fmodule-map-file=$(PODS_ROOT)/React-Core-prebuilt/Headers/module.modulemap\""
         ReactNativePodsUtils.add_flag_to_map_with_inheritance(attributes, "OTHER_CFLAGS", module_map_flag)
+        ReactNativePodsUtils.add_flag_to_map_with_inheritance(attributes, "OTHER_CPLUSPLUSFLAGS", module_map_flag)
         ReactNativePodsUtils.add_flag_to_map_with_inheritance(attributes, "OTHER_SWIFT_FLAGS", " -Xcc" + module_map_flag)
     end
 end


### PR DESCRIPTION
## Summary:

`add_prebuilt_header_search_paths` (`scripts/cocoapods/rncore.rb`) injects the prebuilt ReactNativeHeaders module map into `OTHER_CFLAGS` and `OTHER_SWIFT_FLAGS`, but not `OTHER_CPLUSPLUSFLAGS`. C++ and ObjC++ translation units therefore lose modular resolution of the relocated `react/`, `yoga/` and `RCTDeprecation/` namespaces.

This is a regression: 0.86's VFS implementation (`add_vfs_overlay_flags`) wrote all three compiler-flag keys, the modular rewrite writes two. This adds the third back, reusing the existing quoted `module_map_flag`.

Xcode's `OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS)` default doesn't cover for it, because an explicit value *replaces* the C flags instead of merging — and React Native sets the key explicitly, both in `new_architecture.rb` and in the `pod_target_xcconfig` of ReactCodegen, React-RCTAppDelegate and React-RCTAnimatedModuleProvider.

To be clear about what this is: a correctness fix, not a bug fix. No build fails today, because `HEADER_SEARCH_PATHS` is injected unconditionally and the includes still resolve textually. What is lost is modular resolution.

## Changelog:

[IOS] [FIXED] - Write the prebuilt module-map flag to `OTHER_CPLUSPLUSFLAGS` so C++/ObjC++ sources resolve the relocated namespaces modularly

## Test Plan:

On an app using the prebuilt RNCore (`RCT_USE_PREBUILT_RNCORE=1`, artifacts from Maven), counting pods whose xcconfig carries the module-map flag per key:

| | `OTHER_CFLAGS` | `OTHER_CPLUSPLUSFLAGS` | `OTHER_SWIFT_FLAGS` |
|---|---|---|---|
| before | 211 | **0** | 211 |
| after | 211 | 211 | 211 |

`xcodebuild` succeeds after the change (`** BUILD SUCCEEDED **`, 0 errors), so the flag is accepted by `ScanDependencies` and the explicit-module precompile. This was a static-library build; framework linkage was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
