### PR TITLE
fix(android): crash when setting a percentage borderRadius on Image

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5312,6 +5312,7 @@ public final class com/facebook/react/views/image/ReactImageManager : com/facebo
 	public final fun setBlurRadius (Lcom/facebook/react/views/image/ReactImageView;F)V
 	public final fun setBorderColor (Lcom/facebook/react/views/image/ReactImageView;Ljava/lang/Integer;)V
 	public final fun setBorderRadius (Lcom/facebook/react/views/image/ReactImageView;IF)V
+	public final fun setBorderRadius (Lcom/facebook/react/views/image/ReactImageView;ILcom/facebook/react/bridge/Dynamic;)V
 	public final fun setBorderWidth (Lcom/facebook/react/views/image/ReactImageView;F)V
 	public final fun setDefaultSource (Lcom/facebook/react/views/image/ReactImageView;Ljava/lang/String;)V
 	public final fun setFadeDuration (Lcom/facebook/react/views/image/ReactImageView;I)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -12,13 +12,14 @@ import android.graphics.PorterDuff
 import com.facebook.common.logging.FLog
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator
 import com.facebook.react.uimanager.LengthPercentage
-import com.facebook.react.uimanager.LengthPercentageType
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewProps
@@ -171,13 +172,18 @@ public constructor(
               ViewProps.BORDER_BOTTOM_RIGHT_RADIUS,
               ViewProps.BORDER_BOTTOM_LEFT_RADIUS,
           ],
-      defaultFloat = Float.NaN,
+  )
+  public fun setBorderRadius(view: ReactImageView, index: Int, rawBorderRadius: Dynamic) {
+    val borderRadius = LengthPercentage.setFromDynamic(rawBorderRadius)
+    BackgroundStyleApplicator.setBorderRadius(view, BorderRadiusProp.values()[index], borderRadius)
+  }
+
+  @Deprecated(
+      "Don't use setBorderRadius(view, index, Float) as it was deprecated in React Native 0.87.0.",
+      ReplaceWith("setBorderRadius(view, index, DynamicFromObject(borderRadius))"),
   )
   public fun setBorderRadius(view: ReactImageView, index: Int, borderRadius: Float) {
-    val radius =
-        if (borderRadius.isNaN()) null
-        else LengthPercentage(borderRadius, LengthPercentageType.POINT)
-    BackgroundStyleApplicator.setBorderRadius(view, BorderRadiusProp.values()[index], radius)
+    setBorderRadius(view, index, DynamicFromObject(borderRadius))
   }
 
   @ReactProp(name = ViewProps.RESIZE_MODE)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
@@ -23,9 +23,13 @@ import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactTestHelper.createMockCatalystInstance
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import com.facebook.react.uimanager.BackgroundStyleApplicator
 import com.facebook.react.uimanager.DisplayMetricsHolder
+import com.facebook.react.uimanager.LengthPercentage
+import com.facebook.react.uimanager.LengthPercentageType
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.util.RNLog
 import com.facebook.react.views.imagehelper.ImageSource
 import com.facebook.soloader.SoLoader
