### PR TITLE
Flow: Prefer imported types from `@babel/types` over global `BabelNode*` types (#57752)

### DIFF
--- a/packages/react-native-babel-preset/src/__mocks__/test-helpers.js
+++ b/packages/react-native-babel-preset/src/__mocks__/test-helpers.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {BabelCoreOptions, EntryOptions, PluginEntry} from '@babel/core';
+import type {File as BabelNodeFile, Node as BabelNode} from '@babel/types';
 
 const {transformSync} = require('@babel/core');
 const generate = require('@babel/generator').default;

--- a/packages/react-native-babel-transformer/src/index.js
+++ b/packages/react-native-babel-transformer/src/index.js
@@ -16,6 +16,7 @@
 
 /*::
 import type {BabelCoreOptions, Plugins, TransformResult} from '@babel/core';
+import type {File as BabelNodeFile} from '@babel/types';
 import type {
   BabelTransformer,
   MetroBabelFileMetadata,

--- a/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
@@ -15,6 +15,11 @@ import type {
   PropTypeAnnotation,
 } from '../../CodegenSchema';
 import type {SchemaType} from '../../CodegenSchema';
+import type {
+  ObjectMethod as BabelNodeObjectMethod,
+  ObjectProperty as BabelNodeObjectProperty,
+  SpreadElement as BabelNodeSpreadElement,
+} from '@babel/types';
 
 const core = require('@babel/core');
 

--- a/scripts/js-api/build-types/transforms/typescript/simplifyTypes/alignTypeParameters.js
+++ b/scripts/js-api/build-types/transforms/typescript/simplifyTypes/alignTypeParameters.js
@@ -10,6 +10,7 @@
  */
 
 import type {NodePath} from '@babel/traverse';
+import type {TSType as BabelNodeTSType} from '@babel/types';
 
 import traverse from '@babel/traverse';
 

--- a/scripts/js-api/build-types/transforms/typescript/simplifyTypes/resolveIntersection.js
+++ b/scripts/js-api/build-types/transforms/typescript/simplifyTypes/resolveIntersection.js
@@ -11,6 +11,12 @@
 
 import type {BaseVisitorState} from './visitorState';
 import type {NodePath} from '@babel/traverse';
+import type {
+  Comment as BabelNodeComment,
+  TSPropertySignature as BabelNodeTSPropertySignature,
+  TSType as BabelNodeTSType,
+  TSTypeAnnotation as BabelNodeTSTypeAnnotation,
+} from '@babel/types';
 
 import {replaceWithCleanup} from './utils';
 

--- a/scripts/js-api/build-types/transforms/typescript/simplifyTypes/resolveTSType.js
+++ b/scripts/js-api/build-types/transforms/typescript/simplifyTypes/resolveTSType.js
@@ -10,6 +10,7 @@
  */
 
 import type {NodePath} from '@babel/traverse';
+import type {TSType as BabelNodeTSType} from '@babel/types';
 
 import traverse from '@babel/traverse';
 

--- a/scripts/js-api/build-types/transforms/typescript/simplifyTypes/resolveTypeOperator.js
+++ b/scripts/js-api/build-types/transforms/typescript/simplifyTypes/resolveTypeOperator.js
@@ -11,6 +11,7 @@
 
 import type {BaseVisitorState} from './visitorState';
 import type {NodePath} from '@babel/traverse';
+import type {TSType as BabelNodeTSType} from '@babel/types';
 
 import {replaceWithCleanup} from './utils';
 

--- a/scripts/js-api/build-types/transforms/typescript/versionExportedApis.js
+++ b/scripts/js-api/build-types/transforms/typescript/versionExportedApis.js
@@ -9,6 +9,11 @@
  */
 
 import type {PluginObj} from '@babel/core';
+import type {
+  Identifier as BabelNodeIdentifier,
+  Node as BabelNode,
+  TSQualifiedName as BabelNodeTSQualifiedName,
+} from '@babel/types';
 
 const generate = require('@babel/generator').default;
 const {parse} = require('@babel/parser');

--- a/scripts/js-api/build-types/utils/applyBabelTransformsSeq.js
+++ b/scripts/js-api/build-types/utils/applyBabelTransformsSeq.js
@@ -9,6 +9,7 @@
  */
 
 import type {PluginObj} from '@babel/core';
+import type {File as BabelNodeFile} from '@babel/types';
 
 import * as babel from '@babel/core';
 

--- a/scripts/js-api/diff-api-snapshot/diffApiSnapshot.js
+++ b/scripts/js-api/diff-api-snapshot/diffApiSnapshot.js
@@ -9,6 +9,8 @@
  * @oncall react_native
  */
 
+import type {File as BabelNodeFile} from '@babel/types';
+
 const babel = require('@babel/core');
 const t = require('@babel/types');
 


### PR DESCRIPTION
Summary:

## Rationale
Flow lib defs that declare global types (available anywhere, without an `import`) must be referenced in `.flowconfig` and can't be maintained incrementally.  That's not too bad for very stable APIs and it's necessary for environment/runtime globals, but for 3P libraries it makes the lib defs much more difficult to maintain for little benefit (we have to import the runtime APIs anyway). Secondarily, it's a problem for generating TypeScript types, as TS doesn't declare any 3P library globally. 

Babel is one of few cases where a library declares Flow globals - every one has an importable equivalent.

## This diff
Replaces usages of Babel global types across xplat/js with their `babel/types` equivalents

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D113574665


