### PR TITLE
Fix typo "becuase" -> "because" in processFilter comment

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/processFilter.js
+++ b/packages/react-native/Libraries/StyleSheet/processFilter.js
@@ -110,7 +110,7 @@ export default function processFilter(
           result.push(resultObject);
         } else {
           // If any primitive is invalid then apply none of the filters. This is how
-          // web works and makes it clear that something is wrong becuase no
+          // web works and makes it clear that something is wrong because no
           // graphical effects are happening.
           return [];
         }

--- a/packages/react-native/Libraries/StyleSheet/processFilter.js
+++ b/packages/react-native/Libraries/StyleSheet/processFilter.js
@@ -83,7 +83,7 @@ export default function processFilter(
           result.push(filterFunction);
         } else {
           // If any primitive is invalid then apply none of the filters. This is how
-          // web works and makes it clear that something is wrong becuase no
+          // web works and makes it clear that something is wrong because no
           // graphical effects are happening.
           return [];
         }


### PR DESCRIPTION
## Summary

Corrects a spelling mistake ("becuase" -> "because") in the explanatory
comment for the invalid-primitive short-circuit in `processFilter.js`. The
same comment appears twice; both occurrences are fixed.

This is a comment-only change with no runtime behavior change.

## Changelog:

[INTERNAL] [FIXED] - Fix typo in processFilter.js comment

## Test Plan:

Comment-only change — no runtime behavior is affected, so there is nothing to
exercise at runtime.

- The diff touches only comment text: 2 lines, both `becuase` -> `because`
  (`packages/react-native/Libraries/StyleSheet/processFilter.js`).
- No code tokens changed, so existing type-checking, lint, and tests for this
  file remain valid.
