### PR TITLE
fix: consider extralight fonts in RCTGetFontWeight

### DIFF
--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -24,6 +24,7 @@ RCTFontWeight RCTGetFontWeight(UIFont *font)
     weightSuffixes = @[
       @"normal",
       @"ultralight",
+      @"extralight",
       @"thin",
       @"light",
       @"regular",
@@ -38,6 +39,7 @@ RCTFontWeight RCTGetFontWeight(UIFont *font)
     ];
     fontWeights = @[
       @(UIFontWeightRegular),
+      @(UIFontWeightUltraLight),
       @(UIFontWeightUltraLight),
       @(UIFontWeightThin),
       @(UIFontWeightLight),

--- a/packages/rn-tester/RNTesterUnitTests/RCTFontTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTFontTests.m
@@ -49,6 +49,25 @@
   }
 }
 
+- (void)testWeightFromFontName
+{
+  // "ExtraLight" and "UltraLight" name the same weight (OpenType usWeightClass 200).
+  {
+    UIFont *font = [UIFont fontWithName:@"HelveticaNeue-UltraLight" size:14];
+    XCTAssertEqual(RCTGetFontWeight(font), UIFontWeightUltraLight);
+  }
+#if !TARGET_OS_TV
+  {
+    UIFont *font = [UIFont fontWithName:@"Seravek-ExtraLight" size:14];
+    XCTAssertEqual(RCTGetFontWeight(font), UIFontWeightUltraLight);
+  }
+  {
+    UIFont *font = [UIFont fontWithName:@"Seravek-Light" size:14];
+    XCTAssertEqual(RCTGetFontWeight(font), UIFontWeightLight);
+  }
+#endif
+}
+
 - (void)testSize
 {
   {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

`RCTGetFontWeight`, as the name suggests, gets a UIFontWeight given the font names. Some font names are called `extralight` which is the same weight as the already-covered `ultralight -> UIFontWeightUltraLight` case.

However, they'd incorrectly be classified as `UIFontWeightLight`. This PR fixes that. Note that the `extrabold` case was already covered.

## Changelog:


[iOS] [FIXED] - correctly classify extralight fonts as `UIFontWeightUltraLight` in `RCTGetFontWeight`


## Test Plan:

- green CI