### PR TITLE
Fix premature blob deallocation during FileReader reads

### DIFF
--- a/packages/react-native/Libraries/Blob/FileReader.js
+++ b/packages/react-native/Libraries/Blob/FileReader.js
@@ -46,6 +46,13 @@ class FileReader extends EventTarget {
   _result: ?ReaderResult;
   _aborted: boolean = false;
   _readId: number = 0;
+  // The blob being read must stay strongly referenced until the native read
+  // settles. Otherwise, if the caller drops its own reference (as
+  // whatwg-fetch does in `readBlobAsText`), the Blob can be garbage
+  // collected while the read is still in flight, and its BlobCollector
+  // finalizer deallocates the underlying native buffer, failing the read
+  // with "The specified blob is invalid".
+  _blob: ?Blob;
 
   constructor() {
     super();
@@ -56,6 +63,7 @@ class FileReader extends EventTarget {
     this._readyState = EMPTY;
     this._error = null;
     this._result = null;
+    this._blob = null;
   }
 
   _startRead(methodName: string): number {
@@ -110,12 +118,14 @@ class FileReader extends EventTarget {
     }
 
     const readId = this._startRead('readAsArrayBuffer');
+    this._blob = blob;
 
     NativeFileReaderModule.readAsDataURL(blob.data).then(
       (text: string) => {
         if (readId !== this._readId) {
           return;
         }
+        this._blob = null;
 
         const base64 = text.split(',')[1];
         const typedArray = toByteArray(base64);
@@ -127,6 +137,7 @@ class FileReader extends EventTarget {
         if (readId !== this._readId) {
           return;
         }
+        this._blob = null;
         this._error = this._toDOMException(error);
         this._setReadyState(DONE);
       },
@@ -141,12 +152,14 @@ class FileReader extends EventTarget {
     }
 
     const readId = this._startRead('readAsDataURL');
+    this._blob = blob;
 
     NativeFileReaderModule.readAsDataURL(blob.data).then(
       (text: string) => {
         if (readId !== this._readId) {
           return;
         }
+        this._blob = null;
         this._result = text;
         this._setReadyState(DONE);
       },
@@ -154,6 +167,7 @@ class FileReader extends EventTarget {
         if (readId !== this._readId) {
           return;
         }
+        this._blob = null;
         this._error = this._toDOMException(error);
         this._setReadyState(DONE);
       },
@@ -168,12 +182,14 @@ class FileReader extends EventTarget {
     }
 
     const readId = this._startRead('readAsText');
+    this._blob = blob;
 
     NativeFileReaderModule.readAsText(blob.data, encoding).then(
       (text: string) => {
         if (readId !== this._readId) {
           return;
         }
+        this._blob = null;
         this._result = text;
         this._setReadyState(DONE);
       },
@@ -181,6 +197,7 @@ class FileReader extends EventTarget {
         if (readId !== this._readId) {
           return;
         }
+        this._blob = null;
         this._error = this._toDOMException(error);
         this._setReadyState(DONE);
       },
@@ -192,6 +209,10 @@ class FileReader extends EventTarget {
     if (this._readyState === LOADING) {
       this._aborted = true;
       this._readId++;
+      // The abandoned read's callbacks bail out on the readId check without
+      // clearing _blob, so release it here — before dispatching the abort
+      // event, whose handler may start a new read that sets _blob again.
+      this._blob = null;
       this._setReadyState(DONE);
     }
   }

--- a/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
@@ -275,4 +275,108 @@ describe('FileReader', function () {
     expect(() => reader.readAsText(null)).toThrow(TypeError);
     expect(reader.readyState).toBe(FileReader.EMPTY);
   });
+
+  it('should retain the blob until the read resolves', async () => {
+    let resolveRead: string => void = () => {};
+    const spy = jest
+      .spyOn(FileReaderModuleMock, 'readAsText')
+      .mockImplementation(
+        () =>
+          new Promise(resolve => {
+            resolveRead = resolve;
+          }),
+      );
+
+    const reader = new FileReader();
+    const blob = new Blob();
+    const loadend = new Promise<Event>(resolve => {
+      reader.onloadend = resolve;
+    });
+    reader.readAsText(blob);
+    // $FlowFixMe[prop-missing] - accessing private state for the test
+    expect(reader._blob).toBe(blob);
+
+    resolveRead('');
+    await loadend;
+    // $FlowFixMe[prop-missing] - accessing private state for the test
+    expect(reader._blob).toBe(null);
+
+    spy.mockRestore();
+  });
+
+  it('should release the blob when the read rejects', async () => {
+    let rejectRead: Error => void = () => {};
+    const spy = jest
+      .spyOn(FileReaderModuleMock, 'readAsText')
+      .mockImplementation(
+        () =>
+          new Promise((resolve, reject) => {
+            rejectRead = reject;
+          }),
+      );
+
+    const reader = new FileReader();
+    const blob = new Blob();
+    const loadend = new Promise<Event>(resolve => {
+      reader.onloadend = resolve;
+    });
+    reader.readAsText(blob);
+    // $FlowFixMe[prop-missing] - accessing private state for the test
+    expect(reader._blob).toBe(blob);
+
+    rejectRead(new Error('nope'));
+    await loadend;
+    // $FlowFixMe[prop-missing] - accessing private state for the test
+    expect(reader._blob).toBe(null);
+
+    spy.mockRestore();
+  });
+
+  it('should release the blob when a pending read is aborted', () => {
+    const spy = jest
+      .spyOn(FileReaderModuleMock, 'readAsText')
+      .mockImplementation(() => new Promise(() => {}));
+
+    const reader = new FileReader();
+    const blob = new Blob();
+    reader.readAsText(blob);
+    // $FlowFixMe[prop-missing] - accessing private state for the test
+    expect(reader._blob).toBe(blob);
+
+    reader.abort();
+    // $FlowFixMe[prop-missing] - accessing private state for the test
+    expect(reader._blob).toBe(null);
+
+    spy.mockRestore();
+  });
+
+  it('should keep retaining the new blob when a stale read settles after abort', async () => {
+    const resolvers: Array<(string) => void> = [];
+    const spy = jest
+      .spyOn(FileReaderModuleMock, 'readAsText')
+      .mockImplementation(
+        () =>
+          new Promise(resolve => {
+            resolvers.push(resolve);
+          }),
+      );
+
+    const reader = new FileReader();
+    const staleBlob = new Blob();
+    reader.readAsText(staleBlob);
+    reader.abort();
+
+    const newBlob = new Blob();
+    reader.readAsText(newBlob);
+    // $FlowFixMe[prop-missing] - accessing private state for the test
+    expect(reader._blob).toBe(newBlob);
+
+    // Settle the first (aborted) read; it must not drop the new blob.
+    resolvers[0]('');
+    await Promise.resolve();
+    // $FlowFixMe[prop-missing] - accessing private state for the test
+    expect(reader._blob).toBe(newBlob);
+
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION

## Summary:

`FileReader.readAsText` / `readAsDataURL` / `readAsArrayBuffer` pass only the plain `blob.data` descriptor to the native module and retain no reference to the `Blob` instance itself. If the caller also drops its reference, the Blob — and the `BlobCollector` attached to `blob.data.__collector` — becomes unreachable while the native read is still in flight. When GC runs in that window, the collector's finalizer unconditionally removes the bytes from the native blob store (`BlobCollector.cpp` calls `BlobModule.remove()` on Android; `RCTBlobCollector.mm` calls `[RCTBlobManager remove:]` on iOS), and the pending read rejects with **"The specified blob is invalid"** (Android) / **"Unable to resolve data for blob"** (iOS).

This is not an exotic case: React Native's fetch polyfill (whatwg-fetch) reads blob bodies exactly this way — `readBlobAsText` creates a `FileReader`, calls `reader.readAsText(blob)`, and keeps a reference only to the reader. So a plain `fetch(url).then(r => r.json())`, where the `Response` is not otherwise retained, is subject to this race. This matches the symptom profile of #56884: intermittent failures under many concurrent fetches (GC pressure plus native-module thread-hop latency), affecting both platforms, and disappearing when the same flow is rewritten with `async`/`await` — the suspended frame keeps the `Response` (and therefore the Blob and its collector) reachable, which is exactly the reference this fix restores.

The fix retains the Blob on the FileReader instance until the native read settles, completing the reference chain: pending native promise → callbacks → reader → `_blob` → Blob → collector. The reference is cleared when the current read settles (after the existing read-id staleness check, so a read abandoned by `abort()` cannot drop a newer read's reference) and in `abort()` itself, before the abort event is dispatched, so a read started from an abort handler is retained correctly. Memory impact is negligible: the native bytes must live until the read completes anyway — this change only guarantees they do.

The root cause is in the shared JS layer, so both Android and iOS are fixed.

Fixes #56884

Related prior art: #31392 fixed a different premature-deallocation path in the same subsystem (`blob.slice()` creating a second collector for the same blobId).

## Changelog:

[GENERAL] [FIXED] - Retain Blob reference in FileReader during pending native reads to prevent premature deallocation by BlobCollector

## Test Plan:

- `yarn jest packages/react-native/Libraries/Blob/__tests__/FileReader-test.js` — 19 passed, including 4 new tests: the blob is retained while a read is pending, released on resolve / reject / `abort()`, and a stale read settling after abort does not drop a newer read's blob.
- `yarn flow check` — no errors. `eslint` on both changed files — clean.
- The GC race itself cannot be reproduced deterministically under Jest (it requires a real engine GC collecting the Blob between dispatch and native execution), so the unit tests assert the reference-retention behavior instead. A deterministic on-device repro is in the issue comment below / #56884.
