### PR TITLE
fix(iOS): keep prebuilt Headers/ in place on a Debug/Release swap

### DIFF
--- a/packages/react-native/scripts/__tests__/replace-rncore-version-test.js
+++ b/packages/react-native/scripts/__tests__/replace-rncore-version-test.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+const {replaceRNCoreConfiguration} = require('../replace-rncore-version');
+const {execFileSync} = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const VERSION = '0.87.0-test';
+const SLICE = 'ios-arm64_x86_64-simulator';
+const BINARY = path.join(SLICE, 'React.framework', 'React');
+
+function writeFile(filePath, contents) {
+  fs.mkdirSync(path.dirname(filePath), {recursive: true});
+  fs.writeFileSync(filePath, contents);
+}
+
+function buildTarball(podsRoot, configuration) {
+  const stage = fs.mkdtempSync(path.join(podsRoot, `stage-${configuration}-`));
+  writeFile(path.join(stage, 'React.xcframework', 'Info.plist'), '<plist/>');
+  writeFile(
+    path.join(stage, 'React.xcframework', BINARY),
+    `binary-${configuration}`,
+  );
+  const artifacts = path.join(podsRoot, 'ReactNativeCore-artifacts');
+  fs.mkdirSync(artifacts, {recursive: true});
+  execFileSync('tar', [
+    '-czf',
+    path.join(
+      artifacts,
+      `reactnative-core-${VERSION.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`,
+    ),
+    '-C',
+    stage,
+    '.',
+  ]);
+  fs.rmSync(stage, {recursive: true, force: true});
+}
+
+describe('replaceRNCoreConfiguration', () => {
+  let podsRoot;
+  let pod;
+  let cwd;
+
+  beforeEach(() => {
+    podsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rncore-test-'));
+    pod = path.join(podsRoot, 'React-Core-prebuilt');
+    // What the podspec prepare_command leaves behind after `pod install`.
+    writeFile(
+      path.join(pod, 'Headers', 'module.modulemap'),
+      'module yoga {}\n',
+    );
+    writeFile(path.join(pod, 'React.xcframework', 'Info.plist'), '<plist/>');
+    writeFile(path.join(pod, 'React.xcframework', BINARY), 'binary-Debug');
+    buildTarball(podsRoot, 'Release');
+    cwd = process.cwd();
+    // The script phase runs with Pods/ as its working directory.
+    process.chdir(podsRoot);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    fs.rmSync(podsRoot, {recursive: true, force: true});
+  });
+
+  it('installs the framework for the requested configuration', () => {
+    replaceRNCoreConfiguration('Release', VERSION, podsRoot);
+
+    expect(
+      fs.readFileSync(path.join(pod, 'React.xcframework', BINARY), 'utf8'),
+    ).toBe('binary-Release');
+  });
+
+  // Regression test for #57803: recreating the module map mid-build lets a
+  // concurrent dependency scan miss it, and the React module then precompiles
+  // without -fmodule-map-file and fails on non-modular includes.
+  it('leaves Headers/module.modulemap untouched', () => {
+    const moduleMap = path.join(pod, 'Headers', 'module.modulemap');
+    const before = fs.statSync(moduleMap).ino;
+
+    replaceRNCoreConfiguration('Release', VERSION, podsRoot);
+
+    expect(fs.statSync(moduleMap).ino).toBe(before);
+  });
+
+  it('fails when the tarball has no React.xcframework', () => {
+    const stage = fs.mkdtempSync(path.join(podsRoot, 'stage-bad-'));
+    writeFile(path.join(stage, 'unrelated.txt'), 'nope');
+    execFileSync('tar', [
+      '-czf',
+      path.join(
+        podsRoot,
+        'ReactNativeCore-artifacts',
+        `reactnative-core-${VERSION.toLowerCase()}-release.tar.gz`,
+      ),
+      '-C',
+      stage,
+      '.',
+    ]);
+
+    expect(() =>
+      replaceRNCoreConfiguration('Release', VERSION, podsRoot),
+    ).toThrow(/Extraction verification failed/);
+  });
+});

