### PR TITLE
fix(TextInput): report correct selection after autofill on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputTextWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputTextWatcher.kt
@@ -22,6 +22,7 @@ internal class ReactTextInputTextWatcher(
   private val eventDispatcher: EventDispatcher? = UIManagerHelper.getEventDispatcher(reactContext)
   private val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
   private var previousText: String? = null
+  private var shouldDispatchChange: Boolean = false
 
   override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
     // Incoming charSequence gets mutated before onTextChanged() is invoked
@@ -46,6 +47,15 @@ internal class ReactTextInputTextWatcher(
       return
     }
 
+    shouldDispatchChange = true
+  }
+
+  override fun afterTextChanged(s: Editable) {
+    if (!shouldDispatchChange) {
+      return
+    }
+    shouldDispatchChange = false
+
     val stateWrapper = editText.stateWrapper
 
     if (stateWrapper != null) {
@@ -55,7 +65,10 @@ internal class ReactTextInputTextWatcher(
       stateWrapper.updateState(newStateData)
     }
 
-    // The event that contains the event counter and updates it must be sent first.
+    // Dispatch in afterTextChanged so that the selection reflects the final cursor
+    // position. During autofill, onTextChanged fires before Android updates the
+    // selection, causing {start: 0, end: 0} to be reported instead of the actual
+    // cursor position.
     eventDispatcher?.dispatchEvent(
         ReactTextChangedEvent(
             surfaceId,
@@ -67,6 +80,4 @@ internal class ReactTextInputTextWatcher(
         ),
     )
   }
-
-  override fun afterTextChanged(s: Editable) = Unit
 }


### PR DESCRIPTION
## Summary

Fixes the `onChange` event reporting `selection: {start: 0, end: 0}` instead of the actual cursor position when text is filled via Android's system autofill.

Fixes #57458

## Changelog:

[ANDROID] [FIXED] - TextInput onChange now reports correct selection after system autofill

## Problem

`ReactTextInputTextWatcher.onTextChanged` dispatches the `onChange` event with `editText.selectionStart/End`. During autofill, Android sets the text *before* updating the cursor position — so at `onTextChanged` time, the selection is still at `{0, 0}`.

Paste and keyboard input work correctly because Android updates their selection synchronously before the TextWatcher callbacks.

## Solution

Moved the event dispatch (state update + `ReactTextChangedEvent`) from `onTextChanged` to `afterTextChanged`. By that point the Editable is fully committed and Android has updated the selection to reflect the actual cursor position.

The change detection logic stays in `onTextChanged` (where it has access to the `start`/`before`/`count` parameters) and sets a flag that `afterTextChanged` checks before dispatching.

## Test Plan

- Android autofill: `onChange` now reports `selection: {start: N, end: N}` where N = text length
- Keyboard input: selection still correct (unchanged behavior)
- Paste: selection still correct (unchanged behavior)
- Controlled TextInput: state updates still fire correctly