### PR TITLE
Update ReactPrivate and InitializeCore imports (0.87 Strict API) (#36986) (#57753)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,9 @@ module.exports = {
   },
   resolver: './packages/jest-preset/jest/resolver.js',
   moduleNameMapper: {
-    // `resolver.js` strips `exports`, so alias this subpath to its `src/` impl.
+    // `resolver.js` strips `exports`, so alias these subpaths to their `src/` impl.
+    '^react-native/react-private-interface$':
+      '<rootDir>/packages/react-native/src/react-private-interface.js',
     '^react-native/setup-env$':
       '<rootDir>/packages/react-native/src/setup-env.js',
   },

--- a/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
@@ -33,6 +33,8 @@ eslintTester.run('../no-deep-imports', rule, {
     "require('react-native/src/fb_internal/Foo')",
     "import 'react-native/setup-env';",
     "require('react-native/setup-env');",
+    "import {BatchedBridge} from 'react-native/react-private-interface';",
+    "require('react-native/react-private-interface');",
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-native/no-deep-imports.js
+++ b/packages/eslint-plugin-react-native/no-deep-imports.js
@@ -201,6 +201,7 @@ module.exports = {
 
       return (
         source.value === 'react-native/asset-registry' ||
+        source.value === 'react-native/react-private-interface' ||
         source.value === 'react-native/setup-env'
       );
     }

--- a/packages/jest-preset/jest-preset.js
+++ b/packages/jest-preset/jest-preset.js
@@ -18,10 +18,12 @@ module.exports = {
     platforms: ['android', 'ios', 'native'],
   },
   moduleNameMapper: {
-    // `setup-env` is a secondary entry point exposed via the package's
-    // `exports`, but `./jest/resolver.js` strips `exports` and the generic
-    // mapper below resolves subpaths as literal directory paths. Alias it
-    // explicitly so it resolves to its `src/` implementation.
+    // `setup-env` and `react-private-interface` are secondary entry points
+    // exposed via the package's `exports`, but `./jest/resolver.js` strips
+    // `exports` and the generic mapper below resolves subpaths as literal
+    // directory paths. Alias them explicitly so they resolve to their `src/`
+    // implementations.
+    '^react-native/react-private-interface$': `${path.dirname(require.resolve('react-native'))}/src/react-private-interface.js`,
     '^react-native/setup-env$': `${path.dirname(require.resolve('react-native'))}/src/setup-env.js`,
     '^react-native($|/.*)': `${path.dirname(require.resolve('react-native'))}/$1`,
   },

--- a/packages/react-native/Libraries/Renderer/shims/ReactFabric.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactFabric.js
@@ -7,12 +7,12 @@
  * @noformat
  * @nolint
  * @flow
- * @generated SignedSource<<cf323fc5ca893bab5669c7d321660412>>
+ * @generated SignedSource<<8b6b4d01340cfba2de5eabc3936dfbdd>>
  */
 
 'use strict';
 
-import {BatchedBridge} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
+import {BatchedBridge} from 'react-native/react-private-interface';
 
 import type {ReactFabricType} from './ReactNativeTypes';
 

--- a/packages/react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js
+++ b/packages/react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js
@@ -7,12 +7,12 @@
  * @noformat
  * @nolint
  * @flow strict-local
- * @generated SignedSource<<52163887de05f1cff05388145cf85b3b>>
+ * @generated SignedSource<<26e94f747da2450a86c1e314470813f5>>
  */
 
 'use strict';
 
-import {ReactNativeViewConfigRegistry} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
+import {ReactNativeViewConfigRegistry} from 'react-native/react-private-interface';
 import {type ViewConfig} from './ReactNativeTypes';
 
 const {register} = ReactNativeViewConfigRegistry;


### PR DESCRIPTION
Summary:

## Summary

Migrate internal `Libraries/` import subpaths from `react-native` to the
incoming dedicated entry points in React Native 0.87.

**Motivation**

See [**RFC0894: Removing deep imports from
react-native**](https://github.com/react-native-community/discussions-and-proposals/pull/894)

**Changes**

The `react-private-interface` entry point has been created explicitly
for the private contract between React ↔ React Native, and is 1:1 with
the previous `ReactNativePrivateInterface` module.

Both of the below `Libraries/` paths still exist, but are deprecated —
this is a lagging migration that will enable cleanup in a future RN
version.

- `react-native/Libraries/Core/InitializeCore` →
`react-native/setup-env`
[react/react-native#57475](https://github.com/react/react-native/pull/57475)
- `react-native/Libraries/ReactPrivate/ReactNativePrivateInterface` →
`react-native/react-private-interface`
[react/react-native#57495](https://github.com/react/react-native/pull/57495)

## Test Plan

Flow

DiffTrain build for [96fcba90138e9f1a73ee1cc4f79a653ec12fc3a9](https://github.com/react/react/commit/96fcba90138e9f1a73ee1cc4f79a653ec12fc3a9)

Reviewed By: hoxyq

Differential Revision: D113928305


