### PR TITLE
Fix iOS Codegen fallback for libraries without an iOS config

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -13,6 +13,9 @@
 const fixtures = require('../__fixtures__/fixtures');
 const {execute} = require('../generate-artifacts-executor');
 const {
+  generateRCTThirdPartyComponents,
+} = require('../generate-artifacts-executor/generateRCTThirdPartyComponents');
+const {
   extractSupportedApplePlatforms,
 } = require('../generate-artifacts-executor/generateSchemaInfos');
 const {
@@ -20,6 +23,7 @@ const {
   extractLibrariesFromJSON,
 } = require('../generate-artifacts-executor/utils');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const rootPath = path.join(__dirname, '../../..');
@@ -173,6 +177,53 @@ describe('extractSupportedApplePlatforms', () => {
       tvos: true,
       visionos: false,
     });
+  });
+});
+
+describe('generateRCTThirdPartyComponents', () => {
+  it('crawls component libraries without an iOS config', () => {
+    const libraryPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'react-native-codegen-'),
+    );
+    const outputDir = path.join(libraryPath, 'output');
+
+    fs.writeFileSync(
+      path.join(libraryPath, 'package.json'),
+      JSON.stringify({name: 'component-library'}),
+    );
+    fs.writeFileSync(
+      path.join(libraryPath, 'ExampleComponent.mm'),
+      `Class<RCTComponentViewProtocol> ExampleComponentCls(void) {
+  return RCTExampleComponent.class;
+}
+`,
+    );
+
+    try {
+      generateRCTThirdPartyComponents(
+        [
+          {
+            config: {
+              name: 'ComponentLibraryConfig',
+              type: 'components',
+              jsSrcsDir: 'src',
+            },
+            libraryPath,
+          },
+        ],
+        outputDir,
+      );
+
+      const generatedFile = fs.readFileSync(
+        path.join(outputDir, 'RCTThirdPartyComponentsProvider.mm'),
+        'utf8',
+      );
+      expect(generatedFile).toContain(
+        '@"ExampleComponent": NSClassFromString(@"RCTExampleComponent"), // component-library',
+      );
+    } finally {
+      fs.rmSync(libraryPath, {recursive: true, force: true});
+    }
   });
 });
 

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
@@ -396,17 +396,17 @@ function parseiOSAnnotations(
   const map = {};
 
   for (const library of libraries) {
-    const iosConfig = library?.config?.ios;
-    if (!iosConfig) {
-      continue;
-    }
-
     const libraryName = getLibraryName(library);
     map[libraryName] = map[libraryName] || {
       library,
       modules: {},
       components: {},
     };
+
+    const iosConfig = library?.config?.ios;
+    if (!iosConfig) {
+      continue;
+    }
 
     const {modules, components} = iosConfig;
     if (modules) {


### PR DESCRIPTION
## Summary

- Keep component libraries in the iOS third-party component crawl even when their Codegen config has no `ios` block.
- Add a regression test covering a component library without iOS configuration.

## Changelog:
[iOS] [FIXED] - iOS Codegen now discovers third-party component libraries without an iOS configuration.

Fixes #55308

## Test plan

- Targeted Jest test passes:
  `yarn jest packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js --runInBand --testNamePattern="crawls component libraries without an iOS config"`
- The full test file executes all 44 tests successfully, but Jest exits from an existing Node 26 cleanup-hook incompatibility with `fs.rmdirSync(..., {recursive: true})`.
