### PR TITLE
Repro for #57780: removing borderWidth hides children of a clipped rounded View on Android

### DIFF
--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -12,14 +12,70 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {Pressable, StyleSheet, View} from 'react-native';
 
-function Playground() {
+/**
+ * Repro for #57780.
+ *
+ * Android only: a View with `borderRadius` + `overflow: 'hidden'` stops drawing
+ * ALL of its children once its `borderWidth` prop is *removed* (as opposed to
+ * being set to 0). The view's own background keeps painting, so the row becomes
+ * a correctly sized, correctly rounded, empty box.
+ *
+ * Tap "Row B" in group A: "Row A" keeps its grey background and loses its text.
+ * Group B is identical except its base style sets `borderWidth: 0`, so the prop
+ * is never removed - that one behaves correctly. Both groups undergo the same
+ * 1px geometry change, which is what rules out a layout/measurement cause and
+ * points at the `Float.NaN` that `ReactViewManager` sends for a removed
+ * borderWidth prop (see the issue for the full trace through
+ * BorderInsets.resolve -> clipToPaddingBox -> canvas.clipPath).
+ *
+ * iOS renders both groups correctly.
+ */
+
+const ROWS = ['Row A', 'Row B', 'Row C'];
+
+function Group({
+  title,
+  keepBorderWidth,
+}: {
+  title: string,
+  keepBorderWidth: boolean,
+}): React.Node {
+  const [selected, setSelected] = React.useState<number>(0);
+
+  return (
+    <View style={styles.group}>
+      <RNTesterText style={styles.groupTitle}>{title}</RNTesterText>
+      {ROWS.map((label, i) => (
+        <Pressable
+          key={label}
+          onPress={() => setSelected(i)}
+          style={[
+            styles.row,
+            // Group B only: keeps borderWidth present in every state.
+            keepBorderWidth ? styles.rowZeroBorder : null,
+            // borderWidth appears on select and DISAPPEARS on deselect.
+            i === selected ? styles.rowSelected : null,
+          ]}>
+          <RNTesterText style={styles.rowLabel}>{label}</RNTesterText>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+function Playground(): React.Node {
   return (
     <View style={styles.container}>
-      <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
-      </RNTesterText>
+      <Group
+        keepBorderWidth={false}
+        title="A) BROKEN on Android - unselected style has no borderWidth"
+      />
+      <Group
+        keepBorderWidth={true}
+        title="B) OK - unselected style has borderWidth: 0"
+      />
     </View>
   );
 }
@@ -27,6 +83,36 @@ function Playground() {
 const styles = StyleSheet.create({
   container: {
     padding: 10,
+  },
+  group: {
+    marginBottom: 24,
+  },
+  groupTitle: {
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  row: {
+    backgroundColor: '#e6e8ee',
+    // ingredient 1: rounded corners, so the clip is built as a Path
+    borderRadius: 8,
+    // ingredient 2: installs the padding-box clip on children
+    overflow: 'hidden',
+    minHeight: 48,
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+    marginBottom: 8,
+  },
+  rowZeroBorder: {
+    borderWidth: 0,
+    borderColor: 'transparent',
+  },
+  rowSelected: {
+    borderWidth: 1,
+    borderColor: '#3b5afb',
+  },
+  rowLabel: {
+    fontSize: 16,
+    color: '#111111',
   },
 });
 


### PR DESCRIPTION
## Summary:

Reproducer for #57780, as requested by `react-native-bot` (`Needs: Repro`). **Not intended to be merged** — it edits `RNTesterPlayground.js` per the [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug) guidance.

On Android, a `View` with `borderRadius` and `overflow: 'hidden'` stops drawing **all of its children** once its `borderWidth` prop is *removed* — as opposed to being set to `0`. The view's own background keeps painting, so the row renders as a correctly sized, correctly rounded, completely empty box. The children remain mounted and laid out (the a11y tree still reports their labels and frames); they just are not drawn. Re-adding `borderWidth` restores them.

Suspected cause, traced in the issue:

1. `ReactViewManager` declares the borderWidth prop group with `defaultFloat = Float.NaN`, so removing the prop calls the setter with `NaN` (the parameter is a primitive `Float`, so it can never be `null` there).
2. `BackgroundStyleApplicator.setBorderWidth` documents `null` as the removal signal but receives `NaN`, stores it, and allocates `BorderInsets` on that same call.
3. `BorderInsets.resolve()` is an elvis chain ending in `?: 0f`, which only fires on `null` — so `NaN` passes through and it returns `RectF(NaN, NaN, NaN, NaN)`.
4. `clipToPaddingBoxWithAntiAliasing` subtracts those insets from `composite.bounds`, producing an all-`NaN` padding box; with `borderRadius` set it becomes a `Path` installed via `canvas.clipPath()`, which clips every child away.
5. `ReactViewGroup.dispatchDraw` only applies that clip when overflow is not `visible`, which is why `overflow: 'hidden'` is required. The background survives because background drawables paint in `View.draw()`, before `dispatchDraw()`.

iOS is unaffected: `RCTView` uses `_borderWidth = -1` as its unset sentinel and clamps with `MAX(0, _borderWidth)`. A negative sentinel is neutralised by arithmetic; `NaN` propagates.

This pattern is common in "selectable card" UI, where the selected style adds `borderWidth: 1` and the unselected style omits it.

## Changelog:

[INTERNAL] [CHANGED] - RNTesterPlayground repro for #57780 (not for merge)

## Test Plan:

Open RNTester on **Android** and go to the **Playground** example. Two groups of three rows:

1. In group **A**, tap "Row B" → **"Row A" keeps its grey rounded background but its text disappears.**
2. In group **B** — identical except the base style sets `borderWidth: 0` — tap "Row B" → "Row A" keeps its text, as expected.

Group B is the control that isolates the cause. `borderWidth: 0` and "no `borderWidth` at all" produce an **identical** 1px geometry change, so this is not a layout or measurement problem — only the *removed prop* triggers it. The broken state is also sticky: scrolling the row out of view and back does not restore the text, only re-adding a `borderWidth` does.

On **iOS**, both groups behave correctly.

### Verification provenance

To be precise about what I actually ran: I verified this on a **fresh `@react-native-community/cli init` app on 0.86.0, release build**, on a Pixel 8 (Android 17, SDK 37, Hermes, New Architecture) — no third-party libraries, no patches to React Native, no `ReactNativeFeatureFlags` overrides. Four variants were compared there:

| `overflow: hidden` | unselected `borderWidth` | Result |
| --- | --- | --- |
| yes | absent (setter gets `NaN`) | children not drawn |
| yes | `0` explicit | correct |
| yes | `1` constant, only colour toggles | correct |
| no | absent (`NaN`) | correct |

I have **not** built RNTester from `main` on Android myself, so this Playground patch is a faithful transcription of that verified reproducer rather than an independently re-run one. What I did check on `main` is the source: `BorderInsets.resolve()` still has only the null fallback and no `NaN` guard, on both `v0.86.2` and `main`, so the defect should still be present.

### Suggested fix

Treat `NaN` as unset in `BorderInsets` — either `?.takeUnless { it.isNaN() }` per edge in `resolve()`, or normalise `NaN` to `null` in `setBorderWidth` so the stored value matches that function's own documented contract. The latter fixes every consumer of `BorderInsets` rather than only the clip path.
