### PR TITLE
Preserve TextInput selection color when changing multiline

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -25,6 +25,7 @@ void RCTCopyBackedTextInput(
   toTextInput.attributedText = RCTSanitizeAttributedString(fromTextInput.attributedText);
   toTextInput.placeholder = fromTextInput.placeholder;
   toTextInput.placeholderColor = fromTextInput.placeholderColor;
+  toTextInput.tintColor = fromTextInput.tintColor;
   toTextInput.textContainerInset = fromTextInput.textContainerInset;
   toTextInput.inputAccessoryView = fromTextInput.inputAccessoryView;
   toTextInput.textInputDelegate = fromTextInput.textInputDelegate;

--- a/packages/react-native/React/Tests/Text/RCTTextInputUtilsTest.mm
+++ b/packages/react-native/React/Tests/Text/RCTTextInputUtilsTest.mm
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTTextInputUtils.h>
+#import <React/RCTUITextField.h>
+#import <React/RCTUITextView.h>
+#import <XCTest/XCTest.h>
+
+@interface RCTTextInputUtilsTest : XCTestCase
+@end
+
+@implementation RCTTextInputUtilsTest
+
+- (void)testCopyBackedTextInputPreservesTintColor
+{
+  RCTUITextField *source = [RCTUITextField new];
+  RCTUITextView *destination = [RCTUITextView new];
+  source.tintColor = UIColor.redColor;
+
+  RCTCopyBackedTextInput(source, destination);
+
+  XCTAssertEqualObjects(destination.tintColor, UIColor.redColor);
+}
+
+@end


### PR DESCRIPTION
## Summary:

- Preserve the native text input tint color when switching between single-line and multiline backing views.
- Add a native regression test for copying the tint from `RCTUITextField` to `RCTUITextView`.

Fabric replaces the backing text input view when `multiline` changes. `RCTCopyBackedTextInput` preserved the other native presentation properties but omitted `tintColor`, which implements `selectionColor` on iOS. Since the React prop itself was unchanged, the normal prop diff did not apply it again and the selection color fell back to the system tint.

Fixes #57105

## Changelog:

[IOS] [FIXED] - Preserve TextInput selection color when changing multiline.

## Test Plan:

- Added `RCTTextInputUtilsTest.testCopyBackedTextInputPreservesTintColor`.
- Ran clang-format validation and `git diff --check`.