### PR TITLE
fix(dev-middleware): don't let one bad socket kill the dev server

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxySocketErrors-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxySocketErrors-test.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {fetchJson} from './FetchUtils';
+import {createDeviceMock} from './InspectorDeviceUtils';
+import {withAbortSignalForEachTest} from './ResourceUtils';
+import {withServerForEachTest} from './ServerUtils';
+import until from 'wait-for-expect';
+import WS from 'ws';
+
+// WebSocket is unreliable when using fake timers.
+jest.useRealTimers();
+
+jest.setTimeout(10000);
+
+/**
+ * A socket-level failure on one connection must not be fatal to the proxy.
+ *
+ * Without an 'error' listener on the accepted socket, Node throws on the
+ * unhandled 'error' event and the whole dev server exits — so a single
+ * misbehaving peer can end everyone's session. Reported as #57793, where a
+ * normally-connected iOS simulator tripped the `maxFragments` cap in the
+ * vendored `ws` and took Metro down with it.
+ */
+describe('inspector proxy socket errors', () => {
+  const serverRef = withServerForEachTest({
+    logger: undefined,
+    secure: false,
+  });
+  const autoCleanup = withAbortSignalForEachTest();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([
+    ['device', '/inspector/device?device=badDevice&name=foo&app=bar'],
+    ['debugger', '/inspector/debug?device=badDevice&page=1'],
+  ])(
+    'a protocol error on a %s connection does not take down the proxy',
+    async (_role, path) => {
+      // A well-behaved device, so there is a live session to lose.
+      const device = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      try {
+        device.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          },
+        ]);
+        await until(async () =>
+          expect((await fetchJson(`${serverRef.serverBaseUrl}/json`)).length)
+            .toBeGreaterThan(0),
+        );
+
+        // Now break one connection at the protocol level: a single message in
+        // more fragments than the vendored `ws` permits, which fails the
+        // receiver with RangeError and close code 1008.
+        const bad = new WS(`${serverRef.serverBaseWsUrl}${path}`);
+        bad.on('error', () => {});
+        await new Promise((resolve, reject) => {
+          bad.on('open', resolve);
+          bad.on('close', resolve);
+          bad.on('error', reject);
+        }).catch(() => {});
+
+        if (bad.readyState === WS.OPEN) {
+          const sender = bad._sender;
+          sender.send(Buffer.from('x'), {fin: false, opcode: 1, mask: true}, () => {});
+          for (let i = 0; i < 17000; i++) {
+            sender.send(Buffer.from('x'), {fin: false, opcode: 0, mask: true}, () => {});
+          }
+          sender.send(Buffer.from('x'), {fin: true, opcode: 0, mask: true}, () => {});
+        }
+
+        // The proxy is still serving, and the healthy device is still listed.
+        await until(async () => {
+          const pages = await fetchJson(`${serverRef.serverBaseUrl}/json`);
+          expect(pages.length).toBeGreaterThan(0);
+        });
+      } finally {
+        device.close();
+      }
+    },
+  );
+});

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -334,6 +334,23 @@ export default class InspectorProxy implements InspectorProxyQueries {
     });
     // $FlowFixMe[value-as-type]
     wss.on('connection', async (socket: WS, req) => {
+      // Attached before the first await: this handler is async, so an error
+      // arriving while it is suspended would otherwise have no listener. In
+      // Node an 'error' event with no listener throws, which takes down the
+      // whole dev server over a single bad connection.
+      socket.on('error', error => {
+        this.#logger?.error(
+          'Error on device connection, closing it: %s',
+          error?.message ?? String(error),
+        );
+        // terminate() rather than close(): close() waits for a closing
+        // handshake, and a socket that failed mid-frame may never complete
+        // one, which would leak the connection instead.
+        try {
+          socket.terminate();
+        } catch {}
+      });
+
       const wssTimestamp = Date.now();
 
       const fallbackDeviceId = String(this.#deviceCounter++);
@@ -523,6 +540,23 @@ export default class InspectorProxy implements InspectorProxyQueries {
 
     // $FlowFixMe[value-as-type]
     wss.on('connection', async (socket: WS, req) => {
+      // Attached before the first await: this handler is async, so an error
+      // arriving while it is suspended would otherwise have no listener. In
+      // Node an 'error' event with no listener throws, which takes down the
+      // whole dev server over a single bad connection.
+      socket.on('error', error => {
+        this.#logger?.error(
+          'Error on debugger connection, closing it: %s',
+          error?.message ?? String(error),
+        );
+        // terminate() rather than close(): close() waits for a closing
+        // handshake, and a socket that failed mid-frame may never complete
+        // one, which would leak the connection instead.
+        try {
+          socket.terminate();
+        } catch {}
+      });
+
       const wssTimestamp = Date.now();
 
       const query = tryParseQueryParams(req.url);


### PR DESCRIPTION
## Summary

Fixes #57793.

`InspectorProxy` never attached an `"error"` listener to the WebSocket connections it accepts. In Node, an `'error'` event with no listener throws — so a socket-level failure on **one** connection takes down the whole dev server rather than just that connection.

Both `#createDeviceConnectionWSServer` and `#createDebuggerConnectionWSServer` listened for `"message"` and `"close"` only. They now also listen for `"error"`, log it, and terminate that socket.

Two details worth calling out:

- The listener is attached **synchronously, before the first `await`**. These connection handlers are `async`, so an error arriving while one is suspended would otherwise still have no listener and still be fatal.
- `terminate()` rather than `close()`: `close()` waits for a closing handshake, and a socket that failed mid-frame may never complete one, which would leak the connection instead.

This does **not** touch the `maxFragments: 16 * 1024` / `maxBufferedChunks: 256 * 1024` caps in the vendored `ws`. Those look like deliberate hardening and I'm not proposing they be relaxed. The `RangeError` they raise is simply the error this project happened to hit; the bug is that *any* socket error was fatal to the process.

## Changelog:

[GENERAL] [FIXED] - Dev server no longer exits when a WebSocket connection to the inspector proxy errors

## Test Plan

**What I verified.** Against a pristine `@react-native/dev-middleware@0.81.5` from npm, a ~30-line script that connects to `/inspector/device` and sends one message in more fragments than the vendored `ws` allows kills the process:

```
RangeError: Too many message fragments
    at Receiver.getData (.../ws/lib/receiver.js:359:14)
Emitted 'error' event on WebSocket instance at:
    at Receiver.receiverOnError (.../ws/lib/websocket.js:787:13) {
  [Symbol(status-code)]: 1008
}
```

With this change applied (as a `patch-package` patch over the published `dist/`, which is the same edit as the `src/` change here), the same script instead prints `PROXY SURVIVED — connection dropped, server still up.` The full reproducer is in #57793.

I then ran a real Expo/RN 0.81.5 app against the patched middleware: Metro starts, builds its iOS bundle (HTTP 200, 13.8 MB), and a connected simulator registers two pages on `/json/list` — i.e. the device socket this wraps still works normally.

**What I could not verify, and why.** I was unable to run this repo's own test suite locally: `yarn install` on `main` fails on this machine with

```
error react-native@1000.0.0: The engine "node" is incompatible with this module.
Expected version "^22.13.0 || ^24.3.0 || >= 26.0.0". Got "22.12.0"
```

So **CI will be the first run of the added test** (`InspectorProxySocketErrors-test.js`). It follows the conventions of the neighbouring inspector-proxy tests (`withServerForEachTest`, `createDeviceMock`, `wait-for-expect`) and asserts that after one connection is broken at the protocol level, the proxy is still serving and a healthy device is still listed. I'm happy to iterate on it if CI disagrees, or to drop it and land the fix alone if you'd prefer a separate test PR.

