### PR TITLE
fix(swiftpm): persist --config-command so the in-build sync keeps using it

### DIFF
--- a/packages/react-native/scripts/setup-apple-spm.js
+++ b/packages/react-native/scripts/setup-apple-spm.js
@@ -85,14 +85,18 @@ const {
 const {
   generateAutolinkingConfig,
   parseConfigCommandJson,
+  readEnvConfigCommand,
+  resolveEnvConfigCommand,
 } = require('./spm/generate-spm-autolinking-config');
 const {main: generatePackage} = require('./spm/generate-spm-package');
 const {findSourcePath} = require('./spm/generate-spm-package');
 const {
+  SPM_INJECTED_MARKER,
   cleanupDanglingJavaScriptCoreRef,
   cleanupLeftoverPodsGroup,
   findInjectedXcodeproj,
   injectSpmIntoExistingXcodeproj,
+  readPinnedConfigCommand,
   removeSpmInjection,
 } = require('./spm/generate-spm-xcodeproj');
 const {scaffoldAll} = require('./spm/scaffold-package-swift');
@@ -192,7 +196,7 @@ function parseArgs(argv /*: Array<string> */) /*: SetupArgs */ {
     .option('config-command', {
       type: 'string',
       describe:
-        '[advanced] JSON array of the argv used to generate autolinking.json, overriding the default @react-native-community/cli config command. Also settable via RCT_SPM_AUTOLINKING_CONFIG_COMMAND. Example: \'["npx","expo-modules-autolinking","react-native-config","--json","--platform","ios"]\'',
+        '[advanced] JSON array of the argv used to generate autolinking.json, overriding the default @react-native-community/cli config command. Also settable via RCT_SPM_AUTOLINKING_CONFIG_COMMAND. Either way `add`/`update` remembers the value in .spm-injected.json, so later runs and Xcode builds reuse it. Example: \'["npx","expo-modules-autolinking","react-native-config","--json","--platform","ios"]\'',
     })
     .usage(
       'Usage: $0 [action] [options]\n\nSets up Swift Package Manager support in a React Native app.',
@@ -844,6 +848,7 @@ async function setupXcodeproj(
     // (injectSpmIntoExistingXcodeproj preserves it — see
     // generate-spm-xcodeproj.js).
     artifactsVersionOverride: args.version ?? null,
+    configCommand: resolveConfigCommandToPin(args),
   });
   if (result.status !== 'injected') {
     logError(`SPM injection failed: ${result.reason}`);
@@ -903,6 +908,45 @@ function logNextSteps(
   log('To remove SPM later: `npx react-native spm deinit`');
 }
 
+// The autolinking config command for this run: an explicit `--config-command`
+// first, then the value a previous `add`/`update` pinned into the injection
+// marker. undefined means "no explicit command", which is what makes
+// generateAutolinkingConfig fall back to RCT_SPM_AUTOLINKING_CONFIG_COMMAND and
+// then to the built-in default — so the pin has to be WITHHELD while the env
+// var is set, or a stale pin would outrank a developer's env override.
+function resolveExplicitConfigCommand(
+  args /*: SetupArgs */,
+  appRoot /*: string */,
+) /*: Array<string> | void */ {
+  if (args.configCommand != null) {
+    return args.configCommand;
+  }
+  if (readEnvConfigCommand() != null) {
+    return undefined;
+  }
+  const pinned = readPinnedConfigCommand(appRoot);
+  if (pinned == null) {
+    return undefined;
+  }
+  log(
+    `Autolinking config command (pinned in ${SPM_INJECTED_MARKER}): ` +
+      pinned.join(' '),
+  );
+  return pinned;
+}
+
+// The command to record in the injection marker. The env var is resolved here
+// too, because the Xcode build phase inherits neither the flag nor the shell
+// that set it — an env-only override that went unpinned would leave the build
+// re-deriving autolinking.json with the default command. null pins nothing and
+// preserves any earlier pin. An invalid env value throws, as the flag does,
+// though `add` has already failed closed on it by this point.
+function resolveConfigCommandToPin(
+  args /*: SetupArgs */,
+) /*: ?Array<string> */ {
+  return args.configCommand ?? resolveEnvConfigCommand();
+}
+
 // Generate autolinking.json, failing closed on a config-command error.
 //
 // generateAutolinkingConfig throws ONLY when the config command itself fails —
@@ -937,7 +981,9 @@ function generateAutolinkingConfigOrFailClosed(
         'RCT_SPM_AUTOLINKING_CONFIG_COMMAND (or pass --config-command) to a ' +
         'JSON argv array whose command prints the React Native CLI config, ' +
         'e.g. \'["npx","expo-modules-autolinking","react-native-config",' +
-        '"--json","--platform","ios"]\'.',
+        '"--json","--platform","ios"]\'. An earlier `add`/`update` may also ' +
+        `have pinned a command in ${SPM_INJECTED_MARKER}; re-run with ` +
+        '--config-command to replace a stale one.',
     );
     process.exitCode = 2;
     return null;
@@ -1035,7 +1081,7 @@ async function main(argv /*:: ?: Array<string> */) /*: Promise<void> */ {
     log('Generating autolinking.json (CLI config)...');
     autolinkingConfigResult = generateAutolinkingConfigOrFailClosed({
       projectRoot,
-      configCommand: args.configCommand ?? undefined,
+      configCommand: resolveExplicitConfigCommand(args, appRoot),
     });
     if (autolinkingConfigResult == null) {
       // Fail closed: the config command errored and the helper already set
@@ -1214,6 +1260,8 @@ module.exports = {
   generateAutolinkingConfigOrFailClosed,
   parseArgs,
   resolveAction,
+  resolveConfigCommandToPin,
+  resolveExplicitConfigCommand,
   shouldAutoDeintegrate,
   ensureBothArtifactFlavors,
 };

--- a/packages/react-native/scripts/spm/__doc__/spm-scripts.md
+++ b/packages/react-native/scripts/spm/__doc__/spm-scripts.md
@@ -137,6 +137,40 @@ accepts kebab-case equivalents (e.g. `--skip-codegen`).
 | `--artifacts <path>` | [advanced] Local artifact root containing complete `debug/` and `release/` cache slots |
 | `--download <auto\|skip\|force>` | [advanced] Artifact download policy (default: auto) |
 | `--skipCodegen` | [advanced] Skip the codegen step |
+| `--configCommand <json>` | [advanced] JSON array of the argv used to generate `autolinking.json`, overriding the default `@react-native-community/cli config` command. Also settable via the `RCT_SPM_AUTOLINKING_CONFIG_COMMAND` env var. Either way the value is remembered, so you pass it once. Example: `'["npx","expo-modules-autolinking","react-native-config","--json","--platform","ios"]'` |
+
+### The autolinking config command is remembered
+
+An app that replaces `@react-native-community/cli` autolinking (an Expo app,
+for example) has to tell `spm` how to produce `autolinking.json`. Pass the
+command once, on `add` or `update`:
+
+```bash
+npx react-native spm add --configCommand '["npx","expo-modules-autolinking","react-native-config","--json","--platform","ios"]'
+```
+
+Every action that needs `autolinking.json` — `add`, `update`, `scaffold`, and
+the build-time `sync` — resolves the command in this order:
+
+1. `--configCommand`
+2. `RCT_SPM_AUTOLINKING_CONFIG_COMMAND`
+3. the `configCommand` pinned in `MyApp.xcodeproj/.spm-injected.json` by an
+   earlier `add`/`update`
+4. the default `@react-native-community/cli config`
+
+`add`/`update` pin whichever of the first two routes supplied the command,
+validated as an argv array; a later run that passes neither keeps the existing
+pin, and passing `--configCommand` again replaces it. The pin exists because
+the **Sync SPM Autolinking** build phase inherits neither your flag nor the
+shell that exported the env var — without it, a successful `add` is followed by
+failing builds, because the phase re-derives `autolinking.json` with the
+default command. A pin never shadows the env var, so an override in your shell
+still takes effect, and a pin that no longer parses is ignored in favor of the
+default.
+
+`deinit` deletes `.spm-injected.json`, and the pin with it. A later `add`
+therefore falls back to the default command unless you pass `--configCommand`
+(or export the env var) again.
 
 ### Debug/Release flavor is automatic
 
@@ -161,7 +195,7 @@ package graph, or require a second build.
 | Path | Commit? | Why |
 |------|---------|-----|
 | `MyApp.xcodeproj/` | Yes | Your project, with SwiftPM injected in place. Holds your signing, capabilities, Build Phases — `add` only adds SwiftPM refs/settings, additively. |
-| `MyApp.xcodeproj/.spm-injected.json` | Yes | Marker recording every edit `add` made, so `deinit` can surgically reverse it and re-runs stay idempotent. |
+| `MyApp.xcodeproj/.spm-injected.json` | Yes | Marker recording every edit `add` made, so `deinit` can surgically reverse it and re-runs stay idempotent. Also pins settings later runs and Xcode builds must reuse, such as the [autolinking config command](#the-autolinking-config-command-is-remembered). |
 | `build/generated/` | No | Codegen/autolinking output; regenerated |
 | `build/xcframeworks/` | No | Symlinks to the machine-local artifact cache |
 | `Package.resolved` | No | SwiftPM resolution file; machine-specific |
@@ -335,6 +369,7 @@ across apps; refresh it with `react-native spm update --download force`.
 | "not contained in target" | Re-run setup (regenerates file-level symlinks) |
 | Codegen fails | Use `--skipCodegen` to iterate on other parts |
 | "SPM sync failed" warning | Check Xcode build log for details; node may not be in PATH — ensure `with-environment.sh` is present |
+| "Sync SPM Autolinking" build phase fails: `'npx --no-install @react-native-community/cli config' exited with status 1` | This app replaces `@react-native-community/cli` autolinking (e.g. an Expo app). Re-run `spm add`/`update` with `--configCommand` (or with `RCT_SPM_AUTOLINKING_CONFIG_COMMAND` exported) so the working command is pinned for the build phase to reuse — see [The autolinking config command is remembered](#the-autolinking-config-command-is-remembered). |
 | Autolinking not updating on build | Touch `package.json` to force a sync, or delete `build/generated/autolinking/.spm-sync-stamp` |
 | Stale SwiftPM state or corrupted build | `rm -rf build/ .build/`, then `react-native spm update`, then reopen Xcode |
 | Want to revert to CocoaPods | `react-native spm deinit`, then `pod install` |

--- a/packages/react-native/scripts/spm/__tests__/remove-spm-injection-test.js
+++ b/packages/react-native/scripts/spm/__tests__/remove-spm-injection-test.js
@@ -14,6 +14,7 @@ const {
   SPM_INJECTED_MARKER,
   injectSpmIntoExistingXcodeproj,
   readArtifactsVersionOverride,
+  readPinnedConfigCommand,
   removeSpmInjection,
 } = require('../generate-spm-xcodeproj');
 const fs = require('node:fs');
@@ -391,5 +392,150 @@ describe('readArtifactsVersionOverride', () => {
     );
     expect(() => readArtifactsVersionOverride(appRoot)).not.toThrow();
     expect(readArtifactsVersionOverride(appRoot)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// configCommand — the marker field persisting an explicit `spm add/update
+// --config-command '<json argv>'`. Without the pin, the build-time `sync`
+// re-derived autolinking.json with the default @react-native-community/cli
+// command and failed the "Sync SPM Autolinking" build phase in apps (e.g. Expo
+// apps) that replace it.
+// ---------------------------------------------------------------------------
+describe('configCommand marker field', () => {
+  const EXPO_COMMAND = [
+    'npx',
+    'expo-modules-autolinking',
+    'react-native-config',
+    '--json',
+    '--platform',
+    'ios',
+  ];
+
+  it('records an explicit config command into the marker', () => {
+    const {appRoot, xcodeprojPath, rnRoot} = scaffoldApp();
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+      configCommand: EXPO_COMMAND,
+    });
+    expect(readMarker(xcodeprojPath).configCommand).toEqual(EXPO_COMMAND);
+    expect(readPinnedConfigCommand(appRoot)).toEqual(EXPO_COMMAND);
+  });
+
+  it('defaults to null when --config-command has never been given', () => {
+    const {appRoot, xcodeprojPath, rnRoot} = scaffoldApp();
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+    });
+    expect(readMarker(xcodeprojPath).configCommand).toBeNull();
+    expect(readPinnedConfigCommand(appRoot)).toBeNull();
+  });
+
+  it('preserves the pin on a later run without --config-command', () => {
+    const {appRoot, xcodeprojPath, rnRoot} = scaffoldApp();
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+      configCommand: EXPO_COMMAND,
+    });
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+    });
+    expect(readMarker(xcodeprojPath).configCommand).toEqual(EXPO_COMMAND);
+    expect(readPinnedConfigCommand(appRoot)).toEqual(EXPO_COMMAND);
+  });
+
+  it('a later explicit --config-command overwrites the previous pin', () => {
+    const {appRoot, xcodeprojPath, rnRoot} = scaffoldApp();
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+      configCommand: EXPO_COMMAND,
+    });
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+      configCommand: ['my-cli', 'config'],
+    });
+    expect(readMarker(xcodeprojPath).configCommand).toEqual([
+      'my-cli',
+      'config',
+    ]);
+    expect(readPinnedConfigCommand(appRoot)).toEqual(['my-cli', 'config']);
+  });
+
+  it('deinit drops the pin along with the whole marker', () => {
+    const {appRoot, xcodeprojPath, rnRoot} = scaffoldApp();
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+      configCommand: EXPO_COMMAND,
+    });
+    removeSpmInjection({appRoot, xcodeprojPath});
+    expect(fs.existsSync(path.join(xcodeprojPath, SPM_INJECTED_MARKER))).toBe(
+      false,
+    );
+    expect(readPinnedConfigCommand(appRoot)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readPinnedConfigCommand — pure fs read, used by setup-apple-spm.js (including
+// the build-time `sync`) to reuse the config command an earlier `add`/`update`
+// pinned. A hand-edited or corrupt marker must degrade to the env/default path
+// instead of injecting a bogus argv or throwing mid-build.
+// ---------------------------------------------------------------------------
+describe('readPinnedConfigCommand', () => {
+  it('returns null when no xcodeproj has been injected yet', () => {
+    const {appRoot} = scaffoldApp();
+    expect(readPinnedConfigCommand(appRoot)).toBeNull();
+  });
+
+  it('returns null (never throws) on a malformed marker', () => {
+    const {appRoot, xcodeprojPath, rnRoot} = scaffoldApp();
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+      configCommand: ['my-cli', 'config'],
+    });
+    fs.writeFileSync(
+      path.join(xcodeprojPath, SPM_INJECTED_MARKER),
+      '{ not valid json',
+      'utf8',
+    );
+    expect(() => readPinnedConfigCommand(appRoot)).not.toThrow();
+    expect(readPinnedConfigCommand(appRoot)).toBeNull();
+  });
+
+  it.each([
+    ['a bare string', '"npx expo-modules-autolinking"'],
+    ['an empty array', '[]'],
+    ['a non-string member', '["npx", 7]'],
+    ['an empty-string member', '["npx", ""]'],
+    ['an object', '{"command": "npx"}'],
+  ])('returns null for a pinned value that is %s', (_label, pinned) => {
+    const {appRoot, xcodeprojPath, rnRoot} = scaffoldApp();
+    injectSpmIntoExistingXcodeproj({
+      appRoot,
+      reactNativeRoot: rnRoot,
+      xcodeprojPath,
+      configCommand: ['my-cli', 'config'],
+    });
+    const markerPath = path.join(xcodeprojPath, SPM_INJECTED_MARKER);
+    const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    marker.configCommand = JSON.parse(pinned);
+    fs.writeFileSync(markerPath, JSON.stringify(marker), 'utf8');
+    expect(readPinnedConfigCommand(appRoot)).toBeNull();
   });
 });

