### PR TITLE
Treat NaN border widths as unset

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderInsets.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderInsets.kt
@@ -27,10 +27,10 @@ internal class BorderInsets {
    * Sets the border width for a specific logical edge.
    *
    * @param edge The logical edge to set
-   * @param width The border width in pixels, or null to clear
+   * @param width The border width in pixels, or null or NaN to clear
    */
   fun setBorderWidth(edge: LogicalEdge, width: Float?) {
-    edgeInsets[edge.ordinal] = width
+    edgeInsets[edge.ordinal] = width?.takeUnless { it.isNaN() }
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/style/BorderInsetsTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/style/BorderInsetsTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager.style
+
+import android.content.Context
+import android.util.LayoutDirection
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class BorderInsetsTest {
+  @Test
+  fun nanBorderWidthsAreTreatedAsUnset() {
+    val borderInsets = BorderInsets()
+    borderInsets.setBorderWidth(LogicalEdge.ALL, 4f)
+    borderInsets.setBorderWidth(LogicalEdge.LEFT, Float.NaN)
+
+    val resolved = borderInsets.resolve(LayoutDirection.LTR, mock<Context>())
+
+    assertThat(resolved.left).isEqualTo(4f)
+    assertThat(resolved.top).isEqualTo(4f)
+    assertThat(resolved.right).isEqualTo(4f)
+    assertThat(resolved.bottom).isEqualTo(4f)
+  }
+}


### PR DESCRIPTION
## Summary

- Normalize `Float.NaN` border widths to unset values in the shared logical border-inset resolver.
- Add a regression test confirming NaN edges fall back to the applicable all-edge width.

## Changelog:
[ANDROID] [FIXED] - Resetting border widths no longer clips children in rounded overflow-hidden views.

Fixes #57780

## Test plan

- Added `BorderInsetsTest.nanBorderWidthsAreTreatedAsUnset`.
- Android unit tests could not run locally because this environment has no configured Android SDK (`ANDROID_HOME`/`ANDROID_SDK_ROOT`).
