### PR TITLE
fix(iOS): preserve Selected accessibility trait on recycled Fabric views

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -488,6 +488,17 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
   if (oldViewProps.accessibilityTraits != newViewProps.accessibilityTraits) {
     self.accessibilityElement.accessibilityTraits =
         RCTUIAccessibilityTraitsFromAccessibilityTraits(newViewProps.accessibilityTraits);
+    // Re-apply Selected/NotEnabled from the current accessibilityState. The traits
+    // writer replaces the full bitmask (from role), which doesn't include state bits.
+    // On a recycled view, accessibilityState may not have changed (so its writer below
+    // won't fire), but the traits were just overwritten and need the state bits re-applied.
+    const auto accessibilityState = newViewProps.accessibilityState.value_or(AccessibilityState{});
+    if (accessibilityState.selected) {
+      self.accessibilityTraits |= UIAccessibilityTraitSelected;
+    }
+    if (accessibilityState.disabled) {
+      self.accessibilityTraits |= UIAccessibilityTraitNotEnabled;
+    }
   }
 
   // `accessibilityState`


### PR DESCRIPTION
## Summary

Fixes the `Selected` accessibility trait being lost when a Fabric iOS view is recycled and its role changes while `accessibilityState.selected` remains `true`.

Fixes #57515

## Changelog:

[IOS] [FIXED] - Accessibility Selected/NotEnabled traits are now preserved when a recycled Fabric view's role changes

## Problem

In `RCTViewComponentView updateProps`, two writers update `self.accessibilityTraits`:

1. **`accessibilityTraits`** (role change): replaces the full bitmask — does NOT include `Selected`/`NotEnabled`
2. **`accessibilityState`** (state change): ORs in `Selected`/`NotEnabled`

Both diff against retained props. On a recycled view:
- Lifecycle 1: Button A (role=button, selected=true) → traits = `Button | Selected` ✅
- Lifecycle 2: Plain view (role=none, selected=false) → traits = `None` ✅  
- Lifecycle 3: Button A again (role=button, selected=true) → role changed (none→button) so writer 1 fires: `Button`. But retained props still show `selected=true` from lifecycle 1, so writer 2 skips. **Selected is lost.** ❌

## Solution

After the `accessibilityTraits` writer fires (role change), immediately re-apply `Selected`/`NotEnabled` from the current `accessibilityState`. This is idempotent when the state writer also fires.

## Test Plan

- Recycled view with same `accessibilityState.selected=true` but different role now retains the `Selected` trait
- Accessibility Inspector shows correct traits after toggling between views with different roles
- No change in behavior for non-recycled views (the state bits are ORed in regardless)