### PR TITLE
feat(android): Automatically call `FullyDrawnReporter` to improve production PGOs

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -102,6 +102,7 @@ public class com/facebook/react/ReactActivityDelegate {
 	public fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	protected fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 	protected fun isFabricEnabled ()Z
+	protected fun isFullyDrawnReportingEnabled ()Z
 	protected fun isWideColorGamutEnabled ()Z
 	protected fun loadApp (Ljava/lang/String;)V
 	public fun onActivityResult (IILandroid/content/Intent;)V
@@ -138,6 +139,7 @@ public class com/facebook/react/ReactDelegate {
 	public final fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	public final fun getReactRootView ()Lcom/facebook/react/ReactRootView;
 	protected final fun isFabricEnabled ()Z
+	public final fun isFullyDrawnReportingEnabled ()Z
 	public final fun loadApp ()V
 	public final fun loadApp (Ljava/lang/String;)V
 	public final fun onActivityResult (IILandroid/content/Intent;Z)V
@@ -152,6 +154,7 @@ public class com/facebook/react/ReactDelegate {
 	public final fun onUserLeaveHint ()V
 	public final fun onWindowFocusChanged (Z)V
 	public final fun reload ()V
+	public final fun setFullyDrawnReportingEnabled (Z)V
 	public final fun setReactRootView (Lcom/facebook/react/ReactRootView;)V
 	public final fun setReactSurface (Lcom/facebook/react/interfaces/fabric/ReactSurface;)V
 	public final fun shouldShowDevMenuOrReload (ILandroid/view/KeyEvent;)Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -168,6 +168,7 @@ public class ReactActivityDelegate {
                   }
                 };
           }
+          mReactDelegate.setFullyDrawnReportingEnabled(isFullyDrawnReportingEnabled());
           if (mainComponentName != null) {
             LocalNetworkPermissionUtil.requestLocalNetworkAccessIfNeeded(
                 getPlainActivity(), () -> loadApp(mainComponentName));
@@ -321,5 +322,22 @@ public class ReactActivityDelegate {
    */
   protected boolean isWideColorGamutEnabled() {
     return false;
+  }
+
+  /**
+   * Controls whether {@link Activity#reportFullyDrawn()} is automatically triggered once the
+   * initial content of the React surface has appeared, via the activity's {@code
+   * androidx.activity.FullyDrawnReporter}. Android uses this signal to bound the startup window for
+   * profile guided compilation (Android 12+) and to report time-to-fully-drawn in Android vitals.
+   *
+   * <p>Apps that consider themselves fully drawn only later (e.g. once their initial data has been
+   * rendered) can keep this enabled and additionally register their own reporter on the activity's
+   * {@code FullyDrawnReporter} before the content appears, or override this method to return false
+   * to opt out entirely.
+   *
+   * @return true if fully drawn reporting is enabled for this Activity, false otherwise.
+   */
+  protected boolean isFullyDrawnReportingEnabled() {
+    return true;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
@@ -12,7 +12,10 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.KeyEvent
+import androidx.activity.ComponentActivity
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReactMarker
+import com.facebook.react.bridge.ReactMarkerConstants
 import com.facebook.react.bridge.UiThreadUtil.runOnUiThread
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer
 import com.facebook.react.devsupport.ReleaseDevSupportManager
@@ -50,6 +53,27 @@ public open class ReactDelegate {
    * @return true if Fabric is enabled for this Activity, false otherwise.
    */
   protected val isFabricEnabled: Boolean = true
+
+  /**
+   * Controls whether this delegate reports the host [Activity] as fully drawn once the initial
+   * content of the React surface has appeared.
+   *
+   * When enabled (the default) and the host [Activity] is a [ComponentActivity], a reporter is
+   * added to the activity's [androidx.activity.FullyDrawnReporter] when the surface starts loading
+   * and removed once the first view of the surface is mounted, which calls
+   * [Activity.reportFullyDrawn] after the next frame is drawn. Android uses this signal to bound
+   * the startup window for profile guided compilation (Android 12+) and to report
+   * time-to-fully-drawn in Android vitals.
+   *
+   * Apps that consider themselves fully drawn only later (e.g. once their initial data has been
+   * rendered) can keep this enabled and additionally register their own reporter on the activity's
+   * [androidx.activity.FullyDrawnReporter] before the content appears.
+   *
+   * Must be set before [loadApp] to take effect.
+   */
+  public var isFullyDrawnReportingEnabled: Boolean = true
+
+  private var fullyDrawnMarkerListener: ReactMarker.MarkerListener? = null
 
   /**
    * Do not use this constructor as it's not accounting for New Architecture at all. You should use
@@ -318,6 +342,9 @@ public open class ReactDelegate {
    * @param appKey The ID of the app to load into the surface.
    */
   public fun loadApp(appKey: String) {
+    if (isFullyDrawnReportingEnabled) {
+      reportFullyDrawnWhenContentAppears(appKey)
+    }
     // With Bridgeless enabled, create and start the surface
     if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       val reactHost = reactHost
@@ -340,6 +367,7 @@ public open class ReactDelegate {
 
   /** Stop the React surface started with [ReactDelegate.loadApp]. */
   public fun unloadApp() {
+    cancelFullyDrawnReporting()
     if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       reactSurface?.stop()
       reactSurface = null
@@ -349,6 +377,41 @@ public open class ReactDelegate {
         internalReactRootView = null
       }
     }
+  }
+
+  private fun reportFullyDrawnWhenContentAppears(appKey: String) {
+    if (fullyDrawnMarkerListener != null) {
+      return
+    }
+    val fullyDrawnReporter = (activity as? ComponentActivity)?.fullyDrawnReporter ?: return
+    if (fullyDrawnReporter.isFullyDrawnReported) {
+      return
+    }
+    fullyDrawnReporter.addReporter()
+    val listener =
+        object : ReactMarker.MarkerListener {
+          override fun logMarker(name: ReactMarkerConstants, tag: String?, instanceKey: Int) {
+            if (name == ReactMarkerConstants.CONTENT_APPEARED && tag == appKey) {
+              // CONTENT_APPEARED is logged on the UI thread, so this cannot race with
+              // cancelFullyDrawnReporting or a second loadApp.
+              if (fullyDrawnMarkerListener !== this) {
+                return
+              }
+              fullyDrawnMarkerListener = null
+              ReactMarker.removeListener(this)
+              fullyDrawnReporter.removeReporter()
+            }
+          }
+        }
+    fullyDrawnMarkerListener = listener
+    ReactMarker.addListener(listener)
+  }
+
+  private fun cancelFullyDrawnReporting() {
+    val listener = fullyDrawnMarkerListener ?: return
+    fullyDrawnMarkerListener = null
+    ReactMarker.removeListener(listener)
+    (activity as? ComponentActivity)?.fullyDrawnReporter?.removeReporter()
   }
 
   public fun setReactSurface(reactSurface: ReactSurface?) {


### PR DESCRIPTION

## Summary:

Since Android 12 the Google PlayStore automatically profiles cold starts of new apps on user devices to optimize them for subsequent launches (affects JVM, not native).

This works most effectively if the app reliably calls [`reportFullyDrawn()`](https://developer.android.com/reference/kotlin/android/app/Activity#reportFullyDrawn()) once its content has been... fully drawn.

> See [App startup time: Android Vitals](https://developer.android.com/topic/performance/vitals/launch-time#av) for more information

This is super hard to test isolated, but it should improve performance in production by making these PlayStore profiles more accurate, allowing Android to optimize production apps better as it understands when TTFD (Time-To-Full-Display) actually happens, which is hard to tell for Android in a non-native Android app (i.e. react-native, with asynchronous rendering and whatnot).

Since react-native renders the main UI asynchronously, I do expect this change to make a performance difference in production, but this is merely an assumption and not a tested claim.

Btw., this does not call `reportFullyDrawn()` directly, but instead uses androidx' [`FullyDrawnReporter`](https://developer.android.com/reference/kotlin/androidx/activity/FullyDrawnReporter), which is **collaborative** - meaning this works well in brownfield apps and apps can also extend this to register their reporter to delay their TTFD reporting.

By default, it is enabled and reports on `CONTENT_APPEARED`.

I added a feature flag which allows users (brownfield?) to disable it by overriding `isFullyDrawnReportingEnabled()` to return `false`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID] [ADDED] - Automatically call `FullyDrawnReporter` to improve production performance via profiles

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

### Isolated

Make sure `reportFullyDrawn()` is called:

```sh
adb logcat -s ActivityTaskManager
```

Before this PR you'll see something like
```
Displayed com.app/.MainActivity: +400ms
```

After this PR you'll see something like
```diff
Fully drawn com.app/.MainActivity: +1.4s
```
too.

### Production

Ideally PlayStore can optimize the bytecode better with more accurate TTFDs, and startup time should decrease, but that is speculation.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