@@ -140,6 +144,31 @@ class ReactImagePropertyTest {
     view.maybeUpdateView()
     assertThat(ImageSource.getTransparentBitmapImageSource(view.context))
         .isEqualTo(view.imageSource)
+  }
+
+  @Test
+  fun testBorderRadius() {
+    val viewManager = ReactImageManager()
+    val view = viewManager.createViewInstance(themeContext)
+
+    // Percentage border radii arrive as strings and must not crash the property updater
+    viewManager.updateProperties(view, buildStyles("borderRadius", "50%"))
+    assertThat(BackgroundStyleApplicator.getBorderRadius(view, BorderRadiusProp.BORDER_RADIUS))
+        .isEqualTo(LengthPercentage(50f, LengthPercentageType.PERCENT))
+
+    viewManager.updateProperties(view, buildStyles("borderRadius", 10.0))
+    assertThat(BackgroundStyleApplicator.getBorderRadius(view, BorderRadiusProp.BORDER_RADIUS))
+        .isEqualTo(LengthPercentage(10f, LengthPercentageType.POINT))
+
+    viewManager.updateProperties(view, buildStyles("borderTopLeftRadius", "25%"))
+    assertThat(
+            BackgroundStyleApplicator.getBorderRadius(view, BorderRadiusProp.BORDER_TOP_LEFT_RADIUS)
+        )
+        .isEqualTo(LengthPercentage(25f, LengthPercentageType.PERCENT))
+
+    viewManager.updateProperties(view, buildStyles("borderRadius", null))
+    assertThat(BackgroundStyleApplicator.getBorderRadius(view, BorderRadiusProp.BORDER_RADIUS))
+        .isNull()
   }
 
   @Test

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -1186,6 +1186,11 @@ const styles = StyleSheet.create({
     borderColor: 'red',
     backgroundColor: 'yellow',
   },
+  borderRadiusPercentage: {
+    borderWidth: 4,
+    borderRadius: '50%',
+    borderColor: 'green',
+  },
   boxShadow: {
     margin: 10,
   },
@@ -1446,6 +1451,10 @@ exports.examples = [
           />
           <Image
             style={[styles.base, styles.borderRadius5]}
+            source={fullImage}
+          />
+          <Image
+            style={[styles.base, styles.borderRadiusPercentage]}
             source={fullImage}
           />
         </View>


### PR DESCRIPTION
## Summary

Fixes #53977

Setting a percentage border radius on `<Image>` (e.g. `borderRadius: '50%'`) crashes Android with `java.lang.String cannot be cast to java.lang.Double`. Percentage radii arrive from JS as strings, but `ReactImageManager`'s `borderRadius` `@ReactPropGroup` setter was still typed as `Float`, so the reflection-based property updater (`ViewManagersPropertyCache`) failed on the cast. (The crash reproduces on any API level, not just API 35 as reported.)

This applies the same migration `ReactViewManager` received in 0.75: the setter now accepts a `Dynamic` and parses it with `LengthPercentage.setFromDynamic`, which handles both numbers and `'NN%'` strings (invalid values degrade to a warning + null instead of a crash). The old `Float` overload is kept as a deprecated pass-through so existing subclasses stay source/binary compatible, mirroring the `ReactViewManager` precedent, and the public API dump is updated accordingly.

No rendering changes are needed: the manager already delegates to `BackgroundStyleApplicator`, which resolves `PERCENT` length values against the view bounds.

Note: the same `Float`-typed setter still exists in `ReactTextViewManager`, `PreparedLayoutTextViewManager`, `ReactTextInputManager`, `ReactScrollViewManager`, and `ReactHorizontalScrollViewManager`, so `<Text>`, `<TextInput>`, and `<ScrollView>` crash the same way. I kept this PR scoped to the reported Image crash and I'm happy to follow up with the same fix for the others.

## Changelog:

[ANDROID] [FIXED] - Fix crash when setting a percentage borderRadius on Image

## Test Plan

- Added `testBorderRadius` to `ReactImagePropertyTest`, driving the real crash path (`ViewManager.updateProperties` → reflection prop updater) with `'50%'`, a plain number, a per-corner percentage, and null, asserting the resolved `LengthPercentage` on the view. Without the fix it fails with the exact exception from the issue; with the fix the suite passes (9/9):
  `./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests "com.facebook.react.views.image.ReactImagePropertyTest"`
- Added a `borderRadius: '50%'` image to rn-tester's Image → Border Radius example. Verified on a Pixel 9 Pro emulator (API 36) with rn-tester built from source: the screen that previously redboxed on mount now renders, with the percentage image drawn as a circle and the existing numeric-radius images unchanged (screenshot below).

## Screenshot

<img width="372" height="786" alt="image" src="https://github.com/user-attachments/assets/fa240927-3850-4036-9f73-f9ad9f825b18" />