--- a/packages/react-native/scripts/spm/__tests__/setup-apple-spm-test.js
+++ b/packages/react-native/scripts/spm/__tests__/setup-apple-spm-test.js
@@ -17,6 +17,8 @@ const {
   generateAutolinkingConfigOrFailClosed,
   parseArgs,
   resolveAction,
+  resolveConfigCommandToPin,
+  resolveExplicitConfigCommand,
   shouldAutoDeintegrate,
 } = require('../../setup-apple-spm');
 const {REQUIRED_ARTIFACTS} = require('../download-spm-artifacts');
@@ -28,12 +30,17 @@ const path = require('node:path');
 
 // Create an in-place-injected xcodeproj fixture: a directory carrying the
 // `.spm-injected.json` marker (what injectSpmIntoExistingXcodeproj writes).
-function mkInjectedXcodeproj(appRoot, name) {
+function mkInjectedXcodeproj(appRoot, name, markerFields = {}) {
   const dir = path.join(appRoot, name);
   fs.mkdirSync(dir, {recursive: true});
   fs.writeFileSync(
     path.join(dir, SPM_INJECTED_MARKER),
-    JSON.stringify({rootUuid: 'X', target: 'MyApp', injectedUuids: []}),
+    JSON.stringify({
+      rootUuid: 'X',
+      target: 'MyApp',
+      injectedUuids: [],
+      ...markerFields,
+    }),
   );
   return dir;
 }
@@ -154,6 +161,172 @@ describe('generateAutolinkingConfigOrFailClosed', () => {
     expect(warnings).toMatch(/RCT_SPM_AUTOLINKING_CONFIG_COMMAND/);
     // ...and preserves the underlying cause.
     expect(warnings).toMatch(/exited with status 1/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveExplicitConfigCommand — the autolinking config command every action
+// (add/update/sync/scaffold) runs with: `--config-command` →
+// RCT_SPM_AUTOLINKING_CONFIG_COMMAND → the value pinned in `.spm-injected.json`
+// → the built-in default. undefined means "let generateAutolinkingConfig pick
+// the env var or the default".
+// ---------------------------------------------------------------------------
+
+describe('resolveExplicitConfigCommand', () => {
+  const ENV = 'RCT_SPM_AUTOLINKING_CONFIG_COMMAND';
+  const PINNED = ['npx', 'expo-modules-autolinking', 'react-native-config'];
+  let tempDir;
+  let prevEnv;
+  let logSpy;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'spm-config-command-'));
+    prevEnv = process.env[ENV];
+    delete process.env[ENV];
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+    if (prevEnv === undefined) {
+      delete process.env[ENV];
+    } else {
+      process.env[ENV] = prevEnv;
+    }
+    jest.restoreAllMocks();
+  });
+
+  function pin(configCommand) {
+    mkInjectedXcodeproj(tempDir, 'MyApp.xcodeproj', {configCommand});
+  }
+
+  it('prefers an explicit --config-command over the env var and the pin', () => {
+    process.env[ENV] = '["from-env","config"]';
+    pin(PINNED);
+    expect(
+      resolveExplicitConfigCommand(
+        {configCommand: ['flag', 'config']},
+        tempDir,
+      ),
+    ).toEqual(['flag', 'config']);
+  });
+
+  it('lets the env var win over the pin (a stale pin must not shadow it)', () => {
+    process.env[ENV] = '["from-env","config"]';
+    pin(PINNED);
+    expect(resolveExplicitConfigCommand({configCommand: null}, tempDir)).toBe(
+      undefined,
+    );
+  });
+
+  it('uses the pin when neither the flag nor the env var is set', () => {
+    pin(PINNED);
+    expect(
+      resolveExplicitConfigCommand({configCommand: null}, tempDir),
+    ).toEqual(PINNED);
+    // Names the source, so a stale pin is diagnosable from the build log.
+    expect(logSpy.mock.calls.map(c => c.join(' ')).join('\n')).toMatch(
+      /\.spm-injected\.json/,
+    );
+  });
+
+  it('ignores a blank env var and falls through to the pin', () => {
+    process.env[ENV] = '   ';
+    pin(PINNED);
+    expect(
+      resolveExplicitConfigCommand({configCommand: null}, tempDir),
+    ).toEqual(PINNED);
+  });
+
+  it('falls back to the default (undefined) with no flag, env var or pin', () => {
+    mkInjectedXcodeproj(tempDir, 'MyApp.xcodeproj');
+    expect(resolveExplicitConfigCommand({configCommand: null}, tempDir)).toBe(
+      undefined,
+    );
+  });
+
+  it('falls back to the default when the pinned value is malformed', () => {
+    pin('npx expo-modules-autolinking');
+    expect(resolveExplicitConfigCommand({configCommand: null}, tempDir)).toBe(
+      undefined,
+    );
+  });
+
+  it('falls back to the default when no project is injected yet', () => {
+    expect(resolveExplicitConfigCommand({configCommand: null}, tempDir)).toBe(
+      undefined,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveConfigCommandToPin — what `add`/`update` records in the injection
+// marker: the explicit `--config-command`, else the env override, since the
+// Xcode build phase inherits neither. null pins nothing (and preserves any
+// earlier pin).
+// ---------------------------------------------------------------------------
+
+describe('resolveConfigCommandToPin', () => {
+  const ENV = 'RCT_SPM_AUTOLINKING_CONFIG_COMMAND';
+  const FROM_ENV = ['npx', 'expo-modules-autolinking', 'react-native-config'];
+  let tempDir;
+  let prevEnv;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'spm-config-command-pin-'));
+    prevEnv = process.env[ENV];
+    delete process.env[ENV];
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+    if (prevEnv === undefined) {
+      delete process.env[ENV];
+    } else {
+      process.env[ENV] = prevEnv;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('pins the env-derived command when only the env var is set', () => {
+    process.env[ENV] = JSON.stringify(FROM_ENV);
+    expect(resolveConfigCommandToPin({configCommand: null})).toEqual(FROM_ENV);
+  });
+
+  it('pins the explicit --config-command over the env var', () => {
+    process.env[ENV] = JSON.stringify(FROM_ENV);
+    expect(
+      resolveConfigCommandToPin({configCommand: ['flag', 'config']}),
+    ).toEqual(['flag', 'config']);
+  });
+
+  it('pins nothing when the env var is blank', () => {
+    process.env[ENV] = '  \t ';
+    expect(resolveConfigCommandToPin({configCommand: null})).toBeNull();
+  });
+
+  it('pins nothing when neither the flag nor the env var is set', () => {
+    expect(resolveConfigCommandToPin({configCommand: null})).toBeNull();
+  });
+
+  it('fails loud rather than pinning garbage from an invalid env var', () => {
+    process.env[ENV] = 'npx expo-modules-autolinking';
+    expect(() => resolveConfigCommandToPin({configCommand: null})).toThrow(
+      /RCT_SPM_AUTOLINKING_CONFIG_COMMAND/,
+    );
+  });
+
+  it('is resolved back by a later run with neither flag nor env var', () => {
+    process.env[ENV] = JSON.stringify(FROM_ENV);
+    mkInjectedXcodeproj(tempDir, 'MyApp.xcodeproj', {
+      configCommand: resolveConfigCommandToPin({configCommand: null}),
+    });
+    delete process.env[ENV];
+
+    expect(
+      resolveExplicitConfigCommand({configCommand: null}, tempDir),
+    ).toEqual(FROM_ENV);
   });
 });
 

--- a/packages/react-native/scripts/spm/generate-spm-autolinking-config.js
+++ b/packages/react-native/scripts/spm/generate-spm-autolinking-config.js
@@ -122,17 +122,29 @@ function resolveDefaultConfigCommand(
   return FALLBACK_CONFIG_COMMAND;
 }
 
+const ENV_CONFIG_COMMAND = 'RCT_SPM_AUTOLINKING_CONFIG_COMMAND';
+
+// The raw env override, or null when unset or blank. Exported so callers that
+// only need to know whether the override is in play (setup-apple-spm.js) share
+// this blankness rule instead of re-deriving it.
+function readEnvConfigCommand() /*: ?string */ {
+  const raw = process.env[ENV_CONFIG_COMMAND];
+  return typeof raw === 'string' && raw.trim().length > 0 ? raw : null;
+}
+
+// The env override, parsed and validated, or null when unset or blank. Throws
+// on a set-but-invalid value — never silently degrades to the default.
+function resolveEnvConfigCommand() /*: ?Array<string> */ {
+  const raw = readEnvConfigCommand();
+  return raw == null ? null : parseConfigCommandJson(raw, ENV_CONFIG_COMMAND);
+}
+
 // Env-var / default resolution for the autolinking config command. An explicit
 // `configCommand` (e.g. from `--config-command`) is handled upstream by
 // generateAutolinkingConfig's destructuring default, so it never reaches here —
 // this only decides between the env-var override and the built-in default.
 function resolveConfigCommand(projectRoot /*: string */) /*: Array<string> */ {
-  const raw = process.env.RCT_SPM_AUTOLINKING_CONFIG_COMMAND;
-  if (typeof raw === 'string' && raw.trim().length > 0) {
-    return parseConfigCommandJson(raw, 'RCT_SPM_AUTOLINKING_CONFIG_COMMAND');
-  }
-
-  return resolveDefaultConfigCommand(projectRoot);
+  return resolveEnvConfigCommand() ?? resolveDefaultConfigCommand(projectRoot);
 }
 
 function defaultCliRunner(
@@ -202,6 +214,8 @@ function generateAutolinkingConfig(
 module.exports = {
   generateAutolinkingConfig,
   parseConfigCommandJson,
+  readEnvConfigCommand,
   resolveConfigCommand,
   resolveDefaultConfigCommand,
+  resolveEnvConfigCommand,
 };

--- a/packages/react-native/scripts/spm/generate-spm-xcodeproj.js
+++ b/packages/react-native/scripts/spm/generate-spm-xcodeproj.js
@@ -22,6 +22,7 @@
  */
 
 const {readFlavoredFrameworksManifest} = require('./flavored-frameworks');
+const {parseConfigCommandJson} = require('./generate-spm-autolinking-config');
 const {
   addArrayMembers,
   addArrayStringValues,
@@ -1844,7 +1845,7 @@ function readGeneratedSourcesManifest(
  */
 function readMarker(
   xcodeprojPath /*: string */,
-) /*: ?{generatedSources?: {[string]: Array<string>}, artifactsVersionOverride?: ?string, buildSettingChanges?: Array<BuildSettingChange>, ...} */ {
+) /*: ?{generatedSources?: {[string]: Array<string>}, artifactsVersionOverride?: ?string, configCommand?: ?Array<string>, buildSettingChanges?: Array<BuildSettingChange>, ...} */ {
   const markerPath = path.join(xcodeprojPath, SPM_INJECTED_MARKER);
   try {
     // $FlowFixMe[incompatible-return] JSON.parse returns any
@@ -1857,8 +1858,9 @@ function readMarker(
 // Returns the `*.xcodeproj` under `appRoot` carrying a `.spm-injected.json`
 // marker (the user-owned project SPM packages were injected into in place),
 // or null when none has been injected yet. Pure fs reads — safe for the
-// build-time sync (sync-spm-autolinking.js, via readArtifactsVersionOverride
-// below) to call without pulling in any pbxproj-editing machinery at runtime.
+// marker readers below, and for callers that only locate the project (setup-
+// apple-spm.js's action defaulting and `deinit`), to call without exercising
+// any pbxproj-editing machinery.
 function findInjectedXcodeproj(appRoot /*: string */) /*: string | null */ {
   let entries /*: Array<{name: string, isDirectory(): boolean}> */ = [];
   try {
@@ -1884,11 +1886,13 @@ function findInjectedXcodeproj(appRoot /*: string */) /*: string | null */ {
  * update --version` pinned into the injected xcodeproj's `.spm-injected.json`
  * marker (see the field's doc comment in injectSpmIntoExistingXcodeproj
  * below), or null when no project is injected yet, no override is pinned, or
- * the marker can't be read (never throws). Pure fs reads — the build-time
- * sync (sync-spm-autolinking.js) calls this to prefer the pinned version over
- * the one derived from node_modules/react-native/package.json, so a
- * version-mismatched setup keeps healing against the SAME artifact slot the
- * explicit `--version` selected.
+ * the marker can't be read (never throws). Pure fs reads.
+ *
+ * Nothing in production calls this yet: the pin is written but never read
+ * back, so the build-time sync (sync-spm-autolinking.js) still derives the
+ * version from node_modules/react-native/package.json and can heal against a
+ * different artifact slot than the explicit `--version` selected. Only the
+ * tests cover it.
  */
 function readArtifactsVersionOverride(appRoot /*: string */) /*: ?string */ {
   const xcodeprojPath = findInjectedXcodeproj(appRoot);
@@ -1900,12 +1904,38 @@ function readArtifactsVersionOverride(appRoot /*: string */) /*: ?string */ {
 }
 
 /**
+ * Read the autolinking config command a previous `spm add`/`update` pinned into
+ * the injected xcodeproj's `.spm-injected.json` marker, or null when nothing
+ * usable is pinned. Pure fs reads, like readArtifactsVersionOverride above, but
+ * this one IS wired: setup-apple-spm.js's resolveExplicitConfigCommand reads it
+ * on add/update/scaffold and on the build-time `sync`. Re-validated through the
+ * same parseConfigCommandJson the flag goes through, and never throws, so a
+ * hand-edited marker degrades to the env-var/default command instead of
+ * injecting a bogus argv into the build.
+ */
+function readPinnedConfigCommand(appRoot /*: string */) /*: ?Array<string> */ {
+  const xcodeprojPath = findInjectedXcodeproj(appRoot);
+  if (xcodeprojPath == null) {
+    return null;
+  }
+  const pinned = readMarker(xcodeprojPath)?.configCommand;
+  if (pinned == null) {
+    return null;
+  }
+  try {
+    return parseConfigCommandJson(JSON.stringify(pinned), SPM_INJECTED_MARKER);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Add SPM packages to a user's EXISTING xcodeproj in place. Returns
  * {status: 'injected', target} on success, or {status: 'refused', reason}
  * when the project can't be safely edited (caller surfaces it; fail-loud).
  */
 function injectSpmIntoExistingXcodeproj(
-  opts /*: {appRoot: string, reactNativeRoot: string, xcodeprojPath: string, appName?: ?string, artifactsVersionOverride?: ?string} */,
+  opts /*: {appRoot: string, reactNativeRoot: string, xcodeprojPath: string, appName?: ?string, artifactsVersionOverride?: ?string, configCommand?: ?Array<string>} */,
 ) /*: {status: 'injected', target: string} | {status: 'refused', reason: string} */ {
   const {appRoot, reactNativeRoot, xcodeprojPath} = opts;
   const pbxprojPath = path.join(xcodeprojPath, 'project.pbxproj');
@@ -2022,6 +2052,16 @@ function injectSpmIntoExistingXcodeproj(
     prevMarker?.artifactsVersionOverride ??
     null;
 
+  // Same set-or-preserve contract as the version pin above, for the autolinking
+  // config command `add`/`update` resolved (`--config-command` or
+  // RCT_SPM_AUTOLINKING_CONFIG_COMMAND) — the build-time sync sees neither the
+  // flag nor the developer's shell environment, so without the pin it
+  // re-derives autolinking.json with the default @react-native-community/cli
+  // command and breaks apps that replace it. Read back by
+  // readPinnedConfigCommand (above). No "clear" verb yet either; `deinit` drops
+  // the whole marker, this field with it.
+  const configCommand = opts.configCommand ?? prevMarker?.configCommand ?? null;
+
   // Marker: idempotency signal + the exact, reversible record of every edit so
   // `deinit` (removeSpmInjection) can undo precisely what was added.
   writeIfChanged(
@@ -2038,6 +2078,7 @@ function injectSpmIntoExistingXcodeproj(
         // `update` to reconcile away entries that left the manifest.
         generatedSources: generatedSourceUuids,
         artifactsVersionOverride,
+        configCommand,
         scheme: {
           file: schemeResult.file,
           created: schemeResult.status === 'created',
@@ -2220,5 +2261,6 @@ module.exports = {
   removePreActionFromScheme,
   findInjectedXcodeproj,
   readArtifactsVersionOverride,
+  readPinnedConfigCommand,
   SPM_INJECTED_MARKER,
 };


### PR DESCRIPTION
## Summary:

**`spm add --config-command` worked once, then broke every build.**

An app that replaces `@react-native-community/cli` autolinking — an Expo app, for instance — has to override the autolinking config command, which `--config-command` (and `RCT_SPM_AUTOLINKING_CONFIG_COMMAND`) exists to do. But the flag was never stored anywhere. So:

1. `npx react-native spm add --config-command '[...]'` → succeeds, writes a valid project ✅
2. Build in Xcode → the "Sync SPM Autolinking" phase re-derives `autolinking.json`, doesn't know about the flag, falls back to the default command, and fails ❌

```
PhaseScriptExecution failed with a nonzero exit code
  → Sync SPM Autolinking
  → 'npx --no-install @react-native-community/cli config' exited with status 1
```

The only real workaround was exporting `RCT_SPM_AUTOLINKING_CONFIG_COMMAND` into Xcode's environment — i.e. committing it to `.xcode.env` — which shouldn't be necessary when you already passed a flag. Reported by the Expo team while testing SwiftPM.

**Fix:** pin the command into the `.spm-injected.json` marker at `add`/`update` time, and read it back on later runs — the same set-or-preserve pin the neighbouring `artifactsVersionOverride` already uses.

Resolution order, unchanged at the front and only extended at the back:

```
--config-command  →  RCT_SPM_AUTOLINKING_CONFIG_COMMAND  →  pinned value  →  default
```

**Both input routes persist.** The help text advertises the env var as an equivalent way to supply the command, so pinning only the flag would have left half the documented interface broken in exactly the same way — export the env var, run `spm add`, and the build phase (which does not inherit your shell) still fails. The pin therefore stores the *resolved* command from either route.

Two subtleties worth a reviewer's eye:

- `generateAutolinkingConfig` resolves the env var *internally* when no explicit command is passed, so handing it the pin would silently outrank a developer's env override. The read path therefore **withholds** the pin while the env var is set, letting the existing precedence do its job. The four order cases are tested, including that a whitespace-only env var falls through to the pin rather than stranding it.
- A pinned value is re-validated through the same `parseConfigCommandJson` the flag goes through, so a hand-edited or corrupt marker degrades to the env/default command instead of injecting a bogus argv into a build.

Because this is now persistent state, `add`/`update` logs one line when the command comes from the pin, naming `.spm-injected.json` — a stale pin should be diagnosable from build output rather than invisible. There is no "clear" verb short of `deinit`, same as the version pin; that is noted in the marker comment.

122 added lines across three source files. No new mechanism, no changes to the sync scripts, and nothing baked into the generated build phase.

**Noticed while here, filed separately, deliberately not fixed:** `readArtifactsVersionOverride` — the version pin this is modelled on — has **no production caller**. Only its write half is wired, and two comments claim the build-time sync reads it. Those comments are corrected here (they misled me while writing this); wiring the version pin up is its own change.

### This isn't blocking anyone

Expo's SwiftPM verification is **not blocked** on this, so it needn't be rushed. The env-var half of the override already works at build time: adding

```sh
export RCT_SPM_AUTOLINKING_CONFIG_COMMAND='["node","…/expo-modules-autolinking.js","react-native-config","--json","--platform","ios"]'
```

to the app's `.xcode.env` (or `.xcode.env.local`) gets the command into the sync phase, because the generated phase sources both files before dispatching. That is what unblocks Expo today, and it is exactly the "commit an env var to `.xcode.env`" step this PR removes the need for.

One caveat that argues for fixing it properly rather than documenting the workaround: the phase sources `.xcode.env` **only when `NODE_BINARY` is unset** (`nodeAndRnDirPreamble`). An app that sets `NODE_BINARY` as an Xcode build setting — a documented RN practice — never sources those files, so the workaround silently does nothing there and the build fails with no hint as to why. Persisting the flag doesn't depend on any of that plumbing.

## Changelog:

[Internal] [Fixed] - SwiftPM: persist `spm --config-command` so the in-build autolinking sync keeps using it

## Test Plan:

`yarn jest packages/react-native/scripts` → **31 suites, 703 tests** (25 new).

Each new test written red first, covering:

- the command round-trips through `.spm-injected.json` (marker content asserted)
- `add` → `update` **without** the flag keeps the pin; a later flag overwrites it
- `add` with **only the env var** set pins the env-derived command, and a later run with neither flag nor env resolves it back
- all four resolution-order cases, including that **the env var beats the pin**, and that a whitespace-only env var pins nothing and falls through
- an invalid non-blank env var still fails loud rather than pinning garbage
- a corrupt or hand-edited pin (bare string, `[]`, non-string member, empty-string member, object) degrades to the default rather than throwing
- `deinit` drops it with the marker

Not covered: no test drives a real `sync` end to end, since that needs artifacts, codegen and a real pbxproj. The two halves are tested separately against the same marker field — the injector writes `configCommand`, and the resolver reads it. The original failure was reported from a real Expo app build; confirmation that this fixes that build is still pending on the Expo side.