--- a/packages/react-native/scripts/replace-rncore-version.js
+++ b/packages/react-native/scripts/replace-rncore-version.js
@@ -59,7 +59,7 @@ function replaceRNCoreConfiguration(
   configuration /*: string */,
   version /*: string */,
   podsRoot /*: string */,
-) {
+) /*: void */ {
   // Filename comes from rncore.rb
   const tarballURLPath = `${podsRoot}/ReactNativeCore-artifacts/reactnative-core-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
 
@@ -72,18 +72,6 @@ function replaceRNCoreConfiguration(
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rncore-'));
   const tmpExtractDir = path.join(tmpDir, 'React-Core-prebuilt');
   fs.mkdirSync(tmpExtractDir, {recursive: true});
-
-  // Preserve Expo-generated modulemap before replacing directories
-  const useFrameworksModulemapName = 'React-use-frameworks.modulemap';
-  const useFrameworksModulemapPath = path.join(
-    finalLocation,
-    useFrameworksModulemapName,
-  );
-  let savedModulemap = null;
-  if (fs.existsSync(useFrameworksModulemapPath)) {
-    console.log('Preserving', useFrameworksModulemapName);
-    savedModulemap = fs.readFileSync(useFrameworksModulemapPath);
-  }
 
   try {
     console.log('Extracting the tarball to temp dir', tarballURLPath);
@@ -110,98 +98,30 @@ function replaceRNCoreConfiguration(
       );
     }
 
-    // Delete only directories in finalLocation (e.g. the React.xcframework) -
-    // not files, so any sibling files written during pod install are preserved.
-    const dirs = fs
-      .readdirSync(finalLocation, {withFileTypes: true})
-      .filter(dirent => dirent.isDirectory());
-    for (const dirent of dirs) {
-      const direntName =
-        typeof dirent.name === 'string' ? dirent.name : dirent.name.toString();
-      const dirPath = `${finalLocation}/${direntName}`;
-      console.log('Removing directory', dirPath);
-      fs.rmSync(dirPath, {force: true, recursive: true});
-    }
-
-    // Move extracted directories from temp to final location
-    const extractedEntries = fs
-      .readdirSync(tmpExtractDir, {withFileTypes: true})
-      .filter(dirent => dirent.isDirectory());
-    for (const dirent of extractedEntries) {
-      const direntName =
-        typeof dirent.name === 'string' ? dirent.name : dirent.name.toString();
-      const src = path.join(tmpExtractDir, direntName);
-      const dst = path.join(finalLocation, direntName);
-      const mvResult = spawnSync('mv', [src, dst], {stdio: 'inherit'});
-      if (mvResult.status !== 0) {
-        // Fallback: copy recursively then remove source
-        console.log(`mv failed for ${direntName}, falling back to cp -R`);
-        const cpResult = spawnSync('cp', ['-R', src, dst], {
-          stdio: 'inherit',
-        });
-        if (cpResult.status !== 0) {
-          throw new Error(
-            `cp fallback failed with exit code ${cpResult.status}`,
-          );
-        }
+    // Replace only the compiled framework. Headers/ is flattened from
+    // ReactNativeHeaders by the podspec prepare_command, and the prebuild
+    // compose job emits one set of those headers for both configurations, so a
+    // config switch leaves them identical. Leaving them alone keeps
+    // Headers/module.modulemap — which consumers activate through
+    // -fmodule-map-file — in place for the whole build; deleting and recreating
+    // it mid-build lets a concurrent dependency scan miss it, and the React
+    // module then precompiles without it (#57803).
+    const dest = path.join(finalLocation, 'React.xcframework');
+    console.log('Replacing', dest);
+    fs.rmSync(dest, {force: true, recursive: true});
+    const mvResult = spawnSync('mv', [xcfwPath, dest], {stdio: 'inherit'});
+    if (mvResult.status !== 0) {
+      // Fallback: copy recursively then remove source
+      console.log('mv failed for React.xcframework, falling back to cp -R');
+      const cpResult = spawnSync('cp', ['-R', xcfwPath, dest], {
+        stdio: 'inherit',
+      });
+      if (cpResult.status !== 0) {
+        throw new Error(`cp fallback failed with exit code ${cpResult.status}`);
       }
     }
-
-    // The podspec prepare_command flattens ReactNativeHeaders' headers into a
-    // top-level Headers/ dir, but it does not re-run on a config swap. Mirror
-    // it here: re-flatten the headers (identical across slices) and drop the
-    // now-redundant xcframework so $(PODS_ROOT)/React-Core-prebuilt/Headers
-    // keeps resolving <react/...>, <yoga/...>, etc.
-    //
-    // Fail closed when the swapped-in tarball lacks ReactNativeHeaders: the
-    // directory purge above already deleted the previous Headers/, so
-    // continuing silently would leave the injected -fmodule-map-file flag
-    // dangling and break every <react/...> include only on a config switch —
-    // with no pointer to the version-skewed artifact that caused it.
-    const rnhXcfw = path.join(finalLocation, 'ReactNativeHeaders.xcframework');
-    if (!fs.existsSync(rnhXcfw)) {
-      throw new Error(
-        `ReactNativeHeaders.xcframework not found in the extracted tarball at ${finalLocation}. ` +
-          'The downloaded artifact predates the headers-spec layout (or is incomplete); ' +
-          'use a prebuilt tarball matching this react-native version.',
-      );
-    }
-    const slice = fs
-      .readdirSync(rnhXcfw, {withFileTypes: true})
-      .find(
-        dirent =>
-          dirent.isDirectory() &&
-          fs.existsSync(path.join(rnhXcfw, dirent.name.toString(), 'Headers')),
-      );
-    if (!slice) {
-      throw new Error(
-        `No slice with a Headers directory found inside ${rnhXcfw}.`,
-      );
-    }
-    const headersDest = path.join(finalLocation, 'Headers');
-    fs.rmSync(headersDest, {force: true, recursive: true});
-    const cpHeaders = spawnSync(
-      'cp',
-      ['-R', path.join(rnhXcfw, slice.name.toString(), 'Headers'), headersDest],
-      {stdio: 'inherit'},
-    );
-    if (cpHeaders.status !== 0) {
-      throw new Error(
-        `Flattening ReactNativeHeaders failed with exit code ${cpHeaders.status}`,
-      );
-    }
-    fs.rmSync(rnhXcfw, {force: true, recursive: true});
   } finally {
-    // Clean up temp directory
     fs.rmSync(tmpDir, {force: true, recursive: true});
-
-    // Restore Expo-generated modulemap after directory replacement.
-    // Runs in finally so it is not skipped if mv/cp partially fails.
-    if (savedModulemap != null) {
-      const restoredPath = path.join(finalLocation, useFrameworksModulemapName);
-      fs.writeFileSync(restoredPath, savedModulemap);
-      console.log('Restored', useFrameworksModulemapName);
-    }
   }
 }
 
@@ -252,4 +172,8 @@ const version = argv.reactNativeVersion;
 // $FlowFixMe[prop-missing]
 const podsRoot = argv.podsRoot;
 
-main(configuration, version, podsRoot);
+if (require.main === module) {
+  main(configuration, version, podsRoot);
+}
+
+module.exports = {replaceRNCoreConfiguration};


### PR DESCRIPTION
## Summary

Fixes #57803. An iOS Release build can fail in `PrecompileModule React` with seven `include of non-modular header inside framework module` errors — but only when the build follows a Debug/Release configuration switch, and only when the project contains **a pod target that does not depend on React**.

`replace-rncore-version.js` deleted and recreated `Pods/React-Core-prebuilt/Headers/` on a swap. That directory holds `module.modulemap`, which `rncore.rb` activates on every target through `-fmodule-map-file`.

A pod that depends on React has a target-dependency edge that orders its module scan behind `React-Core-prebuilt`'s script phase. A pod with no React dependency has no such edge, so its scan is free to run *before* the swap. The `React` module is then precompiled without the module map, and `<yoga/...>`, `<react/...>` and `<RCTDeprecation/...>` resolve textually and trip `-Wnon-modular-include-in-framework-module`.

Those headers never needed replacing. The prebuild compose job emits one set of ReactNativeHeaders for both configurations, so they are identical in the Debug and Release tarballs — only the compiled framework differs. This replaces `React.xcframework` and nothing else, so the module map stays put for the whole build and the ordering stops mattering.

## Changelog:

[IOS] [FIXED] - Keep the prebuilt `Headers/` in place on a Debug/Release configuration switch so the React explicit module still resolves its module map

## Test Plan

The premise, on the published 0.87.0-rc.3 artifacts (`ios-arm64_x86_64-simulator`):

| compared between the Debug and Release tarballs | result |
| --- | --- |
| `ReactNativeHeaders…/Headers/module.modulemap` | identical |
| `React.framework/Modules/module.modulemap` | identical |
| `ReactNativeHeaders…/Headers` tree (`diff -rq`) | 0 differences |
| `React.framework/Headers` tree (`diff -rq`) | 0 differences |

The reproducer from #57803, on Xcode 26.3 with CocoaPods 1.15.2:

| build | result |
| --- | --- |
| 0.87.0-rc.3 | **FAIL** — exit 65, 7 errors |
| 0.87.0-rc.3 + this PR | **PASS** — `** BUILD SUCCEEDED **`, 0 errors |

The swap still does its job in the passing build — it logs `Replacing React-Core-prebuilt/React.xcframework`, and the installed binary is the Release one:

```
installed:   55225ccbc283c57c614ff4caf263cb63bad3828240e62cee8893e7001774bd6c
rc3 release: 55225ccbc283c57c614ff4caf263cb63bad3828240e62cee8893e7001774bd6c
rc3 debug:   516215801a6f8a86640aae13c2f2de1bbdb95189edf124e208f528b1497c7e4c
```

A Release→Debug swap was verified the same way. Across a swap, `Headers/module.modulemap` keeps its inode while `React.xcframework` gets a new one.

### Isolating the precondition

On stock 0.87.0-rc.3, changing only the reproducer's `IndependentPod`, and reading back which targets' `ScanDependencies` ran before the swap:

| `IndependentPod.podspec` | scans before the swap | result |
| --- | --- | --- |
| no dependencies (as reported) | `IndependentPod` | **FAIL** 2/2 |
| `+ spec.dependency 'React-Core'` | *none* | **PASS** 2/2 |
| pod removed from the Podfile | *none* | **PASS** 2/2 |

Adding the dependency was the only change — same Podfile declaration, same local `:path` pod, same source file importing only `Foundation`.

Note this is an ordering race, not a structural guarantee: a project with no React-independent pod is very likely safe but not provably so, since a different job count or machine load could reorder scans. This PR removes the race rather than the ordering, so the precondition stops mattering either way.

Adds a unit test for the script (3 cases: correct framework installed, module map untouched, fail on a tarball with no `React.xcframework`). The script needed a `require.main === module` guard and one export to be importable.

## Note for the release crew

This is a candidate for 0.87.0-rc.4. #57803 reproduces on rc.2 and rc.3 and is not fixed by anything currently on `0.87-stable`; I verified #57742 in particular does not address it.

Exposure: a stock template app has no React-independent pod and passed here. Apps that pull a native SDK pod directly (Firebase, Sentry, analytics or networking libraries) or vendor a local utility pod are the exposed shape, including via transitive pods of an RN wrapper.

Not fixed here: `React.xcframework` is still replaced mid-build, and Xcode's xcframework-extraction task is not ordered against this script phase either. No failure was observed from that, and closing it properly means installing both configurations side by side instead of mutating pod content during a build — too large for a release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
