### PR TITLE
Drop RCT_EXPORT_METHOD from RCTImageEditingManager (#57773)

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageEditingManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageEditingManager.mm
@@ -38,20 +38,22 @@ RCT_EXPORT_MODULE()
  *        be scaled down to `displaySize` rather than `size`.
  *        All units are in px (not points).
  */
-RCT_EXPORT_METHOD(
-    cropImage : (NSURLRequest *)imageRequest cropData : (JS::NativeImageEditor::Options &)cropData successCallback : (
-        RCTResponseSenderBlock)successCallback errorCallback : (RCTResponseSenderBlock)errorCallback)
+- (void)cropImage:(NSString *)imageRequestString
+           cropData:(JS::NativeImageEditor::Options &)cropData
+    successCallback:(RCTResponseSenderBlock)successCallback
+      errorCallback:(RCTResponseSenderBlock)errorCallback
 {
+  NSURLRequest *imageRequest = [RCTConvert NSURLRequest:imageRequestString];
+
   CGRect rect = {
-    [RCTConvert CGPoint:@{
-      @"x" : @(cropData.offset().x()),
-      @"y" : @(cropData.offset().y()),
-    }],
-    [RCTConvert CGSize:@{
-      @"width" : @(cropData.size().width()),
-      @"height" : @(cropData.size().height()),
-    }]
-  };
+      [RCTConvert CGPoint:@{
+        @"x" : @(cropData.offset().x()),
+        @"y" : @(cropData.offset().y()),
+      }],
+      [RCTConvert CGSize:@{
+        @"width" : @(cropData.size().width()),
+        @"height" : @(cropData.size().height()),
+      }]};
 
   // We must keep a copy of cropData so that we can access data from it at a later time
   JS::NativeImageEditor::Options cropDataCopy = cropData;


### PR DESCRIPTION
Summary:

RCTImageEditingManager is a TurboModule conforming to `NativeImageEditorSpec`. For TurboModules, JS->ObjC dispatch is driven by codegen via the generated `NativeImageEditorSpecJSI`, not by `RCT_EXPORT_METHOD`'s `__rct_export__` metadata, so the macro is dead weight. Protocol conformance gives compiler-enforced signature parity.

This diff is part of the `CodemodConfigDevmateDropRctExportMethod` pipeline that removes the legacy macro from first-party ObjC TurboModules.

Change:
- Converts `RCT_EXPORT_METHOD(cropImage: ...)` to plain ObjC method `- (void)cropImage:(NSString *)...`

Type-mismatch reconciliation (cAST mod flagged `FLAG type-mismatch`):
- Generated spec requires `(NSString *)uri`, but the legacy impl declared `(NSURLRequest *)imageRequest`.
- The macro was silently coercing the arg via `RCTConvert`.
- Preserve coercion manually: signature now takes `NSString *imageRequestString`, body restores `NSURLRequest *imageRequest = [RCTConvert NSURLRequest:imageRequestString];` at top. Existing `loadImageWithURLRequest:` usage unchanged.

Generated spec (from `FBReactNativeSpec.h`):
```
protocol NativeImageEditorSpec <RCTBridgeModule, RCTTurboModule>
- (void)cropImage:(NSString *)uri
         cropData:(JS::NativeImageEditor::Options &)cropData
  successCallback:(RCTResponseSenderBlock)successCallback
    errorCallback:(RCTResponseSenderBlock)errorCallback;
end
```
`RCT_EXPORT_MODULE()` and `getTurboModule:` are left untouched.

Changelog: [Internal]

Differential Revision: D114288222


