### PR TITLE
Add missing `ListItemComponent` prop to VirtualizedList/FlatList/SectionList TypeScript types

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -189,6 +189,14 @@ export interface VirtualizedListWithoutRenderItemProps<
   ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
 
   /**
+   * Each data item is rendered using this element, as an alternative to `renderItem`.
+   * Can be a React Component Class or a render function. In addition to the data provided
+   * to `renderItem`, this receives `index` and `separators` metadata.
+   */
+  ListItemComponent?:
+    React.ComponentType<any> | React.ReactElement | null | undefined;
+
+  /**
    * The default accessor functions assume this is an Array<{key: string}> but you can override
    * getItem, getItemCount, and keyExtractor to handle any type of index-based data.
    */


### PR DESCRIPTION
## Summary

`ListItemComponent` is a valid prop on `FlatList`, `SectionList` and `VirtualizedList` (it's in the Flow types in `VirtualizedListProps.js`), but it's missing from the `.d.ts`, so TypeScript errors on it even though it works at runtime.

Added it to `VirtualizedListWithoutRenderItemProps` next to the other `List*Component` props, so all three inherit it.

## Changelog:

[GENERAL] [ADDED] - Add missing ListItemComponent type to VirtualizedList props

## Test Plan

Errors on `main`, type-checks with the change:

```tsx
<FlatList data={[]} ListItemComponent={MyItem} />
```

Type-only, addition only, no runtime changes.
